### PR TITLE
test: fix flaky test_launch_options_from_env_defaults due to missing EnvGuard

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5267,6 +5267,7 @@ mod tests {
 
     #[test]
     fn test_launch_options_from_env_defaults() {
+        let _guard = EnvGuard::new(&["AGENT_BROWSER_HEADED"]);
         let opts = launch_options_from_env();
         assert!(opts.headless);
         assert!(opts.args.is_empty());


### PR DESCRIPTION
## Summary

`test_launch_options_from_env_defaults` was reading `AGENT_BROWSER_HEADED` without acquiring `ENV_MUTEX`, causing a race condition with `test_launch_options_from_env_headed_flag` when the two tests run in parallel.

The fix is a one-liner: add `EnvGuard::new(&["AGENT_BROWSER_HEADED"])` to the defaults test, consistent with how the other env-sensitive tests in this module are written.