### PR TITLE
fix: resolve clippy warnings across Rust codebase

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -175,7 +175,7 @@ fn to_snake_case(s: &str) -> String {
             // Only insert underscore at transitions from lowercase to uppercase,
             // or when an uppercase sequence ends (e.g. "DOM" -> "dom", not "d_o_m")
             let prev_upper = chars[i - 1].is_uppercase();
-            let next_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+            let next_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
             if !prev_upper || next_lower {
                 result.push('_');
             }
@@ -202,7 +202,7 @@ fn resolve_ref(
             // Check if this type actually exists in the referenced domain
             if domain_types
                 .get(ref_domain)
-                .map_or(false, |t| t.contains(ref_type))
+                .is_some_and(|t| t.contains(ref_type))
             {
                 format!(
                     "super::cdp_{}::{}",
@@ -323,7 +323,7 @@ fn generate_domain(
 ) {
     let mod_name = to_snake_case(&domain.domain);
     output.push_str(&format!(
-        "#[allow(dead_code, non_snake_case, non_camel_case_types, clippy::enum_variant_names)]\npub mod cdp_{} {{\n",
+        "#[allow(dead_code, non_snake_case, non_camel_case_types, clippy::enum_variant_names, clippy::upper_case_acronyms)]\npub mod cdp_{} {{\n",
         mod_name
     ));
     output.push_str("    use super::*;\n\n");
@@ -339,7 +339,7 @@ fn generate_domain(
                 if variant == "Self" {
                     variant = "SelfValue".to_string();
                 }
-                if variant.chars().next().map_or(false, |c| c.is_ascii_digit()) {
+                if variant.chars().next().is_some_and(|c| c.is_ascii_digit()) {
                     variant = format!("V{}", variant);
                 }
                 if seen_variants.insert(variant.clone()) {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -137,7 +137,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
 
         // === Core Actions ===
         "click" => {
-            let new_tab = rest.iter().any(|arg| *arg == "--new-tab");
+            let new_tab = rest.contains(&"--new-tab");
             let sel = rest
                 .iter()
                 .find(|arg| **arg != "--new-tab")
@@ -588,7 +588,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
 
                     let mut j = 2;
                     while j < rest.len() {
-                        match rest[j].as_ref() {
+                        match rest[j] {
                             "--url" => {
                                 url = rest.get(j + 1).cloned();
                                 j += 1;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -173,7 +173,7 @@ impl DaemonState {
                                     let already_tracked = self
                                         .browser
                                         .as_ref()
-                                        .map_or(true, |b| b.has_target(&te.target_info.target_id));
+                                        .is_none_or(|b| b.has_target(&te.target_info.target_id));
                                     if !already_tracked {
                                         new_targets.push(te);
                                     }
@@ -549,16 +549,16 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     }
 
     // WebDriver backend: reject unsupported CDP-only actions
-    if matches!(state.backend_type, BackendType::WebDriver) {
-        if WEBDRIVER_UNSUPPORTED_ACTIONS.contains(&action) {
-            return error_response(
-                &id,
-                &format!(
-                    "Action '{}' is not supported on the WebDriver backend",
-                    action
-                ),
-            );
-        }
+    if matches!(state.backend_type, BackendType::WebDriver)
+        && WEBDRIVER_UNSUPPORTED_ACTIONS.contains(&action)
+    {
+        return error_response(
+            &id,
+            &format!(
+                "Action '{}' is not supported on the WebDriver backend",
+                action
+            ),
+        );
     }
 
     let result = match action {
@@ -841,15 +841,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     let needs_relaunch = if let Some(ref mgr) = state.browser {
         let has_cdp_arg = cdp_url.is_some() || cdp_port.is_some();
         let was_cdp = mgr.is_cdp_connection();
-        if has_cdp_arg != was_cdp {
-            true
-        } else if has_cdp_arg && !mgr.is_connection_alive().await {
-            true
-        } else if auto_connect && !mgr.is_connection_alive().await {
-            true
-        } else {
-            !mgr.is_connection_alive().await
-        }
+        has_cdp_arg != was_cdp || !mgr.is_connection_alive().await
     } else {
         true
     };
@@ -3234,7 +3226,7 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
 
     fn find_frame(
         tree: &Value,
-        selector: Option<&str>,
+        _selector: Option<&str>,
         name: Option<&str>,
         url: Option<&str>,
     ) -> Option<String> {
@@ -3256,7 +3248,7 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
 
         if let Some(children) = tree.get("childFrames").and_then(|v| v.as_array()) {
             for child in children {
-                if let Some(id) = find_frame(child, selector, name, url) {
+                if let Some(id) = find_frame(child, _selector, name, url) {
                     return Some(id);
                 }
             }
@@ -4015,14 +4007,13 @@ async fn handle_waitfordownload(cmd: &Value, state: &DaemonState) -> Result<Valu
             Ok(Ok(event)) => {
                 if event.method == "Page.downloadProgress"
                     && event.session_id.as_deref() == Some(&session_id)
+                    && event.params.get("state").and_then(|v| v.as_str()) == Some("completed")
                 {
-                    if event.params.get("state").and_then(|v| v.as_str()) == Some("completed") {
-                        let path = cmd
-                            .get("path")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("download");
-                        return Ok(json!({ "path": path }));
-                    }
+                    let path = cmd
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("download");
+                    return Ok(json!({ "path": path }));
                 }
             }
             Ok(Err(_)) => return Err("Event stream closed".to_string()),

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -123,7 +123,7 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
     let has_extensions = options
         .extensions
         .as_ref()
-        .map_or(false, |exts| !exts.is_empty());
+        .is_some_and(|exts| !exts.is_empty());
 
     // Extensions require headed mode in native Chrome (content scripts are not
     // injected in headless mode).  Skip --headless when extensions are loaded.

--- a/cli/src/native/cdp/lightpanda.rs
+++ b/cli/src/native/cdp/lightpanda.rs
@@ -23,20 +23,11 @@ impl Drop for LightpandaProcess {
     }
 }
 
+#[derive(Default)]
 pub struct LightpandaLaunchOptions {
     pub executable_path: Option<String>,
     pub proxy: Option<String>,
     pub port: Option<u16>,
-}
-
-impl Default for LightpandaLaunchOptions {
-    fn default() -> Self {
-        Self {
-            executable_path: None,
-            proxy: None,
-            port: None,
-        }
-    }
 }
 
 pub fn find_lightpanda() -> Option<PathBuf> {

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -65,24 +65,13 @@ const STRUCTURAL_ROLES: &[&str] = &[
     "RootWebArea",
 ];
 
+#[derive(Default)]
 pub struct SnapshotOptions {
     pub selector: Option<String>,
     pub interactive: bool,
     pub compact: bool,
     pub depth: Option<usize>,
     pub cursor: bool,
-}
-
-impl Default for SnapshotOptions {
-    fn default() -> Self {
-        Self {
-            selector: None,
-            interactive: false,
-            compact: false,
-            depth: None,
-            cursor: false,
-        }
-    }
 }
 
 struct TreeNode {
@@ -364,8 +353,7 @@ async fn find_cursor_interactive_elements(
         let escaped = text
             .replace('\\', "\\\\")
             .replace('"', "\\\"")
-            .replace('\n', " ")
-            .replace('\r', " ");
+            .replace(['\n', '\r'], " ");
         lines.push(format!("[ref={}] ({}) \"{}\"", ref_id, kind, escaped));
     }
 

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -467,7 +467,7 @@ pub fn find_auto_state_file(session_name: &str) -> Option<String> {
                 .ok()
                 .and_then(|m| m.modified().ok())
                 .unwrap_or(std::time::UNIX_EPOCH);
-            if best_path.as_ref().map_or(true, |(_, t)| modified > *t) {
+            if best_path.as_ref().is_none_or(|(_, t)| modified > *t) {
                 best_path = Some((path.to_string_lossy().to_string(), modified));
             }
         }


### PR DESCRIPTION
## Summary

- Replace `map_or(false/true, ...)` with `is_some_and`/`is_none_or` (idiomatic Rust)
- Collapse nested `if` blocks into single conditions
- Simplify identical `if/else if/else` branches in relaunch logic
- Replace `iter().any()` with `contains()` for slice lookup
- Remove unnecessary `as_ref()` call
- Derive `Default` instead of manual impl for `LightpandaLaunchOptions` and `SnapshotOptions`
- Use `replace(['\n', '\r'], ...)` instead of chained `replace` calls
- Add `clippy::upper_case_acronyms` allow for generated CDP code
- Prefix unused `selector` parameter with underscore

Reduces clippy warnings from 22 to 1 (remaining: `result_large_err` in stream.rs which would require boxing the tungstenite error type — left as-is to avoid API changes).

## Test plan

- [x] `cargo clippy` passes with only 1 remaining warning
- [x] `cargo check` passes
- [ ] Existing test suite passes

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)