### PR TITLE
feat: add --wait-until flag to open command and change default to domcontentloaded

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -101,6 +101,10 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 format!("https://{}", url)
             };
             let mut nav_cmd = json!({ "id": id, "action": "navigate", "url": url });
+            // If --wait-until flag is set, include waitUntil strategy
+            if let Some(ref wait_until) = flags.wait_until {
+                nav_cmd["waitUntil"] = json!(wait_until);
+            }
             // If --headers flag is set, include headers (scoped to this origin)
             if let Some(ref headers_json) = flags.headers {
                 if let Ok(headers) = serde_json::from_str::<serde_json::Value>(headers_json) {
@@ -1535,6 +1539,7 @@ mod tests {
             device: None,
             auto_connect: false,
             session_name: None,
+            wait_until: None,
             cli_executable_path: false,
             cli_extensions: false,
             cli_profile: false,
@@ -1834,6 +1839,38 @@ mod tests {
         let cmd = parse_command(&args("open api.example.com"), &flags).unwrap();
         // Invalid JSON should result in no headers field (graceful handling)
         assert!(cmd.get("headers").is_none());
+    }
+
+    #[test]
+    fn test_navigate_with_wait_until() {
+        let mut flags = default_flags();
+        flags.wait_until = Some("domcontentloaded".to_string());
+        let cmd = parse_command(&args("open example.com"), &flags).unwrap();
+        assert_eq!(cmd["action"], "navigate");
+        assert_eq!(cmd["waitUntil"], "domcontentloaded");
+    }
+
+    #[test]
+    fn test_navigate_with_wait_until_load() {
+        let mut flags = default_flags();
+        flags.wait_until = Some("load".to_string());
+        let cmd = parse_command(&args("open example.com"), &flags).unwrap();
+        assert_eq!(cmd["waitUntil"], "load");
+    }
+
+    #[test]
+    fn test_navigate_with_wait_until_networkidle() {
+        let mut flags = default_flags();
+        flags.wait_until = Some("networkidle".to_string());
+        let cmd = parse_command(&args("open example.com"), &flags).unwrap();
+        assert_eq!(cmd["waitUntil"], "networkidle");
+    }
+
+    #[test]
+    fn test_navigate_without_wait_until() {
+        let cmd = parse_command(&args("open example.com"), &default_flags()).unwrap();
+        // waitUntil should not be present when flag is not set (daemon uses its own default)
+        assert!(cmd.get("waitUntil").is_none());
     }
 
     // === Set Headers Tests ===

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -491,6 +491,10 @@ https:// is automatically prepended.
 
 Aliases: goto, navigate
 
+Options:
+  --wait-until <strategy>  When to consider navigation done (default: domcontentloaded)
+                           Values: load, domcontentloaded, networkidle
+
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
@@ -501,6 +505,7 @@ Examples:
   agent-browser open example.com
   agent-browser open https://github.com
   agent-browser open localhost:3000
+  agent-browser open example.com --wait-until networkidle
   agent-browser open api.example.com --headers '{"Authorization": "Bearer token"}'
     # ^ Headers only sent to api.example.com, not other domains
 "##
@@ -1872,6 +1877,8 @@ Options:
   --headed                   Show browser window (not headless)
   --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
   --auto-connect             Auto-discover and connect to running Chrome
+  --wait-until <strategy>    Navigation wait strategy: load, domcontentloaded, networkidle
+                             (or AGENT_BROWSER_WAIT_UNTIL, default: domcontentloaded)
   --session-name <name>      Auto-save/restore session state (cookies, localStorage)
   --debug                    Debug output
   --version, -V              Show version
@@ -1885,6 +1892,7 @@ Environment:
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_STREAM_PORT      Enable WebSocket streaming on port (e.g., 9223)
+  AGENT_BROWSER_WAIT_UNTIL       Navigation wait strategy (default: domcontentloaded)
   AGENT_BROWSER_IOS_DEVICE       Default iOS device name
   AGENT_BROWSER_IOS_UDID         Default iOS device UDID
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -511,7 +511,7 @@ async function handleNavigate(
   }
 
   await page.goto(command.url, {
-    waitUntil: command.waitUntil ?? 'load',
+    waitUntil: command.waitUntil ?? 'domcontentloaded',
   });
 
   return successResponse(command.id, {


### PR DESCRIPTION
## Summary

- Add `--wait-until <strategy>` flag to the `open` command (`load`, `domcontentloaded`, `networkidle`)
- Also configurable via `AGENT_BROWSER_WAIT_UNTIL` environment variable
- Change the default `waitUntil` from `load` to `domcontentloaded` in `handleNavigate`, aligning it with `handleTabNew` which already uses `domcontentloaded`

## Motivation

The `load` event waits for **all** resources (images, stylesheets, iframes, third-party scripts) to finish loading. On modern SPAs that depend on external auth providers, analytics, or other async resources, this frequently causes navigation timeouts — especially problematic for AI agent workflows where a timeout wastes an entire agent turn.

`domcontentloaded` fires when the HTML is parsed and the DOM is ready, which is sufficient for most interactions. Agent workflows already follow a `navigate → snapshot → interact` pattern, so waiting for full `load` provides no additional value.

See also: Playwright docs recommend using lighter `waitUntil` strategies combined with element-based assertions for SPA testing.

## Changes

| File | Change |
|---|---|
| `cli/src/flags.rs` | Add `wait_until: Option<String>` field, `--wait-until` flag parsing, `clean_args` support, env var `AGENT_BROWSER_WAIT_UNTIL`, and tests |
| `cli/src/commands.rs` | Pass `flags.wait_until` as `waitUntil` in the navigate JSON command, add `default_flags()` field, and 4 new tests |
| `cli/src/output.rs` | Document `--wait-until` in `open` help, global options, and environment variables |
| `src/actions.ts` | Change default: `command.waitUntil ?? 'load'` → `command.waitUntil ?? 'domcontentloaded'` |

## Usage

```bash
# Use domcontentloaded (new default — no flag needed)
agent-browser open https://example.com

# Explicitly wait for all resources
agent-browser open https://example.com --wait-until load

# Wait for network to settle
agent-browser open https://example.com --wait-until networkidle

# Set via environment variable
AGENT_BROWSER_WAIT_UNTIL=networkidle agent-browser open https://example.com
```

Closes #479