### PR TITLE
feat: add AGENT_BROWSER_VIEWPORT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,17 @@ agent-browser snapshot -i -c -d 5         # Combine options
 | `--cdp <port>` | Connect via Chrome DevTools Protocol |
 | `--debug` | Debug output |
 
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AGENT_BROWSER_SESSION` | Session name for isolated instances | `default` |
+| `AGENT_BROWSER_EXECUTABLE_PATH` | Custom browser executable path | Bundled Chromium |
+| `AGENT_BROWSER_VIEWPORT` | Default viewport size (e.g., `1920x1080` or `1920,1080`) | `1280x720` |
+| `AGENT_BROWSER_STREAM_PORT` | Port for WebSocket stream server (0 to disable) | `0` (disabled) |
+| `AGENT_BROWSER_EXTENSIONS` | Comma-separated list of extension paths | — |
+| `AGENT_BROWSER_DAEMON` | Set to `1` to run as daemon | — |
+
 ## Selectors
 
 ### Refs (Recommended for AI)

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { parseViewportEnv } from './daemon.js';
+
+describe('parseViewportEnv', () => {
+  it('should parse "WIDTHxHEIGHT" format', () => {
+    expect(parseViewportEnv('1920x1080')).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('should parse "WIDTH,HEIGHT" format', () => {
+    expect(parseViewportEnv('1920,1080')).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('should parse default viewport size', () => {
+    expect(parseViewportEnv('1280x720')).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('should return undefined for invalid format', () => {
+    expect(parseViewportEnv('invalid')).toBeUndefined();
+  });
+
+  it('should return undefined for partial format', () => {
+    expect(parseViewportEnv('1920x')).toBeUndefined();
+    expect(parseViewportEnv('x1080')).toBeUndefined();
+  });
+
+  it('should return undefined for empty string', () => {
+    expect(parseViewportEnv('')).toBeUndefined();
+  });
+
+  it('should return undefined for undefined', () => {
+    expect(parseViewportEnv(undefined)).toBeUndefined();
+  });
+
+  it('should reject non-numeric values', () => {
+    expect(parseViewportEnv('abcxdef')).toBeUndefined();
+  });
+
+  it('should reject negative numbers', () => {
+    expect(parseViewportEnv('-1920x1080')).toBeUndefined();
+  });
+
+  it('should reject formats with extra text', () => {
+    expect(parseViewportEnv('1920x1080px')).toBeUndefined();
+    expect(parseViewportEnv('px1920x1080')).toBeUndefined();
+  });
+
+  it('should reject zero width', () => {
+    expect(parseViewportEnv('0x1080')).toBeUndefined();
+  });
+
+  it('should reject zero height', () => {
+    expect(parseViewportEnv('1920x0')).toBeUndefined();
+  });
+
+  it('should reject both zero', () => {
+    expect(parseViewportEnv('0x0')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `AGENT_BROWSER_VIEWPORT` env var to set default viewport size for auto-launched browser sessions (e.g., `1920x1080` or `1920,1080`)
- Extract `parseViewportEnv()` helper in `src/daemon.ts` with full unit test coverage
- Reject non-positive dimensions (e.g., `0x720`) to avoid Playwright errors
- Add Environment Variables reference table to README

## Motivation

The daemon auto-launch hardcodes `1280x720` with no way to persist a preferred viewport. Users had to send an explicit `launch` command or `set viewport` on every session. This follows the same pattern as `AGENT_BROWSER_EXECUTABLE_PATH`, `AGENT_BROWSER_SESSION`, etc.

## Changes

| File | Change |
|------|--------|
| `src/daemon.ts` | Add `parseViewportEnv()` + pass viewport to auto-launch |
| `src/daemon.test.ts` | 13 unit tests for viewport parsing |
| `README.md` | Add Environment Variables table |

## Test plan

- [x] `AGENT_BROWSER_VIEWPORT=1920x1080` → browser reports `innerWidth:1920, innerHeight:1080`
- [x] No env var → defaults to `1280x720`
- [x] New tabs inherit the viewport from context
- [x] `0x1080`, `1920x0`, `0x0` → rejected, falls back to default
- [x] Unit tests: valid formats (`WxH`, `W,H`), invalid/empty/undefined inputs
- [x] Full test suite passes (181 tests)
- [x] TypeScript builds clean