### PR TITLE
feat: support BROWSERBASE_REGION env var for session creation

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -808,6 +808,8 @@ export class BrowserManager {
       );
     }
 
+    const browserbaseRegion = process.env.BROWSERBASE_REGION;
+
     const response = await fetch('https://api.browserbase.com/v1/sessions', {
       method: 'POST',
       headers: {
@@ -816,6 +818,7 @@ export class BrowserManager {
       },
       body: JSON.stringify({
         projectId: browserbaseProjectId,
+        ...(browserbaseRegion && { region: browserbaseRegion }),
       }),
     });
 


### PR DESCRIPTION
## Summary

- Reads `BROWSERBASE_REGION` environment variable and passes it to the Browserbase sessions API when creating a new session
- Allows users to control which region their cloud browser runs in (e.g. `us-west-2`, `us-east-1`, `eu-central-1`, `ap-southeast-1`)
- No-op when the env var is not set (existing behavior unchanged)

## Usage

```bash
export BROWSERBASE_REGION=eu-central-1
agent-browser -p browserbase open https://example.com
```

Valid regions per [Browserbase API](https://docs.browserbase.com/reference/api/create-a-session): `us-west-2`, `us-east-1`, `eu-central-1`, `ap-southeast-1`.