### PR TITLE
fix: accept integer nodeId/childIds in AX tree for Lightpanda compatibility

### DIFF
--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -1,5 +1,50 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
+
+/// Deserialize a value that may be either a string or an integer into a String.
+/// Lightpanda sends numeric nodeIds/childIds in AX tree responses, while Chrome
+/// sends strings. This accepts both.
+fn string_or_int<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = Value::deserialize(deserializer)?;
+    match v {
+        Value::String(s) => Ok(s),
+        Value::Number(n) => Ok(n.to_string()),
+        other => Err(serde::de::Error::custom(format!(
+            "expected string or integer, got {}",
+            other
+        ))),
+    }
+}
+
+/// Deserialize an optional Vec where each element may be a string or integer.
+fn opt_vec_string_or_int<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt: Option<Vec<Value>> = Option::deserialize(deserializer)?;
+    match opt {
+        None => Ok(None),
+        Some(vec) => {
+            let mut result = Vec::with_capacity(vec.len());
+            for v in vec {
+                match v {
+                    Value::String(s) => result.push(s),
+                    Value::Number(n) => result.push(n.to_string()),
+                    other => {
+                        return Err(serde::de::Error::custom(format!(
+                            "expected string or integer in array, got {}",
+                            other
+                        )))
+                    }
+                }
+            }
+            Ok(Some(result))
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // CDP message envelope
@@ -257,12 +302,14 @@ pub struct GetFullAXTreeResult {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AXNode {
+    #[serde(deserialize_with = "string_or_int")]
     pub node_id: String,
     pub role: Option<AXValue>,
     pub name: Option<AXValue>,
     pub value: Option<AXValue>,
     pub description: Option<AXValue>,
     pub properties: Option<Vec<AXProperty>>,
+    #[serde(default, deserialize_with = "opt_vec_string_or_int")]
     pub child_ids: Option<Vec<String>>,
     pub backend_d_o_m_node_id: Option<i64>,
     pub ignored: Option<bool>,


### PR DESCRIPTION
## Summary

- Accept both string and integer values for `nodeId` and `childIds` in `AXNode` deserialization
- Lightpanda returns these as integers while Chrome returns strings; the CDP spec is ambiguous but strict typing breaks Lightpanda compatibility

## Problem

`agent-browser --engine lightpanda` fails on `snapshot` with:
```
Failed to deserialize CDP response for Accessibility.getFullAXTree: invalid type: integer `2`, expected a string
```

Lightpanda serializes `AXNode.nodeId` and `childIds` as JSON integers, while Chrome uses strings. The current serde `Deserialize` on `AXNode` expects `String` for both fields.

## Fix

Add custom deserializers (`string_or_int` and `opt_vec_string_or_int`) that accept both types, converting integers to strings. No behavioral change for Chrome — strings pass through unchanged.

## Note

Filed upstream as lightpanda-io/browser#1822. If Lightpanda fixes their CDP serialization, this patch becomes a no-op (still correct, just unused). But this is currently the only blocker preventing `--engine lightpanda` from working with `snapshot`, which is the core workflow.

## Test

```bash
agent-browser --engine lightpanda open https://example.com
agent-browser snapshot -i
# Before: ✗ Failed to deserialize CDP response...
# After:  - heading "Example Domain" [level=1, ref=e1]
#          - link "Learn more" [ref=e2]
```
