### PR TITLE
fix: prevent browser.close() from killing external Chrome via CDP

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1531,6 +1531,10 @@ export class BrowserManager {
         );
       });
 
+    // Ensure close() only drops the WebSocket connection instead of sending
+    // the CDP Browser.close command which kills the external browser process.
+    (browser as any)._shouldCloseConnectionOnClose = true;
+
     // Validate and set up state, cleaning up browser connection if anything fails
     try {
       const contexts = browser.contexts();


### PR DESCRIPTION
## Summary

When connected via `connectOverCDP()`, calling `browser.close()` sends the CDP `Browser.close` command which terminates the external Chrome process. This happens both in `connectViaCDP` error handling and in `BrowserManager.close()`.

### Root cause

Playwright's `connectOverCDP()` sets `_shouldCloseConnectionOnClose = false` by default, meaning `.close()` sends the CDP kill command rather than just dropping the WebSocket.

### Fix

Set `_shouldCloseConnectionOnClose = true` immediately after connecting via CDP. This makes `.close()` only drop the WebSocket connection, matching the behavior of `chromium.connect()`.

Single line fix that protects both call sites (`connectViaCDP` catch block and `BrowserManager.close()` CDP branch).

## Test plan

- [x] TypeScript compiles without errors
- [ ] Connect to external Chrome via `--cdp 9222`, then close — Chrome stays alive
- [ ] Connect to external Chrome via `--cdp 9222` with invalid state — Chrome stays alive after error

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)