### PR TITLE
chore: replace playwright-core with patchright for anti-detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "homepage": "https://github.com/vercel-labs/agent-browser#readme",
   "dependencies": {
     "node-simctl": "^7.4.0",
-    "playwright-core": "^1.57.0",
+    "patchright": "^1.57.0",
     "webdriverio": "^9.15.0",
     "ws": "^8.19.0",
     "zod": "^3.22.4"
@@ -73,7 +73,7 @@
     "@types/ws": "^8.18.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.2.11",
-    "playwright": "^1.57.0",
+    "patchright": "^1.57.0",
     "prettier": "^3.7.4",
     "tsx": "^4.6.0",
     "typescript": "^5.3.0",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { Page, Frame } from 'playwright-core';
+import type { Page, Frame } from 'patchright';
 import { mkdirSync } from 'node:fs';
 import type { BrowserManager, ScreencastFrame } from './browser.js';
 import { getAppDir } from './daemon.js';

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { BrowserManager, getDefaultTimeout } from './browser.js';
 import { executeCommand } from './actions.js';
-import { chromium } from 'playwright-core';
+import { chromium } from 'patchright';
 
 describe('BrowserManager', () => {
   let browser: BrowserManager;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -13,7 +13,7 @@ import {
   type Locator,
   type CDPSession,
   type Video,
-} from 'playwright-core';
+} from 'patchright';
 import path from 'node:path';
 import os from 'node:os';
 import { existsSync, mkdirSync, rmSync, readFileSync, statSync } from 'node:fs';

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { diffSnapshots, diffScreenshots } from './diff.js';
-import { chromium, type Browser, type BrowserContext, type Page } from 'playwright-core';
+import { chromium, type Browser, type BrowserContext, type Page } from 'patchright';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext } from 'playwright-core';
+import type { BrowserContext } from 'patchright';
 import type { DiffSnapshotData, DiffScreenshotData } from './types.js';
 import { writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';

--- a/src/domain-filter.ts
+++ b/src/domain-filter.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Route } from 'playwright-core';
+import type { BrowserContext, Route } from 'patchright';
 
 /**
  * Checks whether a hostname matches one of the allowed domain patterns.

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -17,7 +17,7 @@
  *   agent-browser click @e2             # Click element by ref
  */
 
-import type { Page, Locator } from 'playwright-core';
+import type { Page, Locator } from 'patchright';
 
 export interface RefMap {
   [ref: string]: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Page, Browser, BrowserContext } from 'playwright-core';
+import type { Page, Browser, BrowserContext } from 'patchright';
 
 // Base command structure
 export interface BaseCommand {


### PR DESCRIPTION
Swap all playwright-core imports and the playwright devDependency for the patchright drop-in replacement, which patches Chromium fingerprinting to reduce bot-detection on grant application portals.

Made-with: Cursor