### PR TITLE
fix: remove unused pnpm setup from global-install CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,16 +178,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The global-install job only uses npm (npm pack, npm install -g) but had pnpm setup with cache enabled. On Windows, the pnpm store directory doesn't exist since pnpm is never used, causing the Post Setup Node.js cache step to fail with a path validation error.