### PR TITLE
fix: allow newTab() in persistent context (--extension/--profile) mode

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1243,6 +1243,32 @@ describe('BrowserManager', () => {
   });
 });
 
+describe('BrowserManager (persistent context / --profile mode)', () => {
+  let profileBrowser: BrowserManager;
+  let tmpProfileDir: string;
+
+  beforeAll(async () => {
+    tmpProfileDir = path.join(os.tmpdir(), `agent-browser-test-profile-${Date.now()}`);
+    profileBrowser = new BrowserManager();
+    await profileBrowser.launch({ headless: true, profile: tmpProfileDir });
+  });
+
+  afterAll(async () => {
+    await profileBrowser.close();
+    rmSync(tmpProfileDir, { recursive: true, force: true });
+  });
+
+  it('should report as launched in persistent context mode', () => {
+    expect(profileBrowser.isLaunched()).toBe(true);
+  });
+
+  it('should create new tab in persistent context mode without throwing', async () => {
+    const result = await profileBrowser.newTab();
+    expect(result.index).toBe(1);
+    expect(result.total).toBe(2);
+  });
+});
+
 describe('getDefaultTimeout', () => {
   const originalEnv = { ...process.env };
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1784,7 +1784,7 @@ export class BrowserManager {
    * Create a new tab in the current context
    */
   async newTab(): Promise<{ index: number; total: number }> {
-    if (!this.browser || this.contexts.length === 0) {
+    if (!this.isLaunched() || this.contexts.length === 0) {
       throw new Error('Browser not launched');
     }
 
@@ -1811,7 +1811,11 @@ export class BrowserManager {
     total: number;
   }> {
     if (!this.browser) {
-      throw new Error('Browser not launched');
+      throw new Error(
+        this.isPersistentContext
+          ? 'newWindow is not supported in extension (persistent context) mode'
+          : 'Browser not launched'
+      );
     }
 
     const context = await this.browser.newContext({


### PR DESCRIPTION
## Problem

When launched with `--extension` or `--profile`, Playwright uses `launchPersistentContext()` which:
- Sets `this.isPersistentContext = true`
- Leaves `this.browser` as `null`

The guard in `newTab()` checked `!this.browser`, causing a false `Browser not launched` error even though the browser was running and other commands (e.g. `tab list`, `eval`, `screenshot`) worked fine.

## Root Cause

```typescript
// src/browser.ts — before
async newTab() {
  if (!this.browser || this.contexts.length === 0) { // this.browser is null in persistent context mode
    throw new Error('Browser not launched');
  }
```

`isLaunched()` (line 167) already handles both launch paths correctly:

```typescript
isLaunched(): boolean {
  return this.browser !== null || this.isPersistentContext;
}
```

`newTab()` just wasn't using it.

## Fix

- `newTab()`: replace `!this.browser` with `!this.isLaunched()`
- `newWindow()`: same guard, but `newWindow` genuinely requires a `Browser` object to create a new context and cannot work in persistent context mode — improve the error message to make this clear

## Tests

Added integration tests that launch with a temporary profile directory (triggering the persistent context path) and verify `newTab()` succeeds:

```
✓ should report as launched in persistent context mode
✓ should create new tab in persistent context mode without throwing
```

Fixes #411