### PR TITLE
fix(windows): prevent CMD window popup when spawning daemon

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -256,11 +256,11 @@ pub fn ensure_daemon(
             cmd.env("AGENT_BROWSER_EXTENSIONS", extensions.join(","));
         }
 
-        // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
-        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
-        const DETACHED_PROCESS: u32 = 0x00000008;
+        // CREATE_NO_WINDOW only - DETACHED_PROCESS and CREATE_NO_WINDOW conflict
+        // for console apps like node.exe
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
         
-        cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS)
+        cmd.creation_flags(CREATE_NO_WINDOW)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())


### PR DESCRIPTION
## Summary

Fixes #159 - CMD window appearing when running agent-browser on Windows.

## Problem

When spawning the Node.js daemon on Windows, a visible CMD window would appear and persist. This happens because `DETACHED_PROCESS` and `CREATE_NO_WINDOW` flags conflict when used together for console applications like `node.exe`.

## Solution

Use only `CREATE_NO_WINDOW` (0x08000000) instead of combining `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`.

## Testing

- Built and tested on Windows 11
- Verified that `agent-browser open <url>` no longer spawns a visible CMD window
- Daemon still runs correctly in the background