### PR TITLE
chore: minor release - Add annotated screenshots with the new --annotate 

### DIFF
--- a/.changeset/release-8be61365.md
+++ b/.changeset/release-8be61365.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": minor
+---
+
+Add annotated screenshots with the new --annotate flag, which overlays numbered labels on interactive elements and prints a legend mapping each label to its element ref. This enables multimodal AI models to reason about visual layout while using the same @eN refs for subsequent interactions. The flag can also be set via the AGENT_BROWSER_ANNOTATE environment variable.


### PR DESCRIPTION
## Release Changeset

**Type:** minor

**Changes:**
Add annotated screenshots with the new --annotate flag, which overlays numbered labels on interactive elements and prints a legend mapping each label to its element ref. This enables multimodal AI models to reason about visual layout while using the same @eN refs for subsequent interactions. The flag can also be set via the AGENT_BROWSER_ANNOTATE environment variable.

---
*This PR was created automatically by autoship*