### PR TITLE
Update skills command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,12 +645,26 @@ Core workflow:
 
 For Claude Code, a [skill](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) provides richer context:
 
+Global:
 ```bash
-cp -r node_modules/agent-browser/skills/agent-browser .claude/skills/
+cp -r "$(npm root -g)/agent-browser/skills/agent-browser" ~/.claude/skills/
+```
+
+Current project:
+```bash
+cp -r "$(npm root -g)/agent-browser/skills/agent-browser" .claude/skills/
 ```
 
 Or download:
 
+Global:
+```bash
+mkdir -p ~/.claude/skills/agent-browser
+curl -o  ~/.claude/skills/agent-browser/SKILL.md \
+  https://raw.githubusercontent.com/vercel-labs/agent-browser/main/skills/agent-browser/SKILL.md
+```
+
+Project:
 ```bash
 mkdir -p .claude/skills/agent-browser
 curl -o .claude/skills/agent-browser/SKILL.md \


### PR DESCRIPTION
Update skills command to ensure it uses the agent-browser skills from the global node_modules regardless of the current directory.

Updated the examples to include commands for global skills or project skills.