### PR TITLE
fix: use correct Browserbase API to release sessions

### DIFF
--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -35,11 +35,13 @@ pub async fn close_provider_session(session: &ProviderSession) {
         "browserbase" => {
             if let Ok(api_key) = env::var("BROWSERBASE_API_KEY") {
                 let _ = client
-                    .delete(format!(
+                    .post(format!(
                         "https://api.browserbase.com/v1/sessions/{}",
                         session.session_id
                     ))
+                    .header("Content-Type", "application/json")
                     .header("X-BB-API-Key", &api_key)
+                    .json(&serde_json::json!({ "status": "REQUEST_RELEASE" }))
                     .send()
                     .await;
             }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -862,12 +862,18 @@ export class BrowserManager {
    * Close a Browserbase session via API
    */
   private async closeBrowserbaseSession(sessionId: string, apiKey: string): Promise<void> {
-    await fetch(`https://api.browserbase.com/v1/sessions/${sessionId}`, {
-      method: 'DELETE',
+    const response = await fetch(`https://api.browserbase.com/v1/sessions/${sessionId}`, {
+      method: 'POST',
       headers: {
+        'Content-Type': 'application/json',
         'X-BB-API-Key': apiKey,
       },
+      body: JSON.stringify({ status: 'REQUEST_RELEASE' }),
     });
+
+    if (!response.ok) {
+      throw new Error(`Failed to close Browserbase session: ${response.statusText}`);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- `closeBrowserbaseSession` sends `DELETE /v1/sessions/:id`, but Browserbase has no DELETE endpoint. The correct API is `POST /v1/sessions/:id` with body `{ status: "REQUEST_RELEASE" }`.
- The response was never checked, so the 404/405 error was silently swallowed. Every cloud session leaked until the 30-min idle timeout.
- Fixed in both Node.js (`src/browser.ts`) and native Rust (`cli/src/native/providers.rs`) paths.

## Details

**Node.js path (`src/browser.ts`):**
- Changed `method: 'DELETE'` to `method: 'POST'` with `Content-Type: application/json` header and `{ status: 'REQUEST_RELEASE' }` body
- Added `response.ok` check with error throw, matching the pattern used by `closeBrowserUseSession` and `closeKernelSession`

**Native path (`cli/src/native/providers.rs`):**
- Changed `.delete()` to `.post()` with `.json()` body containing `{ "status": "REQUEST_RELEASE" }`
- Added `Content-Type: application/json` header

**Note:** The native path's `close_provider_session` is currently only called in the launch-rollback path (CDP connect failure). The normal close path (`handle_close` -> `BrowserManager::close`) does not call the Browserbase release API -- this is a pre-existing gap, not introduced by this change.

## Test plan

- [ ] Deploy with Browserbase provider, launch a session, then close it. Verify the session transitions to `COMPLETED` status in Browserbase dashboard instead of lingering for 30 minutes.
- [ ] Verify launch-failure rollback still works: set an invalid CDP URL after session creation and confirm the session is released.

Generated with [Claude Code](https://claude.com/claude-code)