### PR TITLE
fix: Prevent CDP timeout on empty URL tabs

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -725,7 +725,11 @@ export class BrowserManager {
         throw new Error('No browser context found. Make sure the app has an open window.');
       }
 
-      const allPages = contexts.flatMap((context) => context.pages());
+      // Filter out pages with empty URLs, which can cause Playwright to hang
+      const allPages = contexts
+        .flatMap((context) => context.pages())
+        .filter((page) => page.url());
+
       if (allPages.length === 0) {
         throw new Error('No page found. Make sure the app has loaded content.');
       }


### PR DESCRIPTION
When connecting to a browser via CDP, particularly on Android, tabs with an empty URL can cause Playwright commands to hang indefinitely. This leads to a timeout in agent-browser.

Address: https://github.com/vercel-labs/agent-browser/issues/87

This commit fixes the issue by filtering out any pages that have an empty `page.url()` during the CDP connection process. This prevents agent-browser from attempting to interact with these problematic tabs, resolving the timeout while preserving normal pages.

Added a unit test to verify that pages with empty URLs are correctly ignored. Also increased the timeout for a flaky screencast test to improve test suite stability.

<img width="546" height="339" alt="image" src="https://github.com/user-attachments/assets/70ad2a68-9156-4f7a-b415-002208d0096c" />
