### PR TITLE
Add page range support to PDF command

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1272,10 +1272,20 @@ async function handleDialog(command: DialogCommand, browser: BrowserManager): Pr
 
 async function handlePdf(command: PdfCommand, browser: BrowserManager): Promise<Response> {
   const page = browser.getPage();
-  await page.pdf({
+  const options: {
+    path: string;
+    format: string;
+    pageRanges?: string;
+  } = {
     path: command.path,
     format: command.format ?? 'Letter',
-  });
+  };
+
+  if (command.pageRanges) {
+    options.pageRanges = command.pageRanges;
+  }
+
+  await page.pdf(options);
   return successResponse(command.id, { path: command.path });
 }
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -214,6 +214,7 @@ const pdfSchema = baseCommandSchema.extend({
   format: z
     .enum(['Letter', 'Legal', 'Tabloid', 'Ledger', 'A0', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6'])
     .optional(),
+  pageRanges: z.string().optional(),
 });
 
 const routeSchema = baseCommandSchema.extend({

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,7 @@ export interface PdfCommand extends BaseCommand {
     | 'A4'
     | 'A5'
     | 'A6';
+  pageRanges?: string;
 }
 
 // Network interception


### PR DESCRIPTION
## Summary

Adds `--pages` flag to the `pdf` command to specify which pages to include in the generated PDF, using Playwright's native `pageRanges` option.

## Changes

- **CLI Parser** (`cli/src/commands.rs`): Added `-p/--pages` flag parser
- **Protocol** (`src/protocol.ts`): Added `pageRanges` field to `pdfSchema` validation
- **Types** (`src/types.ts`): Added optional `pageRanges` field to `PdfCommand` interface
- **Actions** (`src/actions.ts`): Pass `pageRanges` to Playwright's `page.pdf()` when specified

## Usage

```bash
# Single page
agent-browser pdf output.pdf --pages "1"

# Page range
agent-browser pdf output.pdf --pages "1-3"

# Multiple ranges
agent-browser pdf output.pdf --pages "1-5, 8, 11-13"
```

## Testing

Tested with Chrome via CDP:
- Single page (`--pages "1"`): ✅ Generates 1-page PDF
- Page range (`--pages "1-3"`): ✅ Generates 3-page PDF
- Specific page (`--pages "5"`): ✅ Generates 1-page PDF with page 5

## Implementation Notes

The `pageRanges` parameter uses Playwright's standard format (e.g., "1-5, 8, 11-13") and is passed directly to Playwright's `page.pdf()` method.