### PR TITLE
cli: only warn about --annotate when explicitly passed via CLI

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -83,7 +83,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
     let rest: Vec<&str> = args[1..].iter().map(|s| s.as_str()).collect();
     let id = gen_id();
 
-    if flags.annotate && cmd != "screenshot" {
+    if flags.cli_annotate && cmd != "screenshot" {
         eprintln!(
             "{} --annotate only applies to the screenshot command",
             color::warning_indicator()
@@ -1863,6 +1863,7 @@ mod tests {
             cli_proxy: false,
             cli_proxy_bypass: false,
             cli_allow_file_access: false,
+            cli_annotate: false,
             annotate: false,
             color_scheme: None,
         }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -215,6 +215,7 @@ pub struct Flags {
     pub cli_proxy: bool,
     pub cli_proxy_bypass: bool,
     pub cli_allow_file_access: bool,
+    pub cli_annotate: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -293,6 +294,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_proxy: false,
         cli_proxy_bypass: false,
         cli_allow_file_access: false,
+        cli_annotate: false,
     };
 
     let mut i = 0;
@@ -429,6 +431,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--annotate" => {
                 let (val, consumed) = parse_bool_arg(args, i);
                 flags.annotate = val;
+                flags.cli_annotate = true;
                 if consumed { i += 1; }
             }
             "--color-scheme" => {
@@ -656,6 +659,19 @@ mod tests {
     fn test_cli_profile_tracking() {
         let flags = parse_flags(&args("--profile /path/to/profile snapshot"));
         assert!(flags.cli_profile);
+    }
+
+    #[test]
+    fn test_cli_annotate_tracking() {
+        let flags = parse_flags(&args("--annotate screenshot"));
+        assert!(flags.cli_annotate);
+        assert!(flags.annotate);
+    }
+
+    #[test]
+    fn test_cli_annotate_not_set_without_flag() {
+        let flags = parse_flags(&args("screenshot"));
+        assert!(!flags.cli_annotate);
     }
 
     #[test]


### PR DESCRIPTION
The `--annotate` warning fires on every non-screenshot command when `annotate` is set in the user-level config file (`~/.agent-browser/config.json`). This is noisy for users who set it as a persistent default — the whole point of a config file.

Adds `cli_annotate` tracking to the `Flags` struct, matching the existing `cli_*` pattern used for `executable_path`, `extensions`, `profile`, etc. The warning now only fires when `--annotate` is explicitly passed as a CLI flag.

Fixes #530