### PR TITLE
feat: support remote CDP WebSocket URLs in --cdp flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,14 @@ agent-browser close
 
 # Or pass --cdp on each command
 agent-browser --cdp 9222 snapshot
+
+# Connect to remote browser via WebSocket URL
+agent-browser --cdp "wss://your-browser-service.com/cdp?token=..." snapshot
 ```
+
+The `--cdp` flag accepts either:
+- A port number (e.g., `9222`) for local connections via `http://localhost:{port}`
+- A full WebSocket URL (e.g., `wss://...` or `ws://...`) for remote browser services
 
 This enables control of:
 - Electron apps

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,7 +80,8 @@ fn run_session(args: &[String], session: &str, json_mode: bool) {
                                     let running = unsafe { libc::kill(pid as i32, 0) == 0 };
                                     #[cfg(windows)]
                                     let running = unsafe {
-                                        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+                                        let handle =
+                                            OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
                                         if handle != 0 {
                                             CloseHandle(handle);
                                             true
@@ -192,7 +193,12 @@ fn main() {
         }
     };
 
-    let daemon_result = match ensure_daemon(&flags.session, flags.headed, flags.executable_path.as_deref(), &flags.extensions) {
+    let daemon_result = match ensure_daemon(
+        &flags.session,
+        flags.headed,
+        flags.executable_path.as_deref(),
+        &flags.extensions,
+    ) {
         Ok(result) => result,
         Err(e) => {
             if flags.json {
@@ -205,7 +211,9 @@ fn main() {
     };
 
     // Warn if executable_path was specified but daemon was already running
-    if daemon_result.already_running && (flags.executable_path.is_some() || !flags.extensions.is_empty()) {
+    if daemon_result.already_running
+        && (flags.executable_path.is_some() || !flags.extensions.is_empty())
+    {
         if !flags.json {
             if flags.executable_path.is_some() {
                 eprintln!("{} --executable-path ignored: daemon already running. Use 'agent-browser close' first to restart with new path.", color::warning_indicator());
@@ -238,47 +246,70 @@ fn main() {
     }
 
     // Connect via CDP if --cdp flag is set
-    if let Some(ref port) = flags.cdp {
-        let cdp_port: u16 = match port.parse::<u32>() {
-            Ok(p) if p == 0 => {
-                let msg = "Invalid CDP port: port must be greater than 0".to_string();
-                if flags.json {
-                    println!(r#"{{"success":false,"error":"{}"}}"#, msg);
-                } else {
-                    eprintln!("{} {}", color::error_indicator(), msg);
+    // Accepts either a port number (e.g., "9222") or a full URL (e.g., "ws://..." or "wss://...")
+    if let Some(ref cdp_value) = flags.cdp {
+        let launch_cmd = if cdp_value.starts_with("ws://")
+            || cdp_value.starts_with("wss://")
+            || cdp_value.starts_with("http://")
+            || cdp_value.starts_with("https://")
+        {
+            // It's a URL - use cdpUrl field
+            json!({
+                "id": gen_id(),
+                "action": "launch",
+                "cdpUrl": cdp_value
+            })
+        } else {
+            // It's a port number - validate and use cdpPort field
+            let cdp_port: u16 = match cdp_value.parse::<u32>() {
+                Ok(p) if p == 0 => {
+                    let msg = "Invalid CDP port: port must be greater than 0".to_string();
+                    if flags.json {
+                        println!(r#"{{"success":false,"error":"{}"}}"#, msg);
+                    } else {
+                        eprintln!("{} {}", color::error_indicator(), msg);
+                    }
+                    exit(1);
                 }
-                exit(1);
-            }
-            Ok(p) if p > 65535 => {
-                let msg = format!("Invalid CDP port: {} is out of range (valid range: 1-65535)", p);
-                if flags.json {
-                    println!(r#"{{"success":false,"error":"{}"}}"#, msg);
-                } else {
-                    eprintln!("{} {}", color::error_indicator(), msg);
+                Ok(p) if p > 65535 => {
+                    let msg = format!(
+                        "Invalid CDP port: {} is out of range (valid range: 1-65535)",
+                        p
+                    );
+                    if flags.json {
+                        println!(r#"{{"success":false,"error":"{}"}}"#, msg);
+                    } else {
+                        eprintln!("{} {}", color::error_indicator(), msg);
+                    }
+                    exit(1);
                 }
-                exit(1);
-            }
-            Ok(p) => p as u16,
-            Err(_) => {
-                let msg = format!("Invalid CDP port: '{}' is not a valid number. Port must be a number between 1 and 65535", port);
-                if flags.json {
-                    println!(r#"{{"success":false,"error":"{}"}}"#, msg);
-                } else {
-                    eprintln!("{} {}", color::error_indicator(), msg);
+                Ok(p) => p as u16,
+                Err(_) => {
+                    let msg = format!(
+                        "Invalid CDP value: '{}' is not a valid port number or URL",
+                        cdp_value
+                    );
+                    if flags.json {
+                        println!(r#"{{"success":false,"error":"{}"}}"#, msg);
+                    } else {
+                        eprintln!("{} {}", color::error_indicator(), msg);
+                    }
+                    exit(1);
                 }
-                exit(1);
-            }
+            };
+            json!({
+                "id": gen_id(),
+                "action": "launch",
+                "cdpPort": cdp_port
+            })
         };
-
-        let launch_cmd = json!({
-            "id": gen_id(),
-            "action": "launch",
-            "cdpPort": cdp_port
-        });
 
         let err = match send_command(launch_cmd, &flags.session) {
             Ok(resp) if resp.success => None,
-            Ok(resp) => Some(resp.error.unwrap_or_else(|| "CDP connection failed".to_string())),
+            Ok(resp) => Some(
+                resp.error
+                    .unwrap_or_else(|| "CDP connection failed".to_string()),
+            ),
             Err(e) => Some(e.to_string()),
         };
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -19,6 +19,18 @@ const launchSchema = baseCommandSchema.extend({
     .optional(),
   browser: z.enum(['chromium', 'firefox', 'webkit']).optional(),
   cdpPort: z.number().positive().optional(),
+  cdpUrl: z
+    .string()
+    .url()
+    .refine(
+      (url) =>
+        url.startsWith('ws://') ||
+        url.startsWith('wss://') ||
+        url.startsWith('http://') ||
+        url.startsWith('https://'),
+      { message: 'CDP URL must start with ws://, wss://, http://, or https://' }
+    )
+    .optional(),
   executablePath: z.string().optional(),
   extensions: z.array(z.string()).optional(),
   headers: z.record(z.string()).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface LaunchCommand extends BaseCommand {
   headers?: Record<string, string>;
   executablePath?: string;
   cdpPort?: number;
+  cdpUrl?: string;
   extensions?: string[];
   proxy?: {
     server: string;


### PR DESCRIPTION
## Summary

- Extends `--cdp` flag to accept either a port number OR a full WebSocket URL
- Enables connecting to remote browser services (Kernel, Browserless, etc.) that provide `wss://` endpoints
- Maintains backward compatibility with existing port-based usage

## Motivation

Previously, `--cdp` only accepted a port number and connected via `http://localhost:{port}`. Remote browser services provide WebSocket URLs like `wss://proxy.example.com/cdp?token=...` that couldn't be used directly.

## Changes

- **`src/types.ts`**: Added `cdpUrl?: string` field to `LaunchCommand`
- **`src/protocol.ts`**: Added URL validation for the new field
- **`src/browser.ts`**: Updated `connectViaCDP` to detect URL vs port and handle both
- **`cli/src/main.rs`**: Updated CLI to send `cdpUrl` for URLs, `cdpPort` for port numbers
- **`README.md`**: Updated documentation with remote connection examples

## Usage

```bash
# Local port (existing behavior)
agent-browser --cdp 9222 snapshot

# Remote WebSocket URL (new!)
agent-browser --cdp "wss://proxy.example.com:8443/browser/cdp?jwt=..." snapshot
```

## Test plan

- [x] Existing tests pass (`pnpm test`)
- [x] Tested with Kernel browser service using `wss://` URL
- [ ] Test with local Chrome remote debugging port
