### PR TITLE
fix: forward environment variables to browser subprocess

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1122,6 +1122,7 @@ export class BrowserManager {
           userAgent: options.userAgent,
           ...(options.proxy && { proxy: options.proxy }),
           ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
+          env: { ...process.env },
         }
       );
       this.isPersistentContext = true;
@@ -1138,6 +1139,7 @@ export class BrowserManager {
         userAgent: options.userAgent,
         ...(options.proxy && { proxy: options.proxy }),
         ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
+        env: { ...process.env },
       });
       this.isPersistentContext = true;
     } else {
@@ -1146,6 +1148,7 @@ export class BrowserManager {
         headless: options.headless ?? true,
         executablePath: options.executablePath,
         args: baseArgs,
+        env: { ...process.env },
       });
       this.cdpEndpoint = null;
       context = await this.browser.newContext({


### PR DESCRIPTION
## Summary

Fixes #369

When launching a browser on Linux in `--headed` mode (e.g., via VNC or Xvfb), Playwright's `launch()` and `launchPersistentContext()` calls did not receive the parent process's environment variables. This caused the `DISPLAY` variable (and any other environment variables) to be missing in the browser subprocess, resulting in the error:

```
Missing X server or $DISPLAY
```

## Root Cause

Playwright's `launch()` accepts an `env` option. When omitted, Playwright uses `process.env` by default in most cases, but in certain deployment scenarios (Docker, VNC, Xvfb), the environment is not correctly inherited by the browser subprocess. Explicitly passing `env: { ...process.env }` ensures all environment variables—including `DISPLAY`—are forwarded reliably.

## Changes

Added `env: { ...process.env }` to all three browser launch calls in `src/browser.ts`:

1. `launcher.launchPersistentContext()` — extensions path
2. `launcher.launchPersistentContext()` — profile path  
3. `launcher.launch()` — regular ephemeral browser

## Impact

This fix affects Linux users running agent-browser in headed mode, particularly in:
- VNC sessions
- Xvfb virtual display environments
- Docker containers with X11 forwarding
- Any setup where `DISPLAY` or other environment variables need to reach the browser process