### PR TITLE
feat: add connect command for persistent CDP sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ agent-browser screenshot [path]       # Take screenshot (--full for full page)
 agent-browser pdf <path>              # Save as PDF
 agent-browser snapshot                # Accessibility tree with refs (best for AI)
 agent-browser eval <js>               # Run JavaScript
+agent-browser connect <port>          # Connect to browser via CDP
 agent-browser close                   # Close browser (aliases: quit, exit)
 ```
 
@@ -465,12 +466,16 @@ export async function handler() {
 Connect to an existing browser via Chrome DevTools Protocol:
 
 ```bash
-# Connect to Electron app
-agent-browser --cdp 9222 snapshot
+# Start Chrome with: google-chrome --remote-debugging-port=9222
 
-# Connect to Chrome with remote debugging
-# (Start Chrome with: google-chrome --remote-debugging-port=9222)
-agent-browser --cdp 9222 open about:blank
+# Connect once, then run commands without --cdp
+agent-browser connect 9222
+agent-browser snapshot
+agent-browser tab
+agent-browser close
+
+# Or pass --cdp on each command
+agent-browser --cdp 9222 snapshot
 ```
 
 This enables control of:

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -323,6 +323,19 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
         // === Close ===
         "close" | "quit" | "exit" => Ok(json!({ "id": id, "action": "close" })),
 
+        // === Connect (CDP) ===
+        "connect" => {
+            let port_str = rest.get(0).ok_or_else(|| ParseError::MissingArguments {
+                context: "connect".to_string(),
+                usage: "connect <port>",
+            })?;
+            let port: u16 = port_str.parse().map_err(|_| ParseError::MissingArguments {
+                context: format!("connect: invalid port '{}'", port_str),
+                usage: "connect <port>",
+            })?;
+            Ok(json!({ "id": id, "action": "launch", "cdpPort": port }))
+        }
+
         // === Get ===
         "get" => parse_get(&rest, &id),
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1131,6 +1131,7 @@ Core Commands:
   pdf <path>                 Save as PDF
   snapshot                   Accessibility tree with refs (for AI)
   eval <js>                  Run JavaScript
+  connect <port>             Connect to browser via CDP (e.g., connect 9222)
   close                      Close browser
 
 Navigation:

--- a/docs/src/app/cdp-mode/page.tsx
+++ b/docs/src/app/cdp-mode/page.tsx
@@ -6,12 +6,16 @@ export default function CDPMode() {
       <div className="prose">
         <h1>CDP Mode</h1>
         <p>Connect to an existing browser via Chrome DevTools Protocol:</p>
-        <CodeBlock code={`# Connect to Electron app
-agent-browser --cdp 9222 snapshot
+        <CodeBlock code={`# Start Chrome with: google-chrome --remote-debugging-port=9222
 
-# Connect to Chrome with remote debugging
-# (Start Chrome with: google-chrome --remote-debugging-port=9222)
-agent-browser --cdp 9222 open about:blank`} />
+# Connect once, then run commands without --cdp
+agent-browser connect 9222
+agent-browser snapshot
+agent-browser tab
+agent-browser close
+
+# Or pass --cdp on each command
+agent-browser --cdp 9222 snapshot`} />
 
         <h2>Use cases</h2>
         <p>This enables control of:</p>


### PR DESCRIPTION
Adds a `connect <port>` command that establishes a CDP connection to a running browser. The daemon remembers the connection, so subsequent commands work without needing `--cdp` on every call.

```bash
agent-browser connect 9222
agent-browser snapshot   # works without --cdp
agent-browser tab
agent-browser close
```

This is useful reducing token usage per command (my use-case is for the Dia browser and automating certain workflows).