### PR TITLE
feat: include link URLs in interactive snapshot mode

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -496,7 +496,11 @@ function processLine(
   if (!match) {
     // Metadata lines (like /url:) or text content
     if (options.interactive) {
-      // In interactive mode, only keep metadata under interactive elements
+      // In interactive mode, keep /url: metadata (hrefs) but skip other content
+      const trimmed = line.trim();
+      if (trimmed.startsWith('- /url:') || trimmed.startsWith('/url:')) {
+        return line;
+      }
       return null;
     }
     return line;


### PR DESCRIPTION
## Summary

In interactive mode (`snapshot -i`), all metadata lines were discarded — including \`/url:\` entries under links. This made it impossible for agents to see where links point to.

Now \`/url:\` metadata lines are preserved in interactive snapshots, giving agents access to both link text and destination.

### Before
\`\`\`
- link "Documentation" [ref=e1]
\`\`\`

### After
\`\`\`
- link "Documentation" [ref=e1]:
    - /url: https://docs.example.com
\`\`\`

Non-interactive snapshots are unaffected.

## Test plan

- [x] TypeScript compiles without errors
- [ ] \`snapshot -i\` shows /url: under link elements
- [ ] Non-interactive snapshot unchanged

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)