### PR TITLE
ci: add clippy check to Rust CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -74,6 +74,9 @@ jobs:
 
       - name: Format check
         run: cargo fmt --manifest-path cli/Cargo.toml -- --check
+
+      - name: Clippy check
+        run: cargo clippy --manifest-path cli/Cargo.toml -- -D warnings
 
       - name: Run Rust tests
         run: cargo test --profile ci --manifest-path cli/Cargo.toml

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -123,7 +123,7 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
     let has_extensions = options
         .extensions
         .as_ref()
-        .map_or(false, |exts| !exts.is_empty());
+        .is_some_and(|exts| !exts.is_empty());
 
     // Extensions require headed mode in native Chrome (content scripts are not
     // injected in headless mode).  Skip --headless when extensions are loaded.


### PR DESCRIPTION
## Summary
- Add `cargo clippy -- -D warnings` step to the Rust CI job so clippy warnings fail the build
- Add `clippy` component to the Rust toolchain setup
- Fix one new `unnecessary_map_or` lint in `cli/src/native/cdp/chrome.rs`

Fixes #672

## Test plan
- [x] `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings` passes locally
- [x] CI Rust job passes with the new clippy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)