### PR TITLE
ci: switch from windows-latest-8-cores to windows-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             target: aarch64-apple-darwin
           - os: macos-latest
             target: x86_64-apple-darwin
-          - os: windows-latest-8-cores
+          - os: windows-latest
             target: x86_64-pc-windows-msvc
 
     steps:
@@ -115,7 +115,7 @@ jobs:
   windows-integration:
     name: Windows Integration Test
     if: github.event_name != 'pull_request'
-    runs-on: windows-latest-8-cores
+    runs-on: windows-latest
     needs: rust-cross
 
     steps:
@@ -243,7 +243,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             binary: agent-browser-darwin-arm64
-          - os: windows-latest-8-cores
+          - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: agent-browser-win32-x64.exe
 


### PR DESCRIPTION
Resolves CI slowdown issues caused by limited availability of Windows containers with 8 cores by switching to the standard Windows runner image.

## Changes Made

- Updated `rust-cross` job to use `windows-latest` instead of `windows-latest-8-cores`
- Updated `windows-integration` job to use `windows-latest` instead of `windows-latest-8-cores`  
- Updated `global-install` job matrix to use `windows-latest` instead of `windows-latest-8-cores`

This change trades some performance for better availability and faster CI queue times, as the standard Windows runners have much better availability than the 8-core variant.

Fixes #741