### PR TITLE
fix(cli): include executablePath in launch command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -439,6 +439,10 @@ fn main() {
             cmd_obj.insert("args".to_string(), json!(args_vec));
         }
 
+        if let Some(ref exec_path) = flags.executable_path {
+            cmd_obj.insert("executablePath".to_string(), json!(exec_path));
+        }
+
         if flags.ignore_https_errors {
             launch_cmd["ignoreHTTPSErrors"] = json!(true);
         }


### PR DESCRIPTION
## Problem

When using `--headed`, `--profile`, `--proxy`, or other flags that trigger a `launch` command, the CLI sends the command **without** `executablePath`, even when `--executable-path` is specified.

This happens because these flags trigger a code path (main.rs:397-454) that sends an explicit `launch` command, bypassing the daemon's auto-launch logic which reads `AGENT_BROWSER_EXECUTABLE_PATH` from environment variables.

**Result:** `--executable-path` is silently ignored and Playwright's default Chrome for Testing is launched instead of the specified browser.

## Fix

Include `executablePath` in the launch command when `flags.executable_path` is set, following the same pattern used for `profile`, `userAgent`, `args`, etc.

## Testing

```bash
# Before fix: launches Chrome for Testing
agent-browser --headed --executable-path /path/to/custom/browser open example.com

# After fix: launches specified browser
agent-browser --headed --executable-path /path/to/custom/browser open example.com
```