### PR TITLE
fix: respect AGENT_BROWSER_HEADED env var for headed mode

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -200,7 +200,7 @@ export async function startDaemon(options?: { streamPort?: number }): Promise<vo
             await browser.launch({
               id: 'auto',
               action: 'launch',
-              headless: true,
+              headless: process.env.AGENT_BROWSER_HEADED !== '1',
               executablePath: process.env.AGENT_BROWSER_EXECUTABLE_PATH,
               extensions: extensions,
             });


### PR DESCRIPTION
## Summary

- Fixes hardcoded `headless: true` in the auto-launch section of `daemon.ts`
- Now respects the `AGENT_BROWSER_HEADED` environment variable
- Setting `AGENT_BROWSER_HEADED=1` will launch the browser in headed mode

## The Bug

In `src/daemon.ts`, line 203, the `headless` option was hardcoded to `true` in the auto-launch section. This meant the `AGENT_BROWSER_HEADED` environment variable was being ignored when the browser was auto-launched.

## The Fix

Changed:
```typescript
headless: true,
```

To:
```typescript
headless: process.env.AGENT_BROWSER_HEADED !== '1',
```

This is consistent with how the environment variable is documented and expected to work.

Fixes #90

## Test plan

- [ ] Set `AGENT_BROWSER_HEADED=1` and verify browser launches in headed mode
- [ ] Without the env var set, verify browser still launches in headless mode (default)
- [ ] Test on Windows where this issue was originally reported