### PR TITLE
fix: Browser args comma to semicolon split

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--headers <json>` | Set HTTP headers scoped to the URL's origin |
 | `--executable-path <path>` | Custom browser executable (or `AGENT_BROWSER_EXECUTABLE_PATH` env) |
 | `--extension <path>` | Load browser extension (repeatable; or `AGENT_BROWSER_EXTENSIONS` env) |
-| `--args <args>` | Browser launch args, comma or newline separated (or `AGENT_BROWSER_ARGS` env) |
+| `--args <args>` | Browser launch args, semicolon or newline separated (or `AGENT_BROWSER_ARGS` env) |
 | `--user-agent <ua>` | Custom User-Agent string (or `AGENT_BROWSER_USER_AGENT` env) |
 | `--proxy <url>` | Proxy server URL with optional auth (or `AGENT_BROWSER_PROXY` env) |
 | `--proxy-bypass <hosts>` | Hosts to bypass proxy (or `AGENT_BROWSER_PROXY_BYPASS` env) |

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -539,9 +539,9 @@ fn main() {
         }
 
         if let Some(ref a) = flags.args {
-            // Parse args (comma or newline separated)
+            // Parse args (semicolon or newline separated)
             let args_vec: Vec<String> = a
-                .split(&[',', '\n'][..])
+                .split(&[';', '\n'][..])
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .collect();

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2045,8 +2045,8 @@ Options:
   --headers <json>           HTTP headers scoped to URL's origin (for auth)
   --executable-path <path>   Custom browser executable (or AGENT_BROWSER_EXECUTABLE_PATH)
   --extension <path>         Load browser extensions (repeatable)
-  --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
-                             e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
+  --args <args>              Browser launch args, semicolon or newline separated (or AGENT_BROWSER_ARGS)
+                             e.g., --args "--no-sandbox;--disable-blink-features=AutomationControlled"
   --user-agent <ua>          Custom User-Agent (or AGENT_BROWSER_USER_AGENT)
   --proxy <server>           Proxy server URL (or AGENT_BROWSER_PROXY)
                              e.g., --proxy "http://user:pass@127.0.0.1:7890"

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -82,7 +82,7 @@ This enables control of:
     <tr><td><code>-p &lt;provider&gt;</code></td><td>Cloud browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>)</td></tr>
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>
     <tr><td><code>--executable-path</code></td><td>Custom browser executable</td></tr>
-    <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (comma-separated)</td></tr>
+    <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (semicolon-separated)</td></tr>
     <tr><td><code>--user-agent &lt;ua&gt;</code></td><td>Custom User-Agent string</td></tr>
     <tr><td><code>--proxy &lt;url&gt;</code></td><td>Proxy server URL</td></tr>
     <tr><td><code>--proxy-bypass &lt;hosts&gt;</code></td><td>Hosts to bypass proxy</td></tr>

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -308,7 +308,7 @@ agent-browser wait --download ./output.zip --timeout 30000
 - **Browser launch configuration** - Fine-grained control over browser startup
 
 ```bash
-agent-browser --args "--disable-gpu,--no-sandbox" open example.com
+agent-browser --args "--disable-gpu;--no-sandbox" open example.com
 agent-browser --user-agent "Custom UA" open example.com
 agent-browser --proxy-bypass "localhost,*.internal" open example.com
 ```

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -229,7 +229,7 @@ agent-browser reload                  # Reload page
 --headers <json>         # HTTP headers scoped to URL's origin
 --executable-path <path> # Custom browser executable
 --extension <path>       # Load browser extension (repeatable)
---args <args>            # Browser launch args (comma separated)
+--args <args>            # Browser launch args (semicolon separated)
 --user-agent <ua>        # Custom User-Agent string
 --proxy <url>            # Proxy server URL
 --proxy-bypass <hosts>   # Hosts to bypass proxy

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -101,7 +101,7 @@ Every CLI flag can be set in the config file using its camelCase equivalent:
 
 ```json
 {
-  "args": "--no-sandbox,--disable-gpu",
+  "args": "--no-sandbox;--disable-gpu",
   "ignoreHttpsErrors": true
 }
 ```

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -396,11 +396,11 @@ export async function startDaemon(options?: {
                     .filter(Boolean)
                 : undefined;
 
-              // Parse args from env (comma or newline separated)
+              // Parse args from env (semicolon or newline separated)
               const argsEnv = process.env.AGENT_BROWSER_ARGS;
               const args = argsEnv
                 ? argsEnv
-                    .split(/[,\n]/)
+                    .split(/[;\n]/)
                     .map((a) => a.trim())
                     .filter((a) => a.length > 0)
                 : undefined;


### PR DESCRIPTION
The --args flag splits arguments by comma, which breaks Chromium arguments that contain commas in their values, for example `--disable-features=ExtensionManifestV2Unsupported,ExtensionManifestV2Disabled`. PR changes the separator from comma to semicolon.