### PR TITLE
chore: patch release - Add --stdin flag for eval command to read JavaScri

### DIFF
--- a/.changeset/release-1845d1cb.md
+++ b/.changeset/release-1845d1cb.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Add --stdin flag for eval command to read JavaScript from stdin, enabling heredoc usage for multiline scripts


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Add --stdin flag for eval command to read JavaScript from stdin, enabling heredoc usage for multiline scripts

---
*This PR was created automatically by autoship*