### PR TITLE
chore: patch release - Fixed browser launch options not being passed corr

### DIFF
--- a/.changeset/release-e0b673be.md
+++ b/.changeset/release-e0b673be.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fixed browser launch options not being passed correctly when using persistent profiles, ensuring args, userAgent, proxy, and ignoreHTTPSErrors settings now work properly. Added pre-flight checks for socket path length limits and directory write permissions to provide clearer error messages when daemon startup fails. Improved error handling to properly exit with failure status when browser launch fails.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Fixed browser launch options not being passed correctly when using persistent profiles, ensuring args, userAgent, proxy, and ignoreHTTPSErrors settings now work properly. Added pre-flight checks for socket path length limits and directory write permissions to provide clearer error messages when daemon startup fails. Improved error handling to properly exit with failure status when browser launch fails.

---
*This PR was created automatically by autoship*