### PR TITLE
fix(cli): allow null path in screenshot command validation

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -642,7 +642,7 @@ const pressSchema = baseCommandSchema.extend({
 
 const screenshotSchema = baseCommandSchema.extend({
   action: z.literal('screenshot'),
-  path: z.string().optional(),
+  path: z.string().nullable().optional(),
   fullPage: z.boolean().optional(),
   selector: z.string().min(1).optional(),
   format: z.enum(['png', 'jpeg']).optional(),


### PR DESCRIPTION
The Rust CLI sends `null` for the `path` argument when it is not provided, but the Zod schema only accepted `undefined`. This change updates the `screenshotSchema` to allow `null` values for `path`, enabling the `screenshot` command to work without a file path argument (outputting to stdout).