### PR TITLE
fix: align native daemon port hash with client on Windows

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -792,4 +792,13 @@ mod tests {
         assert!(!is_transient_error("Permission denied"));
         assert!(!is_transient_error("Daemon not found"));
     }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_get_port_for_session() {
+        assert_eq!(get_port_for_session("default"), 50838);
+        assert_eq!(get_port_for_session("my-session"), 63105);
+        assert_eq!(get_port_for_session("work"), 51184);
+        assert_eq!(get_port_for_session(""), 49152);
+    }
 }

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -258,9 +258,26 @@ fn get_daemon_socket_dir() -> PathBuf {
 
 #[cfg(windows)]
 fn get_port_for_session(session: &str) -> u16 {
-    let mut hash: i64 = 0;
-    for b in session.bytes() {
-        hash = hash.wrapping_mul(31).wrapping_add(b as i64);
+    let mut hash: i32 = 0;
+    for c in session.chars() {
+        hash = ((hash << 5).wrapping_sub(hash)).wrapping_add(c as i32);
     }
-    49152 + (hash.unsigned_abs() % 16383) as u16
+    49152 + ((hash.unsigned_abs() as u32 % 16383) as u16)
+}
+
+#[cfg(test)]
+#[cfg(windows)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_port_matches_client_algorithm() {
+        // These values are computed by the identical djb2 implementation in
+        // connection.rs. Both sides must agree on the port for the daemon to
+        // start successfully.
+        assert_eq!(get_port_for_session("default"), 50838);
+        assert_eq!(get_port_for_session("my-session"), 63105);
+        assert_eq!(get_port_for_session("work"), 51184);
+        assert_eq!(get_port_for_session(""), 49152);
+    }
 }

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as net from 'net';
 import { EventEmitter } from 'events';
-import { getSocketDir, safeWrite } from './daemon.js';
+import { getSocketDir, safeWrite, getPortForSession } from './daemon.js';
 
 /**
  * HTTP request detection pattern used in daemon.ts to prevent cross-origin attacks.
@@ -157,5 +157,28 @@ describe('safeWrite', () => {
     expect(socket.listenerCount('drain')).toBe(0);
     expect(socket.listenerCount('error')).toBe(0);
     expect(socket.listenerCount('close')).toBe(0);
+  });
+});
+
+describe('getPortForSession', () => {
+  it('returns consistent port for "default"', () => {
+    expect(getPortForSession('default')).toBe(50838);
+  });
+
+  it('returns consistent port for named sessions', () => {
+    expect(getPortForSession('my-session')).toBe(63105);
+    expect(getPortForSession('work')).toBe(51184);
+  });
+
+  it('returns base port for empty session', () => {
+    expect(getPortForSession('')).toBe(49152);
+  });
+
+  it('returns port within dynamic range (49152-65535)', () => {
+    for (const name of ['default', 'my-session', 'work', 'test', 'a']) {
+      const port = getPortForSession(name);
+      expect(port).toBeGreaterThanOrEqual(49152);
+      expect(port).toBeLessThanOrEqual(65535);
+    }
   });
 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -185,7 +185,7 @@ export function getSession(): string {
  * Get port number for TCP mode (Windows)
  * Uses a hash of the session name to get a consistent port
  */
-function getPortForSession(session: string): number {
+export function getPortForSession(session: string): number {
   let hash = 0;
   for (let i = 0; i < session.length; i++) {
     hash = (hash << 5) - hash + session.charCodeAt(i);


### PR DESCRIPTION
## Problem

On Windows with `AGENT_BROWSER_NATIVE=1`, the native daemon fails to start:

```
✗ Daemon failed to start (port: 127.0.0.1:50838)
```

The root cause is that `get_port_for_session()` has two incompatible implementations. The client (`connection.rs`) and native daemon (`native/daemon.rs`) compute different ports for the same session name, so the daemon binds port X while the client polls port Y.

| | `connection.rs` (client) | `native/daemon.rs` (daemon) |
|---|---|---|
| Type | `i32` | `i64` |
| Iteration | `.chars()` (Unicode codepoints) | `.bytes()` (raw bytes) |
| Algorithm | djb2: `(hash << 5) - hash + c` | Java hashCode: `hash * 31 + b` |

For `session = "default"`:
- Client computes **50838** (the port shown in the error message)
- Daemon binds **51174**

The Node.js daemon (`daemon.ts`) already uses the same djb2 as the client, so non-native mode works fine. Unix is unaffected because it uses Unix domain sockets.

## Fix

Align `native/daemon.rs` to use the identical djb2 algorithm from `connection.rs`.

## Test plan

- [x] On Windows with `AGENT_BROWSER_NATIVE=1`: `agent-browser open https://example.com` no longer reports daemon startup failure
- [x] Verified mathematically: both functions now return the same port for `"default"` and any other ASCII session name

Fixes #705