### PR TITLE
fix: resolve wait --download race condition

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2442,8 +2442,7 @@ async function handleWaitForDownload(
   command: WaitForDownloadCommand,
   browser: BrowserManager
 ): Promise<Response> {
-  const page = browser.getPage();
-  const download = await page.waitForEvent('download', { timeout: command.timeout });
+  const download = await browser.waitForDownload(command.timeout);
 
   let filePath: string;
   if (command.path) {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -9,6 +9,7 @@ import {
   type Frame,
   type Dialog,
   type Request,
+  type Download,
   type Route,
   type Locator,
   type CDPSession,
@@ -118,6 +119,7 @@ export class BrowserManager {
   private scopedHeaderRoutes: Map<string, (route: Route) => Promise<void>> = new Map();
   private colorScheme: 'light' | 'dark' | 'no-preference' | null = null;
   private downloadPath: string | null = null;
+  private pendingDownloads: Download[] = [];
   private allowedDomains: string[] = [];
 
   /**
@@ -476,6 +478,18 @@ export class BrowserManager {
    */
   clearRequests(): void {
     this.trackedRequests = [];
+  }
+
+  /**
+   * Take a pending download from the queue, or wait for the next one.
+   */
+  async waitForDownload(timeout?: number): Promise<Download> {
+    if (this.pendingDownloads.length > 0) {
+      return this.pendingDownloads.shift()!;
+    }
+    const page = this.getPage();
+    const download = await page.waitForEvent('download', { timeout });
+    return download;
   }
 
   /**
@@ -1734,6 +1748,11 @@ export class BrowserManager {
         message: error.message,
         timestamp: Date.now(),
       });
+    });
+
+    // Track downloads eagerly so wait --download works even after the event fired
+    page.on('download', (download: Download) => {
+      this.pendingDownloads.push(download);
     });
 
     page.on('close', () => {


### PR DESCRIPTION
## Summary

`wait --download` always times out if the download was triggered before the command is sent (e.g., by a prior `click`). This is because `page.waitForEvent('download')` is called lazily and misses events that already fired.

### Fix

- Register `page.on('download')` eagerly in `setupPageTracking()` to queue downloads as they occur
- New `waitForDownload()` method checks the pending queue first, then falls back to `page.waitForEvent()`
- Same pattern as the network request tracking fix

### Before
```bash
agent-browser click @e5          # triggers download
agent-browser wait --download    # ✗ Timeout — event already fired
```

### After
```bash
agent-browser click @e5          # triggers download (queued)
agent-browser wait --download    # ✓ Returns immediately from queue
```

## Test plan

- [x] TypeScript compiles without errors
- [ ] Download triggered by click is captured by subsequent `wait --download`
- [ ] `wait --download` still works when called before the download starts

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)