### PR TITLE
feat: add --auto-connect flag to discover and connect to running Chrome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,19 @@ Instructions for AI coding agents working with this codebase.
 
 - Do not use emojis in code, output, or documentation. Unicode symbols (✓, ✗, →, ⚠) are acceptable.
 - CLI colored output uses `cli/src/color.rs`. This module respects the `NO_COLOR` environment variable. Never use hardcoded ANSI color codes.
+- CLI flags must always use kebab-case (e.g., `--auto-connect`, `--allow-file-access`). Never use camelCase for flags (e.g., `--autoConnect` is wrong).
+
+## Documentation
+
+When adding or changing user-facing features (new flags, commands, behaviors, environment variables, etc.), update **all** of the following:
+
+1. `cli/src/output.rs` -- `--help` output (flags list, examples, environment variables)
+2. `README.md` -- Options table, relevant feature sections, examples
+3. `skills/agent-browser/SKILL.md` -- so AI agents know about the feature
+4. `docs/src/app/` -- the Next.js docs site (MDX pages)
+5. Inline doc comments in the relevant source files
+
+This applies to changes that either human users or AI agents would need to know about. Do not skip any of these locations.
 
 <!-- opensrc:start -->
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ The `-C` flag is useful for modern web apps that use custom clickable elements (
 | `--exact` | Exact text match |
 | `--headed` | Show browser window (not headless) |
 | `--cdp <port>` | Connect via Chrome DevTools Protocol |
+| `--auto-connect` | Auto-discover and connect to running Chrome (or `AGENT_BROWSER_AUTO_CONNECT` env) |
 | `--ignore-https-errors` | Ignore HTTPS certificate errors (useful for self-signed certs) |
 | `--allow-file-access` | Allow file:// URLs to access local files (Chromium only) |
 | `--debug` | Debug output |
@@ -554,6 +555,28 @@ This enables control of:
 - Chrome/Chromium instances with remote debugging
 - WebView2 applications
 - Any browser exposing a CDP endpoint
+
+### Auto-Connect
+
+Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
+
+```bash
+# Auto-discover running Chrome with remote debugging
+agent-browser --auto-connect open example.com
+agent-browser --auto-connect snapshot
+
+# Or via environment variable
+AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
+```
+
+Auto-connect discovers Chrome by:
+1. Reading Chrome's `DevToolsActivePort` file from the default user data directory
+2. Falling back to probing common debugging ports (9222, 9229)
+
+This is useful when:
+- Chrome 144+ has remote debugging enabled via `chrome://inspect/#remote-debugging` (which uses a dynamic port)
+- You want a zero-configuration connection to your existing browser
+- You don't want to track which port Chrome is using
 
 ## Streaming (Browser Preview)
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1429,6 +1429,7 @@ mod tests {
             ignore_https_errors: false,
             allow_file_access: false,
             device: None,
+            auto_connect: false,
             cli_executable_path: false,
             cli_extensions: false,
             cli_profile: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -20,6 +20,7 @@ pub struct Flags {
     pub ignore_https_errors: bool,
     pub allow_file_access: bool,
     pub device: Option<String>,
+    pub auto_connect: bool,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -65,6 +66,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         ignore_https_errors: false,
         allow_file_access: env::var("AGENT_BROWSER_ALLOW_FILE_ACCESS").is_ok(),
         device: env::var("AGENT_BROWSER_IOS_DEVICE").ok(),
+        auto_connect: env::var("AGENT_BROWSER_AUTO_CONNECT").is_ok(),
         // Track CLI-passed flags (default false, set to true when flag is passed)
         cli_executable_path: false,
         cli_extensions: false,
@@ -175,6 +177,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--auto-connect" => flags.auto_connect = true,
             _ => {}
         }
         i += 1;
@@ -194,6 +197,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--debug",
         "--ignore-https-errors",
         "--allow-file-access",
+        "--auto-connect",
     ];
     // Global flags that take a value (need to skip the next arg too)
     const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1778,6 +1778,7 @@ Options:
   --full, -f                 Full page screenshot
   --headed                   Show browser window (not headless)
   --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
+  --auto-connect             Auto-discover and connect to running Chrome
   --debug                    Debug output
   --version, -V              Show version
 
@@ -1785,6 +1786,7 @@ Environment:
   AGENT_BROWSER_SESSION          Session name (default: "default")
   AGENT_BROWSER_EXECUTABLE_PATH  Custom browser executable path
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse)
+  AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_STREAM_PORT      Enable WebSocket streaming on port (e.g., 9223)
   AGENT_BROWSER_IOS_DEVICE       Default iOS device name
   AGENT_BROWSER_IOS_UDID         Default iOS device UDID
@@ -1798,6 +1800,7 @@ Examples:
   agent-browser get text @e1
   agent-browser screenshot --full
   agent-browser --cdp 9222 snapshot      # Connect via CDP port
+  agent-browser --auto-connect snapshot  # Auto-discover running Chrome
   agent-browser --profile ~/.myapp open example.com  # Persistent profile
 
 iOS Simulator (requires Xcode and Appium):

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -34,6 +34,30 @@ The `--cdp` flag accepts either:
 - A port number (e.g., `9222`) for local connections via `http://localhost:{port}`
 - A full WebSocket URL (e.g., `wss://...` or `ws://...`) for remote browser services
 
+## Auto-Connect
+
+Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
+
+```bash
+# Auto-discover running Chrome with remote debugging
+agent-browser --auto-connect open example.com
+agent-browser --auto-connect snapshot
+
+# Or via environment variable
+AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
+```
+
+Auto-connect discovers Chrome by:
+
+1. Reading Chrome's `DevToolsActivePort` file from the default user data directory
+2. Falling back to probing common debugging ports (9222, 9229)
+
+This is useful when:
+
+- Chrome 144+ has remote debugging enabled via `chrome://inspect/#remote-debugging` (which uses a dynamic port)
+- You want a zero-configuration connection to your existing browser
+- You don't want to track which port Chrome is using
+
 ## Use cases
 
 This enables control of:
@@ -63,6 +87,7 @@ This enables control of:
 | `--exact` | Exact text match |
 | `--headed` | Show browser window |
 | `--cdp <port\|url>` | CDP connection (port or WebSocket URL) |
+| `--auto-connect` | Auto-discover and connect to running Chrome |
 | `--debug` | Debug output |
 
 ## Cloud providers

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -168,6 +168,7 @@ agent-browser reload                  # Reload page
 --profile <path>         # Persistent browser profile directory
 --headed                 # Show browser window (not headless)
 --cdp <port>             # Connect via Chrome DevTools Protocol
+--auto-connect           # Auto-discover and connect to running Chrome
 --executable-path <path> # Custom browser executable
 --args <args>            # Browser launch args (comma separated)
 --user-agent <ua>        # Custom User-Agent string

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -122,6 +122,17 @@ agent-browser --session site2 snapshot -i
 agent-browser session list
 ```
 
+### Connect to Existing Chrome
+
+```bash
+# Auto-discover running Chrome with remote debugging enabled
+agent-browser --auto-connect open https://example.com
+agent-browser --auto-connect snapshot
+
+# Or with explicit CDP port
+agent-browser --cdp 9222 snapshot
+```
+
 ### Visual Browser (Debugging)
 
 ```bash

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -31,6 +31,7 @@ const launchSchema = baseCommandSchema.extend({
       { message: 'CDP URL must start with ws://, wss://, http://, or https://' }
     )
     .optional(),
+  autoConnect: z.boolean().optional(),
   executablePath: z.string().optional(),
   extensions: z.array(z.string()).optional(),
   headers: z.record(z.string()).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface LaunchCommand extends BaseCommand {
   executablePath?: string;
   cdpPort?: number;
   cdpUrl?: string;
+  autoConnect?: boolean; // Auto-discover and connect to running Chrome via DevToolsActivePort
   extensions?: string[];
   profile?: string; // Path to persistent browser profile directory
   storageState?: string; // Path to storage state JSON file


### PR DESCRIPTION
- Adds `--auto-connect` flag (and `AGENT_BROWSER_AUTO_CONNECT` env var) that automatically discovers a running Chrome instance with remote debugging enabled and connects via CDP -- no port or URL required.
- Discovery reads Chrome's `DevToolsActivePort` file from default user data directories (macOS, Linux, Windows), then falls back to probing common debug ports (9222, 9229).
- Provides clear, platform-specific error messages when no debuggable Chrome is found.

Closes #412