### PR TITLE
fix: add .exe extension for Windows source binary path

### DIFF
--- a/scripts/copy-native.js
+++ b/scripts/copy-native.js
@@ -12,7 +12,8 @@ import { platform, arch } from 'os';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
 
-const sourcePath = join(projectRoot, 'cli/target/release/agent-browser');
+const sourceExt = platform() === 'win32' ? '.exe' : '';
+const sourcePath = join(projectRoot, `cli/target/release/agent-browser${sourceExt}`);
 const binDir = join(projectRoot, 'bin');
 
 // Determine platform suffix


### PR DESCRIPTION
The copy-native.js script was looking for 'agent-browser' but on Windows the compiled binary is 'agent-browser.exe', causing the copy to fail.