### PR TITLE
chore: minor release - Add iOS Simulator and real device support for mobi

### DIFF
--- a/.changeset/release-17dc02f0.md
+++ b/.changeset/release-17dc02f0.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": minor
+---
+
+Add iOS Simulator and real device support for mobile Safari testing via Appium. New CLI commands include `device list` to show available simulators, `tap` and `swipe` for touch interactions, and the `--device` flag to specify which iOS device to use. Configure with `-p ios` provider flag or `AGENT_BROWSER_PROVIDER=ios` environment variable.


### PR DESCRIPTION
## Release Changeset

**Type:** minor

**Changes:**
Add iOS Simulator and real device support for mobile Safari testing via Appium. New CLI commands include  to show available simulators,  and  for touch interactions, and the  flag to specify which iOS device to use. Configure with  provider flag or  environment variable.

---
*This PR was created automatically by autoship*