### PR TITLE
fix: handle relative URLs in WebSocket domain filter

### DIFF
--- a/src/domain-filter.ts
+++ b/src/domain-filter.ts
@@ -51,8 +51,13 @@ export function buildWebSocketFilterScript(allowedDomains: string[]): string {
   }
   function _checkUrl(url) {
     try {
-      var parsed = new URL(url);
-      return _isDomainAllowed(parsed.hostname);
+      // Handle relative URLs (e.g., /__webpack_hmr) by resolving against page origin
+      var fullUrl = url;
+      if (url.startsWith('/') || url.startsWith('.')) {
+        fullUrl = location.origin + url;
+      }
+      var parsed = new URL(fullUrl);
+      return parsed.hostname ? _isDomainAllowed(parsed.hostname) : true;
     } catch(e) {
       return false;
     }


### PR DESCRIPTION
## Description

Fixes #764 - WebSocket domain filter throws TypeError on relative URLs (e.g. webpack HMR)

## Root Cause

The `_checkUrl()` function used `new URL(url)` which requires an absolute URL. Relative paths like `/__webpack_hmr` (webpack hot module reloading) would throw `TypeError: Failed to construct URL: Invalid URL`.

## Fix

- Handle relative URLs by resolving against `location.origin`
- Return `true` for URLs without hostname (data URLs, etc.)

## Testing

- [x] Code compiles
- [x] WebSocket connections with absolute URLs still filtered correctly
- [x] Relative URLs (webpack HMR) no longer throw errors