### PR TITLE
feat: add --wait-until flag and change default to domcontentloaded

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -129,6 +129,9 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                     nav_cmd["iosDevice"] = json!(device);
                 }
             }
+            if let Some(ref wait_until) = flags.wait_until {
+                nav_cmd["waitUntil"] = json!(wait_until);
+            }
             Ok(nav_cmd)
         }
         "back" => Ok(json!({ "id": id, "action": "back" })),

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -240,6 +240,7 @@ pub struct Flags {
     pub confirm_interactive: bool,
     pub native: bool,
     pub engine: Option<String>,
+    pub wait_until: Option<String>,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -347,6 +348,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             || config.confirm_interactive.unwrap_or(false),
         native: env_var_is_truthy("AGENT_BROWSER_NATIVE") || config.native.unwrap_or(false),
         engine: env::var("AGENT_BROWSER_ENGINE").ok().or(config.engine),
+        wait_until: env::var("AGENT_BROWSER_WAIT_UNTIL").ok(),
         cli_executable_path: false,
         cli_extensions: false,
         cli_profile: false,
@@ -421,6 +423,12 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--cdp" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.cdp = Some(s.clone());
+                    i += 1;
+                }
+            }
+            "--wait-until" => {
+                if let Some(s) = args.get(i + 1) {
+                    flags.wait_until = Some(s.clone());
                     i += 1;
                 }
             }
@@ -640,6 +648,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--confirm-actions",
         "--config",
         "--engine",
+        "--wait-until",
     ];
 
     let mut i = 0;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -626,7 +626,7 @@ async function handleNavigate(
   }
 
   await page.goto(command.url, {
-    waitUntil: command.waitUntil ?? 'load',
+    waitUntil: command.waitUntil ?? 'domcontentloaded',
   });
 
   return successResponse(command.id, {
@@ -2665,7 +2665,7 @@ async function handleDiffScreenshot(
 async function handleDiffUrl(command: DiffUrlCommand, browser: BrowserManager): Promise<Response> {
   const page = browser.getPage();
 
-  const waitUntil = command.waitUntil ?? 'load';
+  const waitUntil = command.waitUntil ?? 'domcontentloaded';
   const snapshotOpts = {
     selector: command.selector,
     compact: command.compact,


### PR DESCRIPTION
## Summary

The `open` command defaulted to `waitUntil: 'load'`, which waits for all resources (analytics, third-party scripts, etc.) and frequently causes timeouts on modern SPAs.

### Changes

1. **Add `--wait-until` CLI flag** — accepts `load`, `domcontentloaded`, or `networkidle`
2. **Change default to `domcontentloaded`** — for both `handleNavigate` and `handleDiffUrl`
3. **Align with `tab new`** — which already used `domcontentloaded`
4. **Env var support** — `AGENT_BROWSER_WAIT_UNTIL`

### Usage
```bash
agent-browser open https://example.com                           # uses domcontentloaded
agent-browser open https://example.com --wait-until load         # wait for all resources
agent-browser open https://example.com --wait-until networkidle  # wait for network idle
```

### Files changed
- `cli/src/flags.rs` — add `wait_until` field + `--wait-until` parsing
- `cli/src/commands.rs` — pass `waitUntil` in navigate JSON command
- `src/actions.ts` — change default from `load` to `domcontentloaded`

## Test plan

- [x] Rust compiles without errors
- [x] TypeScript compiles without errors
- [ ] `open <url>` completes faster on SPA sites
- [ ] `open <url> --wait-until load` preserves old behavior

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)