### PR TITLE
fix: update handleGetText to use innerText for improved text retrieval

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1599,7 +1599,8 @@ async function handleGetAttribute(
 async function handleGetText(command: GetTextCommand, browser: BrowserManager): Promise<Response> {
   const page = browser.getPage();
   const locator = browser.getLocator(command.selector);
-  const text = await locator.textContent();
+  const inner = await locator.innerText();
+  const text = inner || (await locator.textContent()) || '';
   return successResponse(command.id, { text, origin: page.url() });
 }
 


### PR DESCRIPTION
The handleGetText function now retrieves text using innerText, falling back to textContent if innerText is not available. This change enhances the accuracy of text extraction from elements.

@ctate  Please help review this change, thank you!

Fixes #727 