### PR TITLE
fix: prevent check/uncheck from hanging on hidden checkbox elements

### DIFF
--- a/src/safe-check.test.ts
+++ b/src/safe-check.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { safeCheckAction } from './actions.js';
+
+/**
+ * Tests for safeCheckAction - fix for issue #335
+ * Ensures check/uncheck does not hang on hidden checkbox elements
+ * (common in Element UI, Ant Design, Vuetify, etc.)
+ */
+describe('safeCheckAction', () => {
+  it('should call check() normally when element is visible', async () => {
+    const locator = {
+      check: vi.fn().mockResolvedValue(undefined),
+      uncheck: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await safeCheckAction(locator, 'check');
+    expect(locator.check).toHaveBeenCalledWith({ timeout: 5000 });
+  });
+
+  it('should call uncheck() normally when element is visible', async () => {
+    const locator = {
+      check: vi.fn().mockResolvedValue(undefined),
+      uncheck: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await safeCheckAction(locator, 'uncheck');
+    expect(locator.uncheck).toHaveBeenCalledWith({ timeout: 5000 });
+  });
+
+  it('should retry with force:true when element is not visible (check)', async () => {
+    const locator = {
+      check: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Element is not visible'))
+        .mockResolvedValueOnce(undefined),
+      uncheck: vi.fn(),
+    } as any;
+
+    await safeCheckAction(locator, 'check');
+    expect(locator.check).toHaveBeenCalledTimes(2);
+    expect(locator.check).toHaveBeenLastCalledWith({ force: true });
+  });
+
+  it('should retry with force:true when element is not visible (uncheck)', async () => {
+    const locator = {
+      check: vi.fn(),
+      uncheck: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Element is not visible'))
+        .mockResolvedValueOnce(undefined),
+    } as any;
+
+    await safeCheckAction(locator, 'uncheck');
+    expect(locator.uncheck).toHaveBeenCalledTimes(2);
+    expect(locator.uncheck).toHaveBeenLastCalledWith({ force: true });
+  });
+
+  it('should retry with force:true on timeout (hidden checkbox)', async () => {
+    const locator = {
+      check: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Timeout 5000ms exceeded waiting for element'))
+        .mockResolvedValueOnce(undefined),
+      uncheck: vi.fn(),
+    } as any;
+
+    await safeCheckAction(locator, 'check');
+    expect(locator.check).toHaveBeenCalledTimes(2);
+    expect(locator.check).toHaveBeenLastCalledWith({ force: true });
+  });
+
+  it('should retry with force:true when element is hidden', async () => {
+    const locator = {
+      check: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('element is hidden'))
+        .mockResolvedValueOnce(undefined),
+      uncheck: vi.fn(),
+    } as any;
+
+    await safeCheckAction(locator, 'check');
+    expect(locator.check).toHaveBeenCalledTimes(2);
+    expect(locator.check).toHaveBeenLastCalledWith({ force: true });
+  });
+
+  it('should retry with force:true on "waiting for" error', async () => {
+    const locator = {
+      check: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('waiting for locator to be visible'))
+        .mockResolvedValueOnce(undefined),
+      uncheck: vi.fn(),
+    } as any;
+
+    await safeCheckAction(locator, 'check');
+    expect(locator.check).toHaveBeenCalledTimes(2);
+    expect(locator.check).toHaveBeenLastCalledWith({ force: true });
+  });
+
+  it('should rethrow non-visibility errors', async () => {
+    const locator = {
+      check: vi.fn().mockRejectedValue(new Error('strict mode violation')),
+      uncheck: vi.fn(),
+    } as any;
+
+    await expect(safeCheckAction(locator, 'check')).rejects.toThrow('strict mode violation');
+    expect(locator.check).toHaveBeenCalledTimes(1);
+  });
+
+  it('should rethrow unknown errors for uncheck', async () => {
+    const locator = {
+      check: vi.fn(),
+      uncheck: vi.fn().mockRejectedValue(new Error('some other error')),
+    } as any;
+
+    await expect(safeCheckAction(locator, 'uncheck')).rejects.toThrow('some other error');
+    expect(locator.uncheck).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #335

When using UI component libraries like Element UI, Ant Design, or Vuetify, native checkbox `<input>` elements are typically hidden (`display: none`, `opacity: 0`, or `visibility: hidden`) while a styled wrapper/label is shown instead. The `check` and `uncheck` commands directly operate on the native checkbox via Playwright's `locator.check()` / `locator.uncheck()`, which waits for the element to become visible — causing an indefinite hang.

## Changes

- Added a `safeCheckAction()` helper that first attempts `check()`/`uncheck()` with a **5-second timeout**
- If the action fails due to the element being hidden/not visible/timing out, it **retries with `{ force: true }`** to bypass the visibility check
- Non-visibility errors (e.g., strict mode violations) are re-thrown as before
- Updated **all 6 call sites** across `handleCheck`, `handleUncheck`, `handleGetByRole`, `handleGetByLabel`, `handleFilter`, and `handleNth`
- Added **9 unit tests** covering visible elements, hidden elements (various error messages), and error propagation

## How It Works

```
try check/uncheck with timeout: 5000ms
catch →
  if error is about visibility/hidden/timeout → retry with force: true
  else → rethrow
```

This ensures:
1. **Normal checkboxes** work exactly as before (no behavior change)
2. **Hidden checkboxes** (UI framework pattern) complete successfully via `force: true`
3. **Other errors** propagate unchanged