### PR TITLE
fix security docs url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ agent-browser includes security features for safe AI agent deployments. All feat
 | `AGENT_BROWSER_CONFIRM_ACTIONS` | Action categories requiring confirmation |
 | `AGENT_BROWSER_CONFIRM_INTERACTIVE` | Enable interactive confirmation prompts |
 
-See [Security documentation](https://agent-browser.vercel.app/security) for details.
+See [Security documentation](https://agent-browser.dev/security) for details.
 
 ## Snapshot Options
 


### PR DESCRIPTION
Hello! Outdated 404 link on readme