### PR TITLE
fix(cli): console command displays no output due to field name mismatch

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -91,7 +91,7 @@ pub fn print_response(resp: &Response, json_mode: bool) {
             return;
         }
         // Console logs
-        if let Some(logs) = data.get("logs").and_then(|v| v.as_array()) {
+        if let Some(logs) = data.get("messages").and_then(|v| v.as_array()) {
             for log in logs {
                 let level = log.get("type").and_then(|v| v.as_str()).unwrap_or("log");
                 let text = log.get("text").and_then(|v| v.as_str()).unwrap_or("");


### PR DESCRIPTION
## Summary

The `agent-browser console` command silently fails to display any output because of a field name mismatch between the daemon and CLI:

- **Daemon** (`src/actions.ts:1320`): Returns `{ messages: [...] }`
- **CLI** (`cli/src/output.rs:94`): Expected `{ logs: [...] }`

This one-line fix aligns the CLI to read `messages` instead of `logs`.

## Before (broken)
```
$ agent-browser console
✓ Done
```

## After (fixed)
```
$ agent-browser console
[log] Hello from console.log!
[info] This is an info message
[warning] This is a warning message
[error] This is an error message
```

## Root Cause

The mismatch was introduced early in development:
- The TypeScript daemon named the field `messages` to match the internal `consoleMessages` array in `browser.ts`
- The Rust CLI assumed it would be called `logs` (a more intuitive name for "console logs")

The `errors` command works correctly because both sides use `errors` consistently.

## Changes

- `cli/src/output.rs`: Changed `data.get("logs")` to `data.get("messages")` on line 94