### PR TITLE
fix: isolate getEncryptionKey tests from local filesystem

### DIFF
--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -12,19 +12,17 @@ import {
 } from './encryption.js';
 
 // Mock node:fs to isolate getEncryptionKey from the local filesystem
-const fsMocks = vi.hoisted(() => ({
-  mockExistsSync: vi.fn(),
-  mockReadFileSync: vi.fn(),
-  realExistsSync: null as unknown as typeof import('node:fs').existsSync,
-  realReadFileSync: null as unknown as typeof import('node:fs').readFileSync,
+const mockFs = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  originals: {} as Pick<typeof import('node:fs'), 'existsSync' | 'readFileSync'>,
 }));
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  fsMocks.realExistsSync = actual.existsSync;
-  fsMocks.realReadFileSync = actual.readFileSync;
-  fsMocks.mockExistsSync.mockImplementation(actual.existsSync);
-  fsMocks.mockReadFileSync.mockImplementation(actual.readFileSync);
-  return { ...actual, existsSync: fsMocks.mockExistsSync, readFileSync: fsMocks.mockReadFileSync };
+  mockFs.originals = { existsSync: actual.existsSync, readFileSync: actual.readFileSync };
+  mockFs.existsSync.mockImplementation(actual.existsSync);
+  mockFs.readFileSync.mockImplementation(actual.readFileSync);
+  return { ...actual, existsSync: mockFs.existsSync, readFileSync: mockFs.readFileSync };
 });
 
 // Generate a valid test key (256 bits = 32 bytes = 64 hex chars)
@@ -271,21 +269,21 @@ describe('encryption', () => {
 
     function mockKeyFile(content?: string): void {
       const exists = content !== undefined;
-      fsMocks.mockExistsSync.mockImplementation((path: string) => {
+      mockFs.existsSync.mockImplementation((path: string) => {
         if (path === keyFilePath) return exists;
-        return fsMocks.realExistsSync(path);
+        return mockFs.originals.existsSync(path);
       });
       if (exists) {
-        fsMocks.mockReadFileSync.mockImplementation((path: string, encoding?: string) => {
+        mockFs.readFileSync.mockImplementation((path: string, encoding?: string) => {
           if (path === keyFilePath) return content;
-          return fsMocks.realReadFileSync(path, encoding as BufferEncoding);
+          return mockFs.originals.readFileSync(path, encoding as BufferEncoding);
         });
       }
     }
 
     afterEach(() => {
-      fsMocks.mockExistsSync.mockImplementation(fsMocks.realExistsSync);
-      fsMocks.mockReadFileSync.mockImplementation(fsMocks.realReadFileSync);
+      mockFs.existsSync.mockImplementation(mockFs.originals.existsSync);
+      mockFs.readFileSync.mockImplementation(mockFs.originals.readFileSync);
       if (originalEnv !== undefined) {
         process.env[ENCRYPTION_KEY_ENV] = originalEnv;
       } else {


### PR DESCRIPTION
## Problem

`getEncryptionKey()` tests (`should return null when env var is not set`, `should return null for empty string`) fail on local machines where `~/.agent-browser/.encryption-key` exists.

`getEncryptionKey()` checks two sources in order:
1. Environment variable (`AGENT_BROWSER_ENCRYPTION_KEY`)
2. Key file (`~/.agent-browser/.encryption-key`) — fallback

The tests only deleted the env var but did not isolate the file fallback. On CI (Ubuntu) where no key file exists, tests pass. On local machines that have used agent-browser before, the key file exists and the function returns a key from file instead of `null`, causing test failures.


<img width="643" height="381" alt="스크린샷 2026-03-13 오전 1 37 26" src="https://github.com/user-attachments/assets/bb76376c-8212-4373-856d-f0139cdc760d" />


Additionally, the file fallback path had zero test coverage — no tests verified the behavior when the env var is absent but the key file exists (or contains invalid data).

## Solution

- Mock `node:fs` (`existsSync`, `readFileSync`) using `vi.mock` with `vi.hoisted` to isolate `getEncryptionKey()` from the local filesystem
- Split tests into `from env var` / `from key file fallback` describe blocks for clear intent separation
- Add 3 missing tests for file fallback path:
  - Key file exists with valid hex → returns key
  - Key file does not exist → returns null
  - Key file contains invalid hex → returns null
  
<img width="705" height="364" alt="스크린샷 2026-03-13 오전 1 36 42" src="https://github.com/user-attachments/assets/2aab14bc-d3fc-44a6-ac09-d5ba716cdd9d" />


## Test plan

- [x] Tests pass regardless of whether `~/.agent-browser/.encryption-key` exists locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)