### PR TITLE
fix(#335): add --force flag to check/uncheck for hidden checkbox elements

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -171,18 +171,34 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             Ok(json!({ "id": id, "action": "focus", "selector": sel }))
         }
         "check" => {
-            let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
-                context: "check".to_string(),
-                usage: "check <selector>",
-            })?;
-            Ok(json!({ "id": id, "action": "check", "selector": sel }))
+            let force = rest.iter().any(|arg| *arg == "--force");
+            let sel = rest
+                .iter()
+                .find(|arg| **arg != "--force")
+                .ok_or_else(|| ParseError::MissingArguments {
+                    context: "check".to_string(),
+                    usage: "check <selector> [--force]",
+                })?;
+            if force {
+                Ok(json!({ "id": id, "action": "check", "selector": sel, "force": true }))
+            } else {
+                Ok(json!({ "id": id, "action": "check", "selector": sel }))
+            }
         }
         "uncheck" => {
-            let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
-                context: "uncheck".to_string(),
-                usage: "uncheck <selector>",
-            })?;
-            Ok(json!({ "id": id, "action": "uncheck", "selector": sel }))
+            let force = rest.iter().any(|arg| *arg == "--force");
+            let sel = rest
+                .iter()
+                .find(|arg| **arg != "--force")
+                .ok_or_else(|| ParseError::MissingArguments {
+                    context: "uncheck".to_string(),
+                    usage: "uncheck <selector> [--force]",
+                })?;
+            if force {
+                Ok(json!({ "id": id, "action": "uncheck", "selector": sel, "force": true }))
+            } else {
+                Ok(json!({ "id": id, "action": "uncheck", "selector": sel }))
+            }
         }
         "select" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -858,7 +858,7 @@ async function handleFill(command: FillCommand, browser: BrowserManager): Promis
 async function handleCheck(command: CheckCommand, browser: BrowserManager): Promise<Response> {
   const locator = browser.getLocator(command.selector);
   try {
-    await locator.check();
+    await locator.check({ force: command.force ?? false });
   } catch (error) {
     throw toAIFriendlyError(error, command.selector);
   }
@@ -868,7 +868,7 @@ async function handleCheck(command: CheckCommand, browser: BrowserManager): Prom
 async function handleUncheck(command: UncheckCommand, browser: BrowserManager): Promise<Response> {
   const locator = browser.getLocator(command.selector);
   try {
-    await locator.uncheck();
+    await locator.uncheck({ force: command.force ?? false });
   } catch (error) {
     throw toAIFriendlyError(error, command.selector);
   }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -84,11 +84,13 @@ const fillSchema = baseCommandSchema.extend({
 const checkSchema = baseCommandSchema.extend({
   action: z.literal('check'),
   selector: z.string().min(1),
+  force: z.boolean().optional(),
 });
 
 const uncheckSchema = baseCommandSchema.extend({
   action: z.literal('uncheck'),
   selector: z.string().min(1),
+  force: z.boolean().optional(),
 });
 
 const uploadSchema = baseCommandSchema.extend({

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,11 +68,13 @@ export interface FillCommand extends BaseCommand {
 export interface CheckCommand extends BaseCommand {
   action: 'check';
   selector: string;
+  force?: boolean;
 }
 
 export interface UncheckCommand extends BaseCommand {
   action: 'uncheck';
   selector: string;
+  force?: boolean;
 }
 
 export interface UploadCommand extends BaseCommand {


### PR DESCRIPTION
## Summary
Adds `--force` flag to `check` and `uncheck` commands that passes `{ force: true }` to Playwright, bypassing visibility checks on hidden native checkbox elements.

## Problem
UI frameworks like Element UI, Ant Design, etc. hide the native `<input type="checkbox">` element behind a custom overlay. The Playwright `check()`/`uncheck()` methods wait for visibility by default, causing the commands to hang indefinitely.

## Changes
- **cli/src/commands.rs**: Parse `--force` flag for check/uncheck commands
- **src/protocol.ts**: Add `force: z.boolean().optional()` to check/uncheck schemas
- **src/types.ts**: Add `force?: boolean` to CheckCommand/UncheckCommand interfaces
- **src/actions.ts**: Pass `{ force: command.force ?? false }` to Playwright check/uncheck

## Usage
```bash
agent-browser check @e1 --force    # Force check hidden checkbox
agent-browser uncheck @e1 --force  # Force uncheck hidden checkbox
```

Closes #335