### PR TITLE
feat: add macOS-only native no-activate launch option

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2089,6 +2089,7 @@ mod tests {
             json: false,
             full: false,
             headed: false,
+            no_activate: false,
             debug: false,
             headers: None,
             executable_path: None,

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -215,6 +215,7 @@ pub struct DaemonResult {
 /// The daemon only needs `confirm_actions` to gate action categories.
 pub struct DaemonOptions<'a> {
     pub headed: bool,
+    pub no_activate: bool,
     pub debug: bool,
     pub executable_path: Option<&'a str>,
     pub extensions: &'a [String],
@@ -243,6 +244,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
 
     if opts.headed {
         cmd.env("AGENT_BROWSER_HEADED", "1");
+    }
+    if opts.no_activate {
+        cmd.env("AGENT_BROWSER_NO_ACTIVATE", "1");
     }
     if opts.debug {
         cmd.env("AGENT_BROWSER_DEBUG", "1");

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -12,6 +12,7 @@ const PROJECT_CONFIG_FILENAME: &str = "agent-browser.json";
 #[serde(default, rename_all = "camelCase")]
 pub struct Config {
     pub headed: Option<bool>,
+    pub no_activate: Option<bool>,
     pub json: Option<bool>,
     pub full: Option<bool>,
     pub debug: Option<bool>,
@@ -49,6 +50,7 @@ impl Config {
     fn merge(self, other: Config) -> Config {
         Config {
             headed: other.headed.or(self.headed),
+            no_activate: other.no_activate.or(self.no_activate),
             json: other.json.or(self.json),
             full: other.full.or(self.full),
             debug: other.debug.or(self.debug),
@@ -211,6 +213,7 @@ pub struct Flags {
     pub json: bool,
     pub full: bool,
     pub headed: bool,
+    pub no_activate: bool,
     pub debug: bool,
     pub session: String,
     pub headers: Option<String>,
@@ -283,6 +286,8 @@ pub fn parse_flags(args: &[String]) -> Flags {
         json: env_var_is_truthy("AGENT_BROWSER_JSON") || config.json.unwrap_or(false),
         full: env_var_is_truthy("AGENT_BROWSER_FULL") || config.full.unwrap_or(false),
         headed: env_var_is_truthy("AGENT_BROWSER_HEADED") || config.headed.unwrap_or(false),
+        no_activate: env_var_is_truthy("AGENT_BROWSER_NO_ACTIVATE")
+            || config.no_activate.unwrap_or(false),
         debug: env_var_is_truthy("AGENT_BROWSER_DEBUG") || config.debug.unwrap_or(false),
         session: env::var("AGENT_BROWSER_SESSION")
             .ok()
@@ -381,6 +386,13 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--headed" => {
                 let (val, consumed) = parse_bool_arg(args, i);
                 flags.headed = val;
+                if consumed {
+                    i += 1;
+                }
+            }
+            "--no-activate" => {
+                let (val, consumed) = parse_bool_arg(args, i);
+                flags.no_activate = val;
                 if consumed {
                     i += 1;
                 }
@@ -606,6 +618,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--json",
         "--full",
         "--headed",
+        "--no-activate",
         "--debug",
         "--ignore-https-errors",
         "--allow-file-access",
@@ -1114,6 +1127,12 @@ mod tests {
     }
 
     #[test]
+    fn test_no_activate_bare_defaults_true() {
+        let flags = parse_flags(&args("--no-activate open example.com"));
+        assert!(flags.no_activate);
+    }
+
+    #[test]
     fn test_debug_false() {
         let flags = parse_flags(&args("--debug false open example.com"));
         assert!(!flags.debug);
@@ -1183,6 +1202,12 @@ mod tests {
     #[test]
     fn test_clean_args_removes_bare_bool_flag() {
         let cleaned = clean_args(&args("--headed --debug open example.com"));
+        assert_eq!(cleaned, vec!["open", "example.com"]);
+    }
+
+    #[test]
+    fn test_clean_args_removes_no_activate() {
+        let cleaned = clean_args(&args("--no-activate open example.com"));
         assert_eq!(cleaned, vec!["open", "example.com"]);
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -398,6 +398,7 @@ fn main() {
 
     let daemon_opts = DaemonOptions {
         headed: flags.headed,
+        no_activate: flags.no_activate,
         debug: flags.debug,
         executable_path: flags.executable_path.as_deref(),
         extensions: &flags.extensions,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4038,6 +4038,7 @@ async fn handle_waitfordownload(cmd: &Value, state: &DaemonState) -> Result<Valu
 
 async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+    let background_window = mgr.prefers_background_windows();
 
     // Create a new browser context
     let context_result = mgr
@@ -4057,6 +4058,8 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
             &super::cdp::types::CreateTargetParams {
                 url: "about:blank".to_string(),
                 new_window: Some(true),
+                background: background_window.then_some(true),
+                focus: background_window.then_some(false),
                 browser_context_id: Some(context_id.clone()),
             },
             None,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -445,6 +445,8 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                     url: te.target_info.url.clone(),
                     title: te.target_info.title.clone(),
                     target_type: te.target_info.target_type.clone(),
+                    browser_context_id: te.target_info.browser_context_id.clone(),
+                    window_id: None,
                 });
             }
         }
@@ -2483,6 +2485,8 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         url: nav_url.clone(),
         title: String::new(),
         target_type: "page".to_string(),
+        browser_context_id: Some(context_id),
+        window_id: None,
     });
 
     // Navigate to URL
@@ -4050,7 +4054,11 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .client
         .send_command_typed(
             "Target.createTarget",
-            &json!({ "url": "about:blank", "browserContextId": context_id }),
+            &super::cdp::types::CreateTargetParams {
+                url: "about:blank".to_string(),
+                new_window: Some(true),
+                browser_context_id: Some(context_id.clone()),
+            },
             None,
         )
         .await?;
@@ -4073,6 +4081,8 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
         url: "about:blank".to_string(),
         title: String::new(),
         target_type: "page".to_string(),
+        browser_context_id: Some(context_id),
+        window_id: None,
     });
 
     if let Some(viewport) = cmd.get("viewport") {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -767,6 +767,9 @@ fn launch_options_from_env() -> LaunchOptions {
 
     LaunchOptions {
         headless: !headed,
+        no_activate: env::var("AGENT_BROWSER_NO_ACTIVATE")
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false),
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH").ok(),
         proxy: env::var("AGENT_BROWSER_PROXY").ok(),
         proxy_bypass: env::var("AGENT_BROWSER_PROXY_BYPASS").ok(),
@@ -939,6 +942,15 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     let options = LaunchOptions {
         headless,
+        no_activate: cmd
+            .get("noActivate")
+            .and_then(|v| v.as_bool())
+            .or_else(|| {
+                env::var("AGENT_BROWSER_NO_ACTIVATE")
+                    .ok()
+                    .map(|v| v == "1" || v == "true")
+            })
+            .unwrap_or(false),
         executable_path: cmd
             .get("executablePath")
             .and_then(|v| v.as_str())

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -83,6 +83,9 @@ fn validate_lightpanda_options(options: &LaunchOptions) -> Result<(), String> {
             "Custom Chrome arguments (--args) are not supported with Lightpanda".to_string(),
         );
     }
+    if options.no_activate {
+        return Err("--no-activate is only supported with native Chrome on macOS".to_string());
+    }
     Ok(())
 }
 
@@ -143,6 +146,14 @@ pub enum BrowserProcess {
 }
 
 impl BrowserProcess {
+    #[cfg(test)]
+    pub fn pid(&self) -> Option<u32> {
+        match self {
+            BrowserProcess::Chrome(p) => p.pid(),
+            BrowserProcess::Lightpanda(_) => None,
+        }
+    }
+
     pub fn kill(&mut self) {
         match self {
             BrowserProcess::Chrome(p) => p.kill(),
@@ -160,6 +171,8 @@ impl BrowserProcess {
 
 pub struct BrowserManager {
     pub client: CdpClient,
+    #[cfg(test)]
+    pub ws_url: String,
     browser_process: Option<BrowserProcess>,
     pages: Vec<PageInfo>,
     active_page_index: usize,
@@ -222,6 +235,8 @@ impl BrowserManager {
         let client = CdpClient::connect(&ws_url).await?;
         let mut manager = Self {
             client,
+            #[cfg(test)]
+            ws_url,
             browser_process: Some(process),
             pages: Vec::new(),
             active_page_index: 0,
@@ -284,6 +299,8 @@ impl BrowserManager {
         let client = CdpClient::connect(&ws_url).await?;
         let mut manager = Self {
             client,
+            #[cfg(test)]
+            ws_url,
             browser_process: None,
             pages: Vec::new(),
             active_page_index: 0,
@@ -608,6 +625,10 @@ impl BrowserManager {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub fn browser_pid(&self) -> Option<u32> {
+        self.browser_process.as_ref().and_then(|process| process.pid())
+    }
     pub fn has_pages(&self) -> bool {
         !self.pages.is_empty()
     }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -121,6 +121,8 @@ pub struct PageInfo {
     pub url: String,
     pub title: String,
     pub target_type: String, // "page" or "webview"
+    pub browser_context_id: Option<String>,
+    pub window_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -346,6 +348,8 @@ impl BrowserManager {
                     "Target.createTarget",
                     &CreateTargetParams {
                         url: "about:blank".to_string(),
+                        new_window: None,
+                        browser_context_id: None,
                     },
                     None,
                 )
@@ -369,6 +373,8 @@ impl BrowserManager {
                 url: "about:blank".to_string(),
                 title: String::new(),
                 target_type: "page".to_string(),
+                browser_context_id: None,
+                window_id: None,
             });
             self.active_page_index = 0;
             self.enable_domains(&attach_result.session_id).await?;
@@ -392,6 +398,8 @@ impl BrowserManager {
                     url: target.url.clone(),
                     title: target.title.clone(),
                     target_type: target.target_type.clone(),
+                    browser_context_id: target.browser_context_id.clone(),
+                    window_id: None,
                 });
             }
 
@@ -668,6 +676,8 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: "about:blank".to_string(),
+                    new_window: None,
+                    browser_context_id: None,
                 },
                 None,
             )
@@ -691,6 +701,8 @@ impl BrowserManager {
             url: "about:blank".to_string(),
             title: String::new(),
             target_type: "page".to_string(),
+            browser_context_id: None,
+            window_id: None,
         });
         self.active_page_index = 0;
         self.enable_domains(&attach_result.session_id).await?;
@@ -739,6 +751,8 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: target_url.to_string(),
+                    new_window: None,
+                    browser_context_id: None,
                 },
                 None,
             )
@@ -765,6 +779,8 @@ impl BrowserManager {
             url: target_url.to_string(),
             title: String::new(),
             target_type: "page".to_string(),
+            browser_context_id: None,
+            window_id: None,
         });
         self.active_page_index = index;
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -176,6 +176,7 @@ pub struct BrowserManager {
     #[cfg(test)]
     pub ws_url: String,
     browser_process: Option<BrowserProcess>,
+    background_new_windows: bool,
     pages: Vec<PageInfo>,
     active_page_index: usize,
     default_timeout_ms: u64,
@@ -184,6 +185,7 @@ pub struct BrowserManager {
 impl BrowserManager {
     pub async fn launch(options: LaunchOptions, engine: Option<&str>) -> Result<Self, String> {
         let engine = engine.unwrap_or("chrome");
+        let background_new_windows = options.no_activate && !options.headless;
 
         match engine {
             "chrome" => {
@@ -240,6 +242,7 @@ impl BrowserManager {
             #[cfg(test)]
             ws_url,
             browser_process: Some(process),
+            background_new_windows,
             pages: Vec::new(),
             active_page_index: 0,
             default_timeout_ms: 25_000,
@@ -304,6 +307,7 @@ impl BrowserManager {
             #[cfg(test)]
             ws_url,
             browser_process: None,
+            background_new_windows: false,
             pages: Vec::new(),
             active_page_index: 0,
             default_timeout_ms: 10_000,
@@ -349,6 +353,8 @@ impl BrowserManager {
                     &CreateTargetParams {
                         url: "about:blank".to_string(),
                         new_window: None,
+                        background: None,
+                        focus: None,
                         browser_context_id: None,
                     },
                     None,
@@ -433,6 +439,10 @@ impl BrowserManager {
             .get(self.active_page_index)
             .map(|p| p.session_id.as_str())
             .ok_or_else(|| "No active page".to_string())
+    }
+
+    pub fn prefers_background_windows(&self) -> bool {
+        self.background_new_windows
     }
 
     pub async fn navigate(&mut self, url: &str, wait_until: WaitUntil) -> Result<Value, String> {
@@ -677,6 +687,8 @@ impl BrowserManager {
                 &CreateTargetParams {
                     url: "about:blank".to_string(),
                     new_window: None,
+                    background: None,
+                    focus: None,
                     browser_context_id: None,
                 },
                 None,
@@ -752,6 +764,8 @@ impl BrowserManager {
                 &CreateTargetParams {
                     url: target_url.to_string(),
                     new_window: None,
+                    background: None,
+                    focus: None,
                     browser_context_id: None,
                 },
                 None,

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -5,16 +6,43 @@ use std::time::Duration;
 
 use super::types::BrowserVersionInfo;
 
+enum ChromeHandle {
+    Child(Child),
+    Pid(u32),
+}
+
+#[cfg(target_os = "macos")]
+struct ResolvedChromePath {
+    executable_path: PathBuf,
+    app_bundle: Option<PathBuf>,
+}
+
 pub struct ChromeProcess {
-    child: Child,
+    handle: ChromeHandle,
     pub ws_url: String,
+    temp_stderr_log: Option<PathBuf>,
     temp_user_data_dir: Option<PathBuf>,
 }
 
 impl ChromeProcess {
+    #[cfg(test)]
+    pub fn pid(&self) -> Option<u32> {
+        match self.handle {
+            ChromeHandle::Pid(pid) => Some(pid),
+            ChromeHandle::Child(_) => None,
+        }
+    }
+
     pub fn kill(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        match &mut self.handle {
+            ChromeHandle::Child(child) => {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            ChromeHandle::Pid(pid) => {
+                force_kill_pid(*pid);
+            }
+        }
     }
 
     /// Wait for Chrome to exit on its own (after Browser.close CDP command),
@@ -25,10 +53,18 @@ impl ChromeProcess {
         let poll_interval = Duration::from_millis(50);
 
         while start.elapsed() < timeout {
-            match self.child.try_wait() {
-                Ok(Some(_)) => return,
-                Ok(None) => std::thread::sleep(poll_interval),
-                Err(_) => break,
+            match &mut self.handle {
+                ChromeHandle::Child(child) => match child.try_wait() {
+                    Ok(Some(_)) => return,
+                    Ok(None) => std::thread::sleep(poll_interval),
+                    Err(_) => break,
+                },
+                ChromeHandle::Pid(pid) => {
+                    if !is_pid_running(*pid) {
+                        return;
+                    }
+                    std::thread::sleep(poll_interval);
+                }
             }
         }
 
@@ -39,6 +75,9 @@ impl ChromeProcess {
 impl Drop for ChromeProcess {
     fn drop(&mut self) {
         self.kill();
+        if let Some(ref path) = self.temp_stderr_log {
+            let _ = std::fs::remove_file(path);
+        }
         if let Some(ref dir) = self.temp_user_data_dir {
             for attempt in 0..3 {
                 match std::fs::remove_dir_all(dir) {
@@ -61,6 +100,7 @@ impl Drop for ChromeProcess {
 
 pub struct LaunchOptions {
     pub headless: bool,
+    pub no_activate: bool,
     pub executable_path: Option<String>,
     pub proxy: Option<String>,
     pub proxy_bypass: Option<String>,
@@ -79,6 +119,7 @@ impl Default for LaunchOptions {
     fn default() -> Self {
         Self {
             headless: true,
+            no_activate: false,
             executable_path: None,
             proxy: None,
             proxy_bypass: None,
@@ -97,6 +138,7 @@ impl Default for LaunchOptions {
 
 struct ChromeArgs {
     args: Vec<String>,
+    launch_marker: Option<String>,
     temp_user_data_dir: Option<PathBuf>,
 }
 
@@ -180,13 +222,38 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         args.push("--no-sandbox".to_string());
     }
 
+    let launch_marker = no_activate_launch_marker(options);
+    if let Some(ref marker) = launch_marker {
+        args.push(format!("--agent-browser-launch-id={}", marker));
+    }
+
     Ok(ChromeArgs {
         args,
+        launch_marker,
         temp_user_data_dir,
     })
 }
 
+#[cfg(target_os = "macos")]
+fn no_activate_launch_marker(options: &LaunchOptions) -> Option<String> {
+    (options.no_activate && !options.headless).then(|| uuid::Uuid::new_v4().to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn no_activate_launch_marker(_options: &LaunchOptions) -> Option<String> {
+    None
+}
+
 pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
+    #[cfg(not(target_os = "macos"))]
+    if options.no_activate {
+        return Err("--no-activate is only supported on macOS native Chrome".to_string());
+    }
+
+    #[cfg(target_os = "macos")]
+    let chrome = resolve_chrome_path(options.executable_path.as_deref())
+        .ok_or("Chrome not found. Install Chrome or use --executable-path.")?;
+    #[cfg(not(target_os = "macos"))]
     let chrome_path = match &options.executable_path {
         Some(p) => PathBuf::from(p),
         None => {
@@ -196,8 +263,19 @@ pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
 
     let ChromeArgs {
         args,
+        launch_marker,
         temp_user_data_dir,
     } = build_chrome_args(options)?;
+
+    #[cfg(target_os = "macos")]
+    if options.no_activate && !options.headless {
+        return launch_chrome_without_activation(
+            &chrome,
+            &args,
+            launch_marker,
+            temp_user_data_dir,
+        );
+    }
 
     let cleanup_temp_dir = |dir: &Option<PathBuf>| {
         if let Some(ref d) = dir {
@@ -205,7 +283,10 @@ pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
         }
     };
 
-    let mut child = Command::new(&chrome_path)
+    #[cfg(target_os = "macos")]
+    let chrome_path = &chrome.executable_path;
+
+    let mut child = Command::new(chrome_path)
         .args(&args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -233,11 +314,207 @@ pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
     };
 
     Ok(ChromeProcess {
-        child,
+        handle: ChromeHandle::Child(child),
         ws_url,
+        temp_stderr_log: None,
         temp_user_data_dir,
     })
 }
+
+#[cfg(target_os = "macos")]
+fn launch_chrome_without_activation(
+    chrome: &ResolvedChromePath,
+    args: &[String],
+    launch_marker: Option<String>,
+    temp_user_data_dir: Option<PathBuf>,
+) -> Result<ChromeProcess, String> {
+    let cleanup_temp_dir = |dir: &Option<PathBuf>| {
+        if let Some(ref d) = dir {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    };
+
+    let app_bundle = chrome.app_bundle.as_ref().ok_or_else(|| {
+        format!(
+            "--no-activate requires a macOS .app bundle, but '{}' is not inside one",
+            chrome.executable_path.display()
+        )
+    })?;
+
+    let stderr_log_path =
+        std::env::temp_dir().join(format!("agent-browser-chrome-stderr-{}.log", uuid::Uuid::new_v4()));
+    File::create(&stderr_log_path)
+        .map_err(|e| format!("Failed to create temp Chrome stderr log: {}", e))?;
+
+    let status = Command::new("/usr/bin/open")
+        .arg("-g")
+        .arg("-n")
+        .arg("--stderr")
+        .arg(&stderr_log_path)
+        .arg("-a")
+        .arg(&app_bundle)
+        .arg("--args")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|e| {
+            cleanup_temp_dir(&temp_user_data_dir);
+            format!(
+                "Failed to launch Chrome without activation via open at '{}': {}",
+                app_bundle.display(),
+                e
+            )
+        })?;
+
+    if !status.success() {
+        cleanup_temp_dir(&temp_user_data_dir);
+        return Err(format!("Chrome launch via open failed with exit status {}", status));
+    }
+
+    let launch_marker = launch_marker.ok_or_else(|| {
+        cleanup_temp_dir(&temp_user_data_dir);
+        "Missing no-activate Chrome launch marker".to_string()
+    })?;
+
+    let pid = wait_for_pid_by_launch_marker(&launch_marker, Duration::from_secs(10)).ok_or_else(
+        || {
+            cleanup_temp_dir(&temp_user_data_dir);
+            format!(
+                "Timed out locating the Chrome process for launch marker {}",
+                launch_marker
+            )
+        },
+    )?;
+
+    let ws_url = wait_for_ws_url_from_stderr_file(&stderr_log_path, Duration::from_secs(30))
+        .ok_or_else(|| {
+            force_kill_pid(pid);
+            let _ = std::fs::remove_file(&stderr_log_path);
+            cleanup_temp_dir(&temp_user_data_dir);
+            "Timeout waiting for Chrome DevTools URL from redirected stderr".to_string()
+        })?;
+
+    Ok(ChromeProcess {
+        handle: ChromeHandle::Pid(pid),
+        ws_url,
+        temp_stderr_log: Some(stderr_log_path),
+        temp_user_data_dir,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_chrome_path(executable_path: Option<&str>) -> Option<ResolvedChromePath> {
+    match executable_path {
+        Some(path) => {
+            let executable_path = PathBuf::from(path);
+            Some(ResolvedChromePath {
+                app_bundle: app_bundle_for_executable(&executable_path),
+                executable_path,
+            })
+        }
+        None => find_chrome_install(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn app_bundle_for_executable(executable: &Path) -> Option<PathBuf> {
+    executable.ancestors().find_map(|ancestor| {
+        ancestor.extension().is_some_and(|ext| ext == "app").then(|| ancestor.to_path_buf())
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn wait_for_pid_by_launch_marker(launch_marker: &str, timeout: Duration) -> Option<u32> {
+    let needle = format!("--agent-browser-launch-id={}", launch_marker);
+    let deadline = std::time::Instant::now() + timeout;
+
+    while std::time::Instant::now() < deadline {
+        if let Some(pid) = find_pid_by_command_substring(&needle) {
+            return Some(pid);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn find_pid_by_command_substring(needle: &str) -> Option<u32> {
+    let output = Command::new("ps")
+        .args(["axww", "-o", "pid=,command="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| {
+            if !line.contains(needle) {
+                return None;
+            }
+            if line.contains(" --type=") {
+                return None;
+            }
+            line.split_whitespace().next()?.parse::<u32>().ok()
+        })
+}
+
+fn wait_for_ws_url_from_stderr_file(stderr_log_path: &Path, timeout: Duration) -> Option<String> {
+    let deadline = std::time::Instant::now() + timeout;
+    let prefix = "DevTools listening on ";
+
+    while std::time::Instant::now() < deadline {
+        if let Ok(content) = std::fs::read_to_string(stderr_log_path) {
+            for line in content.lines() {
+                if let Some(url) = line.strip_prefix(prefix) {
+                    return Some(url.trim().to_string());
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    None
+}
+
+#[cfg(unix)]
+fn is_pid_running(pid: u32) -> bool {
+    unsafe {
+        libc::kill(pid as i32, 0) == 0
+            || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+}
+
+#[cfg(not(unix))]
+fn is_pid_running(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn force_kill_pid(pid: u32) {
+    unsafe {
+        let _ = libc::kill(pid as i32, libc::SIGTERM);
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_millis(250);
+    while std::time::Instant::now() < deadline {
+        if !is_pid_running(pid) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    unsafe {
+        let _ = libc::kill(pid as i32, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn force_kill_pid(_pid: u32) {}
 
 fn wait_for_ws_url(reader: BufReader<std::process::ChildStderr>) -> Result<String, String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
@@ -322,23 +599,17 @@ fn chrome_launch_error(message: &str, stderr_lines: &[String]) -> String {
 pub fn find_chrome() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
-        let candidates = [
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-        ];
-        for c in &candidates {
-            let p = PathBuf::from(c);
-            if p.exists() {
-                return Some(p);
-            }
-        }
-
-        if let Some(p) = find_playwright_chromium() {
-            return Some(p);
-        }
+        return find_chrome_install().map(|chrome| chrome.executable_path);
     }
 
+    #[cfg(not(target_os = "macos"))]
+    {
+        find_chrome_non_macos()
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn find_chrome_non_macos() -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
         let candidates = [
@@ -380,6 +651,36 @@ pub fn find_chrome() -> Option<PathBuf> {
             if p.exists() {
                 return Some(p);
             }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn find_chrome_install() -> Option<ResolvedChromePath> {
+    #[cfg(target_os = "macos")]
+    {
+        let candidates = [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        ];
+        for c in &candidates {
+            let p = PathBuf::from(c);
+            if p.is_file() {
+                return Some(ResolvedChromePath {
+                    app_bundle: app_bundle_for_executable(&p),
+                    executable_path: p,
+                });
+            }
+        }
+
+        if let Some(p) = find_playwright_chromium() {
+            return Some(ResolvedChromePath {
+                app_bundle: app_bundle_for_executable(&p),
+                executable_path: p,
+            });
         }
     }
 
@@ -838,8 +1139,9 @@ mod tests {
                 .spawn()
                 .unwrap();
             let _process = ChromeProcess {
-                child,
+                handle: ChromeHandle::Child(child),
                 ws_url: String::new(),
+                temp_stderr_log: None,
                 temp_user_data_dir: Some(dir.clone()),
             };
             // _process dropped here

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -99,6 +99,10 @@ pub struct CreateTargetParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_window: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focus: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub browser_context_id: Option<String>,
 }
 

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -96,6 +96,10 @@ pub struct SetDiscoverTargetsParams {
 #[serde(rename_all = "camelCase")]
 pub struct CreateTargetParams {
     pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_window: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_context_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7,9 +7,12 @@
 //! Run serially to avoid Chrome instance contention:
 //!   cargo test e2e -- --ignored --test-threads=1
 
+use std::time::{Duration, Instant};
+
 use serde_json::{json, Value};
 
 use super::actions::{execute_command, DaemonState};
+use super::cdp::chrome::discover_cdp_url;
 
 fn assert_success(resp: &Value) {
     assert_eq!(
@@ -22,6 +25,46 @@ fn assert_success(resp: &Value) {
 
 fn get_data(resp: &Value) -> &Value {
     resp.get("data").expect("Missing 'data' in response")
+}
+
+fn devtools_port_from_ws_url(ws_url: &str) -> Option<u16> {
+    let url = url::Url::parse(ws_url).ok()?;
+    url.port()
+}
+
+#[cfg(unix)]
+fn is_pid_running(pid: u32) -> bool {
+    unsafe {
+        libc::kill(pid as i32, 0) == 0
+            || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+}
+
+#[cfg(unix)]
+struct PidCleanupGuard {
+    pid: u32,
+}
+
+#[cfg(unix)]
+impl Drop for PidCleanupGuard {
+    fn drop(&mut self) {
+        if is_pid_running(self.pid) {
+            unsafe {
+                let _ = libc::kill(self.pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+async fn wait_for_cdp_disconnect(port: u16, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if discover_cdp_url(port).await.is_err() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -1474,5 +1517,140 @@ async fn e2e_profile_cookie_persistence() {
         assert_success(&resp);
     }
 
+    let _ = std::fs::remove_dir_all(&profile_dir);
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+#[ignore]
+async fn e2e_no_activate_launch_and_interact() {
+    let mut state = DaemonState::new();
+    let profile_dir = std::env::temp_dir().join(format!(
+        "agent-browser-no-activate-close-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&profile_dir).unwrap();
+
+    let html = concat!(
+        "<html><body>",
+        "<input id='name' value=''>",
+        "<input id='agree' type='checkbox'>",
+        "</body></html>"
+    );
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": false,
+            "noActivate": true,
+            "profile": profile_dir.display().to_string()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let devtools_port = state
+        .browser
+        .as_ref()
+        .and_then(|browser| devtools_port_from_ws_url(&browser.ws_url))
+        .expect("Connected browser should expose a DevTools port");
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "setcontent", "html": html }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2b", "action": "wait", "selector": "#agree" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "fill", "selector": "#name", "value": "Alice" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "click", "selector": "#agree" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "({ name: document.querySelector('#name').value, agree: document.querySelector('#agree').checked })" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"]["name"], "Alice");
+    assert_eq!(get_data(&resp)["result"]["agree"], true);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    assert!(
+        wait_for_cdp_disconnect(devtools_port, Duration::from_secs(5)).await,
+        "CDP endpoint on port {} should stop responding after Browser.close",
+        devtools_port
+    );
+
+    let _ = std::fs::remove_dir_all(&profile_dir);
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+#[ignore]
+async fn e2e_no_activate_close_kills_stopped_pid() {
+    let mut state = DaemonState::new();
+    let profile_dir = std::env::temp_dir().join(format!(
+        "agent-browser-no-activate-pid-close-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&profile_dir).unwrap();
+
+    let launch_resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": false,
+            "noActivate": true,
+            "profile": profile_dir.display().to_string()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&launch_resp);
+
+    let pid = state
+        .browser
+        .as_ref()
+        .and_then(|browser| browser.browser_pid())
+        .expect("No-activate launch should expose the native browser pid");
+    let guard = PidCleanupGuard { pid };
+
+    unsafe {
+        assert_eq!(libc::kill(pid as i32, libc::SIGSTOP), 0);
+    }
+
+    // This intentionally runs through the full close fallback path. With the
+    // browser stopped, Browser.close cannot answer, so close() waits for the
+    // 30s CdpClient::send_command timeout in native/cdp/client.rs before the
+    // pid-based kill fallback executes.
+    let close_resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&close_resp);
+    assert!(
+        !is_pid_running(pid),
+        "Stopped browser pid {} should be terminated by close fallback",
+        pid
+    );
+
+    std::mem::forget(guard);
     let _ = std::fs::remove_dir_all(&profile_dir);
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2438,6 +2438,7 @@ Options:
   --full, -f                 Full page screenshot
   --annotate                 Annotated screenshot with numbered labels and legend
   --headed                   Show browser window (not headless) (or AGENT_BROWSER_HEADED env)
+  --no-activate              On macOS native Chrome, launch headed without foreground activation when possible
   --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
   --auto-connect             Auto-discover and connect to running Chrome
   --color-scheme <scheme>    Color scheme: dark, light, no-preference (or AGENT_BROWSER_COLOR_SCHEME)
@@ -2483,6 +2484,7 @@ Environment:
   AGENT_BROWSER_EXECUTABLE_PATH  Custom browser executable path
   AGENT_BROWSER_EXTENSIONS       Comma-separated browser extension paths
   AGENT_BROWSER_HEADED           Show browser window (not headless)
+  AGENT_BROWSER_NO_ACTIVATE      On macOS native Chrome, try to launch headed without foreground activation
   AGENT_BROWSER_JSON             JSON output
   AGENT_BROWSER_FULL             Full page screenshot
   AGENT_BROWSER_ANNOTATE         Annotated screenshot with numbered labels and legend


### PR DESCRIPTION
Add a macOS-only `--no-activate` / `AGENT_BROWSER_NO_ACTIVATE` option for native headed Chrome launches.

On macOS native Chrome launches, `--no-activate` now uses `open -g` to start the browser without intentionally foregrounding it, captures the DevTools websocket URL from redirected stderr, and keeps a PID-based fallback so `close` can still terminate the browser if `Browser.close` does not complete.

This is scoped intentionally:
- macOS only
- native Chrome only
- headed only
- opt-in only

Several alternatives were considered and not chosen:

- Fixed `--remote-debugging-port=<port>` for PID lookup.
  This worked, but it introduces a real port-allocation race: the port must be released before Chrome can bind it, so another process can theoretically claim it in between.

- Using `--user-data-dir` as the process identity.
  This is not reliably unique when persistent profiles are reused, so PID lookup can become ambiguous.

- Dropping PID ownership and relying only on `Browser.close`.
  This would reduce code, but it weakens lifecycle control compared with the normal native path, which already prefers owning the browser process and having a fallback kill path.

- A macOS-native launcher via AppKit / `NSWorkspace` (for example through Rust Objective-C bindings).
  That may be a cleaner long-term macOS integration path, but it would require introducing new platform-specific code and dependencies. This change stays within the existing dependency/tooling model and keeps the implementation narrower.

- Extending Playwright / non-native behavior.
  That was intentionally left out of scope. This change is only for the native Chrome path.

Given those tradeoffs, the final implementation uses:
- `open -g` for macOS no-activate launch
- redirected stderr for the DevTools handshake
- a launch marker argument for PID reacquisition
- PID-based fallback termination to stay aligned with native lifecycle expectations

Validation:
- `cargo check`
- `cargo test no_activate`
- `cargo test e2e_no_activate_launch_and_interact -- --ignored --test-threads=1`
- `cargo test e2e_no_activate_close_kills_stopped_pid -- --ignored --test-threads=1`
- local machine test:
  - `cargo run -- --native --headed --no-activate open example.com`

One test tradeoff remains open: `e2e_no_activate_close_kills_stopped_pid` currently takes about 30 seconds because it intentionally stops the browser process and therefore waits through the existing `CdpClient::send_command` timeout before the PID fallback executes. That proves the real production path, but it is slow. It is still unclear whether the better tradeoff is to keep that full-path e2e as-is or add a narrower test-specific close helper with a shorter timeout.
