### PR TITLE
Make agent-browser errors doc more descriptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ agent-browser dialog dismiss          # Dismiss
 ```bash
 agent-browser trace start [path]      # Start recording trace
 agent-browser trace stop [path]       # Stop and save trace
-agent-browser console                 # View console messages
+agent-browser console                 # View console messages (log, error, warn, info)
 agent-browser console --clear         # Clear console
-agent-browser errors                  # View page errors
+agent-browser errors                  # View page errors (uncaught JavaScript exceptions)
 agent-browser errors --clear          # Clear errors
 agent-browser highlight <sel>         # Highlight element
 agent-browser state save <path>       # Save auth state


### PR DESCRIPTION
# docs: clarify distinction between `console` and `errors` commands

## Problem

The documentation for the `console` and `errors` commands was unclear about what each command captures. Users expected `errors` to show all errors including `console.error()` calls, but it only shows uncaught JavaScript exceptions.

This caused confusion when users would see errors in `agent-browser console` output but get empty results from `agent-browser errors`.

## Solution

Updated the documentation in `README.md` to clarify:

- `console` - captures all `console.*` calls (log, error, warn, info)
- `errors` - captures only uncaught JavaScript exceptions (not `console.error()` calls)

## Future Enhancement Suggestion

A useful follow-up feature would be adding type filtering to the `console` command:

```bash
agent-browser console --type error    # Only show console.error() messages
agent-browser console --type warning  # Only show console.warn() messages
```

This would make it easier to filter for specific message types without parsing the full output.
