### PR TITLE
chore: patch release - Improved daemon connection reliability by adding a

### DIFF
--- a/.changeset/release-16324bb7.md
+++ b/.changeset/release-16324bb7.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Improved daemon connection reliability by adding automatic retry logic for transient errors like connection resets, broken pipes, and temporary resource unavailability. The CLI now cleans up stale socket and PID files before starting a new daemon, and includes better detection of daemon responsiveness to handle race conditions during shutdown.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Improved daemon connection reliability by adding automatic retry logic for transient errors like connection resets, broken pipes, and temporary resource unavailability. The CLI now cleans up stale socket and PID files before starting a new daemon, and includes better detection of daemon responsiveness to handle race conditions during shutdown.

---
*This PR was created automatically by autoship*