### PR TITLE
chore: patch release - Fixed an issue where the --native flag was being p

### DIFF
--- a/.changeset/release-a2e4783a.md
+++ b/.changeset/release-a2e4783a.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Fixed an issue where the --native flag was being passed to child processes even when not explicitly specified on the command line. The flag is now only forwarded when the user explicitly provides it, consistent with how other CLI flags like --allow-file-access and --download-path are handled.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Fixed an issue where the --native flag was being passed to child processes even when not explicitly specified on the command line. The flag is now only forwarded when the user explicitly provides it, consistent with how other CLI flags like --allow-file-access and --download-path are handled.

---
*This PR was created automatically by autoship*