### PR TITLE
feat: add support for including request body and query parameters in network requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ agent-browser network route <url> --body <json>  # Mock response
 agent-browser network unroute [url]            # Remove routes
 agent-browser network requests                 # View tracked requests
 agent-browser network requests --filter api    # Filter requests
+agent-browser network requests --query-params --filter api  # Include URL query params
+agent-browser network requests --body --query-params --filter api  # Include request body and params
 ```
 
 ### Tabs & Windows

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1996,11 +1996,19 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some("requests") => {
             let clear = rest.contains(&"--clear");
+            let with_body = rest.contains(&"--body");
+            let with_query_params = rest.contains(&"--query-params");
             let filter_idx = rest.iter().position(|&s| s == "--filter");
             let filter = filter_idx.and_then(|i| rest.get(i + 1).copied());
             let mut cmd = json!({ "id": id, "action": "requests", "clear": clear });
             if let Some(f) = filter {
                 cmd["filter"] = json!(f);
+            }
+            if with_body {
+                cmd["body"] = json!(true);
+            }
+            if with_query_params {
+                cmd["queryParams"] = json!(true);
             }
             Ok(cmd)
         }
@@ -3035,6 +3043,19 @@ mod tests {
         assert_eq!(cmd["action"], "emulatemedia");
         assert_eq!(cmd["colorScheme"], "light");
         assert_eq!(cmd["reducedMotion"], "reduce");
+    }
+
+    #[test]
+    fn test_network_requests_with_body_and_query_params() {
+        let cmd = parse_command(
+            &args("network requests --body --query-params --filter api"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "requests");
+        assert_eq!(cmd["body"], true);
+        assert_eq!(cmd["queryParams"], true);
+        assert_eq!(cmd["filter"], "api");
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -62,6 +62,40 @@ pub struct TrackedRequest {
     pub timestamp: u64,
     #[serde(rename = "resourceType")]
     pub resource_type: String,
+    #[serde(rename = "queryParams", skip_serializing_if = "Option::is_none")]
+    pub query_params: Option<Value>,
+    #[serde(rename = "body", skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+fn extract_query_params(url: &str) -> Option<Value> {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return None;
+    };
+
+    let mut query = serde_json::Map::new();
+    for (key, value) in parsed.query_pairs() {
+        let key = key.into_owned();
+        let value = Value::String(value.into_owned());
+
+        if let Some(existing) = query.get_mut(&key) {
+            match existing {
+                Value::Array(arr) => arr.push(value),
+                _ => {
+                    let first = existing.take();
+                    *existing = Value::Array(vec![first, value]);
+                }
+            }
+        } else {
+            query.insert(key, value);
+        }
+    }
+
+    if query.is_empty() {
+        None
+    } else {
+        Some(Value::Object(query))
+    }
 }
 
 pub struct FetchPausedRequest {
@@ -285,12 +319,19 @@ impl DaemonState {
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map(|d| d.as_millis() as u64)
                                         .unwrap_or(0);
+                                    let query_params = extract_query_params(&url);
+                                    let body = request
+                                        .get("postData")
+                                        .and_then(|v| v.as_str())
+                                        .map(String::from);
                                     self.tracked_requests.push(TrackedRequest {
                                         url,
                                         method,
                                         headers,
                                         timestamp,
                                         resource_type,
+                                        query_params,
+                                        body,
                                     });
                                 }
                             }
@@ -4539,15 +4580,36 @@ async fn handle_requests(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     }
 
     let filter = cmd.get("filter").and_then(|v| v.as_str());
-    let requests: Vec<&TrackedRequest> = if let Some(f) = filter {
+    let with_body = cmd
+        .get("body")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let with_query_params = cmd
+        .get("queryParams")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let mut requests: Vec<TrackedRequest> = if let Some(f) = filter {
         state
             .tracked_requests
             .iter()
             .filter(|r| r.url.contains(f))
+            .cloned()
             .collect()
     } else {
-        state.tracked_requests.iter().collect()
+        state.tracked_requests.clone()
     };
+
+    if !with_body || !with_query_params {
+        for req in &mut requests {
+            if !with_body {
+                req.body = None;
+            }
+            if !with_query_params {
+                req.query_params = None;
+            }
+        }
+    }
 
     Ok(json!({ "requests": requests }))
 }

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -510,12 +510,16 @@ async fn test_tracked_request_struct() {
         headers: json!({"Accept": "text/html"}),
         timestamp: 12345,
         resource_type: "Document".to_string(),
+        query_params: Some(json!({"q": "1"})),
+        body: None,
     };
     let serialized = serde_json::to_value(&tr).unwrap();
     assert_eq!(serialized["url"], "https://example.com/api");
     assert_eq!(serialized["method"], "GET");
     assert_eq!(serialized["resourceType"], "Document");
     assert_eq!(serialized["timestamp"], 12345);
+    assert_eq!(serialized["queryParams"]["q"], "1");
+    assert!(serialized.get("body").is_none());
 }
 
 #[tokio::test]
@@ -530,6 +534,8 @@ async fn test_request_tracking_state() {
         headers: json!({}),
         timestamp: 1,
         resource_type: "Document".to_string(),
+        query_params: None,
+        body: None,
     });
     state.tracked_requests.push(super::actions::TrackedRequest {
         url: "https://other.com".to_string(),
@@ -537,6 +543,8 @@ async fn test_request_tracking_state() {
         headers: json!({}),
         timestamp: 2,
         resource_type: "XHR".to_string(),
+        query_params: None,
+        body: Some("{\"k\":\"v\"}".to_string()),
     });
     assert_eq!(state.tracked_requests.len(), 2);
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -323,6 +323,25 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
                     println!("{} {} ({})", method, url, resource_type);
+
+                  if let Some(query_params) = req.get("queryParams") {
+                    let has_query = query_params
+                      .as_object()
+                      .map(|obj| !obj.is_empty())
+                      .unwrap_or(false);
+                    if has_query {
+                      println!(
+                        "  query: {}",
+                        serde_json::to_string(query_params).unwrap_or_default()
+                      );
+                    }
+                  }
+
+                  if let Some(body) = req.get("body").and_then(|v| v.as_str()) {
+                    if !body.is_empty() {
+                      println!("  body: {}", body);
+                    }
+                  }
                 }
             }
             return;
@@ -1632,6 +1651,8 @@ Subcommands:
   requests [options]         List captured requests
     --clear                  Clear request log
     --filter <pattern>       Filter by URL pattern
+    --body                   Include request body
+    --query-params           Include URL query params
 
 Global Options:
   --json               Output as JSON
@@ -1643,6 +1664,8 @@ Examples:
   agent-browser network unroute
   agent-browser network requests
   agent-browser network requests --filter "api"
+  agent-browser network requests --query-params --filter "api"
+  agent-browser network requests --body --query-params --filter "api"
   agent-browser network requests --clear
 "##
         }

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -163,6 +163,8 @@ agent-browser network unroute [url]            # Remove routes
 agent-browser network requests                 # View tracked requests
 agent-browser network requests --clear         # Clear request log
 agent-browser network requests --filter <pat>  # Filter by URL pattern
+agent-browser network requests --query-params --filter <pat>  # Include URL query params
+agent-browser network requests --body --query-params --filter <pat>  # Include request body + query params
 ```
 
 ## Tabs & frames

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -73,6 +73,8 @@ agent-browser scroll down 500 --selector "div.content"  # Scroll within a specif
 agent-browser get text @e1            # Get element text
 agent-browser get url                 # Get current URL
 agent-browser get title               # Get page title
+agent-browser network requests --query-params --json # Include URL query params
+agent-browser network requests --body --json # Include request body
 
 # Wait
 agent-browser wait @e1                # Wait for element

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1416,7 +1416,11 @@ async function handleRequests(
   // Start tracking if not already
   browser.startRequestTracking();
 
-  const requests = browser.getRequests(command.filter);
+  const requests = browser.getRequests(
+    command.filter,
+    command.body ?? false,
+    command.queryParams ?? false
+  );
   return successResponse(command.id, { requests });
 }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -77,6 +77,8 @@ interface TrackedRequest {
   headers: Record<string, string>;
   timestamp: number;
   resourceType: string;
+  queryParams?: Record<string, string | string[]>;
+  body?: string;
 }
 
 interface ConsoleMessage {
@@ -457,18 +459,56 @@ export class BrowserManager {
         headers: request.headers(),
         timestamp: Date.now(),
         resourceType: request.resourceType(),
+        queryParams: this.parseQueryParams(request.url()),
+        body: request.postData() ?? undefined,
       });
     });
+  }
+
+  private parseQueryParams(url: string): Record<string, string | string[]> | undefined {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return undefined;
+    }
+
+    const queryParams: Record<string, string | string[]> = {};
+    for (const [key, value] of parsed.searchParams.entries()) {
+      const existing = queryParams[key];
+      if (existing === undefined) {
+        queryParams[key] = value;
+      } else if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        queryParams[key] = [existing, value];
+      }
+    }
+
+    return Object.keys(queryParams).length > 0 ? queryParams : undefined;
   }
 
   /**
    * Get tracked requests
    */
-  getRequests(filter?: string): TrackedRequest[] {
-    if (filter) {
-      return this.trackedRequests.filter((r) => r.url.includes(filter));
+  getRequests(
+    filter?: string,
+    withBody: boolean = false,
+    withQueryParams: boolean = false
+  ): TrackedRequest[] {
+    const requests = filter
+      ? this.trackedRequests.filter((r) => r.url.includes(filter))
+      : this.trackedRequests;
+
+    if (withBody && withQueryParams) {
+      return requests;
     }
-    return this.trackedRequests;
+
+    return requests.map((r) => ({
+      ...r,
+      body: withBody ? r.body : undefined,
+      queryParams: withQueryParams ? r.queryParams : undefined,
+    }));
   }
 
   /**

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -244,6 +244,8 @@ const requestsSchema = baseCommandSchema.extend({
   action: z.literal('requests'),
   filter: z.string().optional(),
   clear: z.boolean().optional(),
+  body: z.boolean().optional(),
+  queryParams: z.boolean().optional(),
 });
 
 const downloadSchema = baseCommandSchema.extend({

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,8 @@ export interface RequestsCommand extends BaseCommand {
   action: 'requests';
   filter?: string; // URL pattern to filter
   clear?: boolean;
+  body?: boolean; // Include request body in output
+  queryParams?: boolean; // Include query params in output
 }
 
 // Download handling


### PR DESCRIPTION
This pull request adds support for including request bodies and URL query parameters when listing tracked network requests in the CLI and browser agent. It introduces new CLI options, updates the underlying data structures and logic to capture and display these details, and improves documentation and test coverage for the new features.

**Feature: Enhanced Network Request Inspection**
* Added `--body` and `--query-params` options to the `agent-browser network requests` CLI command, allowing users to include request bodies and URL query parameters in the output. Documentation and usage examples have been updated accordingly (`README.md`, `docs/src/app/commands/page.mdx`, `skills/agent-browser/SKILL.md`, `cli/src/output.rs`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R233-R234) [[2]](diffhunk://#diff-e2affaff85e039ca09b5bb735a405908e49d7f809bef622575ce1d74d5d7ba7bR166-R167) [[3]](diffhunk://#diff-1bda825417f9baea67a0f36d6205565ba396ba7eee320e98bc119443609c58fcR76-R77) [[4]](diffhunk://#diff-32f9428819e00115785fc22d8bfc268b17b52438f538daa67d5352aa8672e0f1R1654-R1655) [[5]](diffhunk://#diff-32f9428819e00115785fc22d8bfc268b17b52438f538daa67d5352aa8672e0f1R1667-R1668)
* Updated CLI command parsing and protocol schemas to support the new options and pass them to the backend (`cli/src/commands.rs`, `src/protocol.ts`, `src/types.ts`). [[1]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bR1999-R2012) [[2]](diffhunk://#diff-8f0bbe5328e7e917f6f6cd8e8746fecd50daa2fc60641d2753f11ebada85e22cR247-R248) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR236-R237)

**Backend Logic and Data Structure Updates**
* Modified request tracking logic in both Rust and TypeScript backends to extract and store query parameters and request bodies for each tracked request (`cli/src/native/actions.rs`, `src/browser.ts`). [[1]](diffhunk://#diff-3b5d6db176b63bfc1b8883e9a7ae7cfff1f50f82da80f74764116065f34d6418R65-R98) [[2]](diffhunk://#diff-3b5d6db176b63bfc1b8883e9a7ae7cfff1f50f82da80f74764116065f34d6418R322-R334) [[3]](diffhunk://#diff-e84e938a5120632cd9bfda48f378416139afdb46dbb35444370bae86a6f1c248R80-R81) [[4]](diffhunk://#diff-e84e938a5120632cd9bfda48f378416139afdb46dbb35444370bae86a6f1c248R462-R511)
* Updated request retrieval methods to filter and include/exclude bodies and query parameters based on CLI options (`cli/src/native/actions.rs`, `src/browser.ts`, `src/actions.ts`). [[1]](diffhunk://#diff-3b5d6db176b63bfc1b8883e9a7ae7cfff1f50f82da80f74764116065f34d6418L4539-R4610) [[2]](diffhunk://#diff-e84e938a5120632cd9bfda48f378416139afdb46dbb35444370bae86a6f1c248R462-R511) [[3]](diffhunk://#diff-1b65654b4e6a4ad772c76520a607abec72eb17b56caaace589a3c5c51a21fdcbL1419-R1423)

**Testing and Output Improvements**
* Added and updated tests to verify correct serialization and filtering of request bodies and query parameters (`cli/src/commands.rs`, `cli/src/native/parity_tests.rs`). [[1]](diffhunk://#diff-e2e916547f7e32f6295257919ded6b0976ca9231d2f0554a1a7f070697d0796bR3047-R3059) [[2]](diffhunk://#diff-717f5e8bc065f0aa3466ba6ab0a62291a9425902557acdc491e58191f47d2023R513-R522) [[3]](diffhunk://#diff-717f5e8bc065f0aa3466ba6ab0a62291a9425902557acdc491e58191f47d2023R537-R547)
* Enhanced CLI output to display query parameters and request bodies when present (`cli/src/output.rs`).

<img width="1047" height="270" alt="image" src="https://github.com/user-attachments/assets/f493621e-a436-4b3c-ab82-4461e22f9a9d" />

<img width="1048" height="290" alt="image" src="https://github.com/user-attachments/assets/578127ea-c8ac-4fdf-9f6b-b8ce71926f82" />
