### PR TITLE
Make KERNEL_API_KEY optional for external credential injection

### DIFF
--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -217,9 +217,7 @@ async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {
     }
 
     let client = reqwest::Client::new();
-    let mut request = client
-        .post(&url)
-        .header("Content-Type", "application/json");
+    let mut request = client.post(&url).header("Content-Type", "application/json");
     if let Some(ref key) = api_key {
         request = request.header("Authorization", format!("Bearer {}", key));
     }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -891,12 +891,14 @@ export class BrowserManager {
   /**
    * Close a Kernel session via API
    */
-  private async closeKernelSession(sessionId: string, apiKey: string): Promise<void> {
+  private async closeKernelSession(sessionId: string, apiKey: string | undefined): Promise<void> {
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
     const response = await fetch(`https://api.onkernel.com/browsers/${sessionId}`, {
       method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers,
     });
 
     if (!response.ok) {
@@ -1100,7 +1102,7 @@ export class BrowserManager {
       }
 
       this.kernelSessionId = session.session_id;
-      this.kernelApiKey = kernelApiKey;
+      this.kernelApiKey = kernelApiKey ?? null;
       this.browser = browser;
       context.setDefaultTimeout(getDefaultTimeout());
       this.contexts.push(context);
@@ -2520,8 +2522,8 @@ export class BrowserManager {
         }
       );
       this.browser = null;
-    } else if (this.kernelSessionId && this.kernelApiKey) {
-      await this.closeKernelSession(this.kernelSessionId, this.kernelApiKey).catch((error) => {
+    } else if (this.kernelSessionId) {
+      await this.closeKernelSession(this.kernelSessionId, this.kernelApiKey ?? undefined).catch((error) => {
         console.error('Failed to close Kernel session:', error);
       });
       this.browser = null;


### PR DESCRIPTION
## Summary

Makes `KERNEL_API_KEY` optional when using `-p kernel`. When running inside environments with external credential injection (e.g. Vercel Sandbox [credentials brokering](https://vercel.com/changelog/safely-inject-credentials-in-http-headers-with-vercel-sandbox)), the API key doesn't need to exist inside the sandbox — the network layer injects the `Authorization` header on outbound requests to `api.onkernel.com`.

**Before:** `KERNEL_API_KEY` is required — agent-browser throws immediately if it's not set, before making any HTTP request. This forces users to set a placeholder value in sandboxed environments even when auth is handled externally.

**After:** If `KERNEL_API_KEY` is set, it's used as before. If not, requests are sent without an `Authorization` header, allowing external injection. Without either, the Kernel API returns 401 with a clear error via the existing error handling.

## Context

When using Vercel Sandbox's `networkPolicy.transform`, the sandbox firewall intercepts TLS and injects HTTP headers on matching domains. This lets the real API key stay outside the sandbox boundary — code inside never sees it. But this only works if agent-browser actually sends the request without requiring the env var first.

See working demo: https://gist.github.com/masnwilliams/d6334ad50bd24b6d48e907b46c120e0b


Made with [Cursor](https://cursor.com)