### PR TITLE
fix: display storage local data in text mode and fix per-key output

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -809,6 +809,34 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
+        // Storage get (all keys)
+        if let Some(storage_data) = data.get("data").and_then(|v| v.as_object()) {
+            if storage_data.is_empty() {
+                println!("{} (empty)", color::success_indicator());
+            } else {
+                for (k, v) in storage_data {
+                    let val_str = match v.as_str() {
+                        Some(s) => s.to_string(),
+                        None => serde_json::to_string(v).unwrap_or_default(),
+                    };
+                    println!("{}: {}", k, val_str);
+                }
+            }
+            return;
+        }
+
+        // Storage get (single key) — value may not be a string
+        if data.get("key").is_some() {
+            if let Some(value) = data.get("value") {
+                match value.as_str() {
+                    Some(s) => println!("{}", s),
+                    None if value.is_null() => println!("null"),
+                    None => println!("{}", serde_json::to_string(value).unwrap_or_default()),
+                }
+                return;
+            }
+        }
+
         // Default success
         println!("{} Done", color::success_indicator());
     }


### PR DESCRIPTION
## Summary

Fixes two bugs in `storage local` text output:

1. **`storage local` prints only "Done"** — The response `{ "data": {...} }` was not matched by any text formatter, falling through to the generic success message. Now prints each key-value pair.

2. **`storage local <key>` fails for non-string values** — The formatter used `as_str()` which filters out null and other types. Now handles all JSON value types.

### Before
```
$ agent-browser storage local
✓ Done

$ agent-browser storage local token
✓ Done
```

### After
```
$ agent-browser storage local
token: abc123
user: alice

$ agent-browser storage local token
abc123
```

JSON mode (`--json`) is unaffected.

## Test plan

- [x] `cargo check` passes
- [ ] Manual test: `storage local` shows all keys in text mode
- [ ] Manual test: `storage local <key>` shows value for string, null, and object types

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)