### PR TITLE
fix: prevent check/uncheck from hanging on hidden checkbox elements

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1136,9 +1136,15 @@ async function handleFill(command: FillCommand, browser: BrowserManager): Promis
 async function handleCheck(command: CheckCommand, browser: BrowserManager): Promise<Response> {
   const locator = browser.getLocator(command.selector);
   try {
-    await locator.check();
-  } catch (error) {
-    throw toAIFriendlyError(error, command.selector);
+    await locator.check({ timeout: 5000 });
+  } catch {
+    // Retry with force for hidden checkboxes (common in UI frameworks like
+    // Element UI, Ant Design, Vuetify that hide native inputs with opacity:0)
+    try {
+      await locator.check({ force: true });
+    } catch (error) {
+      throw toAIFriendlyError(error, command.selector);
+    }
   }
   return successResponse(command.id, { checked: true });
 }
@@ -1146,9 +1152,14 @@ async function handleCheck(command: CheckCommand, browser: BrowserManager): Prom
 async function handleUncheck(command: UncheckCommand, browser: BrowserManager): Promise<Response> {
   const locator = browser.getLocator(command.selector);
   try {
-    await locator.uncheck();
-  } catch (error) {
-    throw toAIFriendlyError(error, command.selector);
+    await locator.uncheck({ timeout: 5000 });
+  } catch {
+    // Retry with force for hidden checkboxes
+    try {
+      await locator.uncheck({ force: true });
+    } catch (error) {
+      throw toAIFriendlyError(error, command.selector);
+    }
   }
   return successResponse(command.id, { unchecked: true });
 }


### PR DESCRIPTION
## Summary

UI frameworks (Element UI, Ant Design, Vuetify) hide native `<input type="checkbox">` with `opacity: 0` and zero dimensions. Playwright's `check()` waits indefinitely for actionability — a condition that never satisfies for hidden inputs.

### Fix

Attempt `check()`/`uncheck()` with a 5-second timeout first. If it fails due to actionability, retry with `force: true` to bypass visibility checks. This handles both standard visible checkboxes and framework-hidden ones without changing behavior for normal cases.

## Test plan

- [x] TypeScript compiles without errors
- [ ] `check` works on visible checkboxes (normal path)
- [ ] `check` works on hidden native checkboxes (force fallback)
- [ ] `check` still reports errors for non-existent selectors

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)