### PR TITLE
fix: forward DISPLAY env var to browser subprocess on Linux

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1365,6 +1365,7 @@ export class BrowserManager {
           ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
           ...(this.colorScheme && { colorScheme: this.colorScheme }),
           ...(this.downloadPath && { downloadsPath: this.downloadPath }),
+          env: process.env,
         }
       );
       this.isPersistentContext = true;
@@ -1383,6 +1384,7 @@ export class BrowserManager {
         ignoreHTTPSErrors: options.ignoreHTTPSErrors ?? false,
         ...(this.colorScheme && { colorScheme: this.colorScheme }),
         ...(this.downloadPath && { downloadsPath: this.downloadPath }),
+        env: process.env,
       });
       this.isPersistentContext = true;
     } else {
@@ -1392,6 +1394,7 @@ export class BrowserManager {
         executablePath: options.executablePath,
         args: baseArgs,
         ...(this.downloadPath && { downloadsPath: this.downloadPath }),
+        env: process.env,
       });
       this.cdpEndpoint = null;
 


### PR DESCRIPTION
## Summary

When using `--headed` mode on Linux with a virtual display (Xvfb, Xvnc), the browser fails to launch because environment variables (including `DISPLAY`) are not forwarded to the Chromium subprocess.

Add `env: process.env` to all three Playwright launch paths:
- `launcher.launch()` (ephemeral browser)
- `launcher.launchPersistentContext()` (extensions)
- `launcher.launchPersistentContext()` (profile)

### Before
```
DISPLAY=:99 agent-browser open --headed https://example.com
# ✗ Missing X server or $DISPLAY
```

### After
```
DISPLAY=:99 agent-browser open --headed https://example.com
# ✓ Browser launches on display :99
```

## Test plan

- [x] TypeScript compiles without errors
- [ ] Manual test on Linux with Xvfb/Xvnc virtual display

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)