### PR TITLE
Fix: Additional CLI parameters for setting cookies: URL, httpOnly

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1082,18 +1082,46 @@ Usage: agent-browser cookies [operation] [args]
 Manage browser cookies for the current context.
 
 Operations:
-  get                  Get all cookies (default)
-  set <name> <value>   Set a cookie
-  clear                Clear all cookies
+  get                                Get all cookies (default)
+  set <name> <value> [options]       Set a cookie with optional properties
+  clear                              Clear all cookies
+
+Cookie Set Options:
+  --url <url>                        URL for the cookie (allows setting before page load)
+  --domain <domain>                  Cookie domain (e.g., ".example.com")
+  --path <path>                      Cookie path (e.g., "/api")
+  --httpOnly                         Set HttpOnly flag (prevents JavaScript access)
+  --secure                           Set Secure flag (HTTPS only)
+  --sameSite <Strict|Lax|None>       SameSite policy
+  --expires <timestamp>              Expiration time (Unix timestamp in seconds)
+
+Note: If --url, --domain, and --path are all omitted, the cookie will be set
+for the current page URL.
 
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
 
 Examples:
-  agent-browser cookies
-  agent-browser cookies get
+  # Simple cookie for current page
   agent-browser cookies set session_id "abc123"
+
+  # Set cookie for a URL before loading it (useful for authentication)
+  agent-browser cookies set session_id "abc123" --url https://app.example.com
+
+  # Set secure, httpOnly cookie with domain and path
+  agent-browser cookies set auth_token "xyz789" --domain example.com --path /api --httpOnly --secure
+
+  # Set cookie with SameSite policy
+  agent-browser cookies set tracking_consent "yes" --sameSite Strict
+
+  # Set cookie with expiration (Unix timestamp)
+  agent-browser cookies set temp_token "temp123" --expires 1735689600
+
+  # Get all cookies
+  agent-browser cookies
+
+  # Clear all cookies
   agent-browser cookies clear
 "##
         }
@@ -1494,7 +1522,7 @@ Network:  agent-browser network <action>
   requests [--clear] [--filter <pattern>]
 
 Storage:
-  cookies [get|set|clear]    Manage cookies
+  cookies [get|set|clear]    Manage cookies (set supports --url, --domain, --path, --httpOnly, --secure, --sameSite, --expires)
   storage <local|session>    Manage web storage
 
 Tabs:


### PR DESCRIPTION
This PR addresses issue #261.

The `agent-browser cookies set` command only allows setting cookies for the currently loaded URL.