### PR TITLE
fix: inherit current viewport for recordings

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } 
 import { BrowserManager, getDefaultTimeout } from './browser.js';
 import { executeCommand } from './actions.js';
 import { chromium } from 'playwright-core';
+import os from 'node:os';
+import path from 'node:path';
+import { existsSync, rmSync } from 'node:fs';
 
 describe('BrowserManager', () => {
   let browser: BrowserManager;
@@ -634,6 +637,25 @@ describe('BrowserManager', () => {
       const size = page.viewportSize();
       expect(size?.width).toBe(1920);
       expect(size?.height).toBe(1080);
+    });
+
+    it('should inherit the current viewport when starting a recording', async () => {
+      const recordingPath = path.join(os.tmpdir(), `agent-browser-recording-${Date.now()}.webm`);
+
+      await browser.setViewport(440, 956);
+
+      try {
+        await browser.startRecording(recordingPath);
+        const recordingPage = (browser as any).recordingPage;
+        expect(recordingPage.viewportSize()).toEqual({ width: 440, height: 956 });
+      } finally {
+        if (browser.isRecording()) {
+          await browser.stopRecording();
+        }
+        if (existsSync(recordingPath)) {
+          rmSync(recordingPath, { force: true });
+        }
+      }
     });
 
     it('should disable viewport when --start-maximized is in args', async () => {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2333,8 +2333,8 @@ export class BrowserManager {
 
     this.recordingOutputPath = outputPath;
 
-    // Create a new context with video recording enabled and restored state
-    const viewport = { width: 1280, height: 720 };
+    // Reuse the active page viewport when available so recording matches the current layout.
+    const viewport = currentPage?.viewportSize() ?? { width: 1280, height: 720 };
     this.recordingContext = await this.browser.newContext({
       viewport,
       recordVideo: {


### PR DESCRIPTION
## Summary
- make `startRecording()` reuse the active page viewport when one exists
- keep the existing `1280x720` fallback when there is no current page viewport
- add a regression test covering recording after `setViewport(440, 956)`

## Problem
`agent-browser record start` recreated a fresh Playwright context with a hardcoded viewport and recording size of `1280x720`.

That meant:
- the active browser session could be in a portrait/mobile viewport
- but the recording context would still switch back to landscape
- resulting videos did not match the layout the user was actually testing

## Root Cause
`src/browser.ts` used:

```ts
const viewport = { width: 1280, height: 720 };
this.recordingContext = await this.browser.newContext({
  viewport,
  recordVideo: {
    dir: this.recordingTempDir,
    size: viewport,
  },
  storageState,
});
```

## Fix
Use `currentPage?.viewportSize()` when available and only fall back to `1280x720` when no active page viewport exists.

## Validation
Local validation after patching the installed build showed:
- `set viewport 320 960` followed by `record start` produced a `320x960` `.webm`
- `set viewport 440 956 3` followed by `record start` produced a `440x956` portrait recording

## Notes
I added a regression test in `src/browser.test.ts` for the inherited viewport behavior.

I did not run the upstream test suite in the fork clone because dependencies were not installed in that checkout.