### PR TITLE
feat: `--video [dir]` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ agent-browser snapshot -i -c -d 5         # Combine options
 | `--exact` | Exact text match |
 | `--headed` | Show browser window (not headless) |
 | `--cdp <port>` | Connect via Chrome DevTools Protocol |
+| `--video <dir>` | Record video to directory (must be set at launch; saved as .webm on close) |
 | `--debug` | Debug output |
 
 ## Selectors

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -9,6 +9,7 @@ pub struct Flags {
     pub headers: Option<String>,
     pub executable_path: Option<String>,
     pub cdp: Option<String>,
+    pub video: Option<String>,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -21,6 +22,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         headers: None,
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH").ok(),
         cdp: None,
+        video: None,
     };
 
     let mut i = 0;
@@ -54,6 +56,12 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--video" => {
+                if let Some(s) = args.get(i + 1) {
+                    flags.video = Some(s.clone());
+                    i += 1;
+                }
+            }
             _ => {}
         }
         i += 1;
@@ -68,7 +76,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
     // Global flags that should be stripped from command args
     const GLOBAL_FLAGS: &[&str] = &["--json", "--full", "--headed", "--debug"];
     // Global flags that take a value (need to skip the next arg too)
-    const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &["--session", "--headers", "--executable-path", "--cdp"];
+    const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &["--session", "--headers", "--executable-path", "--cdp", "--video"];
 
     for arg in args.iter() {
         if skip_next {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -223,17 +223,21 @@ fn main() {
         }
     }
 
-    // Launch headed browser if --headed flag is set (without CDP)
-    if flags.headed && flags.cdp.is_none() {
-        let launch_cmd = json!({
+    // Launch browser if --headed or --video flag is set (without CDP)
+    if (flags.headed || flags.video.is_some()) && flags.cdp.is_none() {
+        let mut launch_cmd = json!({
             "id": gen_id(),
             "action": "launch",
-            "headless": false
+            "headless": !flags.headed
         });
+
+        if let Some(ref video_path) = flags.video {
+            launch_cmd["video"] = json!(video_path);
+        }
 
         if let Err(e) = send_command(launch_cmd, &flags.session) {
             if !flags.json {
-                eprintln!("\x1b[33m⚠\x1b[0m Could not launch headed browser: {}", e);
+                eprintln!("\x1b[33m⚠\x1b[0m Could not launch browser: {}", e);
             }
         }
     }

--- a/docs/src/app/cdp-mode/page.tsx
+++ b/docs/src/app/cdp-mode/page.tsx
@@ -68,6 +68,10 @@ agent-browser --cdp 9222 open about:blank`} />
               <td>CDP connection port</td>
             </tr>
             <tr>
+              <td><code>--video &lt;dir&gt;</code></td>
+              <td>Record video to directory (must be set at launch; saved as .webm on close)</td>
+            </tr>
+            <tr>
               <td><code>--debug</code></td>
               <td>Debug output</td>
             </tr>

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,6 +11,7 @@ import {
   type Request,
   type Route,
   type Locator,
+  BrowserContextOptions,
 } from 'playwright-core';
 import type { LaunchCommand } from './types.js';
 import { type RefMap, type EnhancedSnapshot, getEnhancedSnapshot, parseRef } from './snapshot.js';
@@ -634,11 +635,20 @@ export class BrowserManager {
     });
     this.cdpPort = null;
 
-    // Create context with viewport and optional headers
-    const context = await this.browser.newContext({
-      viewport: options.viewport ?? { width: 1280, height: 720 },
+    // Create context with viewport, optional headers, and video recording
+    const defaultViewport = { width: 1280, height: 720 };
+    const contextOptions = {
+      viewport: options.viewport ?? defaultViewport,
       extraHTTPHeaders: options.headers,
-    });
+      ...(options.video && {
+        recordVideo: {
+          dir: options.video,
+          size: options.viewport ?? defaultViewport,
+        },
+      }),
+    } satisfies BrowserContextOptions;
+
+    const context = await this.browser.newContext(contextOptions);
 
     // Set default timeout to 10 seconds (Playwright default is 30s)
     context.setDefaultTimeout(10000);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -19,6 +19,7 @@ const launchSchema = baseCommandSchema.extend({
     .optional(),
   browser: z.enum(['chromium', 'firefox', 'webkit']).optional(),
   cdpPort: z.number().positive().optional(),
+  video: z.string().optional(),
 });
 
 const navigateSchema = baseCommandSchema.extend({

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface LaunchCommand extends BaseCommand {
   headers?: Record<string, string>;
   executablePath?: string;
   cdpPort?: number;
+  video?: string;
 }
 
 export interface NavigateCommand extends BaseCommand {


### PR DESCRIPTION
wires up `--video` flag (via `recordVideo`) for video recording

```bash
agent-browser --video /tmp/videos open example.com
agent-browser close  # video saved as .webm
```