### PR TITLE
feat: Add popup/new window detection for JavaScript-opened pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,31 @@ agent-browser tab close [n]           # Close tab
 agent-browser window new              # New window
 ```
 
+### Popup Detection
+
+Detect and interact with JavaScript-opened windows (window.open, target="_blank"):
+
+```bash
+agent-browser popup wait [timeout]    # Wait for popup (default 30s)
+agent-browser popup list              # List detected popups
+agent-browser popup clear             # Clear popup history
+```
+
+**Example workflow:**
+
+```bash
+# Click a link that opens in new tab
+agent-browser click "a[target='_blank']"
+
+# Wait for the popup to open
+agent-browser popup wait
+# Returns: {"index": 1, "url": "https://...", "switched": true}
+
+# Now on the new tab - interact normally
+agent-browser snapshot -i
+agent-browser click @e1
+```
+
 ### Frames
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ agent-browser window new              # New window
 Detect and interact with JavaScript-opened windows (window.open, target="_blank"):
 
 ```bash
-agent-browser popup wait [timeout]    # Wait for popup (default 30s)
+agent-browser popup wait [timeout]    # Wait for popup (default 5s)
 agent-browser popup list              # List detected popups
 agent-browser popup clear             # Clear popup history
 ```
@@ -217,7 +217,7 @@ agent-browser click "a[target='_blank']"
 
 # Wait for the popup to open
 agent-browser popup wait
-# Returns: {"index": 1, "url": "https://...", "switched": true}
+# Returns: {"index": 1, "url": "https://...", "title": "Page Title"}
 
 # Now on the new tab - interact normally
 agent-browser snapshot -i

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -347,6 +347,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -643,6 +643,17 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             }
         }
 
+        // === Popup (JavaScript-opened windows) ===
+        "popup" => match rest.get(0).map(|s| *s) {
+            Some("wait") => {
+                let timeout = rest.get(1).and_then(|s| s.parse::<i32>().ok());
+                Ok(json!({ "id": id, "action": "popup_wait", "timeout": timeout }))
+            }
+            Some("list") => Ok(json!({ "id": id, "action": "popup_list" })),
+            Some("clear") => Ok(json!({ "id": id, "action": "popup_clear" })),
+            _ => Ok(json!({ "id": id, "action": "popup_list" })),
+        }
+
         // === Frame ===
         "frame" => {
             if rest.get(0).map(|s| *s) == Some("main") {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1253,6 +1253,35 @@ Examples:
 "##
         }
 
+        // === Popup (JavaScript-opened windows) ===
+        "popup" => r##"
+agent-browser popup - Handle JavaScript-opened popup windows
+
+Usage: agent-browser popup <operation> [args]
+
+Detect and manage popup windows opened via JavaScript (window.open, target="_blank").
+
+Operations:
+  wait [timeout]       Wait for a popup to open (default: 5000ms)
+  list                 List all detected popups (default)
+  clear                Clear popup tracking
+
+Notes:
+  - Popups are windows opened by page JavaScript, not browser UI
+  - wait is useful before interacting with a popup
+  - After popup opens, use tab commands to switch to it
+
+Global Options:
+  --json               Output as JSON
+  --session <name>     Use specific session
+
+Examples:
+  agent-browser popup wait              # Wait up to 5s for popup
+  agent-browser popup wait 10000        # Wait up to 10s
+  agent-browser popup list              # Show detected popups
+  agent-browser popup clear             # Clear popup tracking
+"##,
+
         // === Frame ===
         "frame" => {
             r##"
@@ -1611,6 +1640,11 @@ Storage:
 
 Tabs:
   tab [new|list|close|<n>]   Manage tabs
+
+Popups:  agent-browser popup <action>
+  wait [timeout]             Wait for popup (default 5s)
+  list                       List detected popups
+  clear                      Clear popup tracking
 
 Debug:
   trace start|stop [path]    Record trace

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -107,6 +107,11 @@ import type {
   RecordingStartCommand,
   RecordingStopCommand,
   RecordingRestartCommand,
+  PopupWaitCommand,
+  PopupListCommand,
+  PopupClearCommand,
+  PopupWaitData,
+  PopupListData,
   NavigateData,
   ScreenshotData,
   EvaluateData,
@@ -455,6 +460,12 @@ export async function executeCommand(command: Command, browser: BrowserManager):
         return await handleRecordingStop(command, browser);
       case 'recording_restart':
         return await handleRecordingRestart(command, browser);
+      case 'popup_wait':
+        return await handlePopupWait(command, browser);
+      case 'popup_list':
+        return await handlePopupList(command, browser);
+      case 'popup_clear':
+        return await handlePopupClear(command, browser);
       default: {
         // TypeScript narrows to never here, but we handle it for safety
         const unknownCommand = command as { id: string; action: string };
@@ -2040,4 +2051,33 @@ async function handleRecordingRestart(
     previousPath: result.previousPath,
     stopped: result.stopped,
   });
+}
+
+// Popup handlers
+
+async function handlePopupWait(
+  command: PopupWaitCommand,
+  browser: BrowserManager
+): Promise<Response<PopupWaitData>> {
+  const result = await browser.waitForPopup(command.timeout);
+  return successResponse(command.id, result);
+}
+
+async function handlePopupList(
+  command: PopupListCommand,
+  browser: BrowserManager
+): Promise<Response<PopupListData>> {
+  const popups = browser.getPopupHistory();
+  return successResponse(command.id, {
+    popups,
+    count: popups.length,
+  });
+}
+
+async function handlePopupClear(
+  command: PopupClearCommand,
+  browser: BrowserManager
+): Promise<Response> {
+  browser.clearPopupHistory();
+  return successResponse(command.id, { cleared: true });
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -588,6 +588,20 @@ const bringToFrontSchema = baseCommandSchema.extend({
   action: z.literal('bringtofront'),
 });
 
+// Popup schemas
+const popupWaitSchema = baseCommandSchema.extend({
+  action: z.literal('popup_wait'),
+  timeout: z.number().positive().optional(),
+});
+
+const popupListSchema = baseCommandSchema.extend({
+  action: z.literal('popup_list'),
+});
+
+const popupClearSchema = baseCommandSchema.extend({
+  action: z.literal('popup_clear'),
+});
+
 const waitForFunctionSchema = baseCommandSchema.extend({
   action: z.literal('waitforfunction'),
   expression: z.string().min(1),
@@ -906,6 +920,9 @@ const commandSchema = z.discriminatedUnion('action', [
   inputMouseSchema,
   inputKeyboardSchema,
   inputTouchSchema,
+  popupWaitSchema,
+  popupListSchema,
+  popupClearSchema,
 ]);
 
 // Parse result type

--- a/src/types.ts
+++ b/src/types.ts
@@ -421,6 +421,20 @@ export interface BringToFrontCommand extends BaseCommand {
   action: 'bringtofront';
 }
 
+// Popup/new window detection commands
+export interface PopupWaitCommand extends BaseCommand {
+  action: 'popup_wait';
+  timeout?: number;
+}
+
+export interface PopupListCommand extends BaseCommand {
+  action: 'popup_list';
+}
+
+export interface PopupClearCommand extends BaseCommand {
+  action: 'popup_clear';
+}
+
 // Wait for JS function to return truthy
 export interface WaitForFunctionCommand extends BaseCommand {
   action: 'waitforfunction';
@@ -931,7 +945,10 @@ export type Command =
   | ScreencastStopCommand
   | InputMouseCommand
   | InputKeyboardCommand
-  | InputTouchCommand;
+  | InputTouchCommand
+  | PopupWaitCommand
+  | PopupListCommand
+  | PopupClearCommand;
 
 // Response types
 export interface SuccessResponse<T = unknown> {
@@ -1051,6 +1068,25 @@ export interface ElementStyleInfo {
 
 export interface StylesData {
   elements: ElementStyleInfo[];
+}
+
+// Popup response types
+export interface PopupInfo {
+  index: number;
+  url: string;
+  timestamp: number;
+  openerUrl: string;
+}
+
+export interface PopupWaitData {
+  index: number;
+  url: string;
+  title: string;
+}
+
+export interface PopupListData {
+  popups: PopupInfo[];
+  count: number;
 }
 
 // Browser state


### PR DESCRIPTION
## Summary

This PR adds the ability to detect and interact with pages opened by JavaScript (`window.open()`, `target="_blank"`, etc.), which was previously not possible with the existing tab management system.

### Problem

When automating web applications that open new windows/tabs via JavaScript, the current implementation cannot detect these new pages. The `tab list` command only shows explicitly created tabs, missing any popups triggered by user interactions.

### Solution

Added a `context.on('page')` event listener that captures all new pages created within a browser context, along with new commands to wait for and manage these popups.

## Changes

### Core Implementation (`src/browser.ts`)
- Added `PopupEvent` interface for tracking popup metadata
- Added `context.on('page')` listener in `launch()` to detect JavaScript-opened pages
- Implemented `handlePopup()` to track new pages with their opener URL and timestamp
- Added `waitForPopup(timeout?)` - waits for and returns the next popup
- Added helper methods: `getPopupHistory()`, `getLastPopup()`, `clearPopupHistory()`, `hasPopups()`
- Fixed `newTab()`, `newWindow()`, and `launch()` to prevent explicit page creations from being recorded as popups (using `isCreatingExplicitPage` flag)

### Types (`src/types.ts`)
- Added `PopupWaitCommand`, `PopupListCommand`, `PopupClearCommand` interfaces
- Added `PopupInfo`, `PopupWaitData`, `PopupListData` response types

### Protocol (`src/protocol.ts`)
- Added Zod schemas for `popup_wait`, `popup_list`, `popup_clear` commands

### Actions (`src/actions.ts`)
- Added handlers: `handlePopupWait`, `handlePopupList`, `handlePopupClear`

### CLI (`cli/src/commands.rs`)
- Added new commands:
  - `popup wait [timeout]` - Wait for a popup to be opened
  - `popup list` - List all detected popups
  - `popup clear` - Clear popup history

## Usage

```bash
# Click something that opens a popup, then capture it
click "button#open-popup"
popup wait 5000

# List all detected popups
popup list

# Switch to the popup tab
tab 1

# Clear popup history
popup clear
```

## Test Plan

- [x] All existing tests pass (84/84)
- [x] Tested with real-world site that uses `target="_blank"` links
- [x] Verified explicit `newTab()` calls don't get recorded as popups
- [x] Verified `waitForPopup()` correctly times out when no popup appears