### PR TITLE
test: fix Chrome temp-dir cleanup test on Windows

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -587,6 +587,28 @@ mod tests {
     use super::*;
     use crate::test_utils::EnvGuard;
 
+    #[cfg(unix)]
+    fn spawn_noop_child() -> Child {
+        Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap()
+    }
+
+    #[cfg(windows)]
+    fn spawn_noop_child() -> Child {
+        Command::new("cmd.exe")
+            .args(["/C", "exit 0"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap()
+    }
+
     #[test]
     fn test_find_chrome_returns_some_on_host() {
         // This test only makes sense on systems with Chrome installed
@@ -817,13 +839,7 @@ mod tests {
             // Simulate a ChromeProcess with a temp dir but a dummy child.
             // We can't actually spawn Chrome here, but we can verify the Drop
             // logic by creating a small helper process.
-            let child = Command::new("echo")
-                .arg("test")
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .unwrap();
+            let child = spawn_noop_child();
             let _process = ChromeProcess {
                 child,
                 ws_url: String::new(),


### PR DESCRIPTION
## Summary
- fix the remaining Windows-only failure in `native::cdp::chrome::tests::test_chrome_process_drop_cleans_temp_dir`
- replace the test's `echo` executable assumption with a platform-specific noop child helper
- keep the patch scoped to test code only; production behavior is unchanged

## Root cause
Latest `origin/main` no longer reproduces the earlier Lightpanda Windows failures, but it still fails Windows Rust tests in one place:

- `test_chrome_process_drop_cleans_temp_dir` spawns `Command::new("echo")`
- that works on Unix-like systems where `echo` is commonly available as an executable, but fails on Windows because `echo` is a `cmd.exe` builtin, not a standalone program
- the test then panics with `program not found`

## Fix
- add a small `spawn_noop_child()` helper under `#[cfg(unix)]` / `#[cfg(windows)]`
- use `/bin/sh -c "exit 0"` on Unix and `cmd.exe /C "exit 0"` on Windows
- switch the temp-dir cleanup test to use that helper instead of invoking `echo`

## Validation
Ran on Windows against latest `origin/main` base (`99c732c`):

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test native::cdp::chrome::tests::test_chrome_process_drop_cleans_temp_dir --profile ci --manifest-path cli/Cargo.toml -- --exact --nocapture`
- `cargo test --profile ci --manifest-path cli/Cargo.toml`

Result after this patch:
- `431 passed; 0 failed; 24 ignored`

## Notes
- I re-tested latest upstream first. The earlier Lightpanda Windows failures are no longer present on current `origin/main`, so this PR was reduced to the one failing Chrome test that still reproduces today.