### PR TITLE
fix(cli): omit null fields in screenshot command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -361,7 +361,10 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 }
                 _ => (None, None),
             };
-            Ok(json!({ "id": id, "action": "screenshot", "path": path, "selector": selector, "fullPage": flags.full }))
+            let mut cmd = json!({ "id": id, "action": "screenshot", "fullPage": flags.full });
+            if let Some(p) = path { cmd["path"] = json!(p); }
+            if let Some(s) = selector { cmd["selector"] = json!(s); }
+            Ok(cmd)
         }
         "pdf" => {
             let path = rest.get(0).ok_or_else(|| ParseError::MissingArguments {


### PR DESCRIPTION
## Summary

The CLI was sending `selector: null` and `path: null` in the JSON payload when these optional fields were not provided. While #236 fixed this on the daemon side by changing Zod validation from `.optional()` to `.nullish()`, the CLI should not send null values in the first place.

This is a complementary fix that makes the protocol cleaner:
- **Before**: `{"action": "screenshot", "path": null, "selector": null, "fullPage": false}`
- **After**: `{"action": "screenshot", "fullPage": false}`

## Changes

- Modified `cli/src/commands.rs` to conditionally include `path` and `selector` fields only when they have values

## Testing

- All 123 CLI tests pass
- Manually tested with CDP connection:
  - `agent-browser screenshot` (no args) - works
  - `agent-browser screenshot /tmp/test.png` (with path) - works
  - `agent-browser screenshot @e1` (with selector) - works
  - `agent-browser screenshot @e1 /tmp/test.png` (both) - works

Related to #238