### PR TITLE
fix: use VP9 codec for webm recording output

### DIFF
--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -81,6 +81,7 @@ pub fn recording_stop(state: &mut RecordingState) -> Result<Value, String> {
 
     let result = Command::new("ffmpeg")
         .args(["-y", "-framerate", "30", "-i", &frame_pattern])
+        .args(["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2"])
         .args(codec_args)
         .args(["-pix_fmt", "yuv420p"])
         .arg(output)


### PR DESCRIPTION
## Summary
- Fixed `record stop` failing when output file is `.webm`
- The ffmpeg command hardcoded `libx264` (H.264) which is incompatible with the WebM container (requires VP8/VP9/AV1)
- Now selects codec based on output extension: `libvpx-vp9` for `.webm`, `libx264` for other formats
- Uses CRF mode (`-crf 30 -b:v 0`) for VP9 encoding, the standard approach for screen recording (same as Puppeteer default)
- Added pad filter to handle odd frame dimensions from CDP screencast, which caused h264 encoding to fail

## Test plan
- [x] Reproduced the original failure: `libx264` + `.webm` → ffmpeg exit code 234
- [x] Verified fix: `record start/stop` with `.webm` output succeeds, produces valid VP9 video
- [x] Verified `.mp4` output works with `libx264` (including odd-dimension frames)

Fixes #778