### PR TITLE
fix state load failing when no browser is running

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Instructions for AI coding agents working with this codebase.
 
+## Package Manager
+
+This project uses **pnpm**. Always use `pnpm` instead of `npm` or `yarn` for installing dependencies, running scripts, etc. (e.g., `pnpm install`, `pnpm run build`).
+
 ## Code Style
 
 - Do not use emojis in code, output, or documentation. Unicode symbols (✓, ✗, →, ⚠) are acceptable.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -373,11 +373,12 @@ export async function startDaemon(options?: {
             continue;
           }
 
-          // Auto-launch if not already launched and this isn't a launch/close command
+          // Auto-launch if not already launched and this isn't a launch/close/state_load command
           if (
             !manager.isLaunched() &&
             parseResult.command.action !== 'launch' &&
-            parseResult.command.action !== 'close'
+            parseResult.command.action !== 'close' &&
+            parseResult.command.action !== 'state_load'
           ) {
             if (isIOS && manager instanceof IOSManager) {
               // Auto-launch iOS Safari


### PR DESCRIPTION
`state load` always fails with "Cannot load state while browser is running" even when no browser is running, making the command completely unusable (#526).

The daemon's auto-launch logic starts a browser before `state_load` gets to handle the command. This adds `state_load` to the exclusion list alongside `launch` and `close`, so `handleStateLoad` can perform its own launch with the state file.