### PR TITLE
Fix dialog dismiss command parsing

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -959,6 +959,13 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                     }
                     Ok(cmd)
                 }
+                Some("dismiss") => {
+                    let mut cmd = json!({ "id": id, "action": "dialog", "response": "dismiss" });
+                    if let Some(prompt_text) = rest.get(1) {
+                        cmd["promptText"] = json!(prompt_text);
+                    }
+                    Ok(cmd)
+                }
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
                     valid_options: VALID,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2877,7 +2877,12 @@ async fn handle_permissions(cmd: &Value, state: &DaemonState) -> Result<Value, S
 
 async fn handle_dialog(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-    let accept = cmd.get("accept").and_then(|v| v.as_bool()).unwrap_or(true);
+    let accept = cmd
+        .get("response")
+        .and_then(|v| v.as_str())
+        .map(|r| r == "accept")
+        .or_else(|| cmd.get("accept").and_then(|v| v.as_bool()))
+        .unwrap_or(true);
     let prompt_text = cmd.get("promptText").and_then(|v| v.as_str());
 
     mgr.handle_dialog(accept, prompt_text).await?;


### PR DESCRIPTION
Fixes #553. The dialog dismiss subcommand was listed as valid but not actually handled in the match statement, causing an UnknownSubcommand error. This commit adds proper handling for the dismiss case in both the CLI parser and native daemon.