### PR TITLE
docs: clarify npx setup requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ npm install -g agent-browser
 agent-browser install  # Download Chromium
 ```
 
-This is the fastest option -- commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
+This is the fastest option—commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
 
 ### Quick Start (no install)
 
-Run directly with `npx` if you want to try it without installing globally:
+Run directly with `npx` if you want to try it without installing globally (the browser install step is still required once):
 
 ```bash
 npx agent-browser install   # Download Chromium (first time only)


### PR DESCRIPTION
## Summary\n- clarify that  usage still needs a one-time browser install\n- tighten wording in the installation section for readability\n\n## Why\nThe prior wording can imply that  has zero setup, while users still need to run  once. This small doc update reduces first-run confusion.\n\n## Type\n- Documentation