### PR TITLE
chore: patch release - Added support for chrome:// and chrome-extension:/

### DIFF
--- a/.changeset/release-6125c755.md
+++ b/.changeset/release-6125c755.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Added support for chrome:// and chrome-extension:// URLs in navigation and recording commands. These special browser URLs are now preserved as-is instead of having https:// incorrectly prepended.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Added support for chrome:// and chrome-extension:// URLs in navigation and recording commands. These special browser URLs are now preserved as-is instead of having https:// incorrectly prepended.

---
*This PR was created automatically by autoship*