### PR TITLE
fix: correct misleading SIGPIPE comment

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -164,7 +164,8 @@ fn run_session(args: &[String], session: &str, json_mode: bool) {
 }
 
 fn main() {
-    // Ignore SIGPIPE to prevent panic when piping to head/tail
+    // Rust ignores SIGPIPE by default, causing println! to panic on broken pipes.
+    // Reset to SIG_DFL so the OS terminates the process cleanly instead.
     #[cfg(unix)]
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);


### PR DESCRIPTION
## Summary
The SIGPIPE comment said "Ignore" but the code sets `SIG_DFL` (terminate), not `SIG_IGN` (ignore). Updated to accurately describe what the code does.

## Diff
```diff
-// Ignore SIGPIPE to prevent panic when piping to head/tail
+// Rust ignores SIGPIPE by default, causing println! to panic on broken pipes.
+// Reset to SIG_DFL so the OS terminates the process cleanly instead.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)