### PR TITLE
feat: add idle timeout to daemon to prevent orphaned Chrome processes

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -696,6 +696,26 @@ export async function startDaemon(options?: {
       idleTimer = null;
     }
 
+    // Auto-save session state before closing (same as the explicit `close` command path)
+    if (manager instanceof BrowserManager && manager.isLaunched()) {
+      const savePath = getSessionSaveStatePath();
+      if (savePath) {
+        try {
+          const { encrypted } = await saveStateToFile(manager, savePath);
+          fs.chmodSync(savePath, 0o600);
+          if (process.env.AGENT_BROWSER_DEBUG === '1') {
+            console.error(
+              `Auto-saved session state before shutdown: ${savePath}${encrypted ? ' (encrypted)' : ''}`
+            );
+          }
+        } catch (err) {
+          if (process.env.AGENT_BROWSER_DEBUG === '1') {
+            console.error(`Failed to auto-save session state before shutdown:`, err);
+          }
+        }
+      }
+    }
+
     // Stop stream server if running
     if (streamServer) {
       await streamServer.stop();


### PR DESCRIPTION
## Summary

- Adds a configurable idle timeout (default 15 minutes) that automatically shuts down the daemon when no commands arrive on the socket
- Timer resets on every incoming command, so active sessions are completely unaffected
- Set `AGENT_BROWSER_IDLE_TIMEOUT_MS=0` to disable and preserve old behavior

Fixes #721

## Problem

The daemon process (`daemon.js`) persists indefinitely after browser sessions are used. `process.stdin.resume()` keeps the event loop alive with no idle detection. Each abandoned session leaves behind 1 Node.js daemon + 4+ Chromium processes (main, GPU, network utility, renderer) that accumulate over time.

## Implementation

- New env var `AGENT_BROWSER_IDLE_TIMEOUT_MS` (default: 900000 = 15 min, set to 0 to disable)
- `resetIdleTimer()` called on daemon startup and on every incoming socket command
- Timer uses `.unref()` so it doesn't keep the process alive on its own
- On expiry, calls existing `shutdown()` which cleanly closes browser, server, socket, and PID files
- Timer cleared in `shutdown()` to prevent races

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npx vitest run src/daemon.test.ts` — all 18 existing tests pass
- [x] Manual test: `AGENT_BROWSER_IDLE_TIMEOUT_MS=3000` — daemon auto-shuts down after 3s idle
- [x] Manual test: `AGENT_BROWSER_IDLE_TIMEOUT_MS=0` — daemon stays alive indefinitely (old behavior)
- [ ] Verify active sessions are not interrupted by the timer resetting correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)