### PR TITLE
feat: add Claude marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "agent-browser",
+  "description": "Headless browser automation for AI agents",
+  "owner": {
+    "name": "Vercel Labs",
+    "url": "https://github.com/vercel-labs"
+  },
+  "plugins": [
+    {
+      "name": "agent-browser",
+      "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction",
+      "source": "./",
+      "strict": false,
+      "skills": ["./skills/agent-browser"],
+      "category": "development"
+    }
+  ]
+}

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-browser
 description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
+allowed-tools: Bash
 ---
 
 # Browser Automation with agent-browser


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` manifest for Claude Code marketplace listing
- Add `allowed-tools: Bash` to existing SKILL.md frontmatter

This enables installation via:
```bash
/plugin marketplace add vercel-labs/agent-browser
/plugin install agent-browser
```

## Test plan
- [ ] Verify marketplace.json schema is valid
- [ ] Test plugin installation in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)