### PR TITLE
fix: add profile field to launchSchema in protocol.ts

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -45,6 +45,7 @@ const launchSchema = baseCommandSchema.extend({
   args: z.array(z.string()).optional(),
   userAgent: z.string().optional(),
   provider: z.string().optional(),
+  profile: z.string().optional(),
 });
 
 const navigateSchema = baseCommandSchema.extend({


### PR DESCRIPTION
## Summary
- Adds the missing `profile` field to the `launchSchema` Zod validation schema in `protocol.ts`

## Problem
The `--profile` flag was added in PR #68 to support persistent browser profiles, but the `profile` field was not added to the Zod schema in `protocol.ts`. This caused the profile option to be stripped during command parsing, making the feature non-functional.

## Solution
Added `profile: z.string().optional()` to the `launchSchema`, allowing the profile path to be passed through to the browser launch options.

## Test plan
- [x] Verified `agent-browser --profile ~/.browser-profiles/test --headed open https://example.com` creates profile directory
- [x] Verified cookies persist across browser restarts when using the same profile


🤖 Generated with [Claude Code](https://claude.com/claude-code)