### PR TITLE
fix: sync Cargo.lock when version changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 pnpm lint-staged
 node scripts/sync-version.js
-git add cli/Cargo.toml
+git add cli/Cargo.toml cli/Cargo.lock

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-browser"
-version = "0.7.6"
+version = "0.8.4"
 dependencies = [
  "dirs",
  "libc",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -5,12 +5,14 @@
  * Run this script before building or releasing.
  */
 
+import { execSync } from "child_process";
 import { readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
+const cliDir = join(rootDir, "cli");
 
 // Read version from package.json (single source of truth)
 const packageJson = JSON.parse(
@@ -21,23 +23,47 @@ const version = packageJson.version;
 console.log(`Syncing version ${version} to all config files...`);
 
 // Update Cargo.toml
-const cargoTomlPath = join(rootDir, "cli/Cargo.toml");
+const cargoTomlPath = join(cliDir, "Cargo.toml");
 let cargoToml = readFileSync(cargoTomlPath, "utf-8");
 const cargoVersionRegex = /^version\s*=\s*"[^"]*"/m;
 const newCargoVersion = `version = "${version}"`;
 
+let cargoTomlUpdated = false;
 if (cargoVersionRegex.test(cargoToml)) {
   const oldMatch = cargoToml.match(cargoVersionRegex)?.[0];
   if (oldMatch !== newCargoVersion) {
     cargoToml = cargoToml.replace(cargoVersionRegex, newCargoVersion);
     writeFileSync(cargoTomlPath, cargoToml);
     console.log(`  Updated cli/Cargo.toml: ${oldMatch} -> ${newCargoVersion}`);
+    cargoTomlUpdated = true;
   } else {
     console.log(`  cli/Cargo.toml already up to date`);
   }
 } else {
   console.error("  Could not find version field in cli/Cargo.toml");
   process.exit(1);
+}
+
+// Update Cargo.lock to match Cargo.toml
+if (cargoTomlUpdated) {
+  try {
+    execSync("cargo update -p agent-browser --offline", {
+      cwd: cliDir,
+      stdio: "pipe",
+    });
+    console.log(`  Updated cli/Cargo.lock`);
+  } catch {
+    // --offline may fail if package not in cache, try without it
+    try {
+      execSync("cargo update -p agent-browser", {
+        cwd: cliDir,
+        stdio: "pipe",
+      });
+      console.log(`  Updated cli/Cargo.lock`);
+    } catch (e) {
+      console.error(`  Warning: Could not update Cargo.lock: ${e.message}`);
+    }
+  }
 }
 
 console.log("Version sync complete.");


### PR DESCRIPTION
## Summary

- Update `sync-version.js` to run `cargo update -p agent-browser` after updating `Cargo.toml`, keeping `Cargo.lock` in sync
- Update pre-commit hook to stage `Cargo.lock` along with `Cargo.toml`
- Bring `Cargo.lock` up to date (was stuck at 0.7.6, now matches 0.8.4)

## Test plan

- [x] Verified `Cargo.lock` now shows version 0.8.4
- [x] Tested `sync-version.js` runs without error