### PR TITLE
fix: capture all network requests including document navigations

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -449,16 +449,8 @@ export class BrowserManager {
    * Start tracking requests
    */
   startRequestTracking(): void {
-    const page = this.getPage();
-    page.on('request', (request: Request) => {
-      this.trackedRequests.push({
-        url: request.url(),
-        method: request.method(),
-        headers: request.headers(),
-        timestamp: Date.now(),
-        resourceType: request.resourceType(),
-      });
-    });
+    // Request tracking is now always active via setupPageTracking().
+    // This method is kept for backwards compatibility.
   }
 
   /**
@@ -1733,6 +1725,17 @@ export class BrowserManager {
       this.pageErrors.push({
         message: error.message,
         timestamp: Date.now(),
+      });
+    });
+
+    // Track all network requests (including document navigations, not just XHR/fetch)
+    page.on('request', (request: Request) => {
+      this.trackedRequests.push({
+        url: request.url(),
+        method: request.method(),
+        headers: request.headers(),
+        timestamp: Date.now(),
+        resourceType: request.resourceType(),
       });
     });
 


### PR DESCRIPTION
## Summary

`network requests` only captured XHR/fetch calls because request tracking was activated on-demand when the user first ran the command. Navigations occurring before that call were never recorded.

### Root cause

`startRequestTracking()` registered a `page.on('request')` listener only when called explicitly. Document navigations (page loads, redirects, form submissions) that occurred before the user ran `network requests` were invisible.

### Fix

Move request tracking into `setupPageTracking()` so it is always active for every page from creation. This captures all network activity:
- Document navigations
- Redirect chains (3xx)
- Resource loads (scripts, stylesheets, images)
- XHR/fetch (as before)

`startRequestTracking()` is kept as a no-op for backwards compatibility.

### Before
```bash
agent-browser open https://example.com
agent-browser click @e1  # navigates to /other-page
agent-browser network requests
# (empty)
```

### After
```bash
agent-browser open https://example.com
agent-browser click @e1  # navigates to /other-page
agent-browser network requests
# GET https://example.com/other-page (document)
```

## Test plan

- [x] TypeScript compiles without errors
- [ ] `network requests` captures document navigations
- [ ] `network requests --filter` still works for filtering

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)