### PR TITLE
fix: pin Playwright version in install command to match bundled playwright-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,20 @@ jobs:
           }
         shell: pwsh
 
+      - name: Verify Chromium revision matches playwright-core
+        run: |
+          $expected = node -e "const b=require('./node_modules/playwright-core/browsers.json'); console.log(b.browsers.find(x=>x.name==='chromium-headless-shell').revision)"
+          $dirs = Get-ChildItem "$env:LOCALAPPDATA\ms-playwright" -Directory | Where-Object { $_.Name -like "chromium_headless_shell-*" }
+          $installed = $dirs | ForEach-Object { $_.Name -replace 'chromium_headless_shell-', '' }
+          Write-Host "Expected revision: $expected"
+          Write-Host "Installed revision(s): $installed"
+          if ($installed -notcontains $expected) {
+            Write-Error "Chromium revision mismatch: installed [$installed], expected $expected"
+            exit 1
+          }
+          Write-Host "Chromium revision matches playwright-core"
+        shell: pwsh
+
   serverless-chromium:
     name: Serverless Chromium (@sparticuz/chromium)
     runs-on: ubuntu-latest

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -12,6 +12,29 @@ use std::time::Duration;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 
+/// Strip the `\\?\` extended-length path prefix that Windows `canonicalize()` adds.
+/// Node.js cannot handle these paths, so they must be normalized before being
+/// passed as arguments to Node processes.
+#[cfg(windows)]
+pub fn strip_extended_length_prefix(path: PathBuf) -> PathBuf {
+    let p = path.to_string_lossy();
+    if let Some(stripped) = p.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
+    } else {
+        path
+    }
+}
+
+/// Resolve the exe path, canonicalizing symlinks and stripping the Windows
+/// `\\?\` prefix when present.
+pub fn resolve_exe_dir() -> Option<PathBuf> {
+    let exe_path = env::current_exe().ok()?;
+    let exe_path = exe_path.canonicalize().unwrap_or(exe_path);
+    #[cfg(windows)]
+    let exe_path = strip_extended_length_prefix(exe_path);
+    exe_path.parent().map(|p| p.to_path_buf())
+}
+
 #[derive(Serialize)]
 #[allow(dead_code)]
 pub struct Request {
@@ -352,10 +375,8 @@ pub fn ensure_daemon(
         }
     }
 
-    let exe_path = env::current_exe().map_err(|e| e.to_string())?;
-    // Canonicalize to resolve symlinks (e.g., npm global bin symlink -> actual binary)
-    let exe_path = exe_path.canonicalize().unwrap_or(exe_path);
-    let exe_dir = exe_path.parent().unwrap();
+    let exe_dir = resolve_exe_dir()
+        .ok_or_else(|| "Failed to resolve executable directory".to_string())?;
 
     let mut daemon_paths = vec![
         exe_dir.join("daemon.js"),

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -1,5 +1,40 @@
 use crate::color;
+use crate::connection;
+use std::path::PathBuf;
 use std::process::{exit, Command, Stdio};
+
+/// Read the playwright-core version from its package.json so that the install
+/// command downloads the exact Chromium revision the runtime expects.
+fn resolve_playwright_version() -> Option<String> {
+    let exe_dir = connection::resolve_exe_dir()?;
+
+    let candidates = [
+        exe_dir.join("../node_modules/playwright-core/package.json"),
+        exe_dir.join("node_modules/playwright-core/package.json"),
+    ];
+
+    // Also check AGENT_BROWSER_HOME
+    let home_candidates: Vec<PathBuf> = std::env::var("AGENT_BROWSER_HOME")
+        .ok()
+        .map(|h| {
+            let home = PathBuf::from(h);
+            vec![
+                home.join("node_modules/playwright-core/package.json"),
+            ]
+        })
+        .unwrap_or_default();
+
+    for path in home_candidates.iter().chain(candidates.iter()) {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
+                if let Some(version) = json["version"].as_str() {
+                    return Some(version.to_string());
+                }
+            }
+        }
+    }
+    None
+}
 
 pub fn run_install(with_deps: bool) {
     let is_linux = cfg!(target_os = "linux");
@@ -143,17 +178,24 @@ pub fn run_install(with_deps: bool) {
 
     println!("{}", color::cyan("Installing Chromium browser..."));
 
-    // On Windows, we need to use cmd.exe to run npx because npx is actually npx.cmd
-    // and Command::new() doesn't resolve .cmd files the way the shell does.
-    // Pass the entire command as a single string to /c to handle paths with spaces.
+    // Pin to the same playwright version as the bundled playwright-core so the
+    // downloaded Chromium revision matches what the runtime expects.
+    let pw_package = match resolve_playwright_version() {
+        Some(v) => {
+            println!("  Using playwright@{} (matched to bundled playwright-core)", v);
+            format!("playwright@{}", v)
+        }
+        None => "playwright".to_string(),
+    };
+
     #[cfg(windows)]
     let status = Command::new("cmd")
-        .args(["/c", "npx playwright install chromium"])
+        .args(["/c", &format!("npx {} install chromium", pw_package)])
         .status();
 
     #[cfg(not(windows))]
     let status = Command::new("npx")
-        .args(["playwright", "install", "chromium"])
+        .args([&pw_package, "install", "chromium"])
         .status();
 
     match status {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,9 +29,7 @@ use std::process::Command as ProcessCommand;
 /// These commands don't need a browser, so we handle them directly to avoid
 /// sending passwords through the daemon's Unix socket channel.
 fn run_auth_cli(cmd: &serde_json::Value, json_mode: bool) -> ! {
-    let exe_path = env::current_exe().unwrap_or_default();
-    let exe_path = exe_path.canonicalize().unwrap_or(exe_path);
-    let exe_dir = exe_path.parent().unwrap_or(std::path::Path::new("."));
+    let exe_dir = connection::resolve_exe_dir().unwrap_or_else(|| PathBuf::from("."));
 
     let mut script_paths = vec![
         exe_dir.join("auth-cli.js"),


### PR DESCRIPTION
`agent-browser install` runs `npx playwright install chromium`, which resolves the latest playwright from npm. When that version differs from the bundled playwright-core (e.g., npm has 1.58.2 with revision 1208 but agent-browser ships playwright-core 1.57.0 expecting revision 1200), the downloaded Chromium doesn't match and launch fails with "Executable doesn't exist". (fixes #107, #244)

Changes:
- Add resolve_playwright_version() to read the version from the bundled playwright-core/package.json and pin `npx playwright@<version>`
- Extract resolve_exe_dir() and strip_extended_length_prefix() as shared helpers in connection.rs (reused by main.rs and install.rs)
- Add CI step to verify installed Chromium revision matches playwright-core