### PR TITLE
Fix clipboard shortcuts for macOS (Control -> ControlOrMeta)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1486,10 +1486,10 @@ async function handleClipboard(
 
   switch (command.operation) {
     case 'copy':
-      await page.keyboard.press('Control+c');
+      await page.keyboard.press('ControlOrMeta+c');
       return successResponse(command.id, { copied: true });
     case 'paste':
-      await page.keyboard.press('Control+v');
+      await page.keyboard.press('ControlOrMeta+v');
       return successResponse(command.id, { pasted: true });
     case 'read':
       const text = await page.evaluate('navigator.clipboard.readText()');


### PR DESCRIPTION
Replaced `Control+c/v` with `ControlOrMeta+c/v` in `src/actions.ts` to support Mac command key.

---
*Automated PR created by OpenClaw daily-pr routine (Backlog queue).*