### PR TITLE
fix: escape `!` in markdown code block to avoid bash permission check false positive

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -113,7 +113,7 @@ agent-browser diff url <url1> <url2> --selector "#main"  # Scope to element
 agent-browser open https://example.com/signup
 agent-browser snapshot -i
 agent-browser fill @e1 "Jane Doe"
-agent-browser fill @e2 "jane@example.com"Control+f
+agent-browser fill @e2 "jane@example.com"
 agent-browser select @e3 "California"
 agent-browser check @e4
 agent-browser click @e5


### PR DESCRIPTION
Claude Code's bash permission checker incorrectly flags `!` characters inside markdown inline code blocks as bash history expansion commands, blocking the skill from loading. Replace `!` with HTML entity `&#33;`.

Related: https://github.com/anthropics/claude-code/issues/17267