### PR TITLE
chore: patch release - Fixed version synchronization to automatically upd

### DIFF
--- a/.changeset/release-7627987e.md
+++ b/.changeset/release-7627987e.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fixed version synchronization to automatically update Cargo.lock alongside Cargo.toml during releases, and made the CLI binary executable. This ensures the Rust CLI version stays in sync with the npm package version.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Fixed version synchronization to automatically update Cargo.lock alongside Cargo.toml during releases, and made the CLI binary executable. This ensures the Rust CLI version stays in sync with the npm package version.

---
*This PR was created automatically by autoship*