### PR TITLE
feat: add --kiosk flag for fullscreen Chromium without browser chrome

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1579,6 +1579,7 @@ mod tests {
             provider: None,
             ignore_https_errors: false,
             allow_file_access: false,
+            kiosk: false,
             device: None,
             auto_connect: false,
             session_name: None,
@@ -1591,6 +1592,7 @@ mod tests {
             cli_proxy: false,
             cli_proxy_bypass: false,
             cli_allow_file_access: false,
+            cli_kiosk: false,
             annotate: false,
         }
     }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -195,6 +195,7 @@ pub struct Flags {
     pub provider: Option<String>,
     pub ignore_https_errors: bool,
     pub allow_file_access: bool,
+    pub kiosk: bool,
     pub device: Option<String>,
     pub auto_connect: bool,
     pub session_name: Option<String>,
@@ -211,6 +212,7 @@ pub struct Flags {
     pub cli_proxy: bool,
     pub cli_proxy_bypass: bool,
     pub cli_allow_file_access: bool,
+    pub cli_kiosk: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -270,6 +272,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             || config.ignore_https_errors.unwrap_or(false),
         allow_file_access: env_var_is_truthy("AGENT_BROWSER_ALLOW_FILE_ACCESS")
             || config.allow_file_access.unwrap_or(false),
+        kiosk: env_var_is_truthy("AGENT_BROWSER_KIOSK"),
         device: env::var("AGENT_BROWSER_IOS_DEVICE").ok()
             .or(config.device),
         auto_connect: env_var_is_truthy("AGENT_BROWSER_AUTO_CONNECT")
@@ -287,6 +290,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_proxy: false,
         cli_proxy_bypass: false,
         cli_allow_file_access: false,
+        cli_kiosk: false,
     };
 
     let mut i = 0;
@@ -403,6 +407,10 @@ pub fn parse_flags(args: &[String]) -> Flags {
                 flags.cli_allow_file_access = true;
                 if consumed { i += 1; }
             }
+            "--kiosk" => {
+                flags.kiosk = true;
+                flags.cli_kiosk = true;
+            }
             "--device" => {
                 if let Some(d) = args.get(i + 1) {
                     flags.device = Some(d.clone());
@@ -450,6 +458,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--allow-file-access",
         "--auto-connect",
         "--annotate",
+        "--kiosk",
     ];
     // Global flags that always take a value (need to skip the next arg too)
     const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1967,6 +1967,7 @@ Options:
   --full, -f                 Full page screenshot
   --annotate                 Annotated screenshot with numbered labels and legend
   --headed                   Show browser window (not headless)
+  --kiosk                    Fullscreen kiosk mode (Chromium, implies --headed)
   --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
   --auto-connect             Auto-discover and connect to running Chrome
   --session-name <name>      Auto-save/restore session state (cookies, localStorage)

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -521,6 +521,8 @@ async function handleNavigate(
     waitUntil: command.waitUntil ?? 'load',
   });
 
+  await browser.applyKioskFullscreen();
+
   return successResponse(command.id, {
     url: page.url(),
     title: await page.title(),

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -51,6 +51,7 @@ const launchSchema = baseCommandSchema.extend({
   allowFileAccess: z.boolean().optional(),
   profile: z.string().optional(),
   storageState: z.string().optional(),
+  kiosk: z.boolean().optional(),
 });
 
 const navigateSchema = baseCommandSchema.extend({

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface LaunchCommand extends BaseCommand {
   allowFileAccess?: boolean; // Enable file:// URL access and cross-origin file requests
   // Auto-load state file for session persistence
   autoStateFilePath?: string;
+  kiosk?: boolean; // Launch in kiosk mode (fullscreen, headed Chromium only)
 }
 
 export interface NavigateCommand extends BaseCommand {


### PR DESCRIPTION
## Summary

- Adds `--kiosk` CLI flag and `AGENT_BROWSER_KIOSK` env var for launching Chromium in fullscreen kiosk mode (no address bar, tabs, or browser chrome)
- Passes `--kiosk` as a Chromium launch argument and implies `--headed` (kiosk mode requires a visible window)
- Useful for demos, digital signage, and presentation workflows where a clean fullscreen viewport is needed

## Changes

- `cli/src/flags.rs` - New `kiosk` flag with env var support and CLI tracking
- `cli/src/commands.rs` - Passes kiosk flag through to the daemon launch command
- `cli/src/main.rs` - Implies `--headed` when `--kiosk` is set
- `cli/src/output.rs` - Help text for the new flag
- `src/actions.ts` - Adds `--kiosk` to Chromium launch args when requested
- `src/browser.ts` - Accepts kiosk option in launch config
- `src/protocol.ts` - Validates kiosk field in launch schema
- `src/types.ts` - Adds kiosk to LaunchCommand interface

## Test plan

- [ ] `agent-browser --kiosk open example.com` launches fullscreen without browser chrome
- [ ] `AGENT_BROWSER_KIOSK=1 agent-browser open example.com` works via env var
- [ ] `--kiosk` without `--headed` still opens a visible window (implied headed)
- [ ] Existing tests pass (`npm test`, `cargo test`)