### PR TITLE
chore: release v0.7.0

### DIFF
--- a/.changeset/tough-bees-speak.md
+++ b/.changeset/tough-bees-speak.md
@@ -1,0 +1,26 @@
+---
+"agent-browser": minor
+---
+
+## New Features
+
+- **Cloud browser providers** - Connect to Browserbase or Browser Use for remote browser infrastructure via `-p` flag or `AGENT_BROWSER_PROVIDER` env var
+- **Persistent browser profiles** - Store cookies, localStorage, and login sessions across browser restarts with `--profile`
+- **Remote CDP WebSocket URLs** - Connect to remote browser services via WebSocket URL (e.g., `--cdp "wss://..."`)
+- **Download commands** - New `download` command and `wait --download` for file downloads with ref support
+- **Browser launch configuration** - New `--args`, `--user-agent`, and `--proxy-bypass` flags for fine-grained browser control
+- **Enhanced skills** - Hierarchical structure with references and templates for Claude Code
+
+## Bug Fixes
+
+- Screenshot command now supports refs and has improved error messages
+- WebSocket URLs work in `connect` command
+- Fixed socket file location (uses `~/.agent-browser` instead of TMPDIR)
+- Windows binary path fix (.exe extension)
+- State load and path-based actions now show correct output messages
+
+## Documentation
+
+- Added Claude Code marketplace plugin installation instructions
+- Updated skill documentation with references and templates
+- Improved error documentation


### PR DESCRIPTION
## Summary

Adds changeset to trigger the v0.7.0 release.

When merged, the release workflow will create a "Version Packages" PR. Merging that PR will:
1. Publish `agent-browser@0.7.0` to npm
2. Build native binaries for all platforms
3. Create a GitHub release with the binaries attached

## Changelog

### New Features

- **Cloud browser providers** - Connect to Browserbase or Browser Use via `-p` flag or `AGENT_BROWSER_PROVIDER` env var
- **Persistent browser profiles** - `--profile` flag to store cookies/localStorage across restarts
- **Remote CDP WebSocket URLs** - `--cdp` now accepts full WebSocket URLs
- **Download commands** - New `download` command and `wait --download`
- **Browser launch configuration** - `--args`, `--user-agent`, `--proxy-bypass` flags
- **Enhanced skills** - Hierarchical structure with references and templates

### Bug Fixes

- Screenshot command supports refs with improved error messages
- WebSocket URLs work in `connect` command
- Fixed socket file location (`~/.agent-browser` instead of TMPDIR)
- Windows binary path fix (.exe extension)
- State load/path-based actions output messages fixed

### Documentation

- Claude Code marketplace plugin installation instructions
- Updated skill documentation
- Improved error documentation