### PR TITLE
chore: patch release - Add --stdin flag for the eval command to read Java

### DIFF
--- a/.changeset/release-d55a4e12.md
+++ b/.changeset/release-d55a4e12.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Add --stdin flag for the eval command to read JavaScript from stdin, enabling heredoc usage for multiline scripts. Also fix binary permission issues on macOS/Linux when postinstall scripts don't run (e.g., with bun).


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Add --stdin flag for the eval command to read JavaScript from stdin, enabling heredoc usage for multiline scripts. Also fix binary permission issues on macOS/Linux when postinstall scripts don't run (e.g., with bun).

---
*This PR was created automatically by autoship*