### PR TITLE
fix(#136, #409, #411): CLI input handling

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -500,17 +500,17 @@ fn main() {
 
         // Add executable path if specified
         if let Some(ref exec_path) = flags.executable_path {
-            cmd_obj.insert("executablePath".to_string(), json!(exec_path));
+            cmd_obj.insert("executablePath".to_string(), json!(commands::resolve_path(exec_path)));
         }
 
         // Add profile path if specified
         if let Some(ref profile_path) = flags.profile {
-            cmd_obj.insert("profile".to_string(), json!(profile_path));
+            cmd_obj.insert("profile".to_string(), json!(commands::resolve_path(profile_path)));
         }
 
         // Add state path if specified
         if let Some(ref state_path) = flags.state {
-            cmd_obj.insert("storageState".to_string(), json!(state_path));
+            cmd_obj.insert("storageState".to_string(), json!(commands::resolve_path(state_path)));
         }
 
         if let Some(ref proxy_str) = flags.proxy {


### PR DESCRIPTION
## Group 8: CLI Input Handling

Themed PR combining three related CLI input/parsing fixes plus a follow-up improvement.

### Changes

#### #136 — `--stdin` support for `fill`/`type`
- Adds `--stdin` flag and automatic `IsTerminal` pipe detection for `fill` and `type` commands
- Allows piping content via stdin to avoid shell `$$` expansion issues with special characters
- Usage: `echo 'pa$$word' | agent-browser fill "#password"` or `agent-browser fill "#password" --stdin < file.txt`

#### #409 — `chrome-extension://` URL normalization
- Adds `chrome-extension://` and `chrome://` to the URL normalization whitelist
- Prevents the CLI from prepending `https://` to these internal Chrome URLs

#### #411 — `tab new` with persistent context
- Fixes `tab new` to work correctly with `--extension` and `--profile` flags
- New tabs now inherit the persistent browser context instead of creating isolated contexts

#### Strip trailing newlines from stdin
- Follow-up to #136: trims trailing `\n` and `\r` from stdin input in `fill`/`type`
- Prevents unexpected newline characters from being typed into form fields

### Testing
- `cargo check` — compiles cleanly
- `cargo test` — all 167 tests pass

### Cherry-picked commits
| Commit | Issue | Description |
|--------|-------|-------------|
| `de7e373` | #136 | `--stdin` support for fill/type |
| `66c1342` | #409 | chrome-extension:// URL normalization |
| `4b78dab` | #411 | tab new with persistent context |
| `21db7c8` | — | Strip trailing newlines from stdin |

Closes #136, closes #409, closes #411
