### PR TITLE
chore: patch release - Fixed Windows compatibility issues including prope

### DIFF
--- a/.changeset/release-ccb73f55.md
+++ b/.changeset/release-ccb73f55.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fixed Windows compatibility issues including proper handling of extended-length path prefixes from canonicalize(), prevention of MSYS/Git Bash path translation that could mangle arguments, and improved daemon startup reliability. Also added ARM64 Windows support in postinstall shims and expanded CI testing with a full daemon lifecycle test on Windows.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Fixed Windows compatibility issues including proper handling of extended-length path prefixes from canonicalize(), prevention of MSYS/Git Bash path translation that could mangle arguments, and improved daemon startup reliability. Also added ARM64 Windows support in postinstall shims and expanded CI testing with a full daemon lifecycle test on Windows.

---
*This PR was created automatically by autoship*