### PR TITLE
fix: correct misleading output for cookies clear and tab close

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -318,10 +318,14 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
-        // Cleared requests
+        // Cleared (cookies or request log)
         if let Some(cleared) = data.get("cleared").and_then(|v| v.as_bool()) {
             if cleared {
-                println!("{} Request log cleared", color::success_indicator());
+                let label = match action {
+                    Some("cookies_clear") => "Cookies cleared",
+                    _ => "Request log cleared",
+                };
+                println!("{} {}", color::success_indicator(), label);
                 return;
             }
         }
@@ -382,9 +386,13 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
-        // Closed
+        // Closed (browser or tab)
         if data.get("closed").is_some() {
-            println!("{} Browser closed", color::success_indicator());
+            let label = match action {
+                Some("tab_close") => "Tab closed",
+                _ => "Browser closed",
+            };
+            println!("{} {}", color::success_indicator(), label);
             return;
         }
         // Recording start (has "started" field)


### PR DESCRIPTION
## Summary

Fixes two misleading CLI output messages reported in #556 that confuse both human users and AI agents parsing CLI output.

### Bug 1 — `cookies clear` prints wrong message

**Before:** `✓ Request log cleared`
**After:** `✓ Cookies cleared`

**Root cause:** Both `cookies_clear` and `requests --clear` return `{ cleared: true }`. The output handler matched this generic shape without checking which action produced it, always printing the `requests` message.

**Fix:** Use the `action` parameter (already passed to `print_response_with_opts`) to distinguish `cookies_clear` from other clear operations.

### Bug 2 — `tab close` prints wrong message

**Before:** `✓ Browser closed`
**After:** `✓ Tab closed`

**Root cause:** Both `close` (browser) and `tab_close` return a response with a `closed` field. The output handler matched the generic shape without checking the action.

**Fix:** Use the `action` parameter to distinguish `tab_close` from `close`.

### Bug 3 — Duplicate error output

Investigated the full error path (daemon `executeCommand` → `errorResponse` → socket write → CLI `print_response_with_opts`) and confirmed only one error message is emitted per failed command. The daemon's stderr is piped to `Stdio::null()` when auto-started, `send_command_once` reads exactly one response line, and the `processQueue` serialization prevents duplicate processing. Could not reproduce from code analysis — may be environment-specific or version-dependent.

### Testing

- 256/256 Rust CLI tests pass (2 consecutive clean runs)
- 376/376 applicable TypeScript tests pass (3 test files fail due to pre-existing Playwright environment issues, unrelated to this change)

Closes #556