### PR TITLE
docs: document element screenshot selector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ agent-browser scroll <dir> [px]       # Scroll (up/down/left/right, --selector <
 agent-browser scrollintoview <sel>    # Scroll element into view (alias: scrollinto)
 agent-browser drag <src> <tgt>        # Drag and drop
 agent-browser upload <sel> <files>    # Upload files
-agent-browser screenshot [path]       # Take screenshot (--full for full page, saves to a temporary directory if no path)
+agent-browser screenshot [sel] [path] # Take screenshot (--full for full page, saves to a temporary directory if no path)
+agent-browser screenshot @e3          # Screenshot a specific element
 agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
 agent-browser pdf <path>              # Save as PDF
 agent-browser snapshot                # Accessibility tree with refs (best for AI)
@@ -461,6 +462,17 @@ agent-browser click @e2     # Click the "Home" link labeled [2]
 ```
 
 This is useful for multimodal AI models that can reason about visual layout, unlabeled icon buttons, canvas elements, or visual state that the text accessibility tree cannot capture.
+
+## Element Screenshots
+
+You can screenshot a specific element by passing a selector (ref, CSS selector, etc.):
+
+```bash
+agent-browser screenshot @e3                    # Screenshot element by ref
+agent-browser screenshot @e3 ./element.png      # Save element screenshot to file
+agent-browser screenshot "#hero-banner"         # Screenshot by CSS ID
+agent-browser screenshot ".card"                # Screenshot by CSS class
+```
 
 ## Options
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1233,10 +1233,16 @@ Examples:
             r##"
 agent-browser screenshot - Take a screenshot
 
-Usage: agent-browser screenshot [path]
+Usage: agent-browser screenshot [selector] [path]
 
-Captures a screenshot of the current page. If no path is provided,
-saves to a temporary directory with a generated filename.
+Captures a screenshot of the current page or a specific element.
+If no path is provided, saves to a temporary directory with a generated filename.
+
+Selector:
+  @ref                 Element ref from snapshot (e.g. @e3)
+  .class               CSS class selector
+  #id                  CSS ID selector
+  Any valid CSS selector is accepted.
 
 Options:
   --full, -f           Capture full page (not just viewport)
@@ -1253,6 +1259,9 @@ Examples:
   agent-browser screenshot
   agent-browser screenshot ./screenshot.png
   agent-browser screenshot --full ./full-page.png
+  agent-browser screenshot @e3                     # Screenshot a specific element
+  agent-browser screenshot @e3 ./element.png       # Element screenshot to file
+  agent-browser screenshot "#hero-banner"          # Screenshot by CSS selector
   agent-browser screenshot --annotate              # Labeled screenshot + legend
   agent-browser screenshot --annotate ./page.png   # Save annotated screenshot
   agent-browser screenshot --annotate --json       # JSON output with annotations


### PR DESCRIPTION
## Summary

Closes #587

The `screenshot` command already fully supports element-level screenshots via selector (`@ref`, CSS selectors), but this capability was undocumented in both the CLI `--help` text and the README.

- **CLI help text** (`cli/src/output.rs`): Updated usage from `[path]` to `[selector] [path]`, added a `Selector:` section documenting `@ref`, `.class`, `#id` patterns, and added element screenshot examples
- **README**: Updated command reference table to show `[sel] [path]`, added a new "Element Screenshots" section with usage examples

No code changes — documentation only.

## Verified

- `cargo build` succeeds
- All 19 screenshot tests pass (`cargo test screenshot`)
- Manually tested `agent-browser screenshot @e1`, `agent-browser screenshot "h1"` against a live page

🤖 Generated with [Claude Code](https://claude.com/claude-code)