### PR TITLE
feat: add AGENT_BROWSER_ALLOWED_ORIGIN env var for stream server security

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,22 @@ AGENT_BROWSER_STREAM_PORT=9223 agent-browser open example.com
 
 This starts a WebSocket server on the specified port that streams the browser viewport and accepts input events.
 
+### Security
+
+By default, the stream server rejects connections from web pages (browsers) to prevent malicious sites from connecting to your local browser stream. It allows connections from:
+- Non-browser clients (like CLI tools)
+- Local files (`file://` origin)
+
+To allow connections from specific web origins (e.g., a web-based viewer hosted on a specific domain), set `AGENT_BROWSER_ALLOWED_ORIGIN` to a regex pattern:
+
+```bash
+# Allow connections from localhost:3000
+AGENT_BROWSER_ALLOWED_ORIGIN="http://localhost:3000" agent-browser open example.com
+
+# Allow connections from any subdomain of example.com
+AGENT_BROWSER_ALLOWED_ORIGIN="https://.*\\.example\\.com" agent-browser open example.com
+```
+
 ### WebSocket Protocol
 
 Connect to `ws://localhost:9223` to receive frames and send input:

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1662,7 +1662,7 @@ Environment:
   AGENT_BROWSER_EXECUTABLE_PATH  Custom browser executable path
   AGENT_BROWSER_PROVIDER         Cloud browser provider
   AGENT_BROWSER_STREAM_PORT      Enable WebSocket streaming on port (e.g., 9223)
-
+  AGENT_BROWSER_ALLOWED_ORIGIN   Allowed origin regex for WebSocket connection
 Examples:
   agent-browser open example.com
   agent-browser snapshot -i              # Interactive elements only


### PR DESCRIPTION
## Summary
Added `AGENT_BROWSER_ALLOWED_ORIGIN` environment variable to `src/stream-server.ts` to allow whitelisting WebSocket origins via regex. This enhances security by allowing users to restrict which origins can connect to the stream server.

Also updated:
- `README.md` and `docs/src/app/streaming/page.tsx` with documentation on how to use the new environment variable.
- `cli/src/output.rs` to include the new variable in the help output.
- `skills/agent-browser/SKILL.md` to list the new environment variable.

## Test plan
- Verified that the server rejects connections from disallowed origins.
- Verified that the server allows connections from allowed origins (matching the regex).
- Verified that connections with no origin (e.g. CLI tools) and `file://` origins are still allowed.
- Verified documentation updates.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-cb5aa99e28864b44bf315a440550061f)