### PR TITLE
ci: add retry logic to flaky Windows integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,21 +141,13 @@ jobs:
       - name: Test agent-browser install command
         run: |
           $env:PATH = "$pwd\bin;$env:PATH"
-          $maxRetries = 3
-          $retryCount = 0
-          while ($retryCount -lt $maxRetries) {
-            try {
-              bin/agent-browser-win32-x64.exe install
-              break
-            } catch {
-              $retryCount++
-              if ($retryCount -eq $maxRetries) {
-                throw "Install failed after $maxRetries attempts"
-              }
-              Write-Host "Attempt $retryCount failed, retrying in 10 seconds..."
-              Start-Sleep -Seconds 10
-            }
+          for ($i = 1; $i -le 3; $i++) {
+            bin/agent-browser-win32-x64.exe install
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            Write-Host "Attempt $i failed, retrying in 10 seconds..."
+            Start-Sleep -Seconds 10
           }
+          exit 1
         shell: pwsh
         timeout-minutes: 10
 


### PR DESCRIPTION
## Summary
Add retry logic to the Windows Integration Test which occasionally fails due to network issues when downloading Chromium.

## Changes
- Retry `agent-browser install` up to 3 times with 10 second delays
- Add 10 minute timeout to prevent hanging