### PR TITLE
fix: add channel parameter for Chrome extensions content script injection

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1352,9 +1352,13 @@ export class BrowserManager {
       // Combine extension args with custom args and file access args
       const extArgs = [`--disable-extensions-except=${extPaths}`, `--load-extension=${extPaths}`];
       const allArgs = baseArgs ? [...extArgs, ...baseArgs] : extArgs;
+      // Chrome extensions require channel to be set for content script injection
+      // See: https://playwright.dev/docs/chrome-extensions
+      const extensionChannel = options.channel || 'chromium';
       context = await launcher.launchPersistentContext(
         path.join(os.tmpdir(), `agent-browser-ext-${session}`),
         {
+          channel: extensionChannel,
           headless: options.headless ?? true,
           executablePath: options.executablePath,
           args: allArgs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface LaunchCommand extends BaseCommand {
   headless?: boolean;
   viewport?: { width: number; height: number } | null;
   browser?: 'chromium' | 'firefox' | 'webkit';
+  channel?: 'chrome' | 'chrome-beta' | 'chrome-dev' | 'chrome-canary' | 'chromium'; // Chrome channel for extensions support
   headers?: Record<string, string>;
   executablePath?: string;
   cdpPort?: number;


### PR DESCRIPTION
Fixes #640 - Chrome extensions were not loading content scripts.

## Root Cause

Playwright requires `channel: 'chromium'` (or 'chrome') for Chrome extension
content script injection to work properly.

## Changes

- Add `channel` option to `LaunchCommand` type for Chrome channel selection
- Set `channel: 'chromium'` (default) when launching with extensions

## Testing

Tested locally with a test extension - content scripts now inject correctly in both
headed and headless modes (as documented in README).