### PR TITLE
fix: improve error message when element is blocked by overlay

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { toAIFriendlyError } from './actions.js';
+
+describe('toAIFriendlyError', () => {
+  describe('element blocked by overlay', () => {
+    it('should detect intercepts pointer events even when Timeout is in message', () => {
+      // This is the exact error from Playwright when a cookie banner blocks an element
+      // Bug: Previously this was incorrectly reported as "not found or not visible"
+      const error = new Error(
+        'TimeoutError: locator.click: Timeout 10000ms exceeded.\n' +
+          'Call log:\n' +
+          "  - waiting for getByRole('link', { name: 'Anmelden', exact: true }).first()\n" +
+          '    - locator resolved to <a href="https://example.com/login">Anmelden</a>\n' +
+          '  - attempting click action\n' +
+          '    2 x waiting for element to be visible, enabled and stable\n' +
+          '      - element is visible, enabled and stable\n' +
+          '      - scrolling into view if needed\n' +
+          '      - done scrolling\n' +
+          '      - <body class="font-sans antialiased">...</body> intercepts pointer events\n' +
+          '    - retrying click action'
+      );
+
+      const result = toAIFriendlyError(error, '@e4');
+
+      // Must NOT say "not found" - the element WAS found
+      expect(result.message).not.toContain('not found');
+      // Must indicate the element is blocked
+      expect(result.message).toContain('blocked by another element');
+      expect(result.message).toContain('modal or overlay');
+    });
+
+    it('should suggest dismissing cookie banners', () => {
+      const error = new Error('<div class="cookie-overlay"> intercepts pointer events');
+      const result = toAIFriendlyError(error, '@e1');
+
+      expect(result.message).toContain('cookie banners');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #58

When clicking an element blocked by a cookie banner or modal overlay, the error message now correctly indicates that the element is blocked instead of showing the misleading "not found or not visible" message.

## Changes

- Reorder error detection in `toAIFriendlyError()` to check "intercepts pointer events" before "Timeout"
- Improve error message to suggest dismissing modals/cookie banners
- Export `toAIFriendlyError` for testing
- Add focused unit tests for overlay blocking behavior

## Before/After

**Before:**
```
Element "@e4" not found or not visible. Run 'snapshot' to see current page elements.
```

**After:**
```
Element "@e4" is blocked by another element (likely a modal or overlay).
Try dismissing any modals/cookie banners first.
```

## Test plan

- [x] Unit tests pass (`npm test`)
- [x] Manual test on https://app.ausbildung-in-der-it.de confirms correct error message
- [x] After dismissing cookie banner, click works as expected

---

Generated with [Claude Code](https://claude.ai/code)