### PR TITLE
feat: add browserless provider integration to native browser implementation

### DIFF
--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -160,15 +160,12 @@ async fn connect_browserless() -> Result<(String, Option<ProviderSession>), Stri
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(true);
 
-    let url = format!(
-        "{}/session?token={}",
-        api_url.trim_end_matches('/'),
-        api_key
-    );
+    let url = format!("{}/session", api_url.trim_end_matches('/'));
 
     let client = reqwest::Client::new();
     let response = client
         .post(&url)
+        .query(&[("token", &api_key)])
         .header("Content-Type", "application/json")
         .json(&json!({
             "ttl": ttl,


### PR DESCRIPTION
This PR adds support for the Browserless provider to the native browser implementation, expanding the available remote browser providers from 3 to 4.

## Changes Made

- **Added `connect_browserless()` function**: Implements session creation with Browserless API using environment variables for configuration
- **Updated provider routing**: Added "browserless" case to the main provider switch statement
- **Added session cleanup**: Implemented proper session termination using the stop URL returned by Browserless
- **Updated documentation**: Modified comments and error messages to include Browserless in the supported provider list
- **Environment variable support**: Added support for configurable Browserless settings including API key, URL, browser type, TTL, and stealth mode

## Implementation Details

- Uses standard Browserless session API with POST to create sessions and DELETE to terminate
- Supports both chromium and chrome browser types with validation
- Includes proper error handling for API failures and missing configuration
- Stores the stop URL as session_id for cleanup purposes
- Follows the existing provider pattern for consistency

Fixes #744