### PR TITLE
fix: prevent native file picker dialog during uploads

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -826,14 +826,23 @@ async function handleUncheck(command: UncheckCommand, browser: BrowserManager): 
 }
 
 async function handleUpload(command: UploadCommand, browser: BrowserManager): Promise<Response> {
-  const locator = browser.getLocator(command.selector);
   const files = Array.isArray(command.files) ? command.files : [command.files];
+
   try {
-    await locator.setInputFiles(files);
+    const absoluteFiles = files.map((file) => {
+      if (path.isAbsolute(file)) {
+        return file;
+      }
+      return path.resolve(process.cwd(), file);
+    });
+
+    const locator = browser.getLocator(command.selector);
+    await locator.setInputFiles(absoluteFiles);
+
+    return successResponse(command.id, { uploaded: absoluteFiles });
   } catch (error) {
     throw toAIFriendlyError(error, command.selector);
   }
-  return successResponse(command.id, { uploaded: files });
 }
 
 async function handleDoubleClick(


### PR DESCRIPTION
## Fix file upload with relative paths

The upload command fails when relative file paths are passed because Playwright's `setInputFiles` expects absolute paths. This resolves relative paths to absolute before passing them to `setInputFiles`.

The previous approach of using CDP `DOM.setFileInputFiles` to avoid the native file dialog is unnecessary — Playwright's `setInputFiles` already bypasses the native dialog entirely. The CDP approach actually introduced a regression: cached CDP sessions become stale after page navigations, causing `Target page, context or browser has been closed` errors.

This keeps the fix minimal: just add path resolution while staying with Playwright's built-in API.

Fixes #192