### PR TITLE
fix(cli,browser): robust browser state management and error handling

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -286,10 +286,19 @@ fn main() {
                 .insert("proxy".to_string(), proxy_obj);
         }
 
-        if let Err(e) = send_command(launch_cmd, &flags.session) {
-            if !flags.json {
-                eprintln!("{} Could not configure browser: {}", color::warning_indicator(), e);
+        let err = match send_command(launch_cmd, &flags.session) {
+            Ok(resp) if resp.success => None,
+            Ok(resp) => Some(resp.error.unwrap_or_else(|| "Browser launch failed".to_string())),
+            Err(e) => Some(e.to_string()),
+        };
+
+        if let Some(msg) = err {
+            if flags.json {
+                println!(r#"{{"success":false,"error":"{}"}}"#, msg);
+            } else {
+                eprintln!("{} {}", color::error_indicator(), msg);
             }
+            exit(1);
         }
     }
 

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -404,7 +404,8 @@ describe('BrowserManager', () => {
             on: vi.fn(),
           },
         ],
-        close: vi.fn(),
+        on: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined),
       };
       const spy = vi.spyOn(chromium, 'connectOverCDP').mockResolvedValue(mockBrowser as any);
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -98,10 +98,44 @@ export class BrowserManager {
   private recordingTempDir: string = '';
 
   /**
-   * Check if browser is launched
+   * Check if browser is launched and usable
+   * Returns false if browser was launched but has since disconnected or has no pages
    */
   isLaunched(): boolean {
-    return this.browser !== null || this.isPersistentContext;
+    // For persistent context (extensions), check if we have usable pages
+    if (this.isPersistentContext) {
+      // Filter out any closed pages (handles crash before 'close' event fires)
+      this.pages = this.pages.filter((page) => !page.isClosed());
+      if (this.pages.length === 0) {
+        // All pages closed - clean up stale state
+        this.contexts = [];
+        this.isPersistentContext = false;
+        return false;
+      }
+      return true;
+    }
+
+    // For regular browser, check connection status and pages
+    if (this.browser === null) {
+      return false;
+    }
+
+    // Check if browser is still connected (handles crash/close scenarios)
+    if (!this.browser.isConnected()) {
+      // Browser disconnected - clean up stale state
+      this.browser = null;
+      this.pages = [];
+      this.contexts = [];
+      this.cdpPort = null;
+      return false;
+    }
+
+    // Browser is connected but has no pages - not usable
+    if (this.pages.length === 0) {
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -694,12 +728,32 @@ export class BrowserManager {
         }
       );
       this.isPersistentContext = true;
+
+      // Handle context close (crash, manual close, etc.) for persistent contexts
+      // Note: BrowserContext uses 'close' event, not 'disconnected' like Browser
+      context.on('close', () => {
+        this.browser = null;
+        this.pages = [];
+        this.contexts = [];
+        this.cdpPort = null;
+        this.isPersistentContext = false;
+      });
     } else {
       this.browser = await launcher.launch({
         headless: options.headless ?? true,
         executablePath: options.executablePath,
       });
       this.cdpPort = null;
+
+      // Handle browser disconnect (crash, manual close, etc.)
+      this.browser.on('disconnected', () => {
+        this.browser = null;
+        this.pages = [];
+        this.contexts = [];
+        this.cdpPort = null;
+        this.isPersistentContext = false;
+      });
+
       context = await this.browser.newContext({
         viewport,
         extraHTTPHeaders: options.headers,
@@ -749,6 +803,15 @@ export class BrowserManager {
       this.browser = browser;
       this.cdpPort = cdpPort;
 
+      // Handle browser disconnect (crash, manual close, etc.)
+      this.browser.on('disconnected', () => {
+        this.browser = null;
+        this.pages = [];
+        this.contexts = [];
+        this.cdpPort = null;
+        this.isPersistentContext = false;
+      });
+
       for (const context of contexts) {
         this.contexts.push(context);
         this.setupContextTracking(context);
@@ -762,7 +825,9 @@ export class BrowserManager {
       this.activePageIndex = 0;
     } catch (error) {
       // Clean up browser connection if validation or setup failed
-      await browser.close().catch(() => {});
+      if (browser) {
+        await browser.close().catch(() => {});
+      }
       throw error;
     }
   }


### PR DESCRIPTION
• Fix CLI silently swallowing launch errors when using --headed/--proxy flags
  by checking response.success, not just network errors
• Fix isLaunched() returning true for disconnected browsers by checking
  browser.isConnected() and cleaning up stale state
• Add browser.on('disconnected') handler to proactively reset state when
  browser crashes or is closed externally

Before: Closing browser window caused "Browser not launched. Call launch first" error on next command, requiring manual close to recover.

After: Browser state is properly tracked; auto-relaunch works reliably.

Fixes zombie daemon state issue on Windows (and likely other platforms).