### PR TITLE
fix(native): use reqwest for CDP port discovery instead of broken hand-rolled HTTP client

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -381,55 +381,8 @@ pub async fn discover_cdp_url(port: u16) -> Result<String, String> {
 }
 
 async fn reqwest_get_string(url: &str) -> Result<String, String> {
-    let client = tokio::net::TcpStream::connect(
-        url.strip_prefix("http://")
-            .unwrap_or(url)
-            .split('/')
-            .next()
-            .unwrap_or("127.0.0.1:9222"),
-    )
-    .await
-    .map_err(|e| e.to_string())?;
-
-    let path = url
-        .find('/')
-        .and_then(|i| url[i..].find('/').map(|j| &url[i + j..]))
-        .unwrap_or("/json/version");
-
-    let host = url
-        .strip_prefix("http://")
-        .unwrap_or(url)
-        .split('/')
-        .next()
-        .unwrap_or("127.0.0.1");
-
-    let request = format!(
-        "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
-        path, host
-    );
-
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    let mut client = client;
-    client
-        .write_all(request.as_bytes())
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let mut response = Vec::new();
-    client
-        .read_to_end(&mut response)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let response_str = String::from_utf8_lossy(&response);
-    let body = response_str
-        .split("\r\n\r\n")
-        .nth(1)
-        .unwrap_or("")
-        .to_string();
-
-    Ok(body)
+    let resp = reqwest::get(url).await.map_err(|e| e.to_string())?;
+    resp.text().await.map_err(|e| e.to_string())
 }
 
 pub fn read_devtools_active_port(user_data_dir: &Path) -> Option<(u16, String)> {


### PR DESCRIPTION
## Summary

`reqwest_get_string()` in `cli/src/native/cdp/chrome.rs` hand-rolls HTTP/1.1 over raw TCP despite `reqwest` being an existing dependency (`Cargo.toml`). Might be a remnant of some AI slop. The hand-rolled implementation has two bugs that cause `agent-browser --cdp <port>` to always timeout when `AGENT_BROWSER_NATIVE=1`.

## Bugs

**1. URL path parsing** — `url.find('/')` matches the first `/` in `http://`, producing an invalid request path:
```
Expected: GET /json/version HTTP/1.1
Actual:   GET //127.0.0.1:9222/json/version HTTP/1.1
```

**2. `read_to_end()` hangs** — Chrome's DevTools HTTP server ignores `Connection: close` and keeps the socket open. `read_to_end()` waits for EOF that never comes, hitting the 2-second timeout in `discover_cdp_url`.

The error then gets mangled by `to_ai_friendly_error` into `"Operation timed out. The page may still be loading or the element may not exist."` - masking the real cause.

## Fix

Replace 49 lines of broken hand-rolled TCP with `reqwest::get()`:

```rust
async fn reqwest_get_string(url: &str) -> Result<String, String> {
    let resp = reqwest::get(url).await.map_err(|e| e.to_string())?;
    resp.text().await.map_err(|e| e.to_string())
}
```

## Repro

```bash
# Launch Chrome with remote debugging
"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
  --remote-debugging-port=9222 \
  --user-data-dir="$HOME/.agent-browser/chrome-profile" \
  --no-first-run &

# Verify Chrome responds
curl -s http://localhost:9222/json/version | head -2

# This times out (native mode)
AGENT_BROWSER_NATIVE=1 agent-browser --cdp 9222 open "about:blank"
# ✗ Operation timed out.

# Without native mode works fine (Playwright handles HTTP correctly)
agent-browser --cdp 9222 open "about:blank"
# ✓ about:blank
```

## Note

`to_ai_friendly_error` shadows any error containing "timeout" into a generic page-related message, even for non-page failures like this HTTP fetch. Worth improving separately.