### PR TITLE
fix: respect AGENT_BROWSER_CDP env var in Node.js daemon auto-launch

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -465,6 +465,10 @@ export async function startDaemon(options?: {
                 colorSchemeEnv === 'no-preference'
                   ? colorSchemeEnv
                   : undefined;
+
+              // Check for CDP endpoint from environment (like Rust daemon does)
+              const cdpEndpoint = process.env.AGENT_BROWSER_CDP;
+
               await manager.launch({
                 id: 'auto',
                 action: 'launch' as const,
@@ -482,6 +486,7 @@ export async function startDaemon(options?: {
                 allowFileAccess: allowFileAccess,
                 colorScheme,
                 autoStateFilePath: getSessionAutoStatePath(),
+                ...(cdpEndpoint && { cdpUrl: cdpEndpoint }),
               });
             }
           }


### PR DESCRIPTION
Fixes #674

The `AGENT_BROWSER_CDP` environment variable was supported by the native Rust daemon but ignored by the Node.js daemon's auto-launch path in `daemon.ts`.

**Changes:**
- Added check for `process.env.AGENT_BROWSER_CDP` in the auto-launch code path
- Pass the CDP endpoint as `cdpUrl` to the browser launch options
- This matches the behavior of the Rust daemon at `cli/src/native/actions.rs:731`

**Testing:**
The fix is minimal and follows the existing pattern used for other environment variables (e.g., `AGENT_BROWSER_PROXY`, `AGENT_BROWSER_EXECUTABLE_PATH`). When `AGENT_BROWSER_CDP` is set, the Node.js daemon will now connect to the existing Chrome DevTools Protocol endpoint instead of launching a new browser instance.