### PR TITLE
fix: track dynamically opened tabs in non-CDP mode

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -701,6 +701,7 @@ export class BrowserManager {
     this.pages.push(page);
     this.activePageIndex = 0;
     this.setupPageTracking(page);
+    this.setupContextTracking(context);
   }
 
   /**


### PR DESCRIPTION
  ## Summary

  Fixes #74 - `tab` command doesn't list tabs opened via `window.open()` or `target="_blank"` links.

  ## Problem

  In non-CDP launch mode, `setupContextTracking()` was only called for CDP connections, so the `context.on('page')` event listener was never registered. This caused dynamically opened tabs to not be added to the `pages` array.

  ## Solution

  Add `setupContextTracking(context)` after initial page setup in the standard launch path (line 704), ensuring new pages are tracked regardless of launch mode.

  ## Test

  ```bash
  agent-browser open "https://www.baidu.com" --headed
  agent-browser tab  # Shows 1 tab
  agent-browser eval "window.open('https://www.bing.com', '_blank'); 'done'"
  agent-browser tab  # Now correctly shows 2 tabs

  Before fix: Only showed 1 tab
  After fix: Correctly shows 2 tabs
  ```