### PR TITLE
fix: treat EPERM from kill(pid, 0) as process exists

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -170,7 +170,11 @@ fn run_session(args: &[String], session: &str, json_mode: bool) {
                             if let Ok(pid_str) = fs::read_to_string(&pid_path) {
                                 if let Ok(pid) = pid_str.trim().parse::<u32>() {
                                     #[cfg(unix)]
-                                    let running = unsafe { libc::kill(pid as i32, 0) == 0 };
+                                    let running = unsafe {
+                                        libc::kill(pid as i32, 0) == 0
+                                            || std::io::Error::last_os_error().raw_os_error()
+                                                != Some(libc::ESRCH)
+                                    };
                                     #[cfg(windows)]
                                     let running = unsafe {
                                         let handle =


### PR DESCRIPTION
## Summary

- `kill(pid, 0)` is used to check if the daemon process is alive, but all three call sites treat any failure as "process not running"
- Per POSIX, `EPERM` means the process **exists** but the caller lacks permission to signal it, while `ESRCH` means it does not exist
- Inside a macOS sandbox with `(allow signal (target self))`, `kill` returns `EPERM` for all other PIDs, causing the CLI to incorrectly conclude the daemon is dead
- This leads to deletion of the running daemon's socket/PID files and spawning of a duplicate daemon

### Changes

**`cli/src/connection.rs` — `is_daemon_running`:** Check `errno` after a failed `kill(pid, 0)`; only return `false` when `errno == ESRCH`.

**`cli/src/main.rs` — `run_session` (session list):** Same fix for the inline liveness check.

**`src/daemon.ts` — `isDaemonRunning`:** Check `err.code === 'EPERM'` before cleaning up stale files.

## Test plan

- [x] `cargo test` — all 256 existing tests pass
- [ ] Run CLI inside a macOS sandbox that restricts signals to `(target self)` and verify the daemon is correctly detected as running
- [ ] Verify that stale PID files (where the process is genuinely gone) are still cleaned up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)