### PR TITLE
fix: respect --headed false flag in CLI

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2164,6 +2164,7 @@ mod tests {
             cli_annotate: false,
             cli_download_path: false,
             cli_native: false,
+            cli_headed: false,
             annotate: false,
             color_scheme: None,
             download_path: None,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -267,6 +267,7 @@ pub struct Flags {
     pub cli_annotate: bool,
     pub cli_download_path: bool,
     pub cli_native: bool,
+    pub cli_headed: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -382,6 +383,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_annotate: false,
         cli_download_path: false,
         cli_native: false,
+        cli_headed: false,
     };
 
     let mut i = 0;
@@ -404,6 +406,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--headed" => {
                 let (val, consumed) = parse_bool_arg(args, i);
                 flags.headed = val;
+                flags.cli_headed = true;
                 if consumed {
                     i += 1;
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -496,6 +496,7 @@ fn main() {
             flags.cli_allow_file_access.then_some("--allow-file-access"),
             flags.cli_download_path.then_some("--download-path"),
             flags.cli_native.then_some("--native"),
+            flags.cli_headed.then_some("--headed"),
         ]
         .into_iter()
         .flatten()
@@ -723,6 +724,7 @@ fn main() {
 
     // Launch headed browser or configure browser options (without CDP or provider)
     if (flags.headed
+        || flags.cli_headed  // User explicitly set --headed (even if false)
         || flags.executable_path.is_some()
         || flags.profile.is_some()
         || flags.state.is_some()


### PR DESCRIPTION
Fixes #743

## Problem
When user explicitly sets `--headed false`, the CLI was ignoring this flag. The launch condition only checked if `flags.headed` was true, so `--headed false` would not trigger a launch command. Subsequent commands would auto-launch with default `headless=true`, overriding user's explicit setting.

## Solution
- Added `cli_headed` flag to track when user explicitly sets `--headed` (regardless of value)
- Include this in the launch condition check
- Pass `--headed` to daemon when explicitly set by user

## Changes
- `cli/src/flags.rs`: Add `cli_headed` tracking flag
- `cli/src/main.rs`: Check `cli_headed` in launch condition, pass to daemon
- `cli/src/commands.rs`: Update test fixtures

## Testing
```bash
# Before fix: headless=true (ignored --headed false)
agent-browser --headed false navigate https://example.com

# After fix: headless=false (respects user setting)
agent-browser --headed false navigate https://example.com
```