### PR TITLE
fix: allow first/last as modifiers after role/text locators in find command

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1043,7 +1043,7 @@ Examples:
             r##"
 agent-browser find - Find and interact with elements by locator
 
-Usage: agent-browser find <locator> <value> [action] [text]
+Usage: agent-browser find <locator> <value> [first|last|nth <n>] [action] [text]
 
 Finds elements using semantic locators and optionally performs an action.
 
@@ -1058,6 +1058,11 @@ Locators:
   first <selector>         First matching element
   last <selector>          Last matching element
   nth <index> <selector>   Nth matching element (0-based)
+
+Modifiers (chain after any locator to narrow results):
+  first                    Select the first match
+  last                     Select the last match
+  nth <index>              Select the nth match (0-based)
 
 Actions (default: click):
   click, fill, type, hover, focus, check, uncheck
@@ -1078,6 +1083,9 @@ Examples:
   agent-browser find testid "login-form" click
   agent-browser find first "li.item" click
   agent-browser find nth 2 ".card" hover
+  agent-browser find role spinbutton first fill "20"
+  agent-browser find text "Submit" last click
+  agent-browser find label "Email" nth 2 fill "user@example.com"
 "##
         }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -887,7 +887,10 @@ async function handleGetByRole(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByRole(command.role as any, { name: command.name });
+  let locator = page.getByRole(command.role as any, { name: command.name });
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':
@@ -910,12 +913,18 @@ async function handleGetByText(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByText(command.text, { exact: command.exact });
+  let locator = page.getByText(command.text, { exact: command.exact });
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':
       await locator.click();
       return successResponse(command.id, { clicked: true });
+    case 'fill':
+      await locator.fill(command.value ?? '');
+      return successResponse(command.id, { filled: true });
     case 'hover':
       await locator.hover();
       return successResponse(command.id, { hovered: true });
@@ -927,7 +936,10 @@ async function handleGetByLabel(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByLabel(command.label);
+  let locator = page.getByLabel(command.label);
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':
@@ -947,7 +959,10 @@ async function handleGetByPlaceholder(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByPlaceholder(command.placeholder);
+  let locator = page.getByPlaceholder(command.placeholder);
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':
@@ -1660,7 +1675,10 @@ async function handleGetByAltText(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByAltText(command.text, { exact: command.exact });
+  let locator = page.getByAltText(command.text, { exact: command.exact });
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':
@@ -1677,7 +1695,10 @@ async function handleGetByTitle(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByTitle(command.text, { exact: command.exact });
+  let locator = page.getByTitle(command.text, { exact: command.exact });
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':
@@ -1694,7 +1715,10 @@ async function handleGetByTestId(
   browser: BrowserManager
 ): Promise<Response> {
   const page = browser.getPage();
-  const locator = page.getByTestId(command.testId);
+  let locator = page.getByTestId(command.testId);
+  if (command.index !== undefined) {
+    locator = command.index === -1 ? locator.last() : locator.nth(command.index);
+  }
 
   switch (command.subaction) {
     case 'click':

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface GetByRoleCommand extends BaseCommand {
   action: 'getbyrole';
   role: string;
   name?: string;
+  index?: number; // 0 = first, -1 = last, or nth index
   subaction: 'click' | 'fill' | 'check' | 'hover';
   value?: string;
 }
@@ -116,12 +117,15 @@ export interface GetByTextCommand extends BaseCommand {
   action: 'getbytext';
   text: string;
   exact?: boolean;
-  subaction: 'click' | 'hover';
+  index?: number; // 0 = first, -1 = last, or nth index
+  subaction: 'click' | 'hover' | 'fill';
+  value?: string;
 }
 
 export interface GetByLabelCommand extends BaseCommand {
   action: 'getbylabel';
   label: string;
+  index?: number; // 0 = first, -1 = last, or nth index
   subaction: 'click' | 'fill' | 'check';
   value?: string;
 }
@@ -129,6 +133,7 @@ export interface GetByLabelCommand extends BaseCommand {
 export interface GetByPlaceholderCommand extends BaseCommand {
   action: 'getbyplaceholder';
   placeholder: string;
+  index?: number; // 0 = first, -1 = last, or nth index
   subaction: 'click' | 'fill';
   value?: string;
 }
@@ -335,6 +340,7 @@ export interface GetByAltTextCommand extends BaseCommand {
   action: 'getbyalttext';
   text: string;
   exact?: boolean;
+  index?: number; // 0 = first, -1 = last, or nth index
   subaction: 'click' | 'hover';
 }
 
@@ -342,12 +348,14 @@ export interface GetByTitleCommand extends BaseCommand {
   action: 'getbytitle';
   text: string;
   exact?: boolean;
+  index?: number; // 0 = first, -1 = last, or nth index
   subaction: 'click' | 'hover';
 }
 
 export interface GetByTestIdCommand extends BaseCommand {
   action: 'getbytestid';
   testId: string;
+  index?: number; // 0 = first, -1 = last, or nth index
   subaction: 'click' | 'fill' | 'check' | 'hover';
   value?: string;
 }


### PR DESCRIPTION
## Summary

Fixes #364

Currently, `first` and `last` are only recognized as standalone locator types in the `find` command (e.g., `find first <selector>`). This means chaining them as modifiers after semantic locators like `role`, `text`, `label`, etc. fails with an error.

For example, this command fails:
```
agent-browser find role spinbutton first fill '20'
```

Because `first` at position 3 is interpreted as the subaction (like `click`/`fill`), not as a modifier.

## Changes

### CLI Parser (`cli/src/commands.rs`)
- After parsing a semantic locator (`role`, `text`, `label`, `placeholder`, `alt`, `title`, `testid`) and its value, the parser now checks if the next token is `first`, `last`, or `nth`
- If found, it adds an `index` field to the JSON command (0 for first, -1 for last, or the specified index for nth) and shifts the remaining arguments accordingly
- Standalone `find first <selector>` and `find last <selector>` continue to work as before (backward compatible)

### Server-side Handlers (`src/actions.ts`, `src/types.ts`)
- Added optional `index` field to `GetByRoleCommand`, `GetByTextCommand`, `GetByLabelCommand`, `GetByPlaceholderCommand`, `GetByAltTextCommand`, `GetByTitleCommand`, and `GetByTestIdCommand` interfaces
- Updated all `handleGetBy*` functions to apply `.first()`, `.last()`, or `.nth()` on the locator when an `index` field is present

### Help Text (`cli/src/output.rs`)
- Updated the `find` command help to document the new modifier syntax with examples

### Tests
- Added 13 new tests covering:
  - `find role <role> first/last/nth <n> <action> [value]`
  - `find text <text> first <action>`
  - `find label <label> last <action> <value>`
  - `find placeholder <text> first <action> <value>`
  - `find testid <id> last <action>`
  - Backward compatibility: standalone `find first/last <selector>` still works
  - Backward compatibility: `find role <role> <action>` without modifier has no index field

## Examples

```bash
# Before (fails): first is treated as subaction
agent-browser find role spinbutton first fill '20'

# After (works): first is a modifier, fill is the subaction
agent-browser find role spinbutton first fill '20'
# → getbyrole with role=spinbutton, index=0, subaction=fill, value=20

# Other examples:
agent-browser find text "Submit" last click
agent-browser find label "Email" nth 2 fill "user@example.com"
agent-browser find role listitem nth 3 click
```