### PR TITLE
chore: patch release - Fixed screenshot command parsing to accept null se

### DIFF
--- a/.changeset/release-29db175c.md
+++ b/.changeset/release-29db175c.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fixed screenshot command parsing to accept null selector values, preventing validation errors when the selector field is explicitly set to null.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Fixed screenshot command parsing to accept null selector values, preventing validation errors when the selector field is explicitly set to null.

---
*This PR was created automatically by release-cli*