### PR TITLE
chore: patch release - Add --stdin flag for the eval command to read Java

### DIFF
--- a/.changeset/release-62598154.md
+++ b/.changeset/release-62598154.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Add --stdin flag for the eval command to read JavaScript from stdin, enabling heredoc usage for multiline scripts. Also fix binary execution permissions on macOS/Linux when using package managers like bun that skip lifecycle scripts.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Add --stdin flag for the eval command to read JavaScript from stdin, enabling heredoc usage for multiline scripts. Also fix binary execution permissions on macOS/Linux when using package managers like bun that skip lifecycle scripts.

---
*This PR was created automatically by autoship*