### PR TITLE
fix: use current viewport size for video recording instead of hardcoded 1280x720

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1702,7 +1702,9 @@ export class BrowserManager {
     this.recordingOutputPath = outputPath;
 
     // Create a new context with video recording enabled and restored state
-    const viewport = { width: 1280, height: 720 };
+    // Use the current page's viewport size so the recording matches what the user sees
+    const currentViewport = currentPage?.viewportSize() ?? { width: 1280, height: 720 };
+    const viewport = { width: currentViewport.width, height: currentViewport.height };
     this.recordingContext = await this.browser.newContext({
       viewport,
       recordVideo: {


### PR DESCRIPTION
## Summary

- `startRecording()` creates a new browser context with `recordVideo.size` hardcoded to `{ width: 1280, height: 720 }`. This means that when a custom viewport is set (e.g. `430x932` for mobile emulation), the recording ignores it and always produces a 1280x720 (16:9) video.
- Since Playwright's `recordVideo.size` is immutable after context creation, the only way to get the correct recording dimensions is to read the current page's viewport at the time recording starts.
- This change reads `currentPage.viewportSize()` (already available in scope) and falls back to the previous 1280x720 default when no page exists.

## Reproduction

```bash
agent-browser open https://example.com
agent-browser set viewport 430 932
agent-browser record start ./demo.webm
agent-browser wait 2000
agent-browser record stop
ffprobe -v error -select_streams v:0 -show_entries stream=width,height,display_aspect_ratio -of json ./demo.webm
# Before fix: width=1280, height=720
# After fix:  width=430, height=932
```

## Proof

### Test 1: Custom viewport (430x932) → recording matches

```bash
agent-browser open https://example.com --headed
agent-browser set viewport 430 932
agent-browser record start /tmp/test-recording.webm
agent-browser wait 2000
agent-browser record stop
```

```json
{ "width": 430, "height": 932, "display_aspect_ratio": "215:466" }
```

### Test 2: No viewport set → defaults to 1280x720

```bash
agent-browser open https://example.com --headed
# (no set viewport)
agent-browser record start /tmp/test-default-viewport.webm
agent-browser wait 2000
agent-browser record stop
```

```json
{ "width": 1280, "height": 720, "display_aspect_ratio": "16:9" }
```

### Test 3: `record restart` preserves custom viewport

```bash
agent-browser set viewport 430 932
agent-browser record start /tmp/test-restart-before.webm
agent-browser wait 1000
agent-browser record restart /tmp/test-restart-after.webm
agent-browser wait 1000
agent-browser record stop
```

Both segments:
```json
{ "width": 430, "height": 932, "display_aspect_ratio": "215:466" }
```

## Test plan

- [x] Set a non-default viewport (430x932), start recording, stop recording — output video is 430x932
- [x] Start recording without setting a viewport first — still defaults to 1280x720
- [x] `record restart` also picks up the correct viewport size