### PR TITLE
fix: prevent CDP auto-launch when WebDriver backend (Safari/iOS) is active

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -525,6 +525,9 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         // Check if existing connection is stale and needs re-launch
         let needs_launch = if let Some(ref mgr) = state.browser {
             !mgr.is_connection_alive().await
+        } else if state.webdriver_backend.is_some() {
+            // WebDriver backend (e.g. Safari) is active — skip CDP auto-launch
+            false
         } else {
             true
         };
@@ -742,6 +745,23 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
         state.subscribe_to_browser_events();
         try_auto_restore_state(state).await;
         return Ok(());
+    }
+
+    // Check provider — e.g. Safari uses WebDriver, not CDP/Chrome
+    if let Ok(provider) = env::var("AGENT_BROWSER_PROVIDER") {
+        match provider.to_lowercase().as_str() {
+            "safari" => {
+                let cmd = serde_json::json!({ "provider": "safari" });
+                launch_safari(&cmd, state).await?;
+                return Ok(());
+            }
+            "ios" => {
+                let cmd = serde_json::json!({ "provider": "ios" });
+                launch_ios(&cmd, state).await?;
+                return Ok(());
+            }
+            _ => {} // Fall through to default Chrome launch
+        }
     }
 
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;


### PR DESCRIPTION
## Description

When using `agent-browser --native -p safari open <url>`, the native daemon correctly launches Safari via WebDriver through `launch_safari()`. However, subsequent commands (e.g. `navigate`, `snapshot`, `click`) trigger `auto_launch()` which unconditionally launches Chrome via CDP, because `state.browser` is `None` — Safari only sets `state.webdriver_backend`.

This results in **both Safari and Chrome being launched simultaneously**, with all commands routing through Chrome instead of Safari.

### Root cause

Two issues in `execute_command()` and `auto_launch()`:

1. **`needs_launch` check (line 526)** only inspects `state.browser` (CDP). When Safari is the active backend, `state.browser` is `None` and `state.webdriver_backend` is `Some(...)`, so `needs_launch` evaluates to `true` — incorrectly triggering `auto_launch()`.

2. **`auto_launch()` function** has no awareness of the `AGENT_BROWSER_PROVIDER` environment variable. It always falls through to `BrowserManager::launch()` which launches Chrome via CDP.

### Fix

1. In the `needs_launch` check, added an `else if` branch for `state.webdriver_backend.is_some()` that returns `false` — skipping auto-launch when a WebDriver backend is already active.

2. In `auto_launch()`, added a check for `AGENT_BROWSER_PROVIDER` env var before the default Chrome launch. When set to `"safari"` or `"ios"`, it dispatches to `launch_safari()` / `launch_ios()` respectively, consistent with the existing provider routing in `handle_launch()`.

### Testing

Verified on macOS 15.5 (Apple Silicon):

```bash
# Before fix: launches Chrome alongside Safari
agent-browser --native --headed -p safari open https://example.com
# ps shows both Safari and Chrome processes

# After fix: only Safari launches
agent-browser --native --headed -p safari open https://example.com
# ps shows only Safari and safaridriver processes, no Chrome
```

### Changes

- `cli/src/native/actions.rs`: 2 targeted changes (~20 lines added)
