### PR TITLE
feat: add session state management vercel-labs/agent-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ agent-browser errors --clear          # Clear errors
 agent-browser highlight <sel>         # Highlight element
 agent-browser state save <path>       # Save auth state
 agent-browser state load <path>       # Load auth state
+agent-browser state list              # List saved state files
+agent-browser state show <file>       # Show state summary
+agent-browser state rename <old> <new> # Rename state file
+agent-browser state clear [name]      # Clear states for session
+agent-browser state clear --all       # Clear all saved states
+agent-browser state clean --older-than <days>  # Delete old states
 ```
 
 ### Navigation
@@ -302,6 +308,40 @@ The profile directory stores:
 
 **Tip**: Use different profile paths for different projects to keep their browser state isolated.
 
+## Session Persistence
+
+Alternatively, use `--session-name` to automatically save and restore cookies and localStorage across browser restarts:
+
+```bash
+# Auto-save/load state for "twitter" session
+agent-browser --session-name twitter open twitter.com
+
+# Login once, then state persists automatically
+# State files stored in ~/.agent-browser/sessions/
+
+# Or via environment variable
+export AGENT_BROWSER_SESSION_NAME=twitter
+agent-browser open twitter.com
+```
+
+### State Encryption
+
+Encrypt saved session data at rest with AES-256-GCM:
+
+```bash
+# Generate key: openssl rand -hex 32
+export AGENT_BROWSER_ENCRYPTION_KEY=<64-char-hex-key>
+
+# State files are now encrypted automatically
+agent-browser --session-name secure open example.com
+```
+
+| Variable | Description |
+|----------|-------------|
+| `AGENT_BROWSER_SESSION_NAME` | Auto-save/load state persistence name |
+| `AGENT_BROWSER_ENCRYPTION_KEY` | 64-char hex key for AES-256-GCM encryption |
+| `AGENT_BROWSER_STATE_EXPIRE_DAYS` | Auto-delete states older than N days (default: 30) |
+
 ## Snapshot Options
 
 The `snapshot` command supports filtering to reduce output size:
@@ -346,6 +386,7 @@ The `-C` flag is useful for modern web apps that use custom clickable elements (
 | `--headed` | Show browser window (not headless) |
 | `--cdp <port>` | Connect via Chrome DevTools Protocol |
 | `--auto-connect` | Auto-discover and connect to running Chrome (or `AGENT_BROWSER_AUTO_CONNECT` env) |
+| `--session-name <name>` | Auto-save/restore session state (or `AGENT_BROWSER_SESSION_NAME` env) |
 | `--ignore-https-errors` | Ignore HTTPS certificate errors (useful for self-signed certs) |
 | `--allow-file-access` | Allow file:// URLs to access local files (Chromium only) |
 | `--debug` | Debug output |

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -219,6 +219,7 @@ pub fn ensure_daemon(
     state: Option<&str>,
     provider: Option<&str>,
     device: Option<&str>,
+    session_name: Option<&str>,
 ) -> Result<DaemonResult, String> {
     // Check if daemon is running AND responsive
     if is_daemon_running(session) && daemon_ready(session) {
@@ -359,6 +360,10 @@ pub fn ensure_daemon(
             cmd.env("AGENT_BROWSER_IOS_DEVICE", d);
         }
 
+        if let Some(sn) = session_name {
+            cmd.env("AGENT_BROWSER_SESSION_NAME", sn);
+        }
+
         // Create new process group and session to fully detach
         unsafe {
             cmd.pre_exec(|| {
@@ -436,6 +441,10 @@ pub fn ensure_daemon(
 
         if let Some(d) = device {
             cmd.env("AGENT_BROWSER_IOS_DEVICE", d);
+        }
+
+        if let Some(sn) = session_name {
+            cmd.env("AGENT_BROWSER_SESSION_NAME", sn);
         }
 
         // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -21,6 +21,7 @@ pub struct Flags {
     pub allow_file_access: bool,
     pub device: Option<String>,
     pub auto_connect: bool,
+    pub session_name: Option<String>,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -67,6 +68,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         allow_file_access: env::var("AGENT_BROWSER_ALLOW_FILE_ACCESS").is_ok(),
         device: env::var("AGENT_BROWSER_IOS_DEVICE").ok(),
         auto_connect: env::var("AGENT_BROWSER_AUTO_CONNECT").is_ok(),
+        session_name: env::var("AGENT_BROWSER_SESSION_NAME").ok(),
         // Track CLI-passed flags (default false, set to true when flag is passed)
         cli_executable_path: false,
         cli_extensions: false,
@@ -178,6 +180,12 @@ pub fn parse_flags(args: &[String]) -> Flags {
                 }
             }
             "--auto-connect" => flags.auto_connect = true,
+            "--session-name" => {
+                if let Some(s) = args.get(i + 1) {
+                    flags.session_name = Some(s.clone());
+                    i += 1;
+                }
+            }
             _ => {}
         }
         i += 1;
@@ -215,6 +223,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "-p",
         "--provider",
         "--device",
+        "--session-name",
     ];
 
     for arg in args.iter() {

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -1,0 +1,12 @@
+/// Check if a session name is valid (alphanumeric, hyphens, and underscores only)
+pub fn is_valid_session_name(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Generate error message for invalid session name
+pub fn session_name_error(name: &str) -> String {
+    format!(
+        "Invalid session name '{}'. Only alphanumeric characters, hyphens, and underscores are allowed.",
+        name
+    )
+}

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -149,8 +149,19 @@ agent-browser trace stop [path]       # Stop and save trace
 agent-browser console                 # View console messages
 agent-browser errors                  # View page errors
 agent-browser highlight <sel>         # Highlight element
-agent-browser state save <path>       # Save auth state
-agent-browser state load <path>       # Load auth state
+```
+
+## State management
+
+```bash
+agent-browser state save <path>       # Save auth state to file
+agent-browser state load <path>       # Load auth state from file
+agent-browser state list              # List saved state files
+agent-browser state show <file>       # Show state summary
+agent-browser state rename <old> <new> # Rename state file
+agent-browser state clear [name]      # Clear states for session name
+agent-browser state clear --all       # Clear all saved states
+agent-browser state clean --older-than <days>  # Delete old states
 ```
 
 ## Navigation

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -55,6 +55,92 @@ The profile directory stores:
 - Browser cache
 - Login sessions
 
+## Session persistence
+
+Use `--session-name` to automatically save and restore cookies and localStorage across browser restarts:
+
+```bash
+# Auto-save/load state for "twitter" session
+agent-browser --session-name twitter open twitter.com
+
+# Login once, then state persists automatically
+agent-browser --session-name twitter click "#login"
+
+# Or via environment variable
+export AGENT_BROWSER_SESSION_NAME=twitter
+agent-browser open twitter.com
+```
+
+State files are stored in `~/.agent-browser/sessions/` and automatically loaded on daemon start.
+
+### Session name rules
+
+Session names must contain only alphanumeric characters, hyphens, and underscores:
+
+```bash
+# Valid session names
+agent-browser --session-name my-project open example.com
+agent-browser --session-name test_session_v2 open example.com
+
+# Invalid (will be rejected)
+agent-browser --session-name "../bad" open example.com    # path traversal
+agent-browser --session-name "my session" open example.com # spaces
+agent-browser --session-name "foo/bar" open example.com    # slashes
+```
+
+## State encryption
+
+Encrypt saved state files (cookies, localStorage) using AES-256-GCM:
+
+```bash
+# Generate a 256-bit key (64 hex characters)
+openssl rand -hex 32
+
+# Set the encryption key
+export AGENT_BROWSER_ENCRYPTION_KEY=<your-64-char-hex-key>
+
+# State files are now encrypted automatically
+agent-browser --session-name secure-session open example.com
+
+# List states shows encryption status
+agent-browser state list
+```
+
+## State auto-expiration
+
+Automatically delete old state files to prevent accumulation:
+
+```bash
+# Set expiration (default: 30 days)
+export AGENT_BROWSER_STATE_EXPIRE_DAYS=7
+
+# Manually clean old states
+agent-browser state clean --older-than 7
+```
+
+## State management commands
+
+```bash
+# List all saved states
+agent-browser state list
+
+# Show state summary (cookies, origins, domains)
+agent-browser state show my-session-default.json
+
+# Rename a state file
+agent-browser state rename old-name new-name
+
+# Clear states for a specific session name
+agent-browser state clear my-session
+
+# Clear all saved states
+agent-browser state clear --all
+
+# Manual save/load (for custom paths)
+agent-browser state save ./backup.json
+agent-browser state load ./backup.json
+```
+
 ## Authenticated sessions
 
 Use `--headers` to set HTTP headers for a specific origin:
@@ -92,3 +178,12 @@ For headers on all domains:
 ```bash
 agent-browser set headers '{"X-Custom-Header": "value"}'
 ```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `AGENT_BROWSER_SESSION` | Browser session ID (default: "default") |
+| `AGENT_BROWSER_SESSION_NAME` | Auto-save/load state persistence name |
+| `AGENT_BROWSER_ENCRYPTION_KEY` | 64-char hex key for AES-256-GCM encryption |
+| `AGENT_BROWSER_STATE_EXPIRE_DAYS` | Auto-delete states older than N days (default: 30) |

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -97,6 +97,28 @@ agent-browser state load auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
+### Session Persistence
+
+```bash
+# Auto-save/restore cookies and localStorage across browser restarts
+agent-browser --session-name myapp open https://app.example.com/login
+# ... login flow ...
+agent-browser close  # State auto-saved to ~/.agent-browser/sessions/
+
+# Next time, state is auto-loaded
+agent-browser --session-name myapp open https://app.example.com/dashboard
+
+# Encrypt state at rest
+export AGENT_BROWSER_ENCRYPTION_KEY=$(openssl rand -hex 32)
+agent-browser --session-name secure open https://app.example.com
+
+# Manage saved states
+agent-browser state list
+agent-browser state show myapp-default.json
+agent-browser state clear myapp
+agent-browser state clean --older-than 7
+```
+
 ### Data Extraction
 
 ```bash

--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as crypto from 'crypto';
+import {
+  encryptData,
+  decryptData,
+  getEncryptionKey,
+  isEncryptedPayload,
+  ENCRYPTION_KEY_ENV,
+  IV_LENGTH,
+  type EncryptedPayload,
+} from './encryption.js';
+
+// Generate a valid test key (256 bits = 32 bytes = 64 hex chars)
+const generateTestKey = () => crypto.randomBytes(32);
+const generateTestKeyHex = () => crypto.randomBytes(32).toString('hex');
+
+describe('encryption', () => {
+  describe('encryptData / decryptData', () => {
+    it('should round-trip encrypt and decrypt data correctly', () => {
+      const key = generateTestKey();
+      const plaintext = 'Hello, World! This is a test message.';
+
+      const encrypted = encryptData(plaintext, key);
+      const decrypted = decryptData(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should round-trip with complex JSON data', () => {
+      const key = generateTestKey();
+      const data = {
+        cookies: [{ name: 'session', value: 'abc123', domain: '.example.com' }],
+        localStorage: { theme: 'dark', userId: '12345' },
+        sessionStorage: {},
+      };
+      const plaintext = JSON.stringify(data);
+
+      const encrypted = encryptData(plaintext, key);
+      const decrypted = decryptData(encrypted, key);
+
+      expect(JSON.parse(decrypted)).toEqual(data);
+    });
+
+    it('should round-trip with empty string', () => {
+      const key = generateTestKey();
+      const plaintext = '';
+
+      const encrypted = encryptData(plaintext, key);
+      const decrypted = decryptData(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should round-trip with unicode characters', () => {
+      const key = generateTestKey();
+      const plaintext = '你好世界 🌍 Привет мир émojis: 🔐🔑';
+
+      const encrypted = encryptData(plaintext, key);
+      const decrypted = decryptData(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should round-trip with large data', () => {
+      const key = generateTestKey();
+      const plaintext = 'x'.repeat(100000); // 100KB of data
+
+      const encrypted = encryptData(plaintext, key);
+      const decrypted = decryptData(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+  });
+
+  describe('IV uniqueness', () => {
+    it('should generate different IVs for each encryption', () => {
+      const key = generateTestKey();
+      const plaintext = 'Same message encrypted twice';
+
+      const encrypted1 = encryptData(plaintext, key);
+      const encrypted2 = encryptData(plaintext, key);
+
+      // IVs should be different
+      expect(encrypted1.iv).not.toBe(encrypted2.iv);
+
+      // Ciphertext should also be different due to different IVs
+      expect(encrypted1.data).not.toBe(encrypted2.data);
+
+      // Both should decrypt to the same plaintext
+      expect(decryptData(encrypted1, key)).toBe(plaintext);
+      expect(decryptData(encrypted2, key)).toBe(plaintext);
+    });
+
+    it('should have correct IV length', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      const ivBuffer = Buffer.from(encrypted.iv, 'base64');
+      expect(ivBuffer.length).toBe(IV_LENGTH);
+    });
+  });
+
+  describe('authentication (tamper detection)', () => {
+    it('should throw error when auth tag is tampered', () => {
+      const key = generateTestKey();
+      const plaintext = 'Sensitive data';
+
+      const encrypted = encryptData(plaintext, key);
+
+      // Tamper with the auth tag
+      const tamperedAuthTag = Buffer.from(encrypted.authTag, 'base64');
+      tamperedAuthTag[0] ^= 0xff; // Flip bits
+      const tamperedPayload: EncryptedPayload = {
+        ...encrypted,
+        authTag: tamperedAuthTag.toString('base64'),
+      };
+
+      expect(() => decryptData(tamperedPayload, key)).toThrow();
+    });
+
+    it('should throw error when ciphertext is tampered', () => {
+      const key = generateTestKey();
+      const plaintext = 'Sensitive data';
+
+      const encrypted = encryptData(plaintext, key);
+
+      // Tamper with the ciphertext
+      const tamperedData = Buffer.from(encrypted.data, 'base64');
+      tamperedData[0] ^= 0xff; // Flip bits
+      const tamperedPayload: EncryptedPayload = {
+        ...encrypted,
+        data: tamperedData.toString('base64'),
+      };
+
+      expect(() => decryptData(tamperedPayload, key)).toThrow();
+    });
+
+    it('should throw error when IV is tampered', () => {
+      const key = generateTestKey();
+      const plaintext = 'Sensitive data';
+
+      const encrypted = encryptData(plaintext, key);
+
+      // Tamper with the IV
+      const tamperedIv = Buffer.from(encrypted.iv, 'base64');
+      tamperedIv[0] ^= 0xff; // Flip bits
+      const tamperedPayload: EncryptedPayload = {
+        ...encrypted,
+        iv: tamperedIv.toString('base64'),
+      };
+
+      expect(() => decryptData(tamperedPayload, key)).toThrow();
+    });
+  });
+
+  describe('wrong key handling', () => {
+    it('should throw error when decrypting with wrong key', () => {
+      const key1 = generateTestKey();
+      const key2 = generateTestKey();
+      const plaintext = 'Sensitive data';
+
+      const encrypted = encryptData(plaintext, key1);
+
+      // Try to decrypt with a different key
+      expect(() => decryptData(encrypted, key2)).toThrow();
+    });
+
+    it('should throw error when key is partially wrong', () => {
+      const key = generateTestKey();
+      const plaintext = 'Sensitive data';
+
+      const encrypted = encryptData(plaintext, key);
+
+      // Create a key with one byte different
+      const wrongKey = Buffer.from(key);
+      wrongKey[0] ^= 0xff;
+
+      expect(() => decryptData(encrypted, wrongKey)).toThrow();
+    });
+  });
+
+  describe('malformed payload detection', () => {
+    it('should throw error for empty IV', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      const malformed: EncryptedPayload = {
+        ...encrypted,
+        iv: '',
+      };
+
+      expect(() => decryptData(malformed, key)).toThrow();
+    });
+
+    it('should throw error for empty auth tag', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      const malformed: EncryptedPayload = {
+        ...encrypted,
+        authTag: '',
+      };
+
+      expect(() => decryptData(malformed, key)).toThrow();
+    });
+
+    it('should throw error for invalid base64 in IV', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      const malformed: EncryptedPayload = {
+        ...encrypted,
+        iv: '!!!not-valid-base64!!!',
+      };
+
+      expect(() => decryptData(malformed, key)).toThrow();
+    });
+
+    it('should throw error for truncated auth tag', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      // Truncate auth tag to just 4 bytes (minimum allowed, but wrong value)
+      // This won't match the actual tag, so authentication will fail
+      const truncatedTag = crypto.randomBytes(4); // Random 4 bytes won't match
+      const malformed: EncryptedPayload = {
+        ...encrypted,
+        authTag: truncatedTag.toString('base64'),
+      };
+
+      // Note: With Node.js deprecation warning, very short tags may still be
+      // accepted but will fail authentication during decipher.final()
+      expect(() => decryptData(malformed, key)).toThrow();
+    });
+
+    it('should throw error for completely wrong auth tag length', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      // Use a completely wrong auth tag (right length but wrong value)
+      const wrongTag = crypto.randomBytes(16); // Same length as real tag
+      const malformed: EncryptedPayload = {
+        ...encrypted,
+        authTag: wrongTag.toString('base64'),
+      };
+
+      expect(() => decryptData(malformed, key)).toThrow();
+    });
+  });
+
+  describe('getEncryptionKey', () => {
+    const originalEnv = process.env[ENCRYPTION_KEY_ENV];
+
+    afterEach(() => {
+      // Restore original env
+      if (originalEnv !== undefined) {
+        process.env[ENCRYPTION_KEY_ENV] = originalEnv;
+      } else {
+        delete process.env[ENCRYPTION_KEY_ENV];
+      }
+    });
+
+    it('should return null when env var is not set', () => {
+      delete process.env[ENCRYPTION_KEY_ENV];
+      expect(getEncryptionKey()).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      process.env[ENCRYPTION_KEY_ENV] = '';
+      expect(getEncryptionKey()).toBeNull();
+    });
+
+    it('should return null for invalid hex (too short)', () => {
+      process.env[ENCRYPTION_KEY_ENV] = 'abc123'; // Only 6 chars, need 64
+      expect(getEncryptionKey()).toBeNull();
+    });
+
+    it('should return null for invalid hex (too long)', () => {
+      process.env[ENCRYPTION_KEY_ENV] = 'a'.repeat(128); // 128 chars, need 64
+      expect(getEncryptionKey()).toBeNull();
+    });
+
+    it('should return null for non-hex characters', () => {
+      process.env[ENCRYPTION_KEY_ENV] = 'g'.repeat(64); // 'g' is not hex
+      expect(getEncryptionKey()).toBeNull();
+    });
+
+    it('should return valid key buffer for correct hex string', () => {
+      const keyHex = generateTestKeyHex();
+      process.env[ENCRYPTION_KEY_ENV] = keyHex;
+
+      const key = getEncryptionKey();
+      expect(key).not.toBeNull();
+      expect(key).toBeInstanceOf(Buffer);
+      expect(key!.length).toBe(32); // 256 bits
+      expect(key!.toString('hex')).toBe(keyHex.toLowerCase());
+    });
+
+    it('should accept uppercase hex', () => {
+      const keyHex = generateTestKeyHex().toUpperCase();
+      process.env[ENCRYPTION_KEY_ENV] = keyHex;
+
+      const key = getEncryptionKey();
+      expect(key).not.toBeNull();
+      expect(key!.length).toBe(32);
+    });
+
+    it('should accept mixed case hex', () => {
+      const keyHex = generateTestKeyHex();
+      const mixedCase = keyHex
+        .split('')
+        .map((c, i) => (i % 2 === 0 ? c.toUpperCase() : c.toLowerCase()))
+        .join('');
+      process.env[ENCRYPTION_KEY_ENV] = mixedCase;
+
+      const key = getEncryptionKey();
+      expect(key).not.toBeNull();
+      expect(key!.length).toBe(32);
+    });
+  });
+
+  describe('isEncryptedPayload', () => {
+    it('should return true for valid encrypted payload', () => {
+      const key = generateTestKey();
+      const encrypted = encryptData('test', key);
+
+      expect(isEncryptedPayload(encrypted)).toBe(true);
+    });
+
+    it('should return false for null', () => {
+      expect(isEncryptedPayload(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isEncryptedPayload(undefined)).toBe(false);
+    });
+
+    it('should return false for plain object without encrypted flag', () => {
+      expect(isEncryptedPayload({ data: 'test' })).toBe(false);
+    });
+
+    it('should return false for object with encrypted: false', () => {
+      expect(
+        isEncryptedPayload({
+          encrypted: false,
+          version: 1,
+          iv: 'test',
+          authTag: 'test',
+          data: 'test',
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for object missing version', () => {
+      expect(
+        isEncryptedPayload({
+          encrypted: true,
+          iv: 'test',
+          authTag: 'test',
+          data: 'test',
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for object missing iv', () => {
+      expect(
+        isEncryptedPayload({
+          encrypted: true,
+          version: 1,
+          authTag: 'test',
+          data: 'test',
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for object missing authTag', () => {
+      expect(
+        isEncryptedPayload({
+          encrypted: true,
+          version: 1,
+          iv: 'test',
+          data: 'test',
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for object missing data', () => {
+      expect(
+        isEncryptedPayload({
+          encrypted: true,
+          version: 1,
+          iv: 'test',
+          authTag: 'test',
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for array', () => {
+      expect(isEncryptedPayload([])).toBe(false);
+    });
+
+    it('should return false for string', () => {
+      expect(isEncryptedPayload('encrypted')).toBe(false);
+    });
+
+    it('should return false for number', () => {
+      expect(isEncryptedPayload(42)).toBe(false);
+    });
+  });
+});

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -1,0 +1,111 @@
+/**
+ * Encryption utilities for state file protection using AES-256-GCM.
+ */
+
+import * as crypto from 'crypto';
+
+// ============================================
+// Constants
+// ============================================
+export const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
+export const ENCRYPTION_KEY_ENV = 'AGENT_BROWSER_ENCRYPTION_KEY';
+export const IV_LENGTH = 12; // 96 bits for GCM
+
+/**
+ * Encrypted payload structure.
+ */
+export interface EncryptedPayload {
+  version: 1;
+  encrypted: true;
+  iv: string; // Base64 encoded
+  authTag: string; // Base64 encoded
+  data: string; // Base64 encoded ciphertext
+}
+
+/**
+ * Get encryption key from environment variable.
+ * The key should be a 32-byte (256-bit) hex-encoded string (64 characters).
+ * Generate with: openssl rand -hex 32
+ *
+ * @returns Buffer containing the key, or null if not set/invalid
+ */
+export function getEncryptionKey(): Buffer | null {
+  const keyHex = process.env[ENCRYPTION_KEY_ENV];
+  if (!keyHex) return null;
+
+  // Key should be 64 hex chars = 32 bytes = 256 bits
+  if (!/^[a-fA-F0-9]{64}$/.test(keyHex)) {
+    console.warn(
+      `Warning: ${ENCRYPTION_KEY_ENV} should be a 64-character hex string (256 bits). ` +
+        `Generate one with: openssl rand -hex 32`
+    );
+    return null;
+  }
+
+  return Buffer.from(keyHex, 'hex');
+}
+
+/**
+ * Encrypt data using AES-256-GCM.
+ * Returns a JSON-serializable payload with IV, auth tag, and encrypted data.
+ *
+ * @param plaintext - The string to encrypt
+ * @param key - The 256-bit encryption key
+ * @returns Encrypted payload object
+ */
+export function encryptData(plaintext: string, key: Buffer): EncryptedPayload {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(plaintext, 'utf8');
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+
+  return {
+    version: 1,
+    encrypted: true,
+    iv: iv.toString('base64'),
+    authTag: cipher.getAuthTag().toString('base64'),
+    data: encrypted.toString('base64'),
+  };
+}
+
+/**
+ * Decrypt data using AES-256-GCM.
+ *
+ * @param payload - The encrypted payload object
+ * @param key - The 256-bit encryption key
+ * @returns Decrypted plaintext string
+ * @throws Error if decryption fails (wrong key, tampered data, etc.)
+ */
+export function decryptData(payload: EncryptedPayload, key: Buffer): string {
+  const iv = Buffer.from(payload.iv, 'base64');
+  const authTag = Buffer.from(payload.authTag, 'base64');
+  const encryptedData = Buffer.from(payload.data, 'base64');
+
+  const decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(encryptedData);
+  decrypted = Buffer.concat([decrypted, decipher.final()]);
+
+  return decrypted.toString('utf8');
+}
+
+/**
+ * Check if a parsed JSON object is an encrypted payload.
+ *
+ * @param data - The object to check
+ * @returns True if the object is a valid encrypted payload
+ */
+export function isEncryptedPayload(data: unknown): data is EncryptedPayload {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'encrypted' in data &&
+    (data as EncryptedPayload).encrypted === true &&
+    'version' in data &&
+    'iv' in data &&
+    'authTag' in data &&
+    'data' in data
+  );
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -64,6 +64,7 @@ const clickSchema = baseCommandSchema.extend({
   button: z.enum(['left', 'right', 'middle']).optional(),
   clickCount: z.number().positive().optional(),
   delay: z.number().nonnegative().optional(),
+  newTab: z.boolean().optional(),
 });
 
 const typeSchema = baseCommandSchema.extend({
@@ -388,6 +389,32 @@ const stateSaveSchema = baseCommandSchema.extend({
 const stateLoadSchema = baseCommandSchema.extend({
   action: z.literal('state_load'),
   path: z.string().min(1),
+});
+
+const stateListSchema = baseCommandSchema.extend({
+  action: z.literal('state_list'),
+});
+
+const stateClearSchema = baseCommandSchema.extend({
+  action: z.literal('state_clear'),
+  sessionName: z.string().optional(),
+  all: z.boolean().optional(),
+});
+
+const stateShowSchema = baseCommandSchema.extend({
+  action: z.literal('state_show'),
+  filename: z.string().min(1),
+});
+
+const stateCleanSchema = baseCommandSchema.extend({
+  action: z.literal('state_clean'),
+  days: z.number().int().positive(),
+});
+
+const stateRenameSchema = baseCommandSchema.extend({
+  action: z.literal('state_rename'),
+  oldName: z.string().min(1),
+  newName: z.string().min(1),
 });
 
 const consoleSchema = baseCommandSchema.extend({
@@ -872,6 +899,11 @@ const commandSchema = z.discriminatedUnion('action', [
   harStopSchema,
   stateSaveSchema,
   stateLoadSchema,
+  stateListSchema,
+  stateClearSchema,
+  stateShowSchema,
+  stateCleanSchema,
+  stateRenameSchema,
   consoleSchema,
   errorsSchema,
   keyboardSchema,

--- a/src/state-utils.test.ts
+++ b/src/state-utils.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let tempHome: string;
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return {
+    ...actual,
+    homedir: () => tempHome,
+  };
+});
+
+import {
+  getAutoStateFilePath,
+  isValidSessionName,
+  getSessionsDir,
+  safeHeaderMerge,
+  listStateFiles,
+  cleanupExpiredStates,
+} from './state-utils.js';
+
+describe('state-utils', () => {
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-browser-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  describe('isValidSessionName', () => {
+    it('should accept alphanumeric names', () => {
+      expect(isValidSessionName('twitter')).toBe(true);
+      expect(isValidSessionName('Twitter123')).toBe(true);
+      expect(isValidSessionName('123')).toBe(true);
+      expect(isValidSessionName('ABC')).toBe(true);
+    });
+
+    it('should accept names with hyphens', () => {
+      expect(isValidSessionName('my-session')).toBe(true);
+      expect(isValidSessionName('twitter-prod')).toBe(true);
+      expect(isValidSessionName('a-b-c-d')).toBe(true);
+    });
+
+    it('should accept names with underscores', () => {
+      expect(isValidSessionName('my_session')).toBe(true);
+      expect(isValidSessionName('twitter_prod')).toBe(true);
+      expect(isValidSessionName('a_b_c_d')).toBe(true);
+    });
+
+    it('should accept mixed valid characters', () => {
+      expect(isValidSessionName('my-session_123')).toBe(true);
+      expect(isValidSessionName('Twitter_Prod-v2')).toBe(true);
+    });
+
+    it('should reject empty string', () => {
+      expect(isValidSessionName('')).toBe(false);
+    });
+
+    it('should reject path traversal attempts', () => {
+      expect(isValidSessionName('../../../etc/passwd')).toBe(false);
+      expect(isValidSessionName('..\\..\\windows\\system32')).toBe(false);
+      expect(isValidSessionName('../parent')).toBe(false);
+      expect(isValidSessionName('./current')).toBe(false);
+    });
+
+    it('should reject names with slashes', () => {
+      expect(isValidSessionName('path/to/file')).toBe(false);
+      expect(isValidSessionName('path\\to\\file')).toBe(false);
+      expect(isValidSessionName('/absolute/path')).toBe(false);
+    });
+
+    it('should reject names with spaces', () => {
+      expect(isValidSessionName('my session')).toBe(false);
+      expect(isValidSessionName(' leading')).toBe(false);
+      expect(isValidSessionName('trailing ')).toBe(false);
+    });
+
+    it('should reject names with special characters', () => {
+      expect(isValidSessionName('session@user')).toBe(false);
+      expect(isValidSessionName('session#1')).toBe(false);
+      expect(isValidSessionName('session$var')).toBe(false);
+      expect(isValidSessionName('session%20')).toBe(false);
+      expect(isValidSessionName('session:name')).toBe(false);
+      expect(isValidSessionName('session;drop')).toBe(false);
+      expect(isValidSessionName("session'sql")).toBe(false);
+      expect(isValidSessionName('session"quote')).toBe(false);
+      expect(isValidSessionName('session<script>')).toBe(false);
+      expect(isValidSessionName('session|pipe')).toBe(false);
+    });
+
+    it('should reject names with null bytes', () => {
+      expect(isValidSessionName('session\x00name')).toBe(false);
+    });
+
+    it('should reject names with newlines', () => {
+      expect(isValidSessionName('session\nname')).toBe(false);
+      expect(isValidSessionName('session\rname')).toBe(false);
+    });
+
+    it('should reject Unicode tricks', () => {
+      // Homograph attacks
+      expect(isValidSessionName('sеssion')).toBe(false); // Cyrillic 'е'
+      expect(isValidSessionName('session\u2024')).toBe(false); // One dot leader
+      expect(isValidSessionName('session\u2025')).toBe(false); // Two dot leader
+    });
+  });
+
+  describe('getAutoStateFilePath', () => {
+    it('should return null for empty session name', () => {
+      expect(getAutoStateFilePath('', 'default')).toBeNull();
+    });
+
+    it('should return valid path for valid inputs', () => {
+      const result = getAutoStateFilePath('twitter', 'default');
+      expect(result).not.toBeNull();
+      expect(result).toContain('twitter-default.json');
+      expect(result).toContain('.agent-browser');
+      expect(result).toContain('sessions');
+    });
+
+    it('should throw error for path traversal in session name', () => {
+      expect(() => getAutoStateFilePath('../etc/passwd', 'default')).toThrow(
+        /Invalid session name/
+      );
+    });
+
+    it('should throw error for path traversal in session ID', () => {
+      expect(() => getAutoStateFilePath('twitter', '../../../etc/passwd')).toThrow(
+        /Invalid session ID/
+      );
+    });
+
+    it('should throw error for slashes in session name', () => {
+      expect(() => getAutoStateFilePath('path/to/file', 'default')).toThrow(/Invalid session name/);
+    });
+
+    it('should throw error for slashes in session ID', () => {
+      expect(() => getAutoStateFilePath('twitter', 'path/to/file')).toThrow(/Invalid session ID/);
+    });
+
+    it('should throw error for special characters in session name', () => {
+      expect(() => getAutoStateFilePath('session@evil', 'default')).toThrow(/Invalid session name/);
+    });
+
+    it('should throw error for special characters in session ID', () => {
+      expect(() => getAutoStateFilePath('twitter', 'id@evil')).toThrow(/Invalid session ID/);
+    });
+
+    it('should accept valid session name with hyphens and underscores', () => {
+      const result = getAutoStateFilePath('my-session_v2', 'agent_1');
+      expect(result).not.toBeNull();
+      expect(result).toContain('my-session_v2-agent_1.json');
+    });
+
+    // Security: Ensure the resulting path is within the sessions directory
+    it('should always produce path within sessions directory', () => {
+      const sessionsDir = getSessionsDir();
+      const result = getAutoStateFilePath('twitter', 'default');
+
+      expect(result).not.toBeNull();
+      expect(result!.startsWith(sessionsDir)).toBe(true);
+
+      // Verify the path is actually within the directory (no traversal)
+      const resolvedPath = path.resolve(result!);
+      const resolvedSessionsDir = path.resolve(sessionsDir);
+      expect(resolvedPath.startsWith(resolvedSessionsDir)).toBe(true);
+    });
+  });
+
+  describe('safeHeaderMerge', () => {
+    it('should merge two header objects', () => {
+      const base = { 'Content-Type': 'application/json', Accept: 'text/html' };
+      const override = { Authorization: 'Bearer token' };
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(result['Content-Type']).toBe('application/json');
+      expect(result['Accept']).toBe('text/html');
+      expect(result['Authorization']).toBe('Bearer token');
+    });
+
+    it('should allow override to replace base values', () => {
+      const base = { 'Content-Type': 'text/plain' };
+      const override = { 'Content-Type': 'application/json' };
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(result['Content-Type']).toBe('application/json');
+    });
+
+    it('should filter out __proto__ from base', () => {
+      const base = { 'Content-Type': 'text/plain', __proto__: 'evil' } as Record<string, string>;
+      const override = { Accept: 'text/html' };
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(result['Content-Type']).toBe('text/plain');
+      expect(result['Accept']).toBe('text/html');
+      expect('__proto__' in result).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(false);
+    });
+
+    it('should filter out __proto__ from override', () => {
+      const base = { 'Content-Type': 'text/plain' };
+      const override = { Accept: 'text/html', __proto__: 'evil' } as Record<string, string>;
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(result['Content-Type']).toBe('text/plain');
+      expect(result['Accept']).toBe('text/html');
+      expect('__proto__' in result).toBe(false);
+    });
+
+    it('should filter out constructor key', () => {
+      const base = { constructor: 'evil' } as Record<string, string>;
+      const override = { Accept: 'text/html' };
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(result['Accept']).toBe('text/html');
+      expect('constructor' in result).toBe(false);
+    });
+
+    it('should filter out prototype key', () => {
+      const base = { prototype: 'evil' } as Record<string, string>;
+      const override = { Accept: 'text/html' };
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(result['Accept']).toBe('text/html');
+      expect('prototype' in result).toBe(false);
+    });
+
+    it('should return null-prototype object', () => {
+      const base = { 'Content-Type': 'text/plain' };
+      const override = {};
+
+      const result = safeHeaderMerge(base, override);
+
+      expect(Object.getPrototypeOf(result)).toBeNull();
+    });
+
+    it('should handle empty objects', () => {
+      const result = safeHeaderMerge({}, {});
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+
+  describe('listStateFiles', () => {
+    it('should return empty array when directory does not exist', () => {
+      const result = listStateFiles();
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('cleanupExpiredStates', () => {
+    it('should return empty array for 0 days', () => {
+      const result = cleanupExpiredStates(0);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for negative days', () => {
+      const result = cleanupExpiredStates(-5);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/state-utils.ts
+++ b/src/state-utils.ts
@@ -1,0 +1,224 @@
+/**
+ * Shared utilities for session state management.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  getEncryptionKey,
+  encryptData,
+  decryptData,
+  isEncryptedPayload,
+  type EncryptedPayload,
+  ENCRYPTION_KEY_ENV,
+} from './encryption.js';
+
+/**
+ * Get the session persistence directory.
+ * Located at ~/.agent-browser/sessions/
+ */
+export function getSessionsDir(): string {
+  return path.join(os.homedir(), '.agent-browser', 'sessions');
+}
+
+/**
+ * Ensure the sessions directory exists with proper permissions.
+ * Creates directory with mode 0o700 (owner only).
+ */
+export function ensureSessionsDir(): string {
+  const sessionsDir = getSessionsDir();
+  if (!fs.existsSync(sessionsDir)) {
+    fs.mkdirSync(sessionsDir, { recursive: true, mode: 0o700 });
+  }
+  return sessionsDir;
+}
+
+/**
+ * Validate a session ID to prevent path traversal attacks.
+ * Only allows alphanumeric characters, hyphens, and underscores.
+ */
+function isValidSessionId(id: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(id);
+}
+
+/**
+ * Validate a session name for safety (no path traversal).
+ * Only allows alphanumeric characters, dashes, and underscores.
+ * This validation is critical for security - the daemon reads session names
+ * from environment variables which can be set by attackers bypassing CLI validation.
+ */
+export function isValidSessionName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name);
+}
+
+/**
+ * Get the auto-save state file path for a session.
+ * Pattern: {SESSION_NAME}-{SESSION_ID}.json
+ *
+ * @param sessionName - The session name (e.g., "twitter")
+ * @param sessionId - The session ID (e.g., "default" or "agent1")
+ * @returns Full path to the state file, or null if sessionName is empty
+ * @throws Error if sessionName or sessionId contains invalid characters (path traversal prevention)
+ */
+export function getAutoStateFilePath(sessionName: string, sessionId: string): string | null {
+  if (!sessionName) return null;
+
+  // SECURITY: Validate sessionName to prevent path traversal attacks.
+  // The daemon reads AGENT_BROWSER_SESSION_NAME from environment which
+  // can be set directly by attackers, bypassing CLI validation.
+  if (!isValidSessionName(sessionName)) {
+    throw new Error(
+      `Invalid session name '${sessionName}'. Only alphanumeric characters, hyphens, and underscores are allowed.`
+    );
+  }
+
+  if (!isValidSessionId(sessionId)) {
+    throw new Error(
+      `Invalid session ID '${sessionId}'. Only alphanumeric characters, hyphens, and underscores are allowed.`
+    );
+  }
+  const sessionsDir = ensureSessionsDir();
+  return path.join(sessionsDir, `${sessionName}-${sessionId}.json`);
+}
+
+/**
+ * Check if an auto-state file exists for a session.
+ */
+export function autoStateFileExists(sessionName: string, sessionId: string): boolean {
+  const filePath = getAutoStateFilePath(sessionName, sessionId);
+  return filePath ? fs.existsSync(filePath) : false;
+}
+
+/**
+ * Write state data to file, encrypting if encryption key is available.
+ *
+ * @param filepath - Path to write the state file
+ * @param data - State data object to write
+ * @returns Object indicating whether the file was encrypted
+ */
+export function writeStateFile(filepath: string, data: object): { encrypted: boolean } {
+  const key = getEncryptionKey();
+  const jsonData = JSON.stringify(data, null, 2);
+
+  if (key) {
+    const encrypted = encryptData(jsonData, key);
+    fs.writeFileSync(filepath, JSON.stringify(encrypted, null, 2));
+    return { encrypted: true };
+  }
+
+  fs.writeFileSync(filepath, jsonData);
+  return { encrypted: false };
+}
+
+/**
+ * Read state data from file, decrypting if necessary.
+ *
+ * @param filepath - Path to the state file
+ * @returns Object containing the data and whether it was encrypted
+ * @throws Error if file is encrypted but no key is available
+ */
+export function readStateFile(filepath: string): { data: object; wasEncrypted: boolean } {
+  const content = fs.readFileSync(filepath, 'utf-8');
+  const parsed = JSON.parse(content);
+
+  if (isEncryptedPayload(parsed)) {
+    const key = getEncryptionKey();
+    if (!key) {
+      throw new Error(
+        `State file is encrypted but ${ENCRYPTION_KEY_ENV} is not set. ` +
+          `Set the environment variable to decrypt.`
+      );
+    }
+    const decrypted = decryptData(parsed, key);
+    return { data: JSON.parse(decrypted), wasEncrypted: true };
+  }
+
+  return { data: parsed, wasEncrypted: false };
+}
+
+/**
+ * List all state files in the sessions directory.
+ * @returns Array of filenames ending in .json
+ */
+export function listStateFiles(): string[] {
+  const sessionsDir = getSessionsDir();
+  if (!fs.existsSync(sessionsDir)) {
+    return [];
+  }
+  return fs.readdirSync(sessionsDir).filter((f) => f.endsWith('.json'));
+}
+
+/**
+ * Clean up state files older than specified days.
+ * @param days - Maximum age in days (files older than this are deleted)
+ * @returns Array of deleted filenames
+ */
+export function cleanupExpiredStates(days: number): string[] {
+  if (days <= 0) return [];
+
+  const sessionsDir = getSessionsDir();
+  if (!fs.existsSync(sessionsDir)) {
+    return [];
+  }
+
+  const now = Date.now();
+  const maxAge = days * 24 * 60 * 60 * 1000;
+  const deleted: string[] = [];
+
+  const files = listStateFiles();
+  for (const file of files) {
+    const filepath = path.join(sessionsDir, file);
+    try {
+      const stats = fs.statSync(filepath);
+      if (now - stats.mtime.getTime() > maxAge) {
+        fs.unlinkSync(filepath);
+        deleted.push(file);
+      }
+    } catch {
+      // Ignore individual file errors
+    }
+  }
+
+  return deleted;
+}
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Safely merge headers without prototype pollution risk.
+ * Filters out dangerous keys like __proto__, constructor, prototype.
+ * @param base - Base headers object
+ * @param override - Headers to merge (takes precedence)
+ * @returns Merged headers object (null-prototype)
+ */
+export function safeHeaderMerge(
+  base: Record<string, string>,
+  override: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = Object.create(null);
+
+  for (const [key, value] of Object.entries(base)) {
+    if (!DANGEROUS_KEYS.includes(key)) {
+      result[key] = value;
+    }
+  }
+
+  for (const [key, value] of Object.entries(override)) {
+    if (!DANGEROUS_KEYS.includes(key)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+// Re-export encryption utilities
+export {
+  getEncryptionKey,
+  encryptData,
+  decryptData,
+  isEncryptedPayload,
+  type EncryptedPayload,
+  ENCRYPTION_KEY_ENV,
+};

--- a/src/stream-server.ts
+++ b/src/stream-server.ts
@@ -114,8 +114,12 @@ export class StreamServer {
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
+        // SECURITY: Bind to localhost only to prevent network exposure.
+        // The stream server allows direct input injection (mouse, keyboard, touch)
+        // which would be a critical security risk if exposed to the network.
         this.wss = new WebSocketServer({
           port: this.port,
+          host: '127.0.0.1',
           // Security: Reject cross-origin WebSocket connections from untrusted origins.
           // This prevents malicious web pages from connecting and injecting input events.
           // Localhost origins are allowed so browser-based stream viewers can connect.

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface LaunchCommand extends BaseCommand {
   provider?: string;
   ignoreHTTPSErrors?: boolean;
   allowFileAccess?: boolean; // Enable file:// URL access and cross-origin file requests
+  // Auto-load state file for session persistence
+  autoStateFilePath?: string;
 }
 
 export interface NavigateCommand extends BaseCommand {
@@ -46,6 +48,7 @@ export interface ClickCommand extends BaseCommand {
   button?: 'left' | 'right' | 'middle';
   clickCount?: number;
   delay?: number;
+  newTab?: boolean;
 }
 
 export interface TypeCommand extends BaseCommand {
@@ -597,6 +600,33 @@ export interface StorageStateLoadCommand extends BaseCommand {
   path: string;
 }
 
+// State management commands (v2)
+export interface StateListCommand extends BaseCommand {
+  action: 'state_list';
+}
+
+export interface StateClearCommand extends BaseCommand {
+  action: 'state_clear';
+  sessionName?: string;
+  all?: boolean;
+}
+
+export interface StateShowCommand extends BaseCommand {
+  action: 'state_show';
+  filename: string;
+}
+
+export interface StateCleanCommand extends BaseCommand {
+  action: 'state_clean';
+  days: number;
+}
+
+export interface StateRenameCommand extends BaseCommand {
+  action: 'state_rename';
+  oldName: string;
+  newName: string;
+}
+
 // Console logs
 export interface ConsoleCommand extends BaseCommand {
   action: 'console';
@@ -898,6 +928,11 @@ export type Command =
   | HarStopCommand
   | StorageStateSaveCommand
   | StorageStateLoadCommand
+  | StateListCommand
+  | StateClearCommand
+  | StateShowCommand
+  | StateCleanCommand
+  | StateRenameCommand
   | ConsoleCommand
   | ErrorsCommand
   | KeyboardCommand


### PR DESCRIPTION
This PR implements session persistence with automatic state save/restore, encryption support, and comprehensive state management commands.

Resolves #42
Resolves #86
Resolves #115
Resolves #158 


### Features

#### 1. Session Persistence (`--session-name`)
Automatically save and restore cookies/localStorage across browser restarts:

```bash
# Auto-save/load state for "twitter" session
agent-browser --session-name twitter open twitter.com

# Login once, then state persists automatically
# State files stored in ~/.agent-browser/sessions/

#### 2. State Encryption (AES-256-GCM)

Encrypt sensitive session data at rest:

```bash
# Generate key: openssl rand -hex 32
export AGENT_BROWSER_ENCRYPTION_KEY=<64-char-hex-key>

# State files are now encrypted automatically
agent-browser --session-name secure open example.com
```
#### 3. State Management Commands

| Command | Description |
|---------|-------------|
| `state list` | List saved state files with size, date, encryption status |
| `state show <file>` | Show state summary (cookies, origins, domains) |
| `state rename <old> <new>` | Rename a state file |
| `state clear <session>` | Clear states for a specific session name |
| `state clear --all` | Clear all saved states |
| `state clean --older-than <days>` | Delete states older than N days |
| `state save <path>` | Manual save to custom path |
| `state load <path>` | Manual load from custom path |

#### 4. Auto-Expiration

Automatically clean up old state files:

```bash
export AGENT_BROWSER_STATE_EXPIRE_DAYS=7  # Default: 30

# Or manually clean old states
agent-browser state clean --older-than 7

#### 5. Session Name Validation

Security hardening to prevent path traversal attacks:
- Only alphanumeric, hyphens, underscores allowed
- Rejects `../`, spaces, slashes, special characters

```

### Environment Variables

| Variable | Description |
|----------|-------------|
| `AGENT_BROWSER_SESSION_NAME` | Auto-save/load state persistence name |
| `AGENT_BROWSER_ENCRYPTION_KEY` | 64-char hex key for AES-256-GCM encryption |
| `AGENT_BROWSER_STATE_EXPIRE_DAYS` | Auto-delete states older than N days (default: 30) |
---

# CLI Click Command with `--new-tab` Flag

## How It Works

### 1. **User Input**
```bash
agent-browser click #button --new-tab