### PR TITLE
chore: patch release - ### Bug Fixes

- **Daemon panic on broken stderr p...

### DIFF
--- a/.changeset/release-mmqxu9tl.md
+++ b/.changeset/release-mmqxu9tl.md
@@ -1,0 +1,7 @@
+---
+"agent-browser": patch
+---
+
+### Bug Fixes
+
+- **Daemon panic on broken stderr pipe** - Replaced all `eprintln!` calls with `writeln!(std::io::stderr(), ...)` wrapped in `let _ =` to silently discard write errors, preventing the daemon from panicking when the parent process drops the stderr pipe during Chrome launch (#802)


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
### Bug Fixes

- **Daemon panic on broken stderr pipe** - Replaced all `eprintln!` calls with `writeln!(std::io::stderr(), ...)` wrapped in `let _ =` to silently discard write errors, preventing the daemon from panicking when the parent process drops the stderr pipe during Chrome launch (#802)

---
*This PR was created automatically by the release automation tool*