### PR TITLE
docs: add viewport documentation to SKILL.md

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -85,6 +85,11 @@ agent-browser download @e1 ./file.pdf          # Click element to trigger downlo
 agent-browser wait --download ./output.zip     # Wait for any download to complete
 agent-browser --download-path ./downloads open <url>  # Set default download directory
 
+# Viewport & Device Emulation
+agent-browser set viewport 1920 1080          # Set viewport size (default: 1280x720)
+agent-browser set viewport 1920 1080 2        # 2x retina (same CSS size, higher res screenshots)
+agent-browser set device "iPhone 14"          # Emulate device (viewport + user agent)
+
 # Capture
 agent-browser screenshot              # Screenshot to temp dir
 agent-browser screenshot --full       # Full page screenshot
@@ -218,6 +223,29 @@ AGENT_BROWSER_COLOR_SCHEME=dark agent-browser open https://example.com
 # Or set during session (persists for subsequent commands)
 agent-browser set media dark
 ```
+
+### Viewport & Responsive Testing
+
+```bash
+# Set a custom viewport size (default is 1280x720)
+agent-browser set viewport 1920 1080
+agent-browser screenshot desktop.png
+
+# Test mobile-width layout
+agent-browser set viewport 375 812
+agent-browser screenshot mobile.png
+
+# Retina/HiDPI: same CSS layout at 2x pixel density
+# Screenshots stay at logical viewport size, but content renders at higher DPI
+agent-browser set viewport 1920 1080 2
+agent-browser screenshot retina.png
+
+# Device emulation (sets viewport + user agent in one step)
+agent-browser set device "iPhone 14"
+agent-browser screenshot device.png
+```
+
+The `scale` parameter (3rd argument) sets `window.devicePixelRatio` without changing CSS layout. Use it when testing retina rendering or capturing higher-resolution screenshots.
 
 ### Visual Browser (Debugging)
 


### PR DESCRIPTION
## Summary

- The `set viewport` command is fully implemented in both the Node SDK and Rust CLI, but **SKILL.md** (the primary agent-facing guide) had no mention of viewport control
- Agents relying on SKILL.md would not discover they can resize the viewport, test responsive layouts, or use retina scaling
- Added viewport commands to the Essential Commands section and a "Viewport & Responsive Testing" pattern with practical examples

## What changed

**`skills/agent-browser/SKILL.md`**

1. **Essential Commands** — Added a "Viewport & Device Emulation" block:
   - `set viewport <w> <h>` for basic resizing (default noted as 1280x720)
   - `set viewport <w> <h> <scale>` for retina/HiDPI
   - `set device "<name>"` for device emulation

2. **New "Viewport & Responsive Testing" pattern** — Placed between "Color Scheme" and "Visual Browser" sections with examples for desktop, mobile-width, retina, and device emulation workflows, plus explanation of how `scale` affects `devicePixelRatio` vs CSS layout

## What was NOT changed (and why)

- `references/commands.md` — Already correctly documents `set viewport` (lines 131-132)
- `README.md` — Already lists `set viewport <w> <h> [scale]` in Browser Settings
- Core implementation — Working correctly, no code changes needed

## Test plan

- [x] Verified `set viewport` implementation in `src/actions.ts`, `src/browser.ts`, `cli/src/native/actions.rs`
- [x] Confirmed existing tests cover viewport: unit tests (`src/browser.test.ts`), E2E tests (`cli/src/native/e2e_tests.rs`), parser tests (`cli/src/commands.rs`)
- [x] Verified documentation consistency across SKILL.md, commands.md, and README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)