### PR TITLE
feat: Playwright Extension Provider

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "experimental": {
+    "plan": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,35 @@ agent-browser -p ios --device "John's iPhone" open https://example.com
 - Slightly slower initial connection than simulator
 - Tests against real Safari performance and behavior
 
+### Playwright Extension
+
+Connect to an existing Chrome browser tab via the [Playwright MCP browser extension](https://github.com/microsoft/playwright-mcp). This is useful for automating pages where you are already logged in or want to interact with a specific tab.
+
+**Setup:**
+1. Install the Playwright MCP extension in Chrome.
+2. Run `agent-browser` with the `playwright-extension` provider:
+
+```bash
+agent-browser -p playwright-extension open https://example.com
+```
+
+**Auto-connect:**
+If you have a `PLAYWRIGHT_MCP_EXTENSION_TOKEN` set, the extension will automatically connect to the target tab without a selection UI.
+
+```bash
+export AGENT_BROWSER_EXTENSION_TOKEN="your-token"
+agent-browser -p playwright-extension open https://example.com
+```
+
+| Option | Description |
+|--------|-------------|
+| `--relay-url <url>` | Playwright extension relay URL (optional) |
+| `--extension-token <token>` | Auto-connect token (bypasses tab selection UI) |
+
+**Constraints:**
+- **Single-tab only**: The extension supports exactly one active connection at a time. Multi-tab operations (opening new tabs, tab switching) are not supported.
+- **User-managed browser**: `agent-browser` cannot launch or close the browser; it only connects to an existing tab.
+
 ### Browserbase
 
 [Browserbase](https://browserbase.com) provides remote browser infrastructure to make deployment of agentic browsing agents easy. Use it when running the agent-browser CLI in an environment where a local browser isn't feasible.

--- a/browser-automation-research.md
+++ b/browser-automation-research.md
@@ -1,0 +1,465 @@
+# Browser Automation for AI Agents: Technical Reference
+
+> Consolidated research on **Playwright MCP** and **agent-browser** — two approaches to giving AI agents browser control.
+
+---
+
+## Part 1: Playwright MCP
+
+**Repo:** [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) (thin wrapper)
+**Actual source:** [playwright monorepo](https://github.com/microsoft/playwright/tree/main/packages/playwright/src/mcp)
+**npm:** `@playwright/mcp`
+
+### What It Is
+
+An MCP server that exposes Playwright's browser automation as structured tool calls. Instead of screenshot-based interaction (which requires a vision model), it gives the LLM an **accessibility tree snapshot** — the same semantic representation screen readers use.
+
+### Architecture
+
+```
+LLM Client (Claude, Copilot, Cursor)
+    │  MCP Protocol (STDIO, HTTP/SSE, or WebSocket)
+    v
+MCP Server Layer ─── registers tools, manages heartbeat
+    │
+    v
+BrowserServerBackend ─── routes tool calls
+    │
+    v
+Context ─── manages BrowserContext lifecycle, tabs, network filtering
+    │
+    v
+Tab ─── wraps Playwright Page, captures snapshots, resolves refs
+    │
+    v
+Playwright Browser Engine (Chromium, Firefox, WebKit)
+```
+
+### Transport Options
+
+- **STDIO** (default): Standard for IDE integrations. Client spawns the process.
+- **HTTP/SSE** (`--port 3000`): For remote deployments. Exposes `/mcp` (streamable) and `/sse` (legacy).
+- **WebSocket**: Used internally by extension bridge mode.
+
+### Browser Session Management
+
+**Lazy launch**: Browser starts on first tool call, not on server start.
+
+**Three profile modes:**
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| **Persistent** (default) | Profile at `~/.cache/ms-playwright/mcp-{channel}-profile`. Cookies/localStorage survive between sessions. | Repeated tasks against same sites |
+| **Isolated** (`--isolated`) | In-memory only. Can seed with `--storage-state`. | Clean, reproducible sessions |
+| **Extension bridge** (`--extension`) | Connects to already-running Chrome via browser extension + CDP. | Automate pages where user is already logged in |
+
+**Security:**
+- `--allowed-origins` / `--blocked-origins` for network filtering
+- `file://` blocked by default
+- `--secrets` flag redacts sensitive values from all responses
+
+---
+
+### Extension Bridge Mode (Deep Dive)
+
+Extension mode (`--extension`) is architecturally distinct from server mode. Instead of launching a fresh browser, it connects to an **existing Chrome session** via a browser extension and the Chrome DevTools Protocol (CDP).
+
+#### Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     AI Agent (MCP Client)                   │
+│              listTools() / callTool(name, args)             │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ MCP Protocol
+┌─────────────────────▼───────────────────────────────────────┐
+│                      MCP Server                             │
+│         (--extension mode)                                  │
+│         Translates MCP tool calls → CDP commands            │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ WebSocket (JSON protocol)
+┌─────────────────────▼───────────────────────────────────────┐
+│                      Relay Layer                            │
+│         RelayConnection class                               │
+│         Bridges WebSocket ↔ Chrome Debugger API             │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ chrome.debugger API (CDP)
+┌─────────────────────▼───────────────────────────────────────┐
+│                    Extension Layer                          │
+│         TabShareExtension (Chrome Service Worker)           │
+│         Manages tab lifecycle, UI feedback                  │
+└─────────────────────┬───────────────────────────────────────┘
+                      │
+              [ Browser Tab ]
+```
+
+#### The Browser Extension
+
+The extension (`@playwright/mcp-extension`) is a **Chrome Manifest V3 service worker** with these permissions:
+- `debugger` — attach to tabs via CDP
+- `activeTab`, `tabs` — tab management
+- `storage` — token persistence
+- `<all_urls>` — broad page access
+
+#### Connection Flow
+
+1. **Initiation**: Extension UI parses URL params (`mcpRelayUrl`, `protocolVersion`, `token`)
+2. **Validation**: Ensures `mcpRelayUrl` is a loopback address; checks protocol compatibility
+3. **Auto-connect**: If `PLAYWRIGHT_MCP_EXTENSION_TOKEN` is set, bypasses the approval dialog
+4. **Tab selection**: User picks target tab (or auto-connects with token)
+5. **Debugger attachment**: `chrome.debugger.attach()` connects to the selected tab
+
+#### CDP Relay Protocol
+
+The relay uses a custom JSON protocol over WebSocket:
+
+| Direction | Message Type | Purpose |
+|-----------|--------------|---------|
+| Client → Extension | `attachToTab` | Attach debugger to a tab |
+| Client → Extension | `forwardCDPCommand` | Execute a CDP command on the tab |
+| Extension → Client | `forwardCDPEvent` | Forward CDP events back to the MCP server |
+
+The `RelayConnection` class:
+- Parses incoming `ProtocolCommand` objects
+- Calls `chrome.debugger.sendCommand()` for CDP execution
+- Listens to `chrome.debugger.onEvent` and forwards events to the MCP server
+
+This is the critical layer: the MCP server doesn't talk to the browser directly. It sends structured CDP commands over a WebSocket to the extension, which proxies them through Chrome's `chrome.debugger` API.
+
+---
+
+### The Snapshot System
+
+**Why snapshots instead of screenshots:**
+1. No vision model required — works with text-only LLMs
+2. Deterministic — no ambiguity ("the blue button" vs exact ref)
+3. Token efficient — YAML tree << base64 image
+4. Supports incremental diffs between actions
+
+**How it works:**
+
+The internal API `page._snapshotForAI()` produces a YAML-like accessibility tree where each interactive element gets a **ref**:
+
+```yaml
+- navigation "Main":
+  - link "Home" [ref=e1]
+  - link "Products" [ref=e2]
+- main:
+  - heading "Welcome" [ref=e3]
+  - textbox "Search" [ref=e4]
+  - button "Search" [ref=e5]
+```
+
+The LLM calls:
+```json
+{ "tool": "browser_click", "arguments": { "ref": "e5", "element": "Search button" } }
+```
+
+Refs resolve via `aria-ref=` pseudo-selector (Playwright internal), mapping back to DOM elements through ARIA role + accessible name.
+
+**Three snapshot modes** (`--snapshot-mode`):
+- **`incremental`** (default): First response = full tree, subsequent = diff only. Massive token savings.
+- **`full`**: Always returns complete tree.
+- **`none`**: No snapshot in responses.
+
+### Tool System
+
+~70 tools across 26 source files, organized by **capability gates**:
+
+| Capability | Always On? | Example Tools |
+|---|---|---|
+| `core` | Yes | `browser_snapshot`, `browser_click`, `browser_evaluate`, `browser_close` |
+| `core-navigation` | Yes | `browser_navigate`, `browser_navigate_back` |
+| `core-tabs` | Yes | `browser_tab_list`, `browser_tab_new`, `browser_tab_select` |
+| `core-input` | Yes | `browser_type`, `browser_fill`, `browser_press_key` |
+| `vision` | Opt-in | `browser_screenshot`, coordinate-based mouse tools |
+| `pdf` | Opt-in | `browser_pdf_save` |
+| `testing` | Opt-in | Playwright assertion tools |
+| `devtools` | Opt-in | Trace recording |
+| `storage` | Opt-in | Cookie management |
+| `network` | Opt-in | Request listing, route interception |
+
+Enable opt-in capabilities: `--caps vision,pdf,network`
+
+Each tool handler also emits equivalent Playwright code (`response.addCode()`), so every action produces a runnable test script line.
+
+### Response Format
+
+Every tool response is structured markdown:
+
+```markdown
+### Result
+(tool output)
+
+### Ran Playwright code
+```js
+await page.goto('https://example.com');
+```
+
+### Open tabs
+- 0: (current) [Example](https://example.com)
+
+### Page
+- Page URL: https://example.com
+- Page Title: Example Domain
+
+### Snapshot
+```yaml
+- heading "Example Domain" [ref=e1]
+- link "More information..." [ref=e2]
+```
+```
+
+### Setup
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--browser", "chrome",
+        "--headless",
+        "--caps", "vision,pdf"
+      ]
+    }
+  }
+}
+```
+
+---
+
+## Part 2: agent-browser (Vercel Labs)
+
+**Repo:** [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser)
+**Language:** TypeScript + Rust CLI
+
+### What It Is
+
+A headless browser automation CLI purpose-built for AI agents. Unlike Playwright MCP (which is an MCP server), agent-browser is a **command-line tool** that agents invoke via shell commands.
+
+### Architecture: Three-Tier Client-Daemon-Browser
+
+```
+Rust CLI (fast native binary, sub-ms parsing)
+    │  IPC (Unix socket on Linux/macOS, TCP on Windows)
+    v
+Node.js Daemon (persistent background process)
+    │  Playwright / Appium
+    v
+Browser (Chromium, Firefox, WebKit, iOS Safari)
+```
+
+**Why this architecture:**
+- **Rust CLI**: Sub-millisecond parsing overhead. Matters when agents issue dozens of commands.
+- **Persistent daemon**: Eliminates 2-5s browser cold start on every command. First command boots daemon; subsequent reuse it.
+- **Session isolation**: Each `--session <name>` gets its own socket + browser. Multiple agents run in parallel.
+
+### The Provider System
+
+A **provider** determines where the browser runs. All commands work identically regardless of provider — the abstraction is transparent.
+
+**Provider selection** happens in `BrowserManager.launch()` via a priority chain:
+
+```
+1. CDP connection (explicit --cdp <port|url>)
+2. Auto-connect (--auto-connect, discovers running Chrome)
+3. Named cloud provider (-p <name> or AGENT_BROWSER_PROVIDER env var)
+4. iOS provider (-p ios, uses Appium instead of Playwright)
+5. Default: local Playwright launch
+```
+
+#### All Providers
+
+| Provider | Activation | Env Vars | Backend | Use Case |
+|---|---|---|---|---|
+| **Local** | Default | None | Playwright local | Dev, testing |
+| **CDP** | `--cdp <port\|url>` | None | Chrome DevTools Protocol | Existing Chrome/Electron |
+| **Auto-connect** | `--auto-connect` | None | Auto-discovered Chrome | Zero-config local |
+| **Browserbase** | `-p browserbase` | `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID` | Cloud API → CDP | Serverless, cloud |
+| **Browser Use** | `-p browseruse` | `BROWSER_USE_API_KEY` | Cloud API → CDP | Cloud automation |
+| **Kernel** | `-p kernel` | `KERNEL_API_KEY` | Cloud API → CDP (stealth) | Anti-bot bypass |
+| **iOS** | `-p ios` | Optional device/UDID vars | Appium + WebDriverIO | Mobile Safari |
+
+#### How Cloud Providers Work Internally
+
+All three cloud providers (Browserbase, Browser Use, Kernel) follow the same pattern:
+
+1. Create a remote session via the provider's REST API
+2. Get a CDP WebSocket URL from the response
+3. Connect Playwright via `chromium.connectOverCDP(wsUrl)`
+4. Grab existing context and page
+5. Store session ID for cleanup on `close()`
+
+Example (Browserbase):
+```typescript
+// 1. Create session
+const response = await fetch('https://api.browserbase.com/v1/sessions', {
+  method: 'POST',
+  headers: { 'X-BB-API-Key': apiKey },
+  body: JSON.stringify({ projectId }),
+});
+const session = await response.json();
+
+// 2. Connect Playwright
+const browser = await chromium.connectOverCDP(session.connectUrl);
+
+// 3. Reuse existing page
+const context = browser.contexts()[0];
+const page = context.pages()[0] ?? await context.newPage();
+```
+
+#### Kernel-Specific Features
+
+Optional env vars for Kernel provider:
+- `KERNEL_PROFILE_NAME` — persistent profile
+- `KERNEL_HEADLESS` — headless mode
+- `KERNEL_STEALTH` — stealth/anti-detection
+- `KERNEL_TIMEOUT_SECONDS` — session timeout
+
+#### iOS: A Separate Architecture
+
+iOS uses `IOSManager` instead of `BrowserManager`:
+- **Appium + WebDriverIO** instead of Playwright
+- Controls real Mobile Safari in Simulator or on USB device
+- Own ref system (`IOSRefMap`) mirrors desktop one
+- Mobile-specific commands: `swipe`, `tap`, `device list`
+- Daemon routes iOS commands to `executeIOSCommand()` instead of `executeCommand()`
+
+#### Adding a Custom Provider
+
+**There is no formal plugin interface.** Providers are hard-coded in `BrowserManager.launch()`. To add one:
+
+1. Add a `connectToMyProvider()` private method in `/src/browser.ts`
+2. Add a dispatch case in `launch()`
+3. Add cleanup in `close()`
+4. Update CLI to accept new provider name
+
+**Practical shortcut**: If a service exposes a CDP endpoint, you can use `--cdp <your-ws-url>` directly — no custom provider needed.
+
+### The Snapshot-Ref System
+
+Same core concept as Playwright MCP — accessibility tree with refs:
+
+```
+- heading "Example Domain" [ref=e1] [level=1]
+- button "Submit" [ref=e2]
+- textbox "Email" [ref=e3]
+```
+
+Interaction via refs:
+```bash
+agent-browser click @e2        # Click "Submit"
+agent-browser fill @e3 "test@example.com"
+```
+
+**Ref resolution** uses ARIA role + accessible name (more stable than CSS selectors):
+```typescript
+let locator = page.getByRole(refData.role, { name: refData.name, exact: true });
+if (refData.nth !== undefined) locator = locator.nth(refData.nth);
+```
+
+The `-C` flag adds detection of elements with `cursor: pointer` / `onclick` that lack proper ARIA roles (common in SPAs).
+
+**Ref lifecycle**: Refs are invalidated when the DOM changes. Always re-snapshot after navigation or dynamic content updates.
+
+**Diff support**: `diff snapshot` / `diff screenshot` detect changes between actions. This is an explicit command, unlike Playwright MCP's built-in incremental snapshot mode.
+
+### AI-Friendly Design
+
+- **`--json` flag**: Machine-readable output with explicit `success`/`error` fields
+- **AI-friendly errors**: Rewrites cryptic Playwright errors into actionable guidance
+- **Snapshot stats**: Token count estimates so agents can choose compact vs full snapshot
+- **Annotated screenshots** (`--annotate`): Numbered labels on interactive elements for multimodal models
+
+### Session Persistence
+
+Three levels:
+1. **Ephemeral** (default): Everything lost on close
+2. **Session persistence** (`--session-name`): Auto-saves/restores cookies + localStorage to JSON (optional AES-256-GCM encryption)
+3. **Persistent profiles** (`--profile`): Full Chromium user data directory
+
+### Command Structure
+
+```bash
+agent-browser <command> [args] [options]
+```
+
+| Category | Example Commands |
+|----------|------------------|
+| Navigation | `open <url>`, `back`, `forward`, `reload` |
+| Interaction | `click <sel>`, `fill <sel> <text>`, `hover <sel>` |
+| Data | `get text <sel>`, `screenshot`, `snapshot` |
+| State | `console`, `network`, `cookies` |
+
+Selectors supported: refs (`@e1`), CSS, XPath, text-based, semantic locators.
+
+### The Agent Interaction Loop
+
+```
+AI Agent
+  │ "agent-browser snapshot -i --json"
+  v
+agent-browser CLI (Rust) → daemon (Node.js) → browser
+  │ Returns: JSON accessibility tree + refs
+  v
+AI Agent (parses, decides)
+  │ "agent-browser click @e3"
+  v
+agent-browser CLI (Rust) → daemon (Node.js) → browser
+  │ Returns: { success: true }
+  v
+AI Agent (re-snapshots to verify)
+```
+
+---
+
+## Part 3: Structural Comparison
+
+### Interface Philosophy
+
+| | Playwright MCP | agent-browser |
+|---|---|---|
+| **Protocol** | MCP (standardized JSON-RPC) | CLI (shell exec) |
+| **Integration** | Native in MCP-aware clients | Any system that runs shell commands |
+| **Tool discovery** | Client auto-discovers tools via MCP | Agent must know commands upfront |
+| **Statefulness** | MCP server lifetime = session | Persistent daemon across commands |
+
+### Snapshot Approach
+
+Both use accessibility tree snapshots with refs. The core idea is identical. Differences:
+
+| | Playwright MCP | agent-browser |
+|---|---|---|
+| **Incremental updates** | Built into protocol (`--snapshot-mode incremental`) | Explicit `diff snapshot` command |
+| **Snapshot API** | Internal `_snapshotForAI()` (tightly coupled) | Public Playwright ARIA snapshot API |
+| **Ref format** | `ref=e1` | `@e1` |
+| **Clickable detection** | Standard ARIA roles only | `-C` flag adds `cursor:pointer` / `onclick` detection |
+
+### Provider / Session Models
+
+| | Playwright MCP | agent-browser |
+|---|---|---|
+| **Cloud providers** | None built-in | Browserbase, Browser Use, Kernel |
+| **Mobile** | No | iOS via Appium |
+| **Existing browser** | Extension bridge (CDP via Chrome extension) | `--cdp` flag or `--auto-connect` |
+| **Session isolation** | One session per MCP server | Named sessions via `--session` |
+| **Profile persistence** | `~/.cache/ms-playwright/mcp-{channel}-profile` | `--profile` (Chromium user data dir) |
+
+### The CDP Connection Point
+
+Both tools ultimately interact with browsers via CDP (Chrome DevTools Protocol), but through different paths:
+
+- **Playwright MCP extension mode**: MCP Server → WebSocket → RelayConnection → `chrome.debugger` API → tab
+- **agent-browser CDP provider**: CLI → daemon → `chromium.connectOverCDP(wsUrl)` → remote browser
+- **agent-browser cloud providers**: CLI → daemon → REST API → get CDP URL → `chromium.connectOverCDP(wsUrl)`
+
+---
+
+## References
+
+- [playwright-mcp on DeepWiki](https://deepwiki.com/microsoft/playwright-mcp)
+- [agent-browser on DeepWiki](https://deepwiki.com/vercel-labs/agent-browser)
+- [GitHub: microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
+- [GitHub: vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser)

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -220,6 +220,8 @@ pub fn ensure_daemon(
     provider: Option<&str>,
     device: Option<&str>,
     session_name: Option<&str>,
+    relay_url: Option<&str>,
+    extension_token: Option<&str>,
 ) -> Result<DaemonResult, String> {
     // Check if daemon is running AND responsive
     if is_daemon_running(session) && daemon_ready(session) {
@@ -364,6 +366,14 @@ pub fn ensure_daemon(
             cmd.env("AGENT_BROWSER_SESSION_NAME", sn);
         }
 
+        if let Some(ru) = relay_url {
+            cmd.env("AGENT_BROWSER_RELAY_URL", ru);
+        }
+
+        if let Some(et) = extension_token {
+            cmd.env("AGENT_BROWSER_EXTENSION_TOKEN", et);
+        }
+
         // Create new process group and session to fully detach
         unsafe {
             cmd.pre_exec(|| {
@@ -445,6 +455,14 @@ pub fn ensure_daemon(
 
         if let Some(sn) = session_name {
             cmd.env("AGENT_BROWSER_SESSION_NAME", sn);
+        }
+
+        if let Some(ru) = relay_url {
+            cmd.env("AGENT_BROWSER_RELAY_URL", ru);
+        }
+
+        if let Some(et) = extension_token {
+            cmd.env("AGENT_BROWSER_EXTENSION_TOKEN", et);
         }
 
         // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -39,15 +39,11 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
                     return;
                 }
                 Some("diff_url") => {
-                    if let Some(snap_data) =
-                        obj.get("snapshot").and_then(|v| v.as_object())
-                    {
+                    if let Some(snap_data) = obj.get("snapshot").and_then(|v| v.as_object()) {
                         println!("{}", color::bold("Snapshot diff:"));
                         print_snapshot_diff(snap_data);
                     }
-                    if let Some(ss_data) =
-                        obj.get("screenshot").and_then(|v| v.as_object())
-                    {
+                    if let Some(ss_data) = obj.get("screenshot").and_then(|v| v.as_object()) {
                         println!("\n{}", color::bold("Screenshot diff:"));
                         print_screenshot_diff(ss_data);
                     }
@@ -310,11 +306,7 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
                     }
                     _ => {
                         if let Some(path) = data.get("path").and_then(|v| v.as_str()) {
-                            println!(
-                                "{} Recording started: {}",
-                                color::success_indicator(),
-                                path
-                            );
+                            println!("{} Recording started: {}", color::success_indicator(), path);
                         } else {
                             println!("{} Recording started", color::success_indicator());
                         }
@@ -497,7 +489,10 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
                     let filename = file.get("filename").and_then(|v| v.as_str()).unwrap_or("");
                     let size = file.get("size").and_then(|v| v.as_i64()).unwrap_or(0);
                     let modified = file.get("modified").and_then(|v| v.as_str()).unwrap_or("");
-                    let encrypted = file.get("encrypted").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let encrypted = file
+                        .get("encrypted")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
                     let size_str = if size > 1024 {
                         format!("{:.1}KB", size as f64 / 1024.0)
                     } else {
@@ -505,7 +500,11 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
                     };
                     let date_str = modified.split('T').next().unwrap_or(modified);
                     let enc_str = if encrypted { " [encrypted]" } else { "" };
-                    println!("  {} {}", filename, color::dim(&format!("({}, {}){}", size_str, date_str, enc_str)));
+                    println!(
+                        "  {} {}",
+                        filename,
+                        color::dim(&format!("({}, {}){}", size_str, date_str, enc_str))
+                    );
                 }
             }
             return;
@@ -515,13 +514,22 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
         if let Some(true) = data.get("renamed").and_then(|v| v.as_bool()) {
             let old_name = data.get("oldName").and_then(|v| v.as_str()).unwrap_or("");
             let new_name = data.get("newName").and_then(|v| v.as_str()).unwrap_or("");
-            println!("{} Renamed {} -> {}", color::success_indicator(), old_name, new_name);
+            println!(
+                "{} Renamed {} -> {}",
+                color::success_indicator(),
+                old_name,
+                new_name
+            );
             return;
         }
 
         // State clear
         if let Some(cleared) = data.get("cleared").and_then(|v| v.as_i64()) {
-            println!("{} Cleared {} state file(s)", color::success_indicator(), cleared);
+            println!(
+                "{} Cleared {} state file(s)",
+                color::success_indicator(),
+                cleared
+            );
             return;
         }
 
@@ -529,7 +537,10 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
         if let Some(summary) = data.get("summary") {
             let cookies = summary.get("cookies").and_then(|v| v.as_i64()).unwrap_or(0);
             let origins = summary.get("origins").and_then(|v| v.as_i64()).unwrap_or(0);
-            let encrypted = data.get("encrypted").and_then(|v| v.as_bool()).unwrap_or(false);
+            let encrypted = data
+                .get("encrypted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             let enc_str = if encrypted { " (encrypted)" } else { "" };
             println!("State file summary{}:", enc_str);
             println!("  Cookies: {}", cookies);
@@ -539,7 +550,11 @@ pub fn print_response(resp: &Response, json_mode: bool, action: Option<&str>) {
 
         // State clean
         if let Some(cleaned) = data.get("cleaned").and_then(|v| v.as_i64()) {
-            println!("{} Cleaned {} old state file(s)", color::success_indicator(), cleaned);
+            println!(
+                "{} Cleaned {} old state file(s)",
+                color::success_indicator(),
+                cleaned
+            );
             return;
         }
 
@@ -2054,7 +2069,9 @@ Options:
                              e.g., --proxy-bypass "localhost,*.internal.com"
   --ignore-https-errors      Ignore HTTPS certificate errors
   --allow-file-access        Allow file:// URLs to access local files (Chromium only)
-  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse
+  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, playwright-extension
+  --relay-url <url>          Playwright extension relay URL (or AGENT_BROWSER_RELAY_URL env)
+  --extension-token <token>  Playwright extension auto-connect token (or AGENT_BROWSER_EXTENSION_TOKEN env)
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
   --json                     JSON output
   --full, -f                 Full page screenshot
@@ -2100,7 +2117,9 @@ Environment:
   AGENT_BROWSER_ANNOTATE         Annotated screenshot with numbered labels and legend
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
-  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse)
+  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, playwright-extension)
+  AGENT_BROWSER_RELAY_URL        Playwright extension relay URL
+  AGENT_BROWSER_EXTENSION_TOKEN  Playwright extension auto-connect token
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_STREAM_PORT      Enable WebSocket streaming on port (e.g., 9223)
@@ -2182,10 +2201,7 @@ fn print_screenshot_diff(data: &serde_json::Map<String, serde_json::Value>) {
         .get("mismatchPercentage")
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0);
-    let is_match = data
-        .get("match")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let is_match = data.get("match").and_then(|v| v.as_bool()).unwrap_or(false);
     let dim_mismatch = data
         .get("dimensionMismatch")
         .and_then(|v| v.as_bool())
@@ -2196,7 +2212,10 @@ fn print_screenshot_diff(data: &serde_json::Map<String, serde_json::Value>) {
             color::error_indicator()
         );
     } else if is_match {
-        println!("{} Images match (0% difference)", color::success_indicator());
+        println!(
+            "{} Images match (0% difference)",
+            color::success_indicator()
+        );
     } else {
         println!(
             "{} {:.2}% pixels differ",
@@ -2207,7 +2226,10 @@ fn print_screenshot_diff(data: &serde_json::Map<String, serde_json::Value>) {
     if let Some(diff_path) = data.get("diffPath").and_then(|v| v.as_str()) {
         println!("  Diff image: {}", color::green(diff_path));
     }
-    let total = data.get("totalPixels").and_then(|v| v.as_i64()).unwrap_or(0);
+    let total = data
+        .get("totalPixels")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
     let different = data
         .get("differentPixels")
         .and_then(|v| v.as_i64())

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -1,6 +1,9 @@
 /// Check if a session name is valid (alphanumeric, hyphens, and underscores only)
 pub fn is_valid_session_name(name: &str) -> bool {
-    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
 }
 
 /// Generate error message for invalid session name

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -180,6 +180,31 @@ agent-browser --auto-connect snapshot
 
 # Or with explicit CDP port
 agent-browser --cdp 9222 snapshot
+
+# Via Playwright MCP browser extension
+agent-browser -p playwright-extension open https://example.com
+```
+
+### Playwright Extension Provider
+
+Connect to an existing Chrome browser tab via the Playwright MCP extension. This is useful for automating pages where the user is already logged in.
+
+**Usage:**
+1. Install the Playwright MCP extension in Chrome.
+2. Run `agent-browser -p playwright-extension`.
+3. Open the generated connection URL in Chrome to connect.
+
+```bash
+agent-browser -p playwright-extension snapshot
+# ACTION REQUIRED: Open chrome-extension://... in Chrome
+```
+
+**Auto-connect:**
+Set `AGENT_BROWSER_EXTENSION_TOKEN` to bypass the tab selection UI.
+
+```bash
+export AGENT_BROWSER_EXTENSION_TOKEN="your-token"
+agent-browser -p playwright-extension open https://example.com
 ```
 
 ### Visual Browser (Debugging)

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -430,6 +430,8 @@ export async function startDaemon(options?: {
                 proxy,
                 ignoreHTTPSErrors: ignoreHTTPSErrors,
                 allowFileAccess: allowFileAccess,
+                relayUrl: process.env.AGENT_BROWSER_RELAY_URL,
+                extensionToken: process.env.AGENT_BROWSER_EXTENSION_TOKEN,
                 autoStateFilePath: getSessionAutoStatePath(),
               });
             }

--- a/src/playwright-extension-proxy.ts
+++ b/src/playwright-extension-proxy.ts
@@ -1,0 +1,269 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import { EventEmitter } from 'events';
+import { createServer, Server } from 'http';
+
+interface ExtensionMessage {
+  method: string;
+  id?: number;
+  params?: any;
+  result?: any;
+  error?: any;
+}
+
+export interface ProxyInfo {
+  relayUrl: string;
+  cdpUrl: string;
+}
+
+/**
+ * CDP Proxy for Playwright MCP Extension.
+ * Translates between standard CDP and the extension's JSON-envelope protocol.
+ */
+export class PlaywrightExtensionProxy extends EventEmitter {
+  private relayServer: WebSocketServer;
+  private cdpServer: WebSocketServer;
+  private relayPort: number = 0;
+  private cdpPort: number = 0;
+  private relaySocket: WebSocket | null = null;
+  private cdpSocket: WebSocket | null = null;
+  private targetInfo: any = null;
+  private sessionId: string | null = null;
+  private pendingCommands = new Map<number, (response: any) => void>();
+  private nextId = 1;
+
+  constructor() {
+    super();
+    // Start relay server (for extension to connect)
+    this.relayServer = new WebSocketServer({ port: 0 });
+    this.relayServer.on('connection', (ws) => this.onRelayConnection(ws));
+
+    // Start CDP server (for Playwright to connect)
+    this.cdpServer = new WebSocketServer({ port: 0 });
+    this.cdpServer.on('connection', (ws) => this.onCdpConnection(ws));
+  }
+
+  async start(): Promise<ProxyInfo> {
+    return new Promise((resolve, reject) => {
+      let relayReady = false;
+      let cdpReady = false;
+
+      this.relayServer.on('listening', () => {
+        const addr = this.relayServer.address();
+        if (typeof addr === 'object' && addr) {
+          this.relayPort = addr.port;
+          relayReady = true;
+          if (cdpReady) resolve(this.getInfo());
+        }
+      });
+
+      this.cdpServer.on('listening', () => {
+        const addr = this.cdpServer.address();
+        if (typeof addr === 'object' && addr) {
+          this.cdpPort = addr.port;
+          cdpReady = true;
+          if (relayReady) resolve(this.getInfo());
+        }
+      });
+
+      this.relayServer.on('error', reject);
+      this.cdpServer.on('error', reject);
+    });
+  }
+
+  getInfo(): ProxyInfo {
+    return {
+      relayUrl: `ws://127.0.0.1:${this.relayPort}`,
+      cdpUrl: `ws://127.0.0.1:${this.cdpPort}`,
+    };
+  }
+
+  private async onRelayConnection(ws: WebSocket) {
+    if (this.relaySocket) {
+      ws.close(1013, 'Only one extension connection allowed');
+      return;
+    }
+
+    this.relaySocket = ws;
+    ws.on('message', (data) => this.handleRelayMessage(data.toString()));
+    ws.on('close', () => {
+      this.relaySocket = null;
+      this.emit('extension-disconnected');
+    });
+
+    // Initiate handshake
+    try {
+      const response = await this.sendExtensionCommand('attachToTab', {});
+      this.targetInfo = response.targetInfo;
+      this.sessionId = response.sessionId || null;
+      this.emit('extension-ready', this.targetInfo);
+    } catch (err) {
+      console.error('Handshake failed:', err);
+      ws.close();
+    }
+  }
+
+  private onCdpConnection(ws: WebSocket) {
+    if (this.cdpSocket) {
+      ws.close(1013, 'Only one Playwright connection allowed');
+      return;
+    }
+
+    this.cdpSocket = ws;
+    ws.on('message', (data) => this.handleCdpMessage(data.toString()));
+    ws.on('close', () => {
+      this.cdpSocket = null;
+      this.emit('playwright-disconnected');
+    });
+  }
+
+  private async handleRelayMessage(data: string) {
+    try {
+      const msg: ExtensionMessage = JSON.parse(data);
+
+      // Handle command responses
+      if (msg.id !== undefined && this.pendingCommands.has(msg.id)) {
+        const resolve = this.pendingCommands.get(msg.id)!;
+        this.pendingCommands.delete(msg.id);
+        resolve(msg);
+        return;
+      }
+
+      // Handle events
+      if (msg.method === 'forwardCDPEvent') {
+        if (this.cdpSocket && this.cdpSocket.readyState === WebSocket.OPEN) {
+          const cdpEvent = {
+            method: msg.params.method,
+            params: msg.params.params,
+          };
+          this.cdpSocket.send(JSON.stringify(cdpEvent));
+        }
+        return;
+      }
+    } catch (err) {
+      console.error('Error handling relay message:', err);
+    }
+  }
+
+  private async handleCdpMessage(data: string) {
+    try {
+      const msg = JSON.parse(data);
+      const { id, method, params } = msg;
+
+      // Intercept Target.getTargetInfo
+      if (method === 'Target.getTargetInfo' && this.targetInfo) {
+        this.cdpSocket?.send(
+          JSON.stringify({
+            id,
+            result: { targetInfo: this.targetInfo },
+          })
+        );
+        return;
+      }
+
+      // Intercept Target.getTargets
+      if (method === 'Target.getTargets' && this.targetInfo) {
+        this.cdpSocket?.send(
+          JSON.stringify({
+            id,
+            result: { targetInfos: [this.targetInfo] },
+          })
+        );
+        return;
+      }
+
+      // Intercept Target.setAutoAttach (Playwright calls this)
+      if (method === 'Target.setAutoAttach') {
+        this.cdpSocket?.send(JSON.stringify({ id, result: {} }));
+        return;
+      }
+
+      // Intercept Browser.getVersion
+      if (method === 'Browser.getVersion') {
+        this.cdpSocket?.send(
+          JSON.stringify({
+            id,
+            result: {
+              protocolVersion: '1.3',
+              product: 'Chrome/PlaywrightExtension',
+              revision: '1.0',
+              userAgent: 'Mozilla/5.0 (PlaywrightExtension)',
+              jsVersion: '1.0',
+            },
+          })
+        );
+        return;
+      }
+
+      // Reject Target.createTarget (multi-tab not supported)
+      if (method === 'Target.createTarget') {
+        this.cdpSocket?.send(
+          JSON.stringify({
+            id,
+            error: {
+              message:
+                'Multi-tab operations are not supported by the Playwright Extension provider',
+            },
+          })
+        );
+        return;
+      }
+
+      // Forward to extension
+      if (!this.relaySocket || this.relaySocket.readyState !== WebSocket.OPEN) {
+        this.cdpSocket?.send(
+          JSON.stringify({
+            id,
+            error: { message: 'Extension not connected' },
+          })
+        );
+        return;
+      }
+
+      const response = await this.sendExtensionCommand('forwardCDPCommand', {
+        sessionId: this.sessionId,
+        method,
+        params,
+      });
+
+      if (this.cdpSocket && this.cdpSocket.readyState === WebSocket.OPEN) {
+        if (response.error) {
+          this.cdpSocket.send(JSON.stringify({ id, error: response.error }));
+        } else {
+          // Extension message 'result' field IS the CDP result
+          this.cdpSocket.send(JSON.stringify({ id, result: response }));
+        }
+      }
+    } catch (err) {
+      console.error('Error handling CDP message:', err);
+    }
+  }
+
+  private sendExtensionCommand(method: string, params: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (!this.relaySocket || this.relaySocket.readyState !== WebSocket.OPEN) {
+        return reject(new Error('Extension not connected'));
+      }
+
+      const id = this.nextId++;
+      const msg = { method, id, params };
+
+      this.pendingCommands.set(id, (resp: ExtensionMessage) => {
+        if (resp.error) {
+          reject(resp.error);
+        } else {
+          resolve(resp.result);
+        }
+      });
+
+      this.relaySocket.send(JSON.stringify(msg));
+    });
+  }
+
+  async stop() {
+    this.relayServer.close();
+    this.cdpServer.close();
+    if (this.relaySocket) this.relaySocket.close();
+    if (this.cdpSocket) this.cdpSocket.close();
+    this.pendingCommands.clear();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface LaunchCommand extends BaseCommand {
   args?: string[];
   userAgent?: string;
   provider?: string;
+  relayUrl?: string; // The extension's mcpRelayUrl
+  extensionToken?: string; // For auto-connect (bypasses tab selection UI)
   ignoreHTTPSErrors?: boolean;
   allowFileAccess?: boolean; // Enable file:// URL access and cross-origin file requests
   // Auto-load state file for session persistence

--- a/test/playwright-extension-proxy.test.ts
+++ b/test/playwright-extension-proxy.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PlaywrightExtensionProxy } from '../src/playwright-extension-proxy.js';
+import { WebSocket } from 'ws';
+
+describe('PlaywrightExtensionProxy', () => {
+  let proxy: PlaywrightExtensionProxy;
+
+  beforeEach(async () => {
+    proxy = new PlaywrightExtensionProxy();
+  });
+
+  afterEach(async () => {
+    await proxy.stop();
+  });
+
+  it('should start and provide relay and CDP URLs', async () => {
+    const info = await proxy.start();
+    expect(info.relayUrl).toMatch(/^ws:\/\/127.0.0.1:\d+$/);
+    expect(info.cdpUrl).toMatch(/^ws:\/\/127.0.0.1:\d+$/);
+  });
+
+  it('should handle handshake with extension', async () => {
+    const info = await proxy.start();
+    
+    const extensionSocket = new WebSocket(info.relayUrl);
+    
+    // Mock extension side
+    extensionSocket.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.method === 'attachToTab') {
+        extensionSocket.send(JSON.stringify({
+          id: msg.id,
+          result: {
+            targetInfo: { title: 'Test Page', url: 'https://example.com' },
+            sessionId: 'session-123'
+          }
+        }));
+      }
+    });
+
+    const readyPromise = new Promise<any>((resolve) => {
+      proxy.once('extension-ready', resolve);
+    });
+
+    const targetInfo = await readyPromise;
+    expect(targetInfo.title).toBe('Test Page');
+    expect(targetInfo.url).toBe('https://example.com');
+    
+    extensionSocket.close();
+  });
+
+  it('should translate CDP commands from Playwright to Extension', async () => {
+    const info = await proxy.start();
+    
+    const extensionSocket = new WebSocket(info.relayUrl);
+    
+    // Handshake
+    extensionSocket.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.method === 'attachToTab') {
+        extensionSocket.send(JSON.stringify({
+          id: msg.id,
+          result: { targetInfo: {}, sessionId: 's1' }
+        }));
+      } else if (msg.method === 'forwardCDPCommand') {
+        // Echo back with result
+        expect(msg.params.method).toBe('Page.navigate');
+        expect(msg.params.params.url).toBe('https://example.com');
+        extensionSocket.send(JSON.stringify({
+          id: msg.id,
+          result: { frameId: 'f1' }
+        }));
+      }
+    });
+
+    await new Promise(r => proxy.once('extension-ready', r));
+
+    const playwrightSocket = new WebSocket(info.cdpUrl);
+    
+    await new Promise(r => playwrightSocket.on('open', r));
+
+    const responsePromise = new Promise<any>((resolve) => {
+      playwrightSocket.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.id === 100) resolve(msg);
+      });
+    });
+
+    playwrightSocket.send(JSON.stringify({
+      id: 100,
+      method: 'Page.navigate',
+      params: { url: 'https://example.com' }
+    }));
+
+    const resp = await responsePromise;
+    expect(resp.id).toBe(100);
+    expect(resp.result.frameId).toBe('f1');
+
+    playwrightSocket.close();
+    extensionSocket.close();
+  });
+
+  it('should unwrapp CDP events from Extension to Playwright', async () => {
+    const info = await proxy.start();
+    
+    const extensionSocket = new WebSocket(info.relayUrl);
+    
+    // Handshake
+    extensionSocket.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.method === 'attachToTab') {
+        extensionSocket.send(JSON.stringify({
+          id: msg.id,
+          result: { targetInfo: {}, sessionId: 's1' }
+        }));
+      }
+    });
+
+    await new Promise(r => proxy.once('extension-ready', r));
+
+    const playwrightSocket = new WebSocket(info.cdpUrl);
+    await new Promise(r => playwrightSocket.on('open', r));
+
+    const eventPromise = new Promise<any>((resolve) => {
+      playwrightSocket.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.method === 'Console.messageAdded') resolve(msg);
+      });
+    });
+
+    // Send event from extension
+    extensionSocket.send(JSON.stringify({
+      method: 'forwardCDPEvent',
+      params: {
+        sessionId: 's1',
+        method: 'Console.messageAdded',
+        params: { message: 'hello' }
+      }
+    }));
+
+    const event = await eventPromise;
+    expect(event.method).toBe('Console.messageAdded');
+    expect(event.params.message).toBe('hello');
+
+    playwrightSocket.close();
+    extensionSocket.close();
+  });
+
+  it('should intercept Target.getTargetInfo', async () => {
+    const info = await proxy.start();
+    
+    const extensionSocket = new WebSocket(info.relayUrl);
+    
+    // Handshake
+    extensionSocket.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.method === 'attachToTab') {
+        extensionSocket.send(JSON.stringify({
+          id: msg.id,
+          result: { targetInfo: { targetId: 't1' }, sessionId: 's1' }
+        }));
+      }
+    });
+
+    await new Promise(r => proxy.once('extension-ready', r));
+
+    const playwrightSocket = new WebSocket(info.cdpUrl);
+    await new Promise(r => playwrightSocket.on('open', r));
+
+    const responsePromise = new Promise<any>((resolve) => {
+      playwrightSocket.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.id === 200) resolve(msg);
+      });
+    });
+
+    playwrightSocket.send(JSON.stringify({
+      id: 200,
+      method: 'Target.getTargetInfo',
+      params: {}
+    }));
+
+    const resp = await responsePromise;
+    expect(resp.id).toBe(200);
+    expect(resp.result.targetInfo.targetId).toBe('t1');
+
+    playwrightSocket.close();
+    extensionSocket.close();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a new provider `playwright-extension` to `agent-browser` that allows connecting to an existing browser tab via the Playwright MCP browser extension.

### Key Features:
- **CDP Proxy**: A local WebSocket server that translates between standard CDP and the extension's JSON-envelope protocol.
- **Provider Implementation**: Integration with `BrowserManager` and the background daemon.
- **CLI Support**: New `--relay-url` and `--extension-token` flags.
- **Auto-connect**: Support for token-based automatic connection to bypass the tab selection UI.

## Test Plan
- Unit tests for the proxy protocol translation: `pnpm vitest run test/playwright-extension-proxy.test.ts`
- Full verification suite: `pnpm run typecheck && cargo clippy --manifest-path cli/Cargo.toml`
- Manual verification: Connect to a live Chrome tab using the generated extension URL.