### PR TITLE
chore: patch release - Added support for device scale factor (retina disp

### DIFF
--- a/.changeset/release-e95e7a17.md
+++ b/.changeset/release-e95e7a17.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+Added support for device scale factor (retina display) in the viewport command via an optional scale parameter. Also added webview target type support for better Electron application compatibility, and the pages list now includes target type information.


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
Added support for device scale factor (retina display) in the viewport command via an optional scale parameter. Also added webview target type support for better Electron application compatibility, and the pages list now includes target type information.

---
*This PR was created automatically by autoship*