### PR TITLE
fix: allow pages with empty URLs during CDP connection for Electron support

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -392,13 +392,13 @@ describe('BrowserManager', () => {
       expect(cdp1).toBe(cdp2);
     });
 
-    it('should filter out pages with empty URLs during CDP connection', async () => {
+    it('should include pages with empty URLs during CDP connection for Electron support', async () => {
       const mockBrowser = {
         contexts: () => [
           {
             pages: () => [
               { url: () => 'http://example.com', on: vi.fn() },
-              { url: () => '', on: vi.fn() }, // This page should be filtered out
+              { url: () => '', on: vi.fn() }, // Empty URL pages are kept for Electron app support
               { url: () => 'http://anothersite.com', on: vi.fn() },
             ],
             on: vi.fn(),
@@ -411,13 +411,14 @@ describe('BrowserManager', () => {
       const cdpBrowser = new BrowserManager();
       await cdpBrowser.launch({ cdpPort: 9222 });
 
-      // Should have 2 pages, not 3
-      expect(cdpBrowser.getPages().length).toBe(2);
+      // Should have all 3 pages including the one with empty URL
+      expect(cdpBrowser.getPages().length).toBe(3);
 
-      // Verify that the empty URL page is not in the list
+      // All pages should be included
       const urls = cdpBrowser.getPages().map((p) => p.url());
-      expect(urls).not.toContain('');
       expect(urls).toContain('http://example.com');
+      expect(urls).toContain('');
+      expect(urls).toContain('http://anothersite.com');
       spy.mockRestore();
     });
   });

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -738,8 +738,9 @@ export class BrowserManager {
         throw new Error('No browser context found. Make sure the app has an open window.');
       }
 
-      // Filter out pages with empty URLs, which can cause Playwright to hang
-      const allPages = contexts.flatMap((context) => context.pages()).filter((page) => page.url());
+      // Get all pages from all contexts - don't filter by URL as Electron apps
+      // may have pages with empty URLs during initialization
+      const allPages = contexts.flatMap((context) => context.pages());
 
       if (allPages.length === 0) {
         throw new Error('No page found. Make sure the app has loaded content.');


### PR DESCRIPTION
## Summary

Fixes #187

- Removes the URL filter that excluded pages with empty URLs during CDP connection
- Updates test to verify pages with empty URLs are now included

## Changes

- `src/browser.ts`: Remove `.filter((page) => page.url())` from CDP connection code
- `src/browser.test.ts`: Update test to expect all pages including those with empty URLs

## Problem

When connecting to an Electron app via CDP (`--cdp` flag), the connection fails with "No page found" even when the Electron window is open and has content loaded.

The root cause was that Electron apps often have pages with empty URL strings (`""`) during initialization. The filter `.filter((page) => page.url())` excluded these because empty strings are falsy in JavaScript.

## Solution

Remove the URL filter to allow all valid pages from browser contexts. The validation `if (allPages.length === 0)` still ensures at least one page exists.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)