### PR TITLE
fix: support libasound2t64 on newer Ubuntu versions

### DIFF
--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -198,10 +198,11 @@ fn which_exists(cmd: &str) -> bool {
 
 fn package_exists_apt(pkg: &str) -> bool {
     Command::new("apt-cache")
-        .arg("search")
-        .arg("--names-only")
-        .arg(format!("^{}$", pkg))
-        .output()
-        .map(|o| !o.stdout.is_empty())
+        .arg("show")
+        .arg(pkg)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
         .unwrap_or(false)
 }


### PR DESCRIPTION
Updates the install logic to check if `libasound2t64` is available using `apt-cache` before falling back to `libasound2`. This fixes installation on Ubuntu 24.04 and other systems affected by the 64-bit time_t transition.

Close #80 