### PR TITLE
fix: set browser on persistent context to fix bad browser ref

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1099,6 +1099,7 @@ export class BrowserManager {
           ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
         }
       );
+      this.browser = context.browser();
       this.isPersistentContext = true;
     } else if (hasProfile) {
       // Profile uses persistent context for durable cookies/storage
@@ -1114,6 +1115,7 @@ export class BrowserManager {
         ...(options.proxy && { proxy: options.proxy }),
         ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
       });
+      this.browser = context.browser();
       this.isPersistentContext = true;
     } else {
       // Regular ephemeral browser


### PR DESCRIPTION
Summary

When launching a persistent context, `this.browser` was not being set. Functions checking `this.browser` fail.

Reproduction

```bash
agent-browser close
agent-browser --profile ~/.hello-world open vercel.com # ✓ Verc...
agent-browser record start /tmp/fail.webm # ✗ Browser not launc...
```

Fix

In the two cases where we're launching persistent contexts, we set `this.browser` to `context.browser()`.