### PR TITLE
chore: minor release - Added new diff commands for comparing snapshots, s

### DIFF
--- a/.changeset/release-62817ec1.md
+++ b/.changeset/release-62817ec1.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": minor
+---
+
+Added new diff commands for comparing snapshots, screenshots, and URLs between page states. You can now run visual pixel diffs against baseline images, compare accessibility tree snapshots with customizable depth and selectors, and diff two URLs side-by-side with optional screenshot comparison.


### PR DESCRIPTION
## Release Changeset

**Type:** minor

**Changes:**
Added new diff commands for comparing snapshots, screenshots, and URLs between page states. You can now run visual pixel diffs against baseline images, compare accessibility tree snapshots with customizable depth and selectors, and diff two URLs side-by-side with optional screenshot comparison.

---
*This PR was created automatically by autoship*