### PR TITLE
Fix session state not persisting on macOS

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -76,6 +76,11 @@ const DEFAULT_STREAM_PORT = 9223;
 
 /**
  * Save state to file with optional encryption.
+ *
+ * Note: On macOS, Playwright's storageState() can return empty data when called
+ * without a path argument. We work around this by using a temporary file and
+ * letting Playwright write directly to it, then reading the file content.
+ * This ensures the storage state is properly flushed before capture.
  */
 async function saveStateToFile(
   browser: BrowserManager,
@@ -86,18 +91,45 @@ async function saveStateToFile(
     throw new Error('No browser context available');
   }
 
-  const state = await context.storageState();
-  const jsonData = JSON.stringify(state, null, 2);
+  // Use a temporary file to ensure proper storage flushing on macOS
+  // Playwright's storageState({ path }) is more reliable than storageState()
+  const tempDir = os.tmpdir();
+  const tempFile = path.join(tempDir, `agent-browser-state-${Date.now()}.json`);
 
-  const key = getEncryptionKey();
-  if (key) {
-    const encrypted = encryptData(jsonData, key);
-    fs.writeFileSync(filepath, JSON.stringify(encrypted, null, 2));
-    return { encrypted: true };
+  try {
+    // Let Playwright write directly to a temp file - this ensures proper flushing
+    await context.storageState({ path: tempFile });
+
+    // Read the temp file content
+    const jsonData = fs.readFileSync(tempFile, 'utf8');
+
+    // Clean up temp file
+    try {
+      fs.unlinkSync(tempFile);
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    const key = getEncryptionKey();
+    if (key) {
+      const encrypted = encryptData(jsonData, key);
+      fs.writeFileSync(filepath, JSON.stringify(encrypted, null, 2));
+      return { encrypted: true };
+    }
+
+    fs.writeFileSync(filepath, jsonData);
+    return { encrypted: false };
+  } catch (error) {
+    // Clean up temp file on error
+    try {
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw error;
   }
-
-  fs.writeFileSync(filepath, jsonData);
-  return { encrypted: false };
 }
 
 const AUTO_EXPIRE_ENV = 'AGENT_BROWSER_STATE_EXPIRE_DAYS';


### PR DESCRIPTION
## Problem

On macOS, `--session-name` / `AGENT_BROWSER_SESSION_NAME` writes empty state and restores nothing, even though:
- `--profile` works on the same machine
- `state save` + `--state` works on the same machine

The saved state file would contain:
```json
{"cookies": [], "origins": []}
```

## Root Cause

Playwright's `context.storageState()` (without path argument) can return empty data on macOS, while `context.storageState({ path })` works correctly. The `state save` command was using `browser.saveStorageState()` which calls `context.storageState({ path })`, but the auto-save path for `--session-name` was using `context.storageState()` and manually writing the file.

## Solution

Use a temporary file approach in `saveStateToFile()`:
1. Call `context.storageState({ path: tempFile })` to let Playwright write directly to a temp file
2. Read the temp file content
3. Encrypt if needed and write to final destination
4. Clean up temp file

This ensures proper storage flushing before capture, matching how the working `state save` command operates.

Fixes #677