### PR TITLE
feat: add Claude marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "agent-browser",
+  "description": "Headless browser automation for AI agents",
+  "owner": {
+    "name": "Vercel",
+    "email": "support@vercel.com"
+  },
+  "plugins": [
+    {
+      "name": "agent-browser",
+      "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction",
+      "source": "./",
+      "strict": false,
+      "skills": ["./skills/agent-browser"],
+      "category": "development"
+    }
+  ]
+}

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-browser
 description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
+allowed-tools: Bash(agent-browser:*)
 ---
 
 # Browser Automation with agent-browser


### PR DESCRIPTION
## Summary
- Purpose: Allow claude code users to install the skill as a claude plugin 
- Note that without this, each user of claude code may need to set up their own plugin if they want to install the agent browser skill using claude's plugin system 
- I focused on making this as minimal an update as possible 

## References (for inspo)
- [Anthropic's marketplace for claude plugins](https://github.com/anthropics/claude-plugins-official/) 
- [Upstash's marketplace for context7](https://github.com/upstash/context7)
- [Anthropic's claude marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces)

## Usage
```
/plugin marketplace add vercel-labs/agent-browser
/plugin install agent-browser
```

## Testing
- I checked that I can install the marketplace (from my local clone) in `claude` (claude code cli)
<img width="636" height="128" alt="image" src="https://github.com/user-attachments/assets/593203a2-9e92-4ee8-b2cf-f24efc866ccc" />

- I checked that the skill is discovered and used by `claude` upon user request
<img width="631" height="419" alt="image" src="https://github.com/user-attachments/assets/60124c5f-d1eb-419c-9b77-f9ca7277a22b" />
