### PR TITLE
feat: add frameLocator support for cross-origin iframe interaction

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -916,11 +916,14 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             if rest.first().copied() == Some("main") {
                 Ok(json!({ "id": id, "action": "mainframe" }))
             } else if rest.first().copied() == Some("locator") {
-                let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                    context: "frame locator".to_string(),
-                    usage: "frame locator <selector>",
-                })?;
-                Ok(json!({ "id": id, "action": "framelocator", "selector": sel }))
+                match rest.get(1).copied() {
+                    None | Some("clear") => {
+                        Ok(json!({ "id": id, "action": "framelocator" }))
+                    }
+                    Some(sel) => {
+                        Ok(json!({ "id": id, "action": "framelocator", "selector": sel }))
+                    }
+                }
             } else {
                 let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
                     context: "frame".to_string(),

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1214,16 +1214,19 @@ async function handleFrameLocator(
   command: FrameLocatorCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  browser.setFrameLocator(command.selector);
-  return successResponse(command.id, { switched: true });
+  browser.setFrameLocator(command.selector ?? null);
+  return successResponse(command.id, {
+    switched: !command.selector ? false : true,
+    cleared: !command.selector,
+  });
 }
 
 async function handleGetByRole(
   command: GetByRoleCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByRole(command.role as any, { name: command.name, exact: command.exact });
+  const base = browser.getLocatorBase();
+  const locator = base.getByRole(command.role as any, { name: command.name, exact: command.exact });
 
   switch (command.subaction) {
     case 'click':
@@ -1245,8 +1248,8 @@ async function handleGetByText(
   command: GetByTextCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByText(command.text, { exact: command.exact });
+  const base = browser.getLocatorBase();
+  const locator = base.getByText(command.text, { exact: command.exact });
 
   switch (command.subaction) {
     case 'click':
@@ -1262,8 +1265,8 @@ async function handleGetByLabel(
   command: GetByLabelCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByLabel(command.label, { exact: command.exact });
+  const base = browser.getLocatorBase();
+  const locator = base.getByLabel(command.label, { exact: command.exact });
 
   switch (command.subaction) {
     case 'click':
@@ -1282,8 +1285,8 @@ async function handleGetByPlaceholder(
   command: GetByPlaceholderCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByPlaceholder(command.placeholder, { exact: command.exact });
+  const base = browser.getLocatorBase();
+  const locator = base.getByPlaceholder(command.placeholder, { exact: command.exact });
 
   switch (command.subaction) {
     case 'click':
@@ -2219,8 +2222,8 @@ async function handleGetByAltText(
   command: GetByAltTextCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByAltText(command.text, { exact: command.exact });
+  const base = browser.getLocatorBase();
+  const locator = base.getByAltText(command.text, { exact: command.exact });
 
   switch (command.subaction) {
     case 'click':
@@ -2236,8 +2239,8 @@ async function handleGetByTitle(
   command: GetByTitleCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByTitle(command.text, { exact: command.exact });
+  const base = browser.getLocatorBase();
+  const locator = base.getByTitle(command.text, { exact: command.exact });
 
   switch (command.subaction) {
     case 'click':
@@ -2253,8 +2256,8 @@ async function handleGetByTestId(
   command: GetByTestIdCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const locator = page.getByTestId(command.testId);
+  const base = browser.getLocatorBase();
+  const locator = base.getByTestId(command.testId);
 
   switch (command.subaction) {
     case 'click':

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -7,6 +7,7 @@ import {
   type BrowserContext,
   type Page,
   type Frame,
+  type FrameLocator,
   type Dialog,
   type Request,
   type Route,
@@ -427,6 +428,17 @@ export class BrowserManager {
   setFrameLocator(selector: string | null): void {
     this.activeFrameLocator = selector;
     this.activeFrame = null;
+  }
+
+  /**
+   * Get the locator base for getBy* queries.
+   * Returns the frameLocator if active, otherwise the page.
+   */
+  getLocatorBase(): Page | FrameLocator {
+    if (this.activeFrameLocator) {
+      return this.getPage().frameLocator(this.activeFrameLocator);
+    }
+    return this.getPage();
   }
 
   /**

--- a/src/frame-locator.test.ts
+++ b/src/frame-locator.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { BrowserManager } from './browser.js';
+import { executeCommand } from './actions.js';
+
+describe('frameLocator support', () => {
+  let browser: BrowserManager;
+
+  beforeAll(async () => {
+    browser = new BrowserManager();
+    await browser.launch({ headless: true });
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  describe('setFrameLocator / getLocatorBase', () => {
+    it('should return page when no frameLocator is set', () => {
+      const base = browser.getLocatorBase();
+      expect(base).toBe(browser.getPage());
+    });
+
+    it('should return a FrameLocator when frameLocator is set', () => {
+      browser.setFrameLocator('iframe#child');
+      const base = browser.getLocatorBase();
+      // FrameLocator is not a Page — it should differ
+      expect(base).not.toBe(browser.getPage());
+      // FrameLocator must support locator-producing methods
+      expect(typeof (base as any).getByRole).toBe('function');
+      expect(typeof (base as any).getByText).toBe('function');
+      expect(typeof (base as any).locator).toBe('function');
+    });
+
+    it('should clear frameLocator when set to null', () => {
+      browser.setFrameLocator('iframe#child');
+      expect(browser.getLocatorBase()).not.toBe(browser.getPage());
+
+      browser.setFrameLocator(null);
+      expect(browser.getLocatorBase()).toBe(browser.getPage());
+    });
+
+    it('should clear frameLocator via switchToMainFrame', () => {
+      browser.setFrameLocator('iframe#child');
+      expect(browser.getLocatorBase()).not.toBe(browser.getPage());
+
+      browser.switchToMainFrame();
+      expect(browser.getLocatorBase()).toBe(browser.getPage());
+    });
+  });
+
+  describe('framelocator command via executeCommand', () => {
+    it('should set frameLocator with selector', async () => {
+      const resp = await executeCommand(
+        { id: '1', action: 'framelocator', selector: 'iframe#child' },
+        browser
+      );
+      expect(resp.success).toBe(true);
+      expect((resp as any).data.switched).toBe(true);
+      // getLocatorBase should now scope to the frame
+      expect(browser.getLocatorBase()).not.toBe(browser.getPage());
+    });
+
+    it('should clear frameLocator without selector', async () => {
+      // First set it
+      await executeCommand({ id: '1', action: 'framelocator', selector: 'iframe#child' }, browser);
+
+      // Then clear it
+      const resp = await executeCommand({ id: '2', action: 'framelocator' }, browser);
+      expect(resp.success).toBe(true);
+      expect((resp as any).data.cleared).toBe(true);
+      expect(browser.getLocatorBase()).toBe(browser.getPage());
+    });
+  });
+
+  describe('getLocator respects frameLocator', () => {
+    it('should scope getLocator through frameLocator when set', () => {
+      browser.setFrameLocator('iframe#child');
+      const locator = browser.getLocator('button');
+      // The locator should be scoped; verify it's created without error
+      expect(locator).toBeDefined();
+      browser.setFrameLocator(null);
+    });
+
+    it('should use page.locator when frameLocator is cleared', () => {
+      browser.setFrameLocator(null);
+      const locator = browser.getLocator('button');
+      expect(locator).toBeDefined();
+    });
+  });
+});

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -782,6 +782,31 @@ describe('parseCommand', () => {
       const result = parseCommand(cmd({ id: '1', action: 'mainframe' }));
       expect(result.success).toBe(true);
     });
+
+    it('should parse framelocator with selector', () => {
+      const result = parseCommand(
+        cmd({ id: '1', action: 'framelocator', selector: 'iframe#child' })
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.command.action).toBe('framelocator');
+        expect((result.command as any).selector).toBe('iframe#child');
+      }
+    });
+
+    it('should parse framelocator without selector (clear)', () => {
+      const result = parseCommand(cmd({ id: '1', action: 'framelocator' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.command.action).toBe('framelocator');
+        expect((result.command as any).selector).toBeUndefined();
+      }
+    });
+
+    it('should reject framelocator with empty selector', () => {
+      const result = parseCommand(cmd({ id: '1', action: 'framelocator', selector: '' }));
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('screencast', () => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -133,7 +133,7 @@ const mainframeSchema = baseCommandSchema.extend({
 
 const framelocatorSchema = baseCommandSchema.extend({
   action: z.literal('framelocator'),
-  selector: z.string().min(1),
+  selector: z.string().min(1).optional(),
 });
 
 const getByRoleSchema = baseCommandSchema.extend({

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,7 @@ export interface MainFrameCommand extends BaseCommand {
 
 export interface FrameLocatorCommand extends BaseCommand {
   action: 'framelocator';
-  selector: string;
+  selector?: string;
 }
 
 export interface GetByRoleCommand extends BaseCommand {


### PR DESCRIPTION
## Summary

Add a new `framelocator` action that uses Playwright's `frameLocator()` API to enable interaction with cross-origin iframes. The existing `frame` command uses `page.frame()` / `contentFrame()` which doesn't work across origins due to browser security restrictions.

## Changes

- **`src/browser.ts`**: Add `activeFrameLocator` property, `setFrameLocator()` method, and modify `getLocator()` to scope through `frameLocator()` when active. Also clear frame locator when `switchToMainFrame()` is called.
- **`src/types.ts`**: Add `FrameLocatorCommand` interface
- **`src/protocol.ts`**: Add `framelocator` schema to validation and discriminated union
- **`src/actions.ts`**: Add `framelocator` case in dispatch and `handleFrameLocator` handler
- **`cli/src/commands.rs`**: Add `frame locator <selector>` CLI parsing

## Usage

```bash
# Set frame locator for a cross-origin iframe
frame locator iframe#payment

# Now all subsequent commands target elements inside the iframe
click button#submit
fill input#card-number 4242424242424242

# Return to main frame
frame main
```

## How it works

Playwright's `frameLocator()` is a lazy API that doesn't require the frame to be loaded at the time of the call and works with cross-origin iframes (unlike `frame()`). When a frame locator is active, `getLocator()` scopes all element lookups through `page.frameLocator(selector).locator(...)`.

Closes #279