### PR TITLE
fix: handle relative URLs in WebSocket domain filter

### DIFF
--- a/cli/src/native/network.rs
+++ b/cli/src/native/network.rs
@@ -184,7 +184,7 @@ pub async fn install_domain_filter_script(
             const OrigWS = window.WebSocket;
             window.WebSocket = function(url, protocols) {{
                 try {{
-                    const u = new URL(url);
+                    const u = new URL(url, location.href);
                     if (!_isDomainAllowed(u.hostname)) throw new DOMException('WebSocket blocked: ' + u.hostname, 'SecurityError');
                 }} catch(e) {{ if (e instanceof DOMException) throw e; }}
                 return new OrigWS(url, protocols);

--- a/src/domain-filter.ts
+++ b/src/domain-filter.ts
@@ -51,7 +51,8 @@ export function buildWebSocketFilterScript(allowedDomains: string[]): string {
   }
   function _checkUrl(url) {
     try {
-      var parsed = new URL(url);
+      // Resolve relative URLs against current page origin (e.g., /__webpack_hmr)
+      var parsed = new URL(url, location.href);
       return _isDomainAllowed(parsed.hostname);
     } catch(e) {
       return false;


### PR DESCRIPTION
Resolves TypeError when WebSocket connections use relative URLs like /__webpack_hmr (webpack HMR endpoints).

## Problem
In `src/domain-filter.ts` and `cli/src/native/network.rs`, the WebSocket URL was parsed with:
```js
var parsed = new URL(url);
```

`new URL(url)` requires an absolute URL. Relative paths (e.g. `/__webpack_hmr`) need a base URL to resolve against, otherwise the constructor throws a `TypeError`.

## Solution
Use `location.href` as the base URL when parsing:
```js
var parsed = new URL(url, location.href);
```

This allows relative WebSocket URLs (like webpack HMR endpoints) to be properly resolved against the current page origin without throwing an error.

## Files Changed
- `src/domain-filter.ts` — `_checkUrl()` function
- `cli/src/native/network.rs` — inline WebSocket filter script