### PR TITLE
fix(#171): Git Bash compatibility on Windows

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,6 +251,7 @@ fn main() {
     }
 
     // Prevent MSYS/Git Bash path translation from mangling arguments
+    // in the current (arg-parsing) process, not just the child daemon.
     #[cfg(windows)]
     {
         env::set_var("MSYS_NO_PATHCONV", "1");


### PR DESCRIPTION
## Problem

When running `agent-browser` from Git Bash on Windows, the daemon fails to start due to MSYS2/MinGW environment issues:

1. **Path translation**: MSYS2 automatically translates arguments starting with `/` to Windows paths (e.g., `/json/version` → `C:/Program Files/Git/json/version`), which can mangle internal arguments passed to the daemon.
2. **Node.js invocation**: Git Bash may intercept `node` via a shell wrapper script, causing spawn failures. Using `node.exe` explicitly bypasses this.

## Fix

- Use `node.exe` instead of `node` in the Windows daemon spawn block to avoid MSYS2 shell wrapper issues.
- Set `MSYS_NO_PATHCONV=1` to disable MSYS path translation for the daemon process.
- Set `MSYS2_ARG_CONV_EXCL=*` to disable argument conversion for all arguments.

## Changes

- `cli/src/connection.rs`: Updated the `#[cfg(windows)]` daemon spawn block.

Closes #171