### PR TITLE
chore: patch release - Allow null values for the screenshot selector fiel

### DIFF
--- a/.changeset/release-7099451c.md
+++ b/.changeset/release-7099451c.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Allow null values for the screenshot selector field. Previously, passing a null selector would fail validation, but now it is properly handled as an optional value.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Allow null values for the screenshot selector field. Previously, passing a null selector would fail validation, but now it is properly handled as an optional value.

---
*This PR was created automatically by release-cli*