### PR TITLE
ci(version): add version sync check between package.json and Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
 
 jobs:
+  version-sync:
+    name: Version Sync Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check version sync
+        run: node scripts/check-version-sync.js
+
   typescript:
     name: TypeScript (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 pnpm lint-staged
+node scripts/sync-version.js
+git add cli/Cargo.toml

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:watch": "vitest",
     "postinstall": "node scripts/postinstall.js",
     "changeset": "changeset",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
+    "ci:version": "changeset version && pnpm run version:sync && pnpm install --no-frozen-lockfile",
     "ci:publish": "pnpm run version:sync && pnpm run build && changeset publish"
   },
   "keywords": [

--- a/scripts/check-version-sync.js
+++ b/scripts/check-version-sync.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that package.json and cli/Cargo.toml have the same version.
+ * Used in CI to catch version drift.
+ */
+
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Read package.json version
+const packageJson = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'));
+const packageVersion = packageJson.version;
+
+// Read Cargo.toml version
+const cargoToml = readFileSync(join(rootDir, 'cli/Cargo.toml'), 'utf-8');
+const cargoVersionMatch = cargoToml.match(/^version\s*=\s*"([^"]*)"/m);
+
+if (!cargoVersionMatch) {
+  console.error('Could not find version in cli/Cargo.toml');
+  process.exit(1);
+}
+
+const cargoVersion = cargoVersionMatch[1];
+
+if (packageVersion !== cargoVersion) {
+  console.error('Version mismatch detected!');
+  console.error(`  package.json:    ${packageVersion}`);
+  console.error(`  cli/Cargo.toml:  ${cargoVersion}`);
+  console.error('');
+  console.error("Run 'pnpm run version:sync' to fix this.");
+  process.exit(1);
+}
+
+console.log(`Versions are in sync: ${packageVersion}`);


### PR DESCRIPTION
Add automated verification that package.json and cli/Cargo.toml versions stay in sync. This prevents version drift between the npm package and Rust CLI binary.

- Add CI job to check version sync on push/PR
- Update pre-commit hook to sync versions automatically
- Update ci:version script to include version sync step
- Add check-version-sync.js script for CI validation