### PR TITLE
Security: Reject cross-origin connections to daemon and stream server

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -196,9 +196,22 @@ export async function startDaemon(options?: { streamPort?: number }): Promise<vo
 
   const server = net.createServer((socket) => {
     let buffer = '';
+    let httpChecked = false;
 
     socket.on('data', async (data) => {
       buffer += data.toString();
+
+      // Security: Detect and reject HTTP requests to prevent cross-origin attacks.
+      // Browsers using fetch() must send HTTP headers (e.g., "POST / HTTP/1.1"),
+      // while legitimate clients send raw JSON starting with "{".
+      if (!httpChecked) {
+        httpChecked = true;
+        const trimmed = buffer.trimStart();
+        if (/^(GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH|CONNECT|TRACE)\s/i.test(trimmed)) {
+          socket.destroy();
+          return;
+        }
+      }
 
       // Process complete lines
       while (buffer.includes('\n')) {


### PR DESCRIPTION
## Summary

- Reject HTTP-formatted requests to the daemon TCP socket (Windows)
- Reject browser-originated WebSocket connections to the stream server

## Background

The daemon's TCP socket on Windows and the WebSocket stream server were accessible to web pages running in the user's browser. This could allow a malicious website to send commands to a running daemon while the user browses.

## Changes

**Daemon (src/daemon.ts)**
- Detect connections that begin with HTTP methods (GET, POST, etc.) and close them immediately
- Legitimate clients send raw JSON, which is unaffected

**Stream server (src/stream-server.ts)**  
- Validate the `Origin` header on WebSocket connections
- Reject connections from web page origins (http/https)
- Allow CLI tools and local file:// origins

## Testing

Added unit tests for HTTP request detection pattern.