### PR TITLE
fix(daemon): add backpressure control and command serialization to prevent IPC EAGAIN

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -28,6 +28,22 @@ import {
   ENCRYPTION_KEY_ENV,
 } from './state-utils.js';
 
+/**
+ * Returns the default Playwright timeout for standard operations.
+ * Can be overridden via the AGENT_BROWSER_DEFAULT_TIMEOUT environment variable.
+ * CDP and recording contexts use a shorter fixed timeout (10s) and are not affected.
+ */
+function getDefaultTimeout(): number {
+  const envValue = process.env.AGENT_BROWSER_DEFAULT_TIMEOUT;
+  if (envValue) {
+    const parsed = parseInt(envValue, 10);
+    if (!isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return 60000;
+}
+
 // Screencast frame data from CDP
 export interface ScreencastFrame {
   data: string; // base64 encoded image
@@ -264,7 +280,7 @@ export class BrowserManager {
       context = await this.browser.newContext({
         ...(this.colorScheme && { colorScheme: this.colorScheme }),
       });
-      context.setDefaultTimeout(60000);
+      context.setDefaultTimeout(getDefaultTimeout());
       this.contexts.push(context);
       this.setupContextTracking(context);
     } else {
@@ -1018,7 +1034,7 @@ export class BrowserManager {
       this.kernelSessionId = session.session_id;
       this.kernelApiKey = kernelApiKey;
       this.browser = browser;
-      context.setDefaultTimeout(60000);
+      context.setDefaultTimeout(getDefaultTimeout());
       this.contexts.push(context);
       this.pages.push(page);
       this.activePageIndex = 0;
@@ -1091,7 +1107,7 @@ export class BrowserManager {
       this.browserUseSessionId = session.id;
       this.browserUseApiKey = browserUseApiKey;
       this.browser = browser;
-      context.setDefaultTimeout(60000);
+      context.setDefaultTimeout(getDefaultTimeout());
       this.contexts.push(context);
       this.pages.push(page);
       this.activePageIndex = 0;
@@ -1346,7 +1362,7 @@ export class BrowserManager {
       });
     }
 
-    context.setDefaultTimeout(60000);
+    context.setDefaultTimeout(getDefaultTimeout());
     this.contexts.push(context);
     this.setupContextTracking(context);
 
@@ -1666,7 +1682,7 @@ export class BrowserManager {
       viewport: viewport === undefined ? { width: 1280, height: 720 } : viewport,
       ...(this.colorScheme && { colorScheme: this.colorScheme }),
     });
-    context.setDefaultTimeout(60000);
+    context.setDefaultTimeout(getDefaultTimeout());
     this.contexts.push(context);
     this.setupContextTracking(context);
 


### PR DESCRIPTION
## Summary

Fixes the daemon-side root causes of EAGAIN (os error 35 on macOS / error 11 on Linux) that crash the Rust CLI during IPC reads.

This complements #329 (CLI-side retry logic) by preventing the conditions that trigger EAGAIN in the first place.

### Changes

**`src/browser.ts`** — Configurable Playwright timeout via environment variable
- Add `getDefaultTimeout()` helper that reads `AGENT_BROWSER_DEFAULT_TIMEOUT` env var
- Replace all hardcoded `setDefaultTimeout(60000)` calls (5 locations) with `setDefaultTimeout(getDefaultTimeout())`
- CDP and recording contexts (10s timeout) are **not** affected
- Default remains 60s when env var is unset — fully backward compatible

**`src/daemon.ts`** — Backpressure-aware writes + command serialization
- Add `safeWrite()` helper that waits for `drain` event when `socket.write()` returns `false`, with proper cleanup on `close`/`error`
- Serialize command execution per socket via a queue to prevent concurrent `socket.write()` calls that cause kernel buffer contention
- Add `.catch()` guards for unhandled rejection safety

### Root Cause Analysis

Two daemon-side issues combine to cause EAGAIN:

1. **Playwright timeout > CLI IPC timeout**: `setDefaultTimeout(60000)` means Playwright can block for up to 60s, but the Rust CLI times out earlier. The daemon never responds, and the CLI's `read_line()` hits EAGAIN.

2. **Uncontrolled `socket.write()` concurrency**: Multiple async command handlers can call `socket.write()` in parallel. When payloads are large (e.g., `snapshot` responses), the kernel buffer fills up and subsequent writes/reads fail with EAGAIN.

### Testing

- All 363 existing tests pass (9 skipped)
- Prettier formatting verified
- TypeScript compilation clean
- Manually tested with a heavy React Native/Expo app (~1000+ DOM nodes): 10 consecutive `snapshot` commands complete without os error 35

### Usage

```bash
# Set a shorter timeout (e.g., 30s) to prevent daemon hangs
export AGENT_BROWSER_DEFAULT_TIMEOUT=30000
```

Refs #322