### PR TITLE
fix: add .exe extension for Windows in copy-native.js

### DIFF
--- a/scripts/copy-native.js
+++ b/scripts/copy-native.js
@@ -12,7 +12,8 @@ import { platform, arch } from 'os';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
 
-const sourcePath = join(projectRoot, 'cli/target/release/agent-browser');
+const sourceExt = platform() === 'win32' ? '.exe' : '';
+const sourcePath = join(projectRoot, `cli/target/release/agent-browser${sourceExt}`);
 const binDir = join(projectRoot, 'bin');
 
 // Determine platform suffix


### PR DESCRIPTION
## Problem

When running `pnpm build:native` on Windows, the build fails with:

```
Error: Native binary not found at D:\...\cli\target\release\agent-browser
Run "cargo build --release --manifest-path cli/Cargo.toml" first
```

The Rust compiler successfully builds `agent-browser.exe`, but the `copy-native.js` script looks for `agent-browser` (without the `.exe` extension).

## Solution

Added platform detection to include the `.exe` extension when running on Windows:

```javascript
const sourceExt = platform() === 'win32' ? '.exe' : '';
const sourcePath = join(projectRoot, `cli/target/release/agent-browser${sourceExt}`);
```

## Testing

- Tested on Windows 10/11 x64
- `pnpm build:native` now completes successfully
- The native binary is correctly copied to `bin/agent-browser-win32-x64.exe`