### PR TITLE
fix(windows): improve daemon error messages and add debug logging

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -400,6 +400,10 @@ pub fn ensure_daemon(
 
         // On Windows, call node directly. Command::new handles PATH resolution (node.exe or node.cmd)
         // and automatically quotes arguments containing spaces.
+        eprintln!("[DEBUG] Starting daemon: node {:?}", daemon_path);
+        eprintln!("[DEBUG] Session: {}", session);
+        eprintln!("[DEBUG] Port: {}", get_port_for_session(session));
+        
         let mut cmd = Command::new("node");
         cmd.arg(daemon_path);
         apply_daemon_env(&mut cmd, session, opts);
@@ -425,10 +429,15 @@ pub fn ensure_daemon(
         thread::sleep(Duration::from_millis(100));
     }
 
-    Err(format!(
-        "Daemon failed to start (socket: {})",
+    #[cfg(unix)]
+    let socket_info = format!(
+        "socket: {}",
         get_socket_dir().join(format!("{}.sock", session)).display()
-    ))
+    );
+    #[cfg(windows)]
+    let socket_info = format!("port: {}", get_port_for_session(session));
+
+    Err(format!("Daemon failed to start ({})", socket_info))
 }
 
 fn connect(session: &str) -> Result<Connection, String> {
@@ -714,3 +723,5 @@ mod tests {
         assert!(!is_transient_error("Daemon not found"));
     }
 }
+
+


### PR DESCRIPTION
## Problem

On Windows, when the daemon fails to start, the error message incorrectly shows a Unix socket path instead of the TCP port number that Windows actually uses.

## Solution

- Fix error message to show port number on Windows instead of socket path
- Add debug logging for daemon startup (command, session, port)
- Helps diagnose daemon startup failures on Windows

## Changes

- Modified cli/src/connection.rs to use platform-specific error messages
- Added debug logging with println! for Windows daemon startup

## Testing

Tested on Windows 11 with agent-browser 0.15.1:
- Error messages now correctly show port numbers
- Debug logs help identify startup issues
- Daemon successfully starts and connects