### PR TITLE
fix: screenshot null normalization + browser launch error handling

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -709,9 +709,17 @@ const pressSchema = baseCommandSchema.extend({
 
 const screenshotSchema = baseCommandSchema.extend({
   action: z.literal('screenshot'),
-  path: z.string().nullable().optional(),
+  path: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((v) => v ?? undefined),
   fullPage: z.boolean().optional(),
-  selector: z.string().min(1).nullish(),
+  selector: z
+    .string()
+    .min(1)
+    .nullish()
+    .transform((v) => v ?? undefined),
   format: z.enum(['png', 'jpeg']).optional(),
   quality: z.number().min(0).max(100).optional(),
 });


### PR DESCRIPTION
## Summary

Fixes two categories of bugs:

### Screenshot null→undefined normalization (Closes #238, Closes #237)
The screenshot command's `selector` and `path` fields used `.nullish()` which passes both `null` and `undefined` downstream. Downstream code only handles `undefined`, causing `Expected string, received null` validation errors.

**Fix**: Add `.transform((v) => v ?? undefined)` at the Zod boundary to normalize `null` → `undefined`.

### Browser launch error handling (Closes #244)
When the installed browser executable doesn't match the expected revision, Playwright throws a cryptic `Executable doesn't exist` error with no guidance.

**Fix**: 
- Add `wrapLaunch<T>` private helper that wraps all 3 launch paths (extension, profile, ephemeral)
- Catches `Executable doesn't exist` and provides actionable error: run `npx playwright-core install chromium`
- Pass `env` explicitly to all launch calls for subprocess isolation
- Extensions now respect `--profile` path when both flags are used

### Testing
- 232 TypeScript tests passing
- TypeScript compiles with zero errors
- Minimal, surgical changes to 2 files (`protocol.ts`, `browser.ts`)