### PR TITLE
feat: add WebP format, --format and --quality options for screenshots

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -371,6 +371,60 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
 
         // === Screenshot/PDF ===
         "screenshot" => {
+            // Extract --format and --quality flags before positional parsing
+            let mut filtered_rest: Vec<&str> = Vec::new();
+            let mut format_value: Option<String> = None;
+            let mut quality_value: Option<u32> = None;
+            let mut i = 0;
+            while i < rest.len() {
+                if rest[i] == "--format" {
+                    if let Some(val) = rest.get(i + 1) {
+                        match *val {
+                            "png" | "jpeg" | "webp" => {
+                                format_value = Some(val.to_string());
+                            }
+                            _ => {
+                                return Err(ParseError::InvalidValue {
+                                    message: format!("Invalid format: '{}'. Use 'png', 'jpeg', or 'webp'", val),
+                                    usage: "screenshot [selector] [path] [--format png|jpeg|webp]",
+                                });
+                            }
+                        }
+                        i += 2;
+                        continue;
+                    } else {
+                        return Err(ParseError::MissingArguments {
+                            context: "--format requires a value".to_string(),
+                            usage: "screenshot [selector] [path] [--format png|jpeg|webp]",
+                        });
+                    }
+                } else if rest[i] == "--quality" {
+                    if let Some(val) = rest.get(i + 1) {
+                        match val.parse::<u32>() {
+                            Ok(q) if q <= 100 => {
+                                quality_value = Some(q);
+                            }
+                            _ => {
+                                return Err(ParseError::InvalidValue {
+                                    message: format!("Invalid quality: '{}'. Use a number between 0 and 100", val),
+                                    usage: "screenshot [selector] [path] [--quality 0-100]",
+                                });
+                            }
+                        }
+                        i += 2;
+                        continue;
+                    } else {
+                        return Err(ParseError::MissingArguments {
+                            context: "--quality requires a value".to_string(),
+                            usage: "screenshot [selector] [path] [--quality 0-100]",
+                        });
+                    }
+                }
+                filtered_rest.push(rest[i]);
+                i += 1;
+            }
+            let rest = filtered_rest;
+
             // screenshot [selector] [path]
             // selector: @ref or CSS selector
             // path: file path (contains / or . or ends with known extension)
@@ -399,9 +453,25 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 }
                 _ => (None, None),
             };
-            Ok(
-                json!({ "id": id, "action": "screenshot", "path": path, "selector": selector, "fullPage": flags.full, "annotate": flags.annotate }),
-            )
+            let mut cmd = json!({ "id": id, "action": "screenshot", "path": path, "selector": selector, "fullPage": flags.full, "annotate": flags.annotate });
+            // Format resolution: --format flag > file extension > env var > omit for server default
+            let resolved_format = format_value.or_else(|| {
+                path.and_then(|p| {
+                    if p.ends_with(".webp") { Some("webp".to_string()) }
+                    else if p.ends_with(".jpg") || p.ends_with(".jpeg") { Some("jpeg".to_string()) }
+                    else if p.ends_with(".png") { Some("png".to_string()) }
+                    else { None }
+                })
+            }).or_else(|| flags.screenshot_format.clone());
+            if let Some(fmt) = resolved_format {
+                cmd["format"] = json!(fmt);
+            }
+            // Quality: --quality flag > env var > omit
+            let resolved_quality = quality_value.or(flags.screenshot_quality);
+            if let Some(q) = resolved_quality {
+                cmd["quality"] = json!(q);
+            }
+            Ok(cmd)
         }
         "pdf" => {
             let path = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -1582,6 +1652,8 @@ mod tests {
             device: None,
             auto_connect: false,
             session_name: None,
+            screenshot_format: None,
+            screenshot_quality: None,
             cli_executable_path: false,
             cli_extensions: false,
             cli_profile: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -199,6 +199,8 @@ pub struct Flags {
     pub auto_connect: bool,
     pub session_name: Option<String>,
     pub annotate: bool,
+    pub screenshot_format: Option<String>,
+    pub screenshot_quality: Option<u32>,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -278,6 +280,8 @@ pub fn parse_flags(args: &[String]) -> Flags {
             .or(config.session_name),
         annotate: env_var_is_truthy("AGENT_BROWSER_ANNOTATE")
             || config.annotate.unwrap_or(false),
+        screenshot_format: env::var("AGENT_BROWSER_SCREENSHOT_FORMAT").ok(),
+        screenshot_quality: env::var("AGENT_BROWSER_SCREENSHOT_QUALITY").ok().and_then(|s| s.parse().ok()),
         cli_executable_path: false,
         cli_extensions: false,
         cli_profile: false,

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -990,11 +990,16 @@ Captures a screenshot of the current page. If no path is provided,
 saves to a temporary directory with a generated filename.
 
 Options:
-  --full, -f           Capture full page (not just viewport)
-  --annotate           Overlay numbered labels on interactive elements.
-                       Each label [N] corresponds to ref @eN from snapshot.
-                       Prints a legend mapping labels to element roles/names.
-                       With --json, annotations are included in the response.
+  --full, -f                 Capture full page (not just viewport)
+  --annotate                 Overlay numbered labels on interactive elements.
+                             Each label [N] corresponds to ref @eN from snapshot.
+                             Prints a legend mapping labels to element roles/names.
+                             With --json, annotations are included in the response.
+  --format <png|jpeg|webp>   Image format (default: png, or inferred from path)
+  --quality <0-100>          Compression quality (jpeg and webp only)
+
+Format is auto-detected from file extension when not specified.
+Set defaults via AGENT_BROWSER_SCREENSHOT_FORMAT and AGENT_BROWSER_SCREENSHOT_QUALITY.
 
 Global Options:
   --json               Output as JSON
@@ -1003,6 +1008,8 @@ Global Options:
 Examples:
   agent-browser screenshot
   agent-browser screenshot ./screenshot.png
+  agent-browser screenshot ./shot.webp
+  agent-browser screenshot --format webp --quality 80
   agent-browser screenshot --full ./full-page.png
   agent-browser screenshot --annotate              # Labeled screenshot + legend
   agent-browser screenshot --annotate ./page.png   # Save annotated screenshot
@@ -1881,7 +1888,7 @@ Core Commands:
   scroll <dir> [px]          Scroll (up/down/left/right)
   scrollintoview <sel>       Scroll element into view
   wait <sel|ms>              Wait for element or time
-  screenshot [path]          Take screenshot
+  screenshot [path]          Take screenshot (--format png|jpeg|webp, --quality)
   pdf <path>                 Save as PDF
   snapshot                   Accessibility tree with refs (for AI)
   eval <js>                  Run JavaScript
@@ -2013,6 +2020,8 @@ Environment:
   AGENT_BROWSER_STREAM_PORT      Enable WebSocket streaming on port (e.g., 9223)
   AGENT_BROWSER_IOS_DEVICE       Default iOS device name
   AGENT_BROWSER_IOS_UDID         Default iOS device UDID
+  AGENT_BROWSER_SCREENSHOT_FORMAT     Default screenshot format (png, jpeg, webp)
+  AGENT_BROWSER_SCREENSHOT_QUALITY    Default screenshot quality (0-100, jpeg/webp)
 
 Install (recommended, fastest - native Rust CLI):
   npm install -g agent-browser

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -751,7 +751,7 @@ const screenshotSchema = baseCommandSchema.extend({
   path: z.string().nullable().optional(),
   fullPage: z.boolean().optional(),
   selector: z.string().min(1).nullish(),
-  format: z.enum(['png', 'jpeg']).optional(),
+  format: z.enum(['png', 'jpeg', 'webp']).optional(),
   quality: z.number().min(0).max(100).optional(),
   annotate: z.boolean().optional(),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -805,7 +805,7 @@ export interface ScreenshotCommand extends BaseCommand {
   path?: string;
   fullPage?: boolean;
   selector?: string;
-  format?: 'png' | 'jpeg';
+  format?: 'png' | 'jpeg' | 'webp';
   quality?: number;
   annotate?: boolean;
 }


### PR DESCRIPTION
## Summary

- Adds WebP screenshot support via CDP `Page.captureScreenshot` (Playwright only supports png/jpeg natively)
- New `--format <png|jpeg|webp>` flag to explicitly set screenshot format
- New `--quality <0-100>` flag for compression control (jpeg and webp)
- Auto-detects format from file extension: `screenshot foo.webp` just works
- Configurable defaults via `AGENT_BROWSER_SCREENSHOT_FORMAT` and `AGENT_BROWSER_SCREENSHOT_QUALITY` env vars

**Note:** This PR builds on the `--scale` feature's CDP path. If that PR hasn't been merged yet, this one depends on it.

### Format resolution order

1. Explicit `--format` flag (highest priority)
2. Inferred from output file extension (`.webp`, `.jpg`, `.png`)
3. `AGENT_BROWSER_SCREENSHOT_FORMAT` env var
4. Default: `png`

### Size comparison (myrobotbrain.com viewport screenshot)

| Format | Size | vs PNG |
|---|---|---|
| PNG | 182 KB | baseline |
| WebP (default) | 32 KB | 82% smaller |
| WebP (quality 80) | 32 KB | 82% smaller |
| WebP (quality 60) | 25 KB | 86% smaller |

## Changes

- `src/types.ts` - Adds `'webp'` to ScreenshotCommand format union
- `src/protocol.ts` - Adds `'webp'` to Zod format enum
- `src/actions.ts` - Format inference from file extension, CDP routing for webp, quality support for webp
- `cli/src/flags.rs` - `screenshot_format` and `screenshot_quality` fields from env vars
- `cli/src/commands.rs` - `--format` and `--quality` flag parsing with validation, extension-based inference
- `cli/src/output.rs` - Updated help text and environment variable documentation

## Test plan

- [ ] `agent-browser screenshot foo.webp` saves as webp (extension inference)
- [ ] `agent-browser screenshot --format webp` saves webp with auto-generated filename
- [ ] `agent-browser screenshot --format webp --quality 80 ./shot.webp` compressed webp
- [ ] `agent-browser screenshot --format jpeg --quality 50 ./shot.jpg` compressed jpeg
- [ ] `AGENT_BROWSER_SCREENSHOT_FORMAT=webp agent-browser screenshot` defaults to webp
- [ ] `agent-browser screenshot ./shot.png` still works as before (no regression)
- [ ] Existing tests pass (`npm test`, `cargo test`)