### PR TITLE
fix: allow viewport to follow window resize in headed mode

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1337,10 +1337,11 @@ export class BrowserManager {
     const hasWindowSizeArgs = baseArgs?.some(
       (arg) => arg === '--start-maximized' || arg.startsWith('--window-size=')
     );
+    const isHeaded = hasExtensions || options.headless === false;
     const viewport =
       options.viewport !== undefined
         ? options.viewport
-        : hasWindowSizeArgs
+        : hasWindowSizeArgs || isHeaded
           ? null
           : { width: 1280, height: 720 };
 


### PR DESCRIPTION
## Summary

Fixes #592

When running in headed mode (`--headed`), Playwright's viewport was fixed at `1280x720`, preventing the rendering area from following browser window resizes. This caused the page content to remain locked in a small area while the rest of the window showed blank space — a behavior that never occurs in normal browsers.

This PR sets `viewport: null` in headed mode so the browser viewport naturally follows the window size, matching standard browser behavior.

## Problem

In headed mode, even though the browser window could be resized with the mouse, the actual rendering area stayed at `1280x720`:

- **Window resized larger** → content stayed at 1280x720 with blank space around it
- **Window resized smaller** → content was clipped instead of reflowing

This happened because Playwright's viewport emulation overrides the browser's native sizing behavior.

### Before (v0.15.3 — viewport locked at 1280x720)

The window is resized wider, but the page content remains confined to the original 1280x720 area. Notice the blank space on the right side — the viewport does not follow the window size.

<img width="1823" height="1318" alt="Before: headed mode with fixed viewport — blank space visible after window resize" src="https://github.com/user-attachments/assets/17083985-9714-4467-8107-298135430dba" />

## Solution

```typescript
// Before
const viewport =
  options.viewport !== undefined
    ? options.viewport
    : hasWindowSizeArgs
      ? null
      : { width: 1280, height: 720 };

// After
const isHeaded = hasExtensions || options.headless === false;
const viewport =
  options.viewport !== undefined
    ? options.viewport
    : hasWindowSizeArgs || isHeaded
      ? null
      : { width: 1280, height: 720 };
```

When `viewport` is set to `null`, Playwright does not control the viewport, allowing the browser to handle it natively — just like a regular browser.

## Impact Analysis

| Mode | Before | After |
|------|--------|-------|
| **Headless** (default) | 1280x720 fixed | **No change** — `isHeaded = false` |
| **Headed** (`--headed`) | 1280x720 fixed | **viewport = null** — follows window size |
| **Headed + explicit viewport** (`set viewport <w> <h>`) | Respects user value | **No change** — `options.viewport !== undefined` takes priority |
| **Extensions** (always headed) | 1280x720 fixed | **viewport = null** — follows window size |

- The `viewport` variable is used in 3 places (lines 1362, 1380, 1467) — all reference the same variable, so this single change applies everywhere.
- Users who need a fixed viewport in headed mode can still set it explicitly via `set viewport`.

## Verification

1. `npm run build` — builds successfully
2. `npm test` — all 481 tests pass
3. Manual testing:
   - `agent-browser open https://naver.com --headed`
   - **Before fix**: resizing window leaves blank space, `window.innerWidth/Height` stays `1280x720`
   - **After fix**: content fills the window, `window.innerWidth/Height` updates on resize

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all existing tests pass
- [x] Headed mode: viewport follows window resize
- [x] Headless mode: unchanged (1280x720 default)
- [x] Headed mode with explicit `set viewport 1024 768`: respects user-specified value

🤖 Generated with [Claude Code](https://claude.com/claude-code)