### PR TITLE
fix: add missing cursor field to snapshot command schema

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -719,6 +719,7 @@ const screenshotSchema = baseCommandSchema.extend({
 const snapshotSchema = baseCommandSchema.extend({
   action: z.literal('snapshot'),
   interactive: z.boolean().optional(),
+  cursor: z.boolean().optional(),
   maxDepth: z.number().nonnegative().optional(),
   compact: z.boolean().optional(),
   selector: z.string().optional(),


### PR DESCRIPTION
## Summary

The `-C`/`--cursor` flag for detecting cursor-interactive elements (#374) was not working because the `cursor` field was missing from the Zod validation schema in `protocol.ts`.

The Rust CLI correctly sends `{"cursor": true}` in the command JSON, but Zod strips undeclared fields during validation, so `options.cursor` was always `undefined` in the snapshot handler.

**Fix**: Add `cursor: z.boolean().optional()` to `snapshotSchema` in `src/protocol.ts` (one line).

## Reproduction

```bash
agent-browser open https://any-react-app
agent-browser snapshot -i -C
# cursor-interactive elements were NOT shown
```

## After fix

```bash
agent-browser snapshot -i -C
# Now correctly shows:
# Cursor-interactive elements:
# - clickable "Card Title" [ref=e7] [cursor:pointer, onclick]
```

## Test plan

- [x] `npx vitest run src/protocol.test.ts` — 115 tests pass
- [x] Manual E2E: `snapshot -i -C` now detects and outputs cursor-interactive elements
- [x] Clicking cursor-interactive refs correctly triggers navigation

Fixes #434