### PR TITLE
feat: network mock

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1327,7 +1327,11 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             let abort = rest.iter().any(|&s| s == "--abort");
             let body_idx = rest.iter().position(|&s| s == "--body");
             let body = body_idx.and_then(|i| rest.get(i + 1).map(|s| *s));
-            Ok(json!({ "id": id, "action": "route", "url": url, "abort": abort, "body": body }))
+            let mut cmd = json!({ "id": id, "action": "route", "url": url, "abort": abort });
+            if let Some(b) = body {
+                cmd["response"] = json!({ "body": b, "contentType": "application/json" });
+            }
+            Ok(cmd)
         }
         Some("unroute") => {
             let mut cmd = json!({ "id": id, "action": "unroute" });


### PR DESCRIPTION
Why this change?                                                                                         
                                                                                                           
  1. Structured response data: Wraps body into a response object and adds a contentType: "application/json" field. This allows the backend to know the MIME type when processing the response.                      
  2. Conditional addition: The response field is only added when the user provides the --body parameter,    avoiding passing unnecessary null values.                                                                
  3. Extensibility: The new structure allows adding more properties to the response object in the future    (such as statusCode, headers, etc.) without adding more top-level fields.                                
  4. Backend API alignment: This structure better aligns with common API design patterns for network        interception/mock responses. The backend likely expects this nested format to properly handle route interception responses.