### PR TITLE
Add screen recording commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,14 @@ agent-browser diff url https://v1.com https://v2.com --wait-until networkidle  #
 agent-browser diff url https://v1.com https://v2.com --selector "#main"  # Scope to element
 ```
 
+### Screen Recording
+
+```bash
+agent-browser record start [path]     # Start recording video (.webm)
+agent-browser record stop             # Stop and save recording
+agent-browser record restart [path]   # Stop current + start new recording
+```
+
 ### Debug
 
 ```bash


### PR DESCRIPTION
Adds the `record start/stop/restart` commands to the README's command reference

These commands were introduced in #116 but weren't added to the main README. The details are already documented in the skill reference file: [`skills/agent-browser/references/video-recording.md`](https://github.com/vercel-labs/agent-browser/blob/main/skills/agent-browser/references/video-recording.md)