### PR TITLE
Fix CDP connection failure on IPv6-first systems

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1514,10 +1514,10 @@ export class BrowserManager {
       cdpUrl = cdpEndpoint;
     } else if (/^\d+$/.test(cdpEndpoint)) {
       // Numeric string - treat as port number (handles JSON serialization quirks)
-      cdpUrl = `http://localhost:${cdpEndpoint}`;
+      cdpUrl = `http://127.0.0.1:${cdpEndpoint}`;
     } else {
       // Unknown format - still try as port for backward compatibility
-      cdpUrl = `http://localhost:${cdpEndpoint}`;
+      cdpUrl = `http://127.0.0.1:${cdpEndpoint}`;
     }
 
     const browser = await chromium
@@ -1525,7 +1525,7 @@ export class BrowserManager {
       .catch(() => {
         throw new Error(
           `Failed to connect via CDP to ${cdpUrl}. ` +
-            (cdpUrl.includes('localhost')
+            (cdpUrl.includes('127.0.0.1')
               ? `Make sure the app is running with --remote-debugging-port=${cdpEndpoint}`
               : 'Make sure the remote browser is accessible and the URL is correct.')
         );


### PR DESCRIPTION
## Problem

Closes #681

When connecting via CDP with a port number (e.g., `--cdp 9222`), `connectViaCDP()` constructs the URL as `http://localhost:9222`. This works on systems where `localhost` resolves to `127.0.0.1` (IPv4), but **fails on systems where the resolver prioritizes IPv6** — such as Ubuntu 24.04, where `systemd-resolved` resolves `localhost` to `::1` first.

### Root Cause

Chrome's `--remote-debugging-port` binds **only to IPv4** (`127.0.0.1`):

```
Chrome CDP Server
├── 127.0.0.1:9222 (IPv4) ✅ Listening
└── [::1]:9222      (IPv6) ❌ Not bound
```

The resolution of `localhost` is not fixed — it depends on the OS resolver configuration (`/etc/hosts` order, `nsswitch.conf`, `systemd-resolved`, etc.). On Ubuntu 24.04, `systemd-resolved` resolves `localhost` to `::1` (IPv6) first. So the connection flow becomes:

```
agent-browser → http://localhost:9222
                       ↓
              OS resolves to ::1 (IPv6)
                       ↓
              Chrome not listening on [::1]:9222
                       ↓
              ❌ Connection refused
```

### Inconsistency

`probeDebugPort()` in the same file already uses `http://127.0.0.1:${port}` (correct), but `connectViaCDP()` was using `http://localhost:${port}` — an inconsistency within the same connection flow.

## Solution

Replace `localhost` with `127.0.0.1` in `connectViaCDP()` when constructing the CDP URL from a port number. This bypasses DNS resolution entirely and connects directly via IPv4, matching Chrome's binding behavior.

### Changes in `src/browser.ts`

| Line | Before | After |
|------|--------|-------|
| 1517 | `` `http://localhost:${cdpEndpoint}` `` | `` `http://127.0.0.1:${cdpEndpoint}` `` |
| 1520 | `` `http://localhost:${cdpEndpoint}` `` | `` `http://127.0.0.1:${cdpEndpoint}` `` |
| 1528 | `cdpUrl.includes('localhost')` | `cdpUrl.includes('127.0.0.1')` |

### Connection flow after fix

```
agent-browser → http://127.0.0.1:9222
                       ↓
              No DNS resolution needed (IP literal)
                       ↓
              Chrome listening on 127.0.0.1:9222
                       ↓
              ✅ Connection succeeds (all platforms)
```

## Impact

- **Fixes**: CDP connection on systems where `localhost` resolves to `::1` (e.g., Ubuntu 24.04)
- **No regression**: Systems that already resolve `localhost` to `127.0.0.1` work exactly the same
- **Full URL passthrough unaffected**: `--cdp http://...` or `--cdp ws://...` bypass this code path entirely
- **Consistent**: Now matches `probeDebugPort()` which already uses `127.0.0.1`

## Verification

- `npx tsc --noEmit` — passes
- `npm test` — no new failures (existing browser.test.ts timeouts are pre-existing)


🤖 Generated with [Claude Code](https://claude.com/claude-code)