### PR TITLE
fix(cli): read AGENT_BROWSER_CDP from environment variable

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -53,7 +53,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         session: env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
         headers: None,
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH").ok(),
-        cdp: None,
+        cdp: env::var("AGENT_BROWSER_CDP").ok(),
         extensions: extensions_env,
         profile: env::var("AGENT_BROWSER_PROFILE").ok(),
         state: env::var("AGENT_BROWSER_STATE").ok(),


### PR DESCRIPTION
## Summary

The `--cdp` flag allows connecting to an existing browser via CDP, but unlike every other CLI flag (`AGENT_BROWSER_EXECUTABLE_PATH`, `AGENT_BROWSER_PROFILE`, `AGENT_BROWSER_PROXY`, `AGENT_BROWSER_ARGS`, etc.), it had no environment variable fallback. The default was hardcoded to `None`.

This one-line fix reads `AGENT_BROWSER_CDP` from the environment, following the exact same pattern as all sibling flags in `flags.rs`.

### Use case

Users who always connect to an existing browser via CDP (e.g., a remote Chrome instance over SSH tunnel) had to pass `--cdp <port>` on every single invocation. With this fix, they can set `AGENT_BROWSER_CDP=9223` once in their shell profile and all commands just work.

### Before
```bash
# Every command needs --cdp
agent-browser --cdp 9223 open https://example.com
agent-browser --cdp 9223 snapshot -i
agent-browser --cdp 9223 tab list
```

### After
```bash
export AGENT_BROWSER_CDP=9223
agent-browser open https://example.com
agent-browser snapshot -i
agent-browser tab list
```

## Changes

- `cli/src/flags.rs`: `cdp: None` → `cdp: env::var("AGENT_BROWSER_CDP").ok()`
