### PR TITLE
fix: resolve stale session, ref resolution and cursor-ref collision bugs

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -191,6 +191,35 @@ agent-browser find placeholder "Search" type "query"
 agent-browser find testid "submit-btn" click
 ```
 
+## JavaScript Evaluation (eval)
+
+Use `eval` to run JavaScript in the browser context. **Shell quoting can corrupt complex expressions** -- use `--stdin` or `-b` to avoid issues.
+
+```bash
+# Simple expressions work with regular quoting
+agent-browser eval 'document.title'
+agent-browser eval 'document.querySelectorAll("img").length'
+
+# Complex JS: use --stdin with heredoc (RECOMMENDED)
+agent-browser eval --stdin <<'EVALEOF'
+JSON.stringify(
+  Array.from(document.querySelectorAll("img"))
+    .filter(i => !i.alt)
+    .map(i => ({ src: i.src.split("/").pop(), width: i.width }))
+)
+EVALEOF
+
+# Alternative: base64 encoding (avoids all shell escaping issues)
+agent-browser eval -b "$(echo -n 'Array.from(document.querySelectorAll("a")).map(a => a.href)' | base64)"
+```
+
+**Why this matters:** When the shell processes your command, inner double quotes, `!` characters (history expansion), backticks, and `$()` can all corrupt the JavaScript before it reaches agent-browser. The `--stdin` and `-b` flags bypass shell interpretation entirely.
+
+**Rules of thumb:**
+- Single-line, no nested quotes -> regular `eval 'expression'` with single quotes is fine
+- Nested quotes, arrow functions, template literals, or multiline -> use `eval --stdin <<'EVALEOF'`
+- Programmatic/generated scripts -> use `eval -b` with base64
+
 ## Deep-Dive Documentation
 
 | Reference | When to Use |

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -651,7 +651,7 @@ async function handleScroll(command: ScrollCommand, browser: BrowserManager): Pr
   const page = browser.getPage();
 
   if (command.selector) {
-    const element = page.locator(command.selector);
+    const element = browser.getLocator(command.selector);
     await element.scrollIntoViewIfNeeded();
 
     if (command.x !== undefined || command.y !== undefined) {
@@ -1843,8 +1843,7 @@ async function handleScrollIntoView(
   command: ScrollIntoViewCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  await page.locator(command.selector).scrollIntoViewIfNeeded();
+  await browser.getLocator(command.selector).scrollIntoViewIfNeeded();
   return successResponse(command.id, { scrolled: true });
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -329,6 +329,17 @@ export async function startDaemon(options?: {
             }
           }
 
+          // Recover from stale state: browser is launched but all pages were closed
+          if (
+            manager instanceof BrowserManager &&
+            manager.isLaunched() &&
+            !manager.hasPages() &&
+            parseResult.command.action !== 'launch' &&
+            parseResult.command.action !== 'close'
+          ) {
+            await manager.ensurePage();
+          }
+
           // Handle close command specially - shuts down daemon
           if (parseResult.command.action === 'close') {
             const response =

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -204,7 +204,16 @@ async function findCursorInteractiveElements(
         }
         path.unshift(sel);
         current = current.parentElement;
-        if (path.length >= 3) break;
+        // Stop once the selector uniquely identifies the element (max 10 levels)
+        if (path.length >= 1) {
+          try {
+            const candidate = path.join(' > ');
+            if (document.querySelectorAll(candidate).length === 1) break;
+          } catch (e) {
+            // If selector is invalid, keep building
+          }
+        }
+        if (path.length >= 10) break;
       }
       return path.join(' > ');
     };


### PR DESCRIPTION
Fixes four bugs surfaced by a real-world session using agent-browser for automated QA:

- **Stale daemon recovery**: `open` fails with "Browser not launched" when a previous session's pages were all closed but the daemon is still running. Added `hasPages()` and `ensurePage()` to `BrowserManager`, and recovery logic in the daemon so it creates a new page instead of erroring.
- **Ref resolution in scroll commands**: `scrollintoview @e1` and `scroll @e1` passed refs directly to `page.locator()` as CSS selectors, causing parse errors. Changed both handlers to use `browser.getLocator()` which properly resolves `@ref` syntax.
- **Cursor-ref selector collision**: `buildSelector` in snapshot used a hard 3-level depth cutoff, producing identical CSS selectors for elements in repeated deeply-nested structures (strict mode violation). Replaced with a uniqueness check that extends the path until `querySelectorAll` returns exactly 1 match.
- **Eval shell quoting**: Added documentation in `SKILL.md` for `eval --stdin` (heredoc) and `eval -b` (base64) to prevent shell corruption of complex JS expressions.
