### PR TITLE
fix: forward environment variables to browser subprocess

### DIFF
--- a/.changeset/fix-headed-display-env.md
+++ b/.changeset/fix-headed-display-env.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fix `--headed` mode on Linux by forwarding environment variables (including `DISPLAY`) to the browser subprocess

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1097,6 +1097,7 @@ export class BrowserManager {
           userAgent: options.userAgent,
           ...(options.proxy && { proxy: options.proxy }),
           ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
+          env: { ...process.env },
         }
       );
       this.isPersistentContext = true;
@@ -1113,6 +1114,7 @@ export class BrowserManager {
         userAgent: options.userAgent,
         ...(options.proxy && { proxy: options.proxy }),
         ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
+        env: { ...process.env },
       });
       this.isPersistentContext = true;
     } else {
@@ -1121,6 +1123,7 @@ export class BrowserManager {
         headless: options.headless ?? true,
         executablePath: options.executablePath,
         args: options.args,
+        env: { ...process.env },
       });
       this.cdpEndpoint = null;
       context = await this.browser.newContext({


### PR DESCRIPTION
## Summary

- Forward environment variables to browser subprocess via Playwright's `env` option
- Enables `--headed` mode on Linux with virtual displays (Xvnc, Xvfb)
- Adds `env: { ...process.env }` to all 3 browser launch paths

## Problem

When using `--headed` mode on Linux with a virtual display, the browser fails to launch because the `DISPLAY` environment variable is not forwarded to the Chromium subprocess. Without the `env` option, Playwright doesn't pass any environment variables to the browser process.

Error: `Missing X server or $DISPLAY`

## Solution

Pass `env: { ...process.env }` to Playwright's launch options:
- `launcher.launch()` for regular ephemeral browsers
- `launcher.launchPersistentContext()` for extension mode
- `launcher.launchPersistentContext()` for profile mode

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test` passes (203 tests)
- [x] Manual verification with VNC on Linux

Fixes #369
Related: #155, #150

🤖 Generated with [Claude Code](https://claude.ai/code)