### PR TITLE
feat: add Kernel as cloud browser provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,40 @@ When enabled, agent-browser connects to a Browser Use cloud session instead of l
 
 Get your API key from the [Browser Use Cloud Dashboard](https://cloud.browser-use.com/settings?tab=api-keys). Free credits are available to get started, with pay-as-you-go pricing after.
 
+### Kernel
+
+[Kernel](https://www.kernel.sh) provides cloud browser infrastructure for AI agents with features like stealth mode and persistent profiles.
+
+To enable Kernel, use the `-p` flag:
+
+```bash
+export KERNEL_API_KEY="your-api-key"
+agent-browser -p kernel open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=kernel
+export KERNEL_API_KEY="your-api-key"
+agent-browser open https://example.com
+```
+
+Optional configuration via environment variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KERNEL_HEADLESS` | Run browser in headless mode (`true`/`false`) | `false` |
+| `KERNEL_STEALTH` | Enable stealth mode to avoid bot detection (`true`/`false`) | `true` |
+| `KERNEL_TIMEOUT_SECONDS` | Session timeout in seconds | `300` |
+| `KERNEL_PROFILE_NAME` | Browser profile name for persistent cookies/logins (created if it doesn't exist) | (none) |
+
+When enabled, agent-browser connects to a Kernel cloud session instead of launching a local browser. All commands work identically.
+
+**Profile Persistence:** When `KERNEL_PROFILE_NAME` is set, the profile will be created if it doesn't already exist. Cookies, logins, and session data are automatically saved back to the profile when the browser session ends, making them available for future sessions.
+
+Get your API key from the [Kernel Dashboard](https://dashboard.onkernel.com).
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

- Add [Kernel](https://kernel.sh) as a third-party cloud browser provider, following the same pattern as Browserbase and Browser Use integrations
- Configurable via environment variables: `KERNEL_API_KEY`, `KERNEL_HEADLESS`, `KERNEL_STEALTH`, `KERNEL_TIMEOUT_SECONDS`, `KERNEL_PROFILE_NAME`
- Profile find-or-create: automatically creates profile if it doesn't exist
- Profile persistence: cookies/logins saved back to profile on session close

## Test plan

Tested locally with integration test script: https://gist.github.com/rgarcia/68f2d24c800cc9e82e620f724dd1f2dd

```
$ KERNEL_API_KEY="..." ./test-kernel-provider.sh

=== Test Suite 1: Basic Provider Launch ===
Testing: Launch with -p kernel flag... ✓ PASSED
Testing: Get page title... ✓ PASSED
Testing: Get current URL... ✓ PASSED
Testing: Take accessibility snapshot... ✓ PASSED
Testing: Take screenshot (base64)... ✓ PASSED
Testing: Close browser... ✓ PASSED

=== Test Suite 2: Navigation & Interactions ===
Testing: Launch with stealth mode... ✓ PASSED
Testing: Get body text... ✓ PASSED
Testing: Navigate to new URL... ✓ PASSED
Testing: Wait for selector... ✓ PASSED
Testing: Get h1 text... ✓ PASSED
Testing: Close browser... ✓ PASSED

=== Test Suite 3: Tab Management ===
Testing: Launch browser... ✓ PASSED
Testing: Create new tab... ✓ PASSED
Testing: Navigate in new tab... ✓ PASSED
Testing: List all tabs... ✓ PASSED
Testing: Switch to first tab... ✓ PASSED
Testing: Verify first tab URL... ✓ PASSED
Testing: Close browser... ✓ PASSED

=== Test Suite 4: Profile Persistence ===
Testing: Launch with new profile (creates profile)... ✓ PASSED
Testing: Verify cookie page response... ✓ PASSED
Testing: Close browser (saves profile)... ✓ PASSED
Testing: Re-launch with existing profile... ✓ PASSED
Testing: Cookie persistence in profile... ✓ PASSED (cookie persisted)
Testing: Close browser... ✓ PASSED

=== Test Suite 5: Environment Variables ===
Testing: Launch via AGENT_BROWSER_PROVIDER env var... ✓ PASSED
Testing: Verify page loaded... ✓ PASSED
Testing: Close browser... ✓ PASSED

========================================
Test Results: 28 passed, 0 failed
========================================
```

🤖 Generated with [Claude Code](https://claude.ai/code)