### PR TITLE
fix(windows): Fix npm wrapper scripts for Windows

### DIFF
--- a/bin/agent-browser
+++ b/bin/agent-browser
@@ -15,7 +15,11 @@ ARCH=$(uname -m)
 case "$OS" in darwin) OS="darwin" ;; linux) OS="linux" ;; mingw*|msys*|cygwin*) OS="win32" ;; esac
 case "$ARCH" in x86_64|amd64) ARCH="x64" ;; aarch64|arm64) ARCH="arm64" ;; esac
 
-BINARY="$SCRIPT_DIR/agent-browser-${OS}-${ARCH}"
+# Add .exe extension for Windows binaries
+EXT=""
+case "$OS" in win32) EXT=".exe" ;; esac
+
+BINARY="$SCRIPT_DIR/agent-browser-${OS}-${ARCH}${EXT}"
 
 if [ -f "$BINARY" ] && [ -x "$BINARY" ]; then
   exec "$BINARY" "$@"

--- a/bin/agent-browser.cmd
+++ b/bin/agent-browser.cmd
@@ -1,5 +1,26 @@
 @echo off
 setlocal
+
+:: Detect architecture
+set "ARCH=x64"
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "ARCH=arm64"
+if "%PROCESSOR_ARCHITECTURE%"=="x86" (
+    if not defined PROCESSOR_ARCHITEW6432 set "ARCH=x86"
+)
+
+:: Get script directory
 set "SCRIPT_DIR=%~dp0"
-node "%SCRIPT_DIR%..\dist\index.js" %*
+
+:: Path to the Windows binary
+set "BINARY=%SCRIPT_DIR%agent-browser-win32-%ARCH%.exe"
+
+:: Check if binary exists
+if not exist "%BINARY%" (
+    echo Error: agent-browser binary not found at %BINARY% >&2
+    echo Run 'npm install' to download the binary, or 'npm run build:native' to build it locally. >&2
+    exit /b 1
+)
+
+:: Run the binary with all arguments
+"%BINARY%" %*
 exit /b %errorlevel%


### PR DESCRIPTION
This PR fixes the Windows wrapper scripts generated by npm to properly call the native Windows binary instead of failing to find /bin/sh.

## Changes
- Updated `bin/agent-browser.cmd` to detect architecture and directly call the `agent-browser-win32-{arch}.exe` binary
- Updated `bin/agent-browser` shell script to properly add `.exe` extension for Windows binaries when running in Git Bash/MSYS environments
- Added proper error messages when binary is not found

## Problem
On Windows, running `agent-browser` would fail with errors like:
- "The system cannot find the path specified"
- "/bin/sh.exe not found"

This was because the npm-generated wrapper scripts tried to use `/bin/sh` which doesn't exist on standard Windows installations.

## Solution
Modified the wrapper scripts to directly invoke the platform-specific native binary (`agent-browser-win32-x64.exe`) instead of trying to run a shell script through `/bin/sh`.

## Testing
- Tested on Windows 11 with PowerShell
- Tested on Windows 11 with CMD
- Verified binary detection and execution works correctly
- Confirmed `agent-browser` command now works without errors
