### PR TITLE
Fix dialog dismiss parsing in CLI

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -709,6 +709,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                     }
                     Ok(cmd)
                 }
+                Some("dismiss") => Ok(json!({ "id": id, "action": "dialog", "response": "dismiss" })),
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
                     valid_options: VALID,


### PR DESCRIPTION
## What’s going on
The CLI help and README list `dialog dismiss` as a valid subcommand, but the dialog parser only handles `accept`. Any other value (including `dismiss`) falls into `UnknownSubcommand` and the CLI exits with an error.

- README docs: https://github.com/vercel-labs/agent-browser/blob/main/README.md#L209-L214
- CLI parser today: https://github.com/vercel-labs/agent-browser/blob/main/cli/src/commands.rs#L701-L719

## Fix
Add a `dismiss` branch to the dialog parser to emit the correct command JSON:

```
{ "id": id, "action": "dialog", "response": "dismiss" }
```

This matches the existing protocol and runtime support:
- Dialog schema accepts `dismiss`: https://github.com/vercel-labs/agent-browser/blob/main/src/protocol.ts#L198-L202
- Dialog command type: https://github.com/vercel-labs/agent-browser/blob/main/src/types.ts#L177-L181
- Runtime handler supports dismiss: https://github.com/vercel-labs/agent-browser/blob/main/src/browser.ts#L246-L262

## Why this is safe
It only changes CLI parsing for `dialog` and doesn’t touch the protocol or Playwright behavior.

## Testing
Not run (no CLI tests in repo).
