### PR TITLE
chore: minor release - Added Kernel cloud browser provider integration wi

### DIFF
--- a/.changeset/release-18a32425.md
+++ b/.changeset/release-18a32425.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": minor
+---
+
+Added Kernel cloud browser provider integration with support for stealth mode and persistent profiles. Added --ignore-https-errors flag for working with self-signed certificates. Enhanced cookies set command with additional options for domain, path, httpOnly, secure, sameSite, and expires parameters.


### PR DESCRIPTION
## Release Changeset

**Type:** minor

**Changes:**
Added Kernel cloud browser provider integration with support for stealth mode and persistent profiles. Added --ignore-https-errors flag for working with self-signed certificates. Enhanced cookies set command with additional options for domain, path, httpOnly, secure, sameSite, and expires parameters.

---
*This PR was created automatically by release-cli*