### PR TITLE
fix: save session state before drain_cdp_events on close (#677)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -157,6 +157,24 @@ impl DaemonState {
         }
     }
 
+    /// Save session state if a session name is set and a page is active.
+    pub async fn save_session_state(&self) {
+        if let Some(ref mgr) = self.browser {
+            if let Some(ref session_name) = self.session_name {
+                if let Ok(session_id) = mgr.active_session_id() {
+                    let _ = state::save_state(
+                        &mgr.client,
+                        session_id,
+                        None,
+                        Some(session_name.as_str()),
+                        &self.session_id,
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+
     /// Update the stream server's CDP client slot when browser is set or cleared.
     pub async fn update_stream_client(&self) {
         if let Some(ref slot) = self.stream_client {
@@ -418,6 +436,12 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+
+    // Save session state before draining events — drain removes destroyed targets,
+    // leaving no pages to collect cookies/storage from.
+    if action == "close" {
+        state.save_session_state().await;
+    }
 
     // Drain pending CDP events (console, errors, screencast frames, target lifecycle, fetch)
     let (pending_acks, new_targets, destroyed_targets, fetch_paused) = state.drain_cdp_events();
@@ -1301,20 +1325,6 @@ async fn handle_evaluate(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
 }
 
 async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
-    if let Some(ref mgr) = state.browser {
-        if let Some(ref session_name) = state.session_name {
-            if let Ok(session_id) = mgr.active_session_id() {
-                let _ = state::save_state(
-                    &mgr.client,
-                    session_id,
-                    None,
-                    Some(session_name.as_str()),
-                    &state.session_id,
-                )
-                .await;
-            }
-        }
-    }
     if let Some(ref mut mgr) = state.browser {
         mgr.close().await?;
     }

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -124,6 +124,7 @@ async fn run_socket_server(
                 }
             }, if idle_timeout_ms.is_some() => {
                 let mut s = state.lock().await;
+                s.save_session_state().await;
                 if let Some(ref mut mgr) = s.browser {
                     let _ = mgr.close().await;
                 }
@@ -134,6 +135,7 @@ async fn run_socket_server(
             }
             _ = shutdown_signal() => {
                 let mut s = state.lock().await;
+                s.save_session_state().await;
                 if let Some(ref mut mgr) = s.browser {
                     let _ = mgr.close().await;
                 }
@@ -197,6 +199,7 @@ async fn run_socket_server(
                 }
             }, if idle_timeout_ms.is_some() => {
                 let mut s = state.lock().await;
+                s.save_session_state().await;
                 if let Some(ref mut mgr) = s.browser {
                     let _ = mgr.close().await;
                 }
@@ -208,6 +211,7 @@ async fn run_socket_server(
             }
             _ = shutdown_signal() => {
                 let mut s = state.lock().await;
+                s.save_session_state().await;
                 if let Some(ref mut mgr) = s.browser {
                     let _ = mgr.close().await;
                 }


### PR DESCRIPTION
## Summary

When closing with `--session-name`, `drain_cdp_events()` removed destroyed targets before `handle_close()` could save state, resulting in empty `{"cookies": [], "origins": []}` being persisted.

Fix: save session state **before** `drain_cdp_events()` via a new `DaemonState::save_session_state()` method. Also add saves to daemon shutdown paths (idle timeout, SIGTERM) which previously had no save logic at all.

Fixes #677

## Before / After

```mermaid
graph TD
    subgraph "Before (bug)"
        A1["execute_command('close')"] --> B1["drain_cdp_events()"]
        B1 --> C1["remove_page_by_target_id()"]
        C1 --> D1["handle_close()"]
        D1 --> E1["save_state()"]
        E1 --> F1["get_cookies() → page gone → []"]
        E1 --> G1["localStorage → page gone → []"]
        F1 --> H1["saved: {'cookies':[],'origins':[]}"]
        G1 --> H1
    end
```

```mermaid
graph TD
    subgraph "After (fix)"
        A2["execute_command('close')"] --> B2["save_session_state()"]
        B2 --> C2["get_cookies() → page alive → ✅"]
        B2 --> D2["localStorage → page alive → ✅"]
        C2 --> E2["drain_cdp_events()"]
        D2 --> E2
        E2 --> F2["remove_page_by_target_id()"]
        F2 --> G2["handle_close()"]
        G2 --> H2["mgr.close() — save already done"]
    end
```

## Test plan

```bash
export AGENT_BROWSER_SESSION_NAME=test-fix
agent-browser state clear --all
agent-browser open https://example.com
agent-browser eval 'localStorage.setItem("persist_test","ok"); document.cookie="ab_cookie=1; max-age=3600; path=/"; "done"'
agent-browser close
agent-browser open https://example.com
agent-browser eval 'JSON.stringify({ls: localStorage.getItem("persist_test"), cookie: document.cookie})'
# Expected: {"ls":"ok","cookie":"ab_cookie=1"}
```