### PR TITLE
fix: check browser.isConnected() in isLaunched()

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -164,7 +164,7 @@ export class BrowserManager {
    * Check if browser is launched
    */
   isLaunched(): boolean {
-    return this.browser !== null || this.isPersistentContext;
+    return (this.browser !== null && this.browser.isConnected()) || this.isPersistentContext;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `isLaunched()` now checks `browser.isConnected()` in addition to the null check
- When a browser is manually closed or crashes, `isLaunched()` correctly returns false

## Problem
After a browser was manually closed or crashed, `isLaunched()` still returned `true` because the browser reference was non-null. This caused subsequent commands like `goto` to throw confusing errors instead of indicating the browser needs to be relaunched.

## Test plan
- [x] TypeScript compiles cleanly
- [x] Existing stale-session recovery test still passes (closing pages doesn't disconnect the browser)

Fixes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)