### PR TITLE
fix "Daemon failed to start" error on Windows

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -104,7 +104,7 @@ fn get_port_for_session(session: &str) -> u16 {
     for c in session.chars() {
         hash = ((hash << 5).wrapping_sub(hash)).wrapping_add(c as i32);
     }
-    49152 + ((hash.abs() as u16) % 16383)
+    49152 + ((hash.abs() % 16383) as u16)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
The original code cast hash.abs() to u16 before taking modulo, which truncates large i32 values and causes incorrect port calculations. Now takes modulo on the full i32 value first, then safely casts to u16.