### PR TITLE
fix: detect position modifiers misused after find locators

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1707,6 +1707,20 @@ fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                 },
             })?;
             let subaction = rest.get(2).unwrap_or(&"click");
+
+            // Detect position modifiers (first/last/nth) used after a locator type
+            // e.g., "find role spinbutton first fill '20'" — "first" is in the subaction slot
+            if matches!(*subaction, "first" | "last" | "nth") && !matches!(*locator, "first" | "last" | "nth") {
+                return Err(ParseError::InvalidValue {
+                    message: format!(
+                        "\"{}\" cannot be used as a modifier after \"{}\". \
+                         Use it as the primary locator: find {} <selector> [action] [text]",
+                        subaction, locator, subaction
+                    ),
+                    usage: "find first <selector> [action] [text]",
+                });
+            }
+
             let fill_value = if rest.len() > 3 {
                 Some(rest[3..].join(" "))
             } else {


### PR DESCRIPTION
## Summary
- Detects when `first`/`last`/`nth` appears in the subaction position after a semantic locator
- Returns a clear error message with the correct syntax instead of a confusing Zod validation error

## Problem
Running `find role spinbutton first fill '20'` produces:
```
✗ Validation error: name: Expected string, received null, subaction: Invalid enum value.
Expected 'click' | 'fill' | 'check' | 'hover', received 'first'
```

Now it produces:
```
"first" cannot be used as a modifier after "role". Use it as the primary locator: find first <selector> [action] [text]
```

## Test plan
- [x] `cargo check` passes
- [x] Verified error message is clear and suggests correct syntax

Fixes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)