### PR TITLE
fix: ensure binary is executable after npm install

### DIFF
--- a/.changeset/fix-binary-permissions.md
+++ b/.changeset/fix-binary-permissions.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fix binary permissions on install. npm doesn't preserve execute bits, so postinstall now ensures the native binary is executable.

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -68,7 +68,11 @@ async function downloadFile(url, dest) {
 async function main() {
   // Check if binary already exists
   if (existsSync(binaryPath)) {
-    console.log(`✓ Native binary already exists: ${binaryName}`);
+    // Ensure binary is executable (npm doesn't preserve execute bit)
+    if (platform() !== 'win32') {
+      chmodSync(binaryPath, 0o755);
+    }
+    console.log(`✓ Native binary ready: ${binaryName}`);
     return;
   }
 


### PR DESCRIPTION
## Summary

npm doesn't preserve execute permissions on files. This causes the native binary to be installed without the execute bit, making `agent-browser` fail with "No binary found".

## Fix

The postinstall script now runs `chmod` on the binary even when it already exists (bundled with package), ensuring it's executable.

## Test

```bash
npm cache clean --force
npm uninstall -g agent-browser
npm install -g agent-browser@<new-version>
agent-browser --version
```