### PR TITLE
fix: reject invalid --headers JSON, empty frame commands, and --cdp + --extension combo

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -336,6 +336,16 @@ fn main() {
         exit(1);
     }
 
+    if flags.cdp.is_some() && !flags.extensions.is_empty() {
+        let msg = "Cannot use --extension with --cdp (extensions require local browser)";
+        if flags.json {
+            println!(r#"{{"success":false,"error":"{}"}}"#, msg);
+        } else {
+            eprintln!("{} {}", color::error_indicator(), msg);
+        }
+        exit(1);
+    }
+
     // Auto-connect to existing browser
     if flags.auto_connect {
         let mut launch_cmd = json!({

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -733,6 +733,21 @@ describe('parseCommand', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should reject frame with no selector, name, or url', () => {
+      const result = parseCommand(cmd({ id: '1', action: 'frame' }));
+      expect(result.success).toBe(false);
+    });
+
+    it('should parse frame with name', () => {
+      const result = parseCommand(cmd({ id: '1', action: 'frame', name: 'myframe' }));
+      expect(result.success).toBe(true);
+    });
+
+    it('should parse frame with url', () => {
+      const result = parseCommand(cmd({ id: '1', action: 'frame', url: 'https://example.com' }));
+      expect(result.success).toBe(true);
+    });
+
     it('should parse mainframe', () => {
       const result = parseCommand(cmd({ id: '1', action: 'mainframe' }));
       expect(result.success).toBe(true);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1001,6 +1001,14 @@ export function parseCommand(input: string): ParseResult {
     return { success: false, error: 'Either content or url must be provided', id };
   }
 
+  if (command.action === 'frame' && !command.selector && !command.name && !command.url) {
+    return {
+      success: false,
+      error: 'frame command requires at least one of: selector, name, or url',
+      id,
+    };
+  }
+
   return { success: true, command };
 }
 


### PR DESCRIPTION
## Summary

- Return a `ParseError` when `--headers` receives invalid JSON instead of silently dropping the headers and proceeding
- Reject `frame` commands that provide no `selector`, `name`, or `url` (previously returned `{ switched: true }` without doing anything)
- Add missing mutual exclusion check for `--cdp` + `--extension` (extensions require a local browser, not a CDP connection)