### PR TITLE
Fix keyboard events for Backspace/Delete keys

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1314,6 +1314,7 @@ export class BrowserManager {
     key?: string;
     code?: string;
     text?: string;
+    keyCode?: number;
     modifiers?: number; // 1=Alt, 2=Ctrl, 4=Meta, 8=Shift
   }): Promise<void> {
     const cdp = await this.getCDPSession();
@@ -1323,6 +1324,8 @@ export class BrowserManager {
       key: params.key,
       code: params.code,
       text: params.text,
+      windowsVirtualKeyCode: params.keyCode,
+      nativeVirtualKeyCode: params.keyCode,
       modifiers: params.modifiers ?? 0,
     });
   }

--- a/src/stream-server.ts
+++ b/src/stream-server.ts
@@ -35,6 +35,7 @@ export interface InputKeyboardMessage {
   key?: string;
   code?: string;
   text?: string;
+  keyCode?: number;
   modifiers?: number;
 }
 
@@ -215,6 +216,7 @@ export class StreamServer {
             key: message.key,
             code: message.code,
             text: message.text,
+            keyCode: message.keyCode,
             modifiers: message.modifiers,
           });
           break;


### PR DESCRIPTION
## Summary
- Add `keyCode` parameter to `injectKeyboardEvent` to pass `windowsVirtualKeyCode` and `nativeVirtualKeyCode` to CDP
- Update `InputKeyboardMessage` interface to include `keyCode`
- Pass `keyCode` from WebSocket message to the keyboard event handler

## Problem
Backspace and Delete keys were not working when using the streaming server. CDP's `Input.dispatchKeyEvent` requires `windowsVirtualKeyCode` for non-character keys like Backspace (keyCode 8) and Delete (keyCode 46) to function properly.