### PR TITLE
Fix extensions not being loaded from config.json

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -732,7 +732,8 @@ fn main() {
         || flags.allow_file_access
         || flags.color_scheme.is_some()
         || flags.download_path.is_some()
-        || flags.engine.is_some())
+        || flags.engine.is_some()
+        || !flags.extensions.is_empty())
         && flags.cdp.is_none()
         && flags.provider.is_none()
     {
@@ -784,6 +785,10 @@ fn main() {
                 .filter(|s| !s.is_empty())
                 .collect();
             cmd_obj.insert("args".to_string(), json!(args_vec));
+        }
+
+        if !flags.extensions.is_empty() {
+            cmd_obj.insert("extensions".to_string(), json!(&flags.extensions));
         }
 
         if flags.ignore_https_errors {


### PR DESCRIPTION
Fix issue where Chrome extensions specified in the `extensions` field of `config.json` were not being loaded when launching the browser.

## Problem
Extensions configured via the `extensions` field in `config.json` were not being passed to the Chrome browser launch command, causing them to be ignored.

## Changes
- Added `!flags.extensions.is_empty()` to the launch trigger condition to ensure browser launch is triggered when extensions are configured
- Added extensions to the launch command JSON payload so they are properly passed to the browser

Fixes #726