### PR TITLE
feat: support BROWSERBASE_REGION env var for session creation

### DIFF
--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -85,12 +85,19 @@ async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), Stri
     let project_id = env::var("BROWSERBASE_PROJECT_ID")
         .map_err(|_| "BROWSERBASE_PROJECT_ID environment variable is not set")?;
 
+    let region = env::var("BROWSERBASE_REGION").ok();
+
+    let mut body = json!({ "projectId": project_id });
+    if let Some(ref region) = region {
+        body["region"] = json!(region);
+    }
+
     let client = reqwest::Client::new();
     let response = client
         .post("https://api.browserbase.com/v1/sessions")
         .header("Content-Type", "application/json")
         .header("X-BB-API-Key", &api_key)
-        .json(&json!({ "projectId": project_id }))
+        .json(&body)
         .send()
         .await
         .map_err(|e| format!("Browserbase request failed: {}", e))?;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -926,6 +926,8 @@ export class BrowserManager {
       );
     }
 
+    const browserbaseRegion = process.env.BROWSERBASE_REGION;
+
     const response = await fetch('https://api.browserbase.com/v1/sessions', {
       method: 'POST',
       headers: {
@@ -934,6 +936,7 @@ export class BrowserManager {
       },
       body: JSON.stringify({
         projectId: browserbaseProjectId,
+        ...(browserbaseRegion && { region: browserbaseRegion }),
       }),
     });
 


### PR DESCRIPTION
## Summary

Based on #478 by @akselleirv — thank you for the contribution!

- Reads `BROWSERBASE_REGION` environment variable and passes it to the Browserbase sessions API when creating a new session
- Allows users to control which region their cloud browser runs in (e.g. `us-west-2`, `us-east-1`, `eu-central-1`, `ap-southeast-1`)
- No-op when the env var is not set (existing behavior unchanged)
- **Also adds Rust native CLI parity** — the same `BROWSERBASE_REGION` support is added to `cli/src/native/providers.rs`

## Usage

```bash
export BROWSERBASE_REGION=eu-central-1
agent-browser -p browserbase open https://example.com
```

Valid regions per [Browserbase API](https://docs.browserbase.com/reference/api/create-a-session): `us-west-2`, `us-east-1`, `eu-central-1`, `ap-southeast-1`.

## Changes

- `src/browser.ts` — read `BROWSERBASE_REGION` env var and conditionally include `region` in session creation payload (from #478)
- `cli/src/native/providers.rs` — same change for Rust native CLI parity

Closes #478