### PR TITLE
fix: implement runtime state load functionality

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1303,10 +1303,11 @@ async function handleStateLoad(
   command: Command & { action: 'state_load'; path: string },
   browser: BrowserManager
 ): Promise<Response> {
-  // Storage state is loaded at context creation
+  const result = await browser.loadStorageState(command.path);
   return successResponse(command.id, {
-    note: 'Storage state must be loaded at browser launch. Use --state flag.',
     path: command.path,
+    cookiesLoaded: result.cookiesLoaded,
+    originsLoaded: result.originsLoaded,
   });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface LaunchCommand extends BaseCommand {
   executablePath?: string;
   cdpPort?: number;
   extensions?: string[];
+  storageState?: string;
 }
 
 export interface NavigateCommand extends BaseCommand {


### PR DESCRIPTION
  ## Summary

  Previously, `state load` command only returned a note telling users to use the --state flag. This commit implements actual runtime state loading using Playwright's context.addCookies() API.

  ## Changes
  - Add `storageState` option to LaunchCommand for loading state at launch
  - Add `loadStorageState()` method to BrowserManager
  - Update `handleStateLoad()` to actually load cookies and localStorage

  ## Why
  This allows AI agents to restore login sessions without restarting the browser, which is essential for multi-session automation workflows.

  ## Test Plan
  1. `agent-browser open "https://example.com" --headed`
  2. Login manually, then `agent-browser state save ./auth.json`
  3. `agent-browser close`
  4. `agent-browser open "https://example.com" --headed`
  5. `agent-browser state load ./auth.json`
  6. Navigate to protected page - should be logged in