### PR TITLE
fix: prevent --name and --exact flags from being appended to fill values

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1707,8 +1707,33 @@ fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                 },
             })?;
             let subaction = rest.get(2).unwrap_or(&"click");
+
+            // Filter out --name, --exact flags and their values from fill_value
             let fill_value = if rest.len() > 3 {
-                Some(rest[3..].join(" "))
+                let mut filtered = Vec::new();
+                let mut skip_next = false;
+
+                for &arg in rest[3..].iter() {
+                    if skip_next {
+                        skip_next = false;
+                        continue;
+                    }
+                    if arg == "--name" || arg == "--exact" {
+                        // Skip the flag
+                        if arg == "--name" {
+                            // Also skip the next argument (the value for --name)
+                            skip_next = true;
+                        }
+                        continue;
+                    }
+                    filtered.push(arg);
+                }
+
+                if filtered.is_empty() {
+                    None
+                } else {
+                    Some(filtered.join(" "))
+                }
             } else {
                 None
             };
@@ -3066,6 +3091,76 @@ mod tests {
         assert_eq!(cmd["action"], "nth");
         assert_eq!(cmd["index"], 2);
         assert!(cmd.get("value").is_none());
+    }
+
+    // === Find Role Tests ===
+
+    #[test]
+    fn test_find_role_fill_with_name_flag() {
+        let cmd = parse_command(
+            &args("find role combobox fill hello --name Recipient"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "getbyrole");
+        assert_eq!(cmd["role"], "combobox");
+        assert_eq!(cmd["subaction"], "fill");
+        assert_eq!(cmd["value"], "hello");
+        assert_eq!(cmd["name"], "Recipient");
+    }
+
+    #[test]
+    fn test_find_role_fill_multiword_with_name_flag() {
+        let cmd = parse_command(
+            &args("find role textbox fill hello world --name MessageBox"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "getbyrole");
+        assert_eq!(cmd["role"], "textbox");
+        assert_eq!(cmd["subaction"], "fill");
+        assert_eq!(cmd["value"], "hello world");
+        assert_eq!(cmd["name"], "MessageBox");
+    }
+
+    #[test]
+    fn test_find_role_fill_with_exact_and_name_flags() {
+        let cmd = parse_command(
+            &args("find role textbox fill test value --name Email --exact"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "getbyrole");
+        assert_eq!(cmd["role"], "textbox");
+        assert_eq!(cmd["subaction"], "fill");
+        assert_eq!(cmd["value"], "test value");
+        assert_eq!(cmd["name"], "Email");
+        assert_eq!(cmd["exact"], true);
+    }
+
+    #[test]
+    fn test_find_role_click_with_name_flag() {
+        let cmd = parse_command(
+            &args("find role button click --name Submit"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "getbyrole");
+        assert_eq!(cmd["role"], "button");
+        assert_eq!(cmd["subaction"], "click");
+        assert!(cmd.get("value").is_none());
+        assert_eq!(cmd["name"], "Submit");
+    }
+
+    #[test]
+    fn test_find_role_fill_without_name_flag() {
+        let cmd =
+            parse_command(&args("find role textbox fill plain text"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "getbyrole");
+        assert_eq!(cmd["role"], "textbox");
+        assert_eq!(cmd["subaction"], "fill");
+        assert_eq!(cmd["value"], "plain text");
+        assert!(cmd.get("name").is_none() || cmd["name"].is_null());
     }
 
     // === Download Tests ===

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -529,15 +529,10 @@ pub fn ensure_daemon(session: &str, opts: &DaemonOptions) -> Result<DaemonResult
     #[cfg(unix)]
     let endpoint_info = format!(
         "socket: {}",
-        get_socket_dir()
-            .join(format!("{}.sock", session))
-            .display()
+        get_socket_dir().join(format!("{}.sock", session)).display()
     );
     #[cfg(windows)]
-    let endpoint_info = format!(
-        "port: 127.0.0.1:{}",
-        get_port_for_session(session)
-    );
+    let endpoint_info = format!("port: 127.0.0.1:{}", get_port_for_session(session));
 
     Err(format!("Daemon failed to start ({})", endpoint_info))
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5174,7 +5174,10 @@ mod tests {
         let _guard = EnvGuard::new(&["AGENT_BROWSER_HEADED"]);
         _guard.set("AGENT_BROWSER_HEADED", "1");
         let opts = launch_options_from_env();
-        assert!(!opts.headless, "AGENT_BROWSER_HEADED=1 should set headless=false");
+        assert!(
+            !opts.headless,
+            "AGENT_BROWSER_HEADED=1 should set headless=false"
+        );
     }
 
     #[tokio::test]

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -118,8 +118,8 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         args.push(format!("--user-data-dir={}", expanded));
         None
     } else {
-        let dir = std::env::temp_dir()
-            .join(format!("agent-browser-chrome-{}", uuid::Uuid::new_v4()));
+        let dir =
+            std::env::temp_dir().join(format!("agent-browser-chrome-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir)
             .map_err(|e| format!("Failed to create temp profile dir: {}", e))?;
         args.push(format!("--user-data-dir={}", dir.display()));
@@ -190,14 +190,11 @@ pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
             format!("Failed to launch Chrome at {:?}: {}", chrome_path, e)
         })?;
 
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| {
-            let _ = child.kill();
-            cleanup_temp_dir(&temp_user_data_dir);
-            "Failed to capture Chrome stderr".to_string()
-        })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        let _ = child.kill();
+        cleanup_temp_dir(&temp_user_data_dir);
+        "Failed to capture Chrome stderr".to_string()
+    })?;
     let reader = BufReader::new(stderr);
 
     let ws_url = match wait_for_ws_url(reader) {
@@ -489,10 +486,7 @@ fn should_disable_sandbox(existing_args: &[String]) -> bool {
 
         // Generic container detection: cgroup contains docker/kubepods/lxc
         if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
-            if cgroup.contains("docker")
-                || cgroup.contains("kubepods")
-                || cgroup.contains("lxc")
-            {
+            if cgroup.contains("docker") || cgroup.contains("kubepods") || cgroup.contains("lxc") {
                 return true;
             }
         }
@@ -636,10 +630,7 @@ mod tests {
 
     #[test]
     fn test_chrome_launch_error_generic() {
-        let lines = vec![
-            "info line".to_string(),
-            "another info line".to_string(),
-        ];
+        let lines = vec!["info line".to_string(), "another info line".to_string()];
         let msg = chrome_launch_error("Chrome exited", &lines);
         assert!(msg.contains("last 2 lines"));
     }
@@ -660,10 +651,7 @@ mod tests {
         };
         let result = build_chrome_args(&opts).unwrap();
         assert!(result.args.iter().any(|a| a == "--headless=new"));
-        assert!(result
-            .args
-            .iter()
-            .any(|a| a == "--window-size=1280,720"));
+        assert!(result.args.iter().any(|a| a == "--window-size=1280,720"));
         // Temp dir created when no profile
         assert!(result.temp_user_data_dir.is_some());
         let dir = result.temp_user_data_dir.unwrap();
@@ -722,14 +710,8 @@ mod tests {
             ..Default::default()
         };
         let result = build_chrome_args(&opts).unwrap();
-        assert!(!result
-            .args
-            .iter()
-            .any(|a| a == "--window-size=1280,720"));
-        assert!(result
-            .args
-            .iter()
-            .any(|a| a == "--window-size=1920,1080"));
+        assert!(!result.args.iter().any(|a| a == "--window-size=1280,720"));
+        assert!(result.args.iter().any(|a| a == "--window-size=1920,1080"));
         if let Some(ref dir) = result.temp_user_data_dir {
             let _ = std::fs::remove_dir_all(dir);
         }


### PR DESCRIPTION
When using 'find role <type> fill "text" --name "field"', the --name parameter and its value were incorrectly included in the fill text.

This fix filters out --name and --exact flags during argument parsing, ensuring only the intended text is used for the fill value.

Added 5 test cases to verify the fix works correctly.