### PR TITLE
Fix linting and formatting issues to resolve CI build failures

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1141,14 +1141,10 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                     usage: "clipboard write <text>",
                 })?;
                 let text = rest[1..].join(" ");
-                Ok(
-                    json!({ "id": id, "action": "clipboard", "operation": "write", "text": text }),
-                )
+                Ok(json!({ "id": id, "action": "clipboard", "operation": "write", "text": text }))
             }
             Some("copy") => Ok(json!({ "id": id, "action": "clipboard", "operation": "copy" })),
-            Some("paste") => {
-                Ok(json!({ "id": id, "action": "clipboard", "operation": "paste" }))
-            }
+            Some("paste") => Ok(json!({ "id": id, "action": "clipboard", "operation": "paste" })),
             Some(sub) => Err(ParseError::UnknownSubcommand {
                 subcommand: sub.to_string(),
                 valid_options: &["read", "write", "copy", "paste"],
@@ -2804,8 +2800,11 @@ mod tests {
 
     #[test]
     fn test_wait_text_with_timeout() {
-        let cmd =
-            parse_command(&args("wait --text Welcome --timeout 5000"), &default_flags()).unwrap();
+        let cmd = parse_command(
+            &args("wait --text Welcome --timeout 5000"),
+            &default_flags(),
+        )
+        .unwrap();
         assert_eq!(cmd["action"], "wait");
         assert_eq!(cmd["text"], "Welcome");
         assert_eq!(cmd["timeout"], 5000);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -956,8 +956,7 @@ async function handleWait(command: WaitCommand, browser: BrowserManager): Promis
 
   if (command.text) {
     await page.waitForFunction(
-      (t: string) => (document.body.innerText || '').includes(t),
-      command.text,
+      `(document.body.innerText || '').includes(${JSON.stringify(command.text)})`,
       { timeout: command.timeout }
     );
   } else if (command.selector) {


### PR DESCRIPTION
This PR fixes CI build failures by addressing code formatting and linting issues that were causing the builds to fail.

**Changes made:**

1. **Rust formatting fixes in `cli/src/commands.rs`:**
   - Removed unnecessary multi-line formatting for clipboard operations
   - Applied consistent single-line formatting for return statements
   - Fixed line length and formatting for the `test_wait_text_with_timeout` test function

2. **TypeScript fixes in `src/actions.ts`:**
   - Fixed `waitForFunction` usage in the `handleWait` function by replacing the function parameter approach with a string-based implementation
   - Properly escaped the text parameter using `JSON.stringify` to prevent potential injection issues

These changes ensure the code passes linting checks (clippy for Rust, ESLint for TypeScript) and formatting validation (rustfmt, prettier) that are enforced in the CI pipeline.

Fixes #751