### PR TITLE
fix: support AGENT_BROWSER_CDP env var in Node.js daemon auto-launch

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -431,6 +431,19 @@ export async function startDaemon(options?: {
               });
             } else if (manager instanceof BrowserManager) {
               // Auto-launch desktop browser
+              // Check for CDP connection via environment variable (mirrors native daemon behavior)
+              const cdpEnv = process.env.AGENT_BROWSER_CDP;
+              if (cdpEnv) {
+                const cdpPort = /^\d+$/.test(cdpEnv) ? parseInt(cdpEnv, 10) : undefined;
+                const cdpUrl = cdpPort === undefined ? cdpEnv : undefined;
+                await manager.launch({
+                  id: 'auto',
+                  action: 'launch' as const,
+                  cdpPort,
+                  cdpUrl,
+                  autoStateFilePath: getSessionAutoStatePath(),
+                });
+              } else {
               const extensions = process.env.AGENT_BROWSER_EXTENSIONS
                 ? process.env.AGENT_BROWSER_EXTENSIONS.split(/[,\n]/)
                     .map((p) => p.trim())
@@ -483,6 +496,7 @@ export async function startDaemon(options?: {
                 colorScheme,
                 autoStateFilePath: getSessionAutoStatePath(),
               });
+              }
             }
           }
 


### PR DESCRIPTION
Fixes #674

## Summary

The `AGENT_BROWSER_CDP` environment variable is supported by the native Rust daemon's `auto_launch` function (`cli/src/native/actions.rs:731`), but the Node.js daemon's auto-launch path in `daemon.ts` ignores it entirely.

When a user sets `AGENT_BROWSER_CDP=9222` and runs a command (e.g., `agent-browser snapshot`), the daemon auto-launches because no explicit `launch` command was sent. The native daemon correctly routes to CDP connection, but the Node.js daemon (default) launches a fresh Chromium instance with `about:blank` instead of connecting to the user's existing Chrome via CDP.

This adds the same `AGENT_BROWSER_CDP` check to the Node.js daemon auto-launch path, mirroring the native daemon behavior.

## Reproduction

1. Start Chrome with `--remote-debugging-port=9222`
2. Run `AGENT_BROWSER_CDP=9222 agent-browser snapshot -i`
3. **Expected**: agent-browser connects to existing Chrome and snapshots the current tab
4. **Actual**: agent-browser launches a new Chromium with `about:blank`

## Fix

- Check `process.env.AGENT_BROWSER_CDP` in the auto-launch code path
- If set, parse as port number or URL (same logic as `connectViaCDP`)
- Route to `manager.launch()` with `cdpPort`/`cdpUrl` instead of launching fresh Chromium