### PR TITLE
fix: allow null selector in screenshot command schema

### DIFF
--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -122,6 +122,13 @@ describe('parseCommand', () => {
       const result = parseCommand(cmd({ id: '1', action: 'screenshot', fullPage: true }));
       expect(result.success).toBe(true);
     });
+
+    it('should parse screenshot with null selector', () => {
+      const result = parseCommand(
+        cmd({ id: '1', action: 'screenshot', path: 'test.png', selector: null })
+      );
+      expect(result.success).toBe(true);
+    });
   });
 
   describe('cookies', () => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -693,7 +693,7 @@ const screenshotSchema = baseCommandSchema.extend({
   action: z.literal('screenshot'),
   path: z.string().nullable().optional(),
   fullPage: z.boolean().optional(),
-  selector: z.string().min(1).optional(),
+  selector: z.string().min(1).nullish(),
   format: z.enum(['png', 'jpeg']).optional(),
   quality: z.number().min(0).max(100).optional(),
 });


### PR DESCRIPTION
## Problem

The screenshot command was failing with validation error when only a path was provided:

```
agent-browser screenshot ~/Desktop/test.png
✗ Validation error: selector: Expected string, received null
```

This worked in version 0.6.0 but broke in 0.7.5.

## Root Cause

The Rust CLI serializes `None` values as `null` in JSON. However, the Zod schema for the screenshot command's `selector` field used `.optional()`, which only allows `undefined` (missing field), not `null` (explicitly set to null).

## Solution

Changed the `selector` field in the screenshot schema from:
```typescript
selector: z.string().min(1).optional()
```
to:
```typescript
selector: z.string().min(1).nullish()
```

The `.nullish()` method accepts both `null` and `undefined`, which matches the behavior of the Rust CLI.

## Testing

- Tested with `agent-browser open x.com && agent-browser screenshot ~/Desktop/test.png` ✓
- Added test case to verify null selector values are accepted ✓

## Related

Fixes the regression introduced in 0.7.5 where screenshot command without selector fails validation.