### PR TITLE
docs: add Claude Code plugin installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,13 +643,22 @@ Core workflow:
 
 ### Claude Code Skill
 
-For Claude Code, a [skill](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) provides richer context:
+For Claude Code, a [skill](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) provides richer context.
+
+**Plugin (recommended):**
+
+```bash
+/plugin marketplace add vercel-labs/agent-browser
+/plugin install agent-browser
+```
+
+**Manual install:**
 
 ```bash
 cp -r node_modules/agent-browser/skills/agent-browser .claude/skills/
 ```
 
-Or download:
+Or download directly:
 
 ```bash
 mkdir -p .claude/skills/agent-browser


### PR DESCRIPTION
## Summary
- Add instructions for installing the agent-browser skill as a Claude Code plugin using the marketplace
- Mark plugin installation as the recommended approach
- Keep manual installation methods as alternatives

This follows up on #106 which added Claude marketplace plugin support.

## Test plan
- Verify the `/plugin marketplace add` and `/plugin install` commands work as documented