### PR TITLE
fix(cli): handle SIGPIPE to prevent panic when piping output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -124,6 +124,12 @@ fn run_session(args: &[String], session: &str, json_mode: bool) {
 }
 
 fn main() {
+    // Ignore SIGPIPE to prevent panic when piping to head/tail
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let args: Vec<String> = env::args().skip(1).collect();
     let flags = parse_flags(&args);
     let clean = clean_args(&args);


### PR DESCRIPTION
CLI panics when output is piped to `head`, `tail`, or other commands that close stdout early:

```
agent-browser snapshot -c | head -30
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
```

Fix: Reset SIGPIPE handler to default on Unix systems.