### PR TITLE
chore: patch release - Fixed the Windows CMD wrapper to use the native bi

### DIFF
--- a/.changeset/release-a90eda8f.md
+++ b/.changeset/release-a90eda8f.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fixed the Windows CMD wrapper to use the native binary directly instead of routing through Node.js, improving startup performance and reliability. Added retry logic to the CI install command to handle transient failures during browser installation.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Fixed the Windows CMD wrapper to use the native binary directly instead of routing through Node.js, improving startup performance and reliability. Added retry logic to the CI install command to handle transient failures during browser installation.

---
*This PR was created automatically by mkrelease*