### PR TITLE
docs: add guidance for apps with persistent connections (SSE/WebSocket)

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -451,6 +451,30 @@ agent-browser wait 5000
 
 When dealing with consistently slow websites, use `wait --load networkidle` after `open` to ensure the page is fully loaded before taking a snapshot. If a specific element is slow to render, wait for it directly with `wait <selector>` or `wait @ref`.
 
+### Apps with Persistent Connections (SSE, WebSockets)
+
+**`wait --load networkidle` will always time out** on apps that maintain persistent server connections — this includes any app using Server-Sent Events (SSE), WebSockets, or long-polling. Playwright's `networkidle` waits for zero network activity for 500ms, which never happens when a connection is held open.
+
+This affects many modern web apps: chat interfaces, real-time dashboards, notification systems, collaborative editors, and any app with live updates.
+
+Use these alternatives instead:
+
+```bash
+# Wait for the DOM to be ready (ignores ongoing network connections)
+agent-browser wait --load domcontentloaded
+
+# Wait for specific content to appear
+agent-browser wait --text "Welcome back"
+
+# Wait for a specific element
+agent-browser wait "#main-content"
+
+# Wait for app-specific readiness
+agent-browser wait --fn "window.appReady === true"
+```
+
+**Rule of thumb:** If the app updates in real time, avoid `networkidle` entirely. Prefer `domcontentloaded`, element waits, or text waits.
+
 ## Session Management and Cleanup
 
 When running multiple agents or automations concurrently, always use named sessions to avoid conflicts:


### PR DESCRIPTION
## Summary

- Adds a "Apps with Persistent Connections (SSE, WebSockets)" subsection under "Timeouts and Slow Pages" in `skills/agent-browser/SKILL.md`
- Explains why `wait --load networkidle` always times out on apps with SSE, WebSocket, or long-polling connections
- Provides alternative wait strategies: `domcontentloaded`, element waits, text waits, JS condition waits

## Context

We hit this while using agent-browser to QA a Django app that maintains an SSE connection on every authenticated page (for real-time chat updates). `wait --load networkidle` timed out every time because Playwright's networkidle requires zero network activity for 500ms, which never happens with a persistent connection.

The current SKILL.md recommends `networkidle` in multiple code examples without noting this limitation. This affects any app using SSE, WebSockets, long-polling, or similar persistent connection patterns — which includes most real-time web apps (chat, dashboards, collaborative editors, notification systems).

Related to #479 (changing `open` default to `domcontentloaded`).

## Test plan

- [x] Verified the timeout behavior against a real SSE app
- [x] Confirmed `wait --load domcontentloaded` works as a replacement
- [ ] Review: does this section belong here or in `references/commands.md`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)