### PR TITLE
chore: patch release - Added AGENT_BROWSER_HEADED environment variable su

### DIFF
--- a/.changeset/release-c4c2b53d.md
+++ b/.changeset/release-c4c2b53d.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Added AGENT_BROWSER_HEADED environment variable support for running the browser in headed mode, and improved temporary profile cleanup when launching Chrome directly. Also includes documentation clarification that browser extensions work in both headed and headless modes.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Added AGENT_BROWSER_HEADED environment variable support for running the browser in headed mode, and improved temporary profile cleanup when launching Chrome directly. Also includes documentation clarification that browser extensions work in both headed and headless modes.

---
*This PR was created automatically by autoship*