### PR TITLE
fix: narrow "not found" pattern in to_ai_friendly_error to avoid catching   non-element errors

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1241,7 +1241,7 @@ mod tests {
     /// Errors containing "not found" but NOT "element" should pass through unchanged.
     #[test]
     fn test_to_ai_friendly_error_ignores_non_element_not_found() {
-        let err = "Browser not found";
+        let err = "Chrome not found. Install Chrome or use --executable-path.";
         assert_eq!(to_ai_friendly_error(err), err);
     }
 


### PR DESCRIPTION
## Summary

Narrow `contains("not found")` to `contains("element not found")` in `to_ai_friendly_error()` so that non-element errors like "Browser not found" pass through unchanged instead of being incorrectly mapped to the "Element not found" message

  Closes #758

