### PR TITLE
feat: enhance response output with network request details and cleared status

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -118,6 +118,27 @@ pub fn print_response(resp: &Response, json_mode: bool) {
             }
             return;
         }
+        // Network requests
+        if let Some(requests) = data.get("requests").and_then(|v| v.as_array()) {
+            if requests.is_empty() {
+                println!("No requests captured");
+            } else {
+                for req in requests {
+                    let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("GET");
+                    let url = req.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                    let resource_type = req.get("resourceType").and_then(|v| v.as_str()).unwrap_or("");
+                    println!("{} {} ({})", method, url, resource_type);
+                }
+            }
+            return;
+        }
+        // Cleared requests
+        if let Some(cleared) = data.get("cleared").and_then(|v| v.as_bool()) {
+            if cleared {
+                println!("\x1b[32m✓\x1b[0m Request log cleared");
+                return;
+            }
+        }
         // Bounding box
         if let Some(box_data) = data.get("box") {
             println!(


### PR DESCRIPTION
This pull request refactors how command arguments are parsed and improves output handling for network requests in the CLI tool. The main focus is on making command JSON construction more robust by only including optional fields when present, and enhancing the output for network requests to be more user-friendly.

### Command argument parsing improvements
* Updated the construction of command JSON objects in `parse_command` and `parse_network` to only include optional fields (like `path`, `index`, `promptText`, `url`, `filter`) when they are actually provided, instead of always setting them to `Some` or `None`. This makes the resulting JSON cleaner and avoids sending unnecessary null values. [[1]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bL276-R280) [[2]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bL370-R381) [[3]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bL416-R428) [[4]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bL434-R453) [[5]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bL831-R864)

### Output improvements for network requests
* Enhanced `print_response` in `cli/src/output.rs` to display a readable summary of network requests, including method, URL, and resource type. Also added a clear message when the request log is empty or has been cleared.

<img width="1388" height="344" alt="image" src="https://github.com/user-attachments/assets/9df9219a-2fb4-47b9-a655-205159315210" />
