### PR TITLE
fix: pass --executable-path to launch command in CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -415,6 +415,7 @@ fn main() {
 
     // Launch headed browser or configure browser options (without CDP or provider)
     if (flags.headed
+        || flags.executable_path.is_some()
         || flags.profile.is_some()
         || flags.state.is_some()
         || flags.proxy.is_some()
@@ -433,6 +434,11 @@ fn main() {
         let cmd_obj = launch_cmd
             .as_object_mut()
             .expect("json! macro guarantees object type");
+
+        // Add executable path if specified
+        if let Some(ref exec_path) = flags.executable_path {
+            cmd_obj.insert("executablePath".to_string(), json!(exec_path));
+        }
 
         // Add profile path if specified
         if let Some(ref profile_path) = flags.profile {


### PR DESCRIPTION
Fixes #422

## Problem

The `--executable-path` option (and `AGENT_BROWSER_EXECUTABLE_PATH` env var) was silently ignored when combined with other flags like `--headed`. The CLI always launched Playwright's bundled Chrome for Testing instead of the specified browser executable.

## Root Cause

Two bugs in `cli/src/main.rs` in the block that sends an explicit launch command to the daemon:

1. The condition that triggers the explicit launch block did not include `executable_path.is_some()`, so `--executable-path` alone would not send a launch command with the path included.

2. When the block was triggered by another flag (e.g. `--headed`), the `executablePath` field was never added to the launch JSON. Every other launch option (profile, state, proxy, userAgent, args, allowFileAccess, ignoreHTTPSErrors) was included, but `executablePath` was missing.

## Fix

- Added `flags.executable_path.is_some()` to the trigger condition
- Added the `executablePath` field to the launch command JSON when present

## Testing

- All 159 Rust tests pass
- All 226 TypeScript tests pass
- End-to-end verified: `--executable-path` with `--headed` now launches the specified browser executable