### PR TITLE
fix(#491): auto-disable viewport for --start-maximized and --window-size args

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -484,6 +484,42 @@ describe('BrowserManager', () => {
       expect(size?.width).toBe(1920);
       expect(size?.height).toBe(1080);
     });
+
+    it('should disable viewport when --start-maximized is in args', async () => {
+      const testBrowser = new BrowserManager();
+      await testBrowser.launch({ headless: true, args: ['--start-maximized'] });
+      const page = testBrowser.getPage();
+      expect(page.viewportSize()).toBeNull();
+      await testBrowser.close();
+    });
+
+    it('should disable viewport when --window-size is in args', async () => {
+      const testBrowser = new BrowserManager();
+      await testBrowser.launch({ headless: true, args: ['--window-size=800,600'] });
+      const page = testBrowser.getPage();
+      expect(page.viewportSize()).toBeNull();
+      await testBrowser.close();
+    });
+
+    it('should use default viewport when no window size args', async () => {
+      const testBrowser = new BrowserManager();
+      await testBrowser.launch({ headless: true });
+      const page = testBrowser.getPage();
+      expect(page.viewportSize()).toEqual({ width: 1280, height: 720 });
+      await testBrowser.close();
+    });
+
+    it('should use explicit viewport even with --start-maximized', async () => {
+      const testBrowser = new BrowserManager();
+      await testBrowser.launch({
+        headless: true,
+        args: ['--start-maximized'],
+        viewport: { width: 800, height: 600 },
+      });
+      const page = testBrowser.getPage();
+      expect(page.viewportSize()).toEqual({ width: 800, height: 600 });
+      await testBrowser.close();
+    });
   });
 
   describe('snapshot', () => {

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -598,6 +598,31 @@ describe('parseCommand', () => {
         expect(result.command.allowFileAccess).toBe(false);
       }
     });
+
+    it('should parse launch with viewport dimensions', () => {
+      const result = parseCommand(
+        cmd({ id: '1', action: 'launch', viewport: { width: 1920, height: 1080 } })
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.command.viewport).toEqual({ width: 1920, height: 1080 });
+      }
+    });
+
+    it('should parse launch with viewport null', () => {
+      const result = parseCommand(cmd({ id: '1', action: 'launch', viewport: null }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.command.viewport).toBeNull();
+      }
+    });
+
+    it('should reject launch with invalid viewport', () => {
+      const result = parseCommand(
+        cmd({ id: '1', action: 'launch', viewport: { width: -1, height: 720 } })
+      );
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('mouse actions', () => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -16,6 +16,7 @@ const launchSchema = baseCommandSchema.extend({
       width: z.number().positive(),
       height: z.number().positive(),
     })
+    .nullable()
     .optional(),
   browser: z.enum(['chromium', 'firefox', 'webkit']).optional(),
   cdpPort: z.number().positive().optional(),
@@ -822,6 +823,7 @@ const windowNewSchema = baseCommandSchema.extend({
       width: z.number().positive(),
       height: z.number().positive(),
     })
+    .nullable()
     .optional(),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface BaseCommand {
 export interface LaunchCommand extends BaseCommand {
   action: 'launch';
   headless?: boolean;
-  viewport?: { width: number; height: number };
+  viewport?: { width: number; height: number } | null;
   browser?: 'chromium' | 'firefox' | 'webkit';
   headers?: Record<string, string>;
   executablePath?: string;
@@ -850,7 +850,7 @@ export interface TabCloseCommand extends BaseCommand {
 
 export interface WindowNewCommand extends BaseCommand {
   action: 'window_new';
-  viewport?: { width: number; height: number };
+  viewport?: { width: number; height: number } | null;
 }
 
 // Union of all command types


### PR DESCRIPTION
Fixes #491

When `--start-maximized` or `--window-size` is passed as a browser arg, Playwright's default viewport (1280x720) overrides the browser's own window sizing, making those flags have no effect on the page content.

This change auto-detects those args and sets `viewport: null` so Playwright defers to the browser's window size. Explicit viewport values still take priority.

Also allows `viewport: null` in the launch protocol for agents that want to disable viewport emulation directly.