### PR TITLE
fix: carry over context options (userAgent, etc.) to recording context 

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1306,6 +1306,31 @@ describe('BrowserManager', () => {
       await testBrowser.stopRecording();
       await testBrowser.close();
     });
+
+    it('should not leak context options across close/relaunch cycles', async () => {
+      const testBrowser = new BrowserManager();
+
+      // First session: launch with custom userAgent
+      await testBrowser.launch({ headless: true, userAgent: 'StaleAgent/1.0' });
+      await testBrowser.close();
+
+      // Second session: launch without custom userAgent
+      await testBrowser.launch({ headless: true });
+      const page = testBrowser.getPage();
+      await page.goto('about:blank');
+
+      const outputPath = `/tmp/test-recording-stale-${Date.now()}.webm`;
+      await testBrowser.startRecording(outputPath);
+
+      // Recording should use default UA, not the stale one from the first session
+      const recordingPage = testBrowser.getPage();
+      const ua = await recordingPage.evaluate(() => navigator.userAgent);
+      expect(ua).not.toContain('StaleAgent');
+      expect(ua).toContain('HeadlessChrome');
+
+      await testBrowser.stopRecording();
+      await testBrowser.close();
+    });
   });
 });
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2565,5 +2565,6 @@ export class BrowserManager {
     this.refMap = {};
     this.lastSnapshot = '';
     this.frameCallback = null;
+    this.contextOptions = {};
   }
 }


### PR DESCRIPTION
follow up to: https://github.com/vercel-labs/agent-browser/pull/116

`record start` creates a fresh BrowserContext but was not passing through
context options from the original launch — userAgent, ignoreHTTPSErrors,
proxy, colorScheme, and extraHTTPHeaders were all lost.

This stores the context options during launch() and spreads them into the
recording context's newContext() call. Uses Playwright's
BrowserContextOptions type so any new options added upstream are
automatically carried over.

Fixes the issue where `--user-agent` and `--ignore-https-errors` flags
(or their config equivalents) had no effect during video recording.

