### PR TITLE
Add regression test for Didomi-style quoted ARIA snapshot buttons

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -1426,6 +1426,35 @@ mod tests {
         assert!(!dups.contains_key("button:Cancel"));
     }
 
+    /// Regression guard for Didomi-style consent buttons, whose accessible name
+    /// is itself a quoted "key: description" string (e.g. "Agree and close:
+    /// Agree to our data processing and close") while the AX value carries the
+    /// short label. Interactive snapshots must keep BOTH: the quoted name and
+    /// the trailing value text. An earlier parser dropped the value suffix,
+    /// leaving agents unable to tell such buttons apart.
+    #[test]
+    fn test_render_tree_keeps_button_value_text_in_interactive_mode() {
+        let mut node = TreeNode::empty();
+        node.role = "button".to_string();
+        node.name = "Agree and close: Agree to our data processing and close".to_string();
+        node.value_text = Some("Agree and close".to_string());
+        node.has_ref = true;
+        node.ref_id = Some("e1".to_string());
+
+        let options = SnapshotOptions {
+            interactive: true,
+            ..SnapshotOptions::default()
+        };
+        let mut output = String::new();
+
+        render_tree(&[node], 0, 0, &mut output, &options);
+
+        assert_eq!(
+            output.trim(),
+            "- button \"Agree and close: Agree to our data processing and close\" [ref=e1]: Agree and close"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Cursor-interactive text dedup (Issue #841 regression guard)
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a regression test for the snapshot formatting behavior that originally broke on a Didomi cookie modal on `https://borsen.dk/aktiespil/forside`.

At the time this PR was opened, `agent-browser snapshot -i` could see the consent modal but dropped the actionable buttons from snapshot output. The visible failure was that the modal rendered buttons like:

- `Agree and close`
- `Disagree and close`
- `Learn More`

but the snapshot only surfaced unrelated content such as `our 89 partners`.

The underlying issue was that these controls were represented with a longer accessible name plus a visible value text, for example:

- `button "Agree and close: Agree to our data processing and close" ... : Agree and close`

During review and subsequent rebases, upstream `main` changed substantially and the original implementation path used for the initial fix was removed. After merging the branch forward, the remaining diff is now just the regression test that asserts this button/value-text formatting is preserved.

So this PR is no longer proposing the original implementation change. It now serves as a regression guard for behavior that appears to already be present in current `main`.

## What this PR adds

- a native snapshot regression test that verifies interactive snapshot rendering keeps visible button value text alongside the accessible name
- coverage for the specific shape that originally reproduced on the Didomi consent modal

## Why this still may be useful

Even though the functional fix is no longer part of the diff, this test documents the original failure mode and helps prevent it from silently reappearing in future snapshot refactors.

If maintainers feel existing coverage is already sufficient, closing this PR would also be reasonable.

## Verification

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test snapshot --manifest-path cli/Cargo.toml`
