### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ use commands::{gen_id, parse_command, ParseError};
 use connection::{ensure_daemon, send_command};
 use flags::{clean_args, parse_flags};
 use install::run_install;
-use output::{print_command_help, print_help, print_response};
+use output::{print_command_help, print_help, print_response, print_version};
 
 fn run_session(args: &[String], session: &str, json_mode: bool) {
     let subcommand = args.get(1).map(|s| s.as_str());
@@ -99,11 +99,7 @@ fn main() {
     let clean = clean_args(&args);
 
     let has_help = args.iter().any(|a| a == "--help" || a == "-h");
-
-    if clean.is_empty() {
-        print_help();
-        return;
-    }
+    let has_version = args.iter().any(|a| a == "--version" || a == "-V");
 
     if has_help {
         if let Some(cmd) = clean.get(0) {
@@ -111,6 +107,16 @@ fn main() {
                 return;
             }
         }
+        print_help();
+        return;
+    }
+
+    if has_version {
+        print_version();
+        return;
+    }
+
+    if clean.is_empty() {
         print_help();
         return;
     }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1197,6 +1197,7 @@ Options:
   --headed                   Show browser window (not headless)
   --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
   --debug                    Debug output
+  --version, -V              Show version
 
 Environment:
   AGENT_BROWSER_SESSION          Session name (default: "default")
@@ -1214,4 +1215,8 @@ Examples:
   agent-browser --cdp 9222 snapshot      # Connect via CDP port
 "#
     );
+}
+
+pub fn print_version() {
+    println!("agent-browser {}", env!("CARGO_PKG_VERSION"));
 }


### PR DESCRIPTION
## Summary
- Give users the ability to check the current version of the tool
- The version flag format (`--version`, `-V`) matches `rustc` and `ruff`.

## Usage
```
$ agent-browser --version
agent-browser 0.5.0
```

## Test plan
- [x] Run `cargo test` 
- [x] Build CLI with `cargo build --release`
- [x] Run `./target/release/agent-browser --version` and verify it outputs `agent-browser 0.5.0`
- [x] Run `./target/release/agent-browser -V` and verify it outputs `agent-browser 0.5.0`
