### PR TITLE
Add 1Password-backed auth vault profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ agent-browser provides multiple ways to persist login sessions so you don't re-a
 | **Session persistence** | Auto-save/restore cookies + localStorage by name | `--session-name <name>` / `AGENT_BROWSER_SESSION_NAME` |
 | **Import from your browser** | Grab auth from a Chrome session you already logged into | `--auto-connect` + `state save` |
 | **State file** | Load a previously saved state JSON on launch | `--state <path>` / `AGENT_BROWSER_STATE` |
-| **Auth vault** | Store credentials locally (encrypted), login by name | `auth save` / `auth login` |
+| **Auth vault** | Store credentials locally (encrypted), optionally resolve username, password, and OTP from 1Password, login by name | `auth save` / `auth login` |
 
 ### Import auth from your browser
 
@@ -512,6 +512,24 @@ agent-browser --session-name myapp state load ./my-auth.json
 > - State files contain session tokens in plaintext. Add them to `.gitignore` and delete when no longer needed. For encryption at rest, set `AGENT_BROWSER_ENCRYPTION_KEY` (see [State Encryption](#state-encryption)).
 
 For full details on login flows, OAuth, 2FA, cookie-based auth, and the auth vault, see the [Authentication](docs/src/app/sessions/page.mdx) docs.
+
+### Auth vault with 1Password CLI
+
+For sites where you want agent-browser to fill a username, password, and optional TOTP code without storing those values directly in the profile, you can point the auth vault at a single 1Password Login item.
+
+```bash
+# Requires the 1Password CLI (`op`) to be installed and already signed in
+agent-browser auth save github \
+  --url https://github.com/login \
+  --onepassword-item GitHub \
+  --onepassword-vault Work
+
+agent-browser auth login github
+```
+
+This keeps the saved profile encrypted locally while resolving the username, password, and any built-in OTP field at login time via the local `op` CLI.
+
+If you need field-level control, agent-browser still supports advanced 1Password secret references via `--username-op`, `--password-op`, and `--otp-op`.
 
 ## Sessions
 
@@ -628,7 +646,7 @@ agent-browser --session-name secure open example.com
 
 agent-browser includes security features for safe AI agent deployments. All features are opt-in -- existing workflows are unaffected until you explicitly enable a feature:
 
-- **Authentication Vault** -- Store credentials locally (always encrypted), reference by name. The LLM never sees passwords. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). A key is auto-generated at `~/.agent-browser/.encryption-key` if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
+- **Authentication Vault** -- Store credentials locally (always encrypted), reference them by name, and optionally resolve usernames, passwords, and OTP codes from 1Password using either a Login item or advanced `op://...` secret references. The LLM never sees secrets. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). A key is auto-generated at `~/.agent-browser/.encryption-key` if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
 - **Content Boundary Markers** -- Wrap page output in delimiters so LLMs can distinguish tool output from untrusted content: `--content-boundaries`
 - **Domain Allowlist** -- Restrict navigation to trusted domains (wildcards like `*.example.com` also match the bare domain): `--allowed-domains "example.com,*.example.com"`. Sub-resource requests (scripts, images, fetch) and WebSocket/EventSource connections to non-allowed domains are also blocked. Include any CDN domains your target pages depend on (e.g., `*.cdn.example.com`).
 - **Action Policy** -- Gate destructive actions with a static policy file: `--action-policy ./policy.json`

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -796,16 +796,23 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 Some("save") => {
                     let name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                         context: "auth save".to_string(),
-                        usage: "agent-browser auth save <name> --url <url> --username <user> --password <pass>",
+                        usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
                     })?;
 
                     let mut url = None;
+                    let mut onepassword_item = None;
+                    let mut onepassword_vault = None;
                     let mut username = None;
+                    let mut username_op_ref = None;
                     let mut password = None;
+                    let mut password_op_ref = None;
                     let mut password_stdin = false;
                     let mut username_selector = None;
                     let mut password_selector = None;
                     let mut submit_selector = None;
+                    let mut otp_op_ref = None;
+                    let mut otp_selector = None;
+                    let mut otp_submit_selector = None;
 
                     let mut j = 2;
                     while j < rest.len() {
@@ -814,12 +821,28 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 url = rest.get(j + 1).cloned();
                                 j += 1;
                             }
+                            "--onepassword-item" => {
+                                onepassword_item = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--onepassword-vault" => {
+                                onepassword_vault = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
                             "--username" => {
                                 username = rest.get(j + 1).cloned();
                                 j += 1;
                             }
+                            "--username-op" => {
+                                username_op_ref = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
                             "--password" => {
                                 password = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--password-op" => {
+                                password_op_ref = rest.get(j + 1).cloned();
                                 j += 1;
                             }
                             "--password-stdin" => {
@@ -837,11 +860,23 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 submit_selector = rest.get(j + 1).cloned();
                                 j += 1;
                             }
+                            "--otp-op" => {
+                                otp_op_ref = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--otp-selector" => {
+                                otp_selector = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--otp-submit-selector" => {
+                                otp_submit_selector = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
                             other => {
                                 if other.starts_with("--") {
                                     return Err(ParseError::InvalidValue {
                                         message: format!("unknown flag '{}' for auth save", other),
-                                        usage: "agent-browser auth save <name> --url <url> --username <user> --password <pass>",
+                                        usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
                                     });
                                 }
                             }
@@ -851,17 +886,80 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
                     let url_val = url.ok_or_else(|| ParseError::MissingArguments {
                         context: "auth save".to_string(),
-                        usage: "agent-browser auth save <name> --url <url> --username <user> --password <pass> [--password-stdin]",
-                    })?;
-                    let user_val = username.ok_or_else(|| ParseError::MissingArguments {
-                        context: "auth save".to_string(),
-                        usage: "agent-browser auth save <name> --url <url> --username <user> --password <pass> [--password-stdin]",
+                        usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
                     })?;
 
-                    if !password_stdin && password.is_none() {
+                    let using_onepassword_item = onepassword_item.is_some();
+
+                    if onepassword_vault.is_some() && !using_onepassword_item {
+                        return Err(ParseError::InvalidValue {
+                            message: "--onepassword-vault requires --onepassword-item"
+                                .to_string(),
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
+                        });
+                    }
+
+                    let username_source_count =
+                        usize::from(username.is_some()) + usize::from(username_op_ref.is_some());
+
+                    if using_onepassword_item
+                        && (username.is_some()
+                            || username_op_ref.is_some()
+                            || password.is_some()
+                            || password_stdin
+                            || password_op_ref.is_some()
+                            || otp_op_ref.is_some())
+                    {
+                        return Err(ParseError::InvalidValue {
+                            message: "Use either --onepassword-item or the individual username/password/otp flags".to_string(),
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
+                        });
+                    }
+
+                    if !using_onepassword_item && username_source_count > 1 {
+                        return Err(ParseError::InvalidValue {
+                            message: "Use exactly one of --username or --username-op".to_string(),
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
+                        });
+                    }
+
+                    if !using_onepassword_item && username_source_count == 0 {
                         return Err(ParseError::MissingArguments {
                             context: "auth save".to_string(),
-                            usage: "agent-browser auth save <name> --url <url> --username <user> --password <pass> [--password-stdin]",
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
+                        });
+                    }
+
+                    let password_source_count = usize::from(password.is_some())
+                        + usize::from(password_stdin)
+                        + usize::from(password_op_ref.is_some());
+
+                    if !using_onepassword_item && password_source_count > 1 {
+                        return Err(ParseError::InvalidValue {
+                            message: "Use exactly one of --password, --password-stdin, or --password-op".to_string(),
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
+                        });
+                    }
+
+                    if !using_onepassword_item
+                        && !password_stdin
+                        && password.is_none()
+                        && password_op_ref.is_none()
+                    {
+                        return Err(ParseError::MissingArguments {
+                            context: "auth save".to_string(),
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
+                        });
+                    }
+
+                    if !using_onepassword_item
+                        && otp_op_ref.is_none()
+                        && (otp_selector.is_some() || otp_submit_selector.is_some())
+                    {
+                        return Err(ParseError::InvalidValue {
+                            message: "--otp-selector and --otp-submit-selector require --otp-op"
+                                .to_string(),
+                            usage: "agent-browser auth save <name> --url <url> [--onepassword-item <item> [--onepassword-vault <vault>] | ((--username <user> | --username-op <op://...>) (--password <pass> | --password-stdin | --password-op <op://...>))]",
                         });
                     }
 
@@ -870,13 +968,27 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         "action": "auth_save",
                         "name": name,
                         "url": url_val,
-                        "username": user_val,
                     });
+                    if let Some(item) = onepassword_item {
+                        cmd["onePasswordItem"] = json!(item);
+                    }
+                    if let Some(vault) = onepassword_vault {
+                        cmd["onePasswordVault"] = json!(vault);
+                    }
+                    if let Some(user_val) = username {
+                        cmd["username"] = json!(user_val);
+                    }
+                    if let Some(username_op) = username_op_ref {
+                        cmd["usernameOpRef"] = json!(username_op);
+                    }
                     if password_stdin {
                         cmd["passwordStdin"] = json!(true);
                     }
                     if let Some(pass_val) = password {
                         cmd["password"] = json!(pass_val);
+                    }
+                    if let Some(password_op) = password_op_ref {
+                        cmd["passwordOpRef"] = json!(password_op);
                     }
                     if let Some(us) = username_selector {
                         cmd["usernameSelector"] = json!(us);
@@ -886,6 +998,15 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     }
                     if let Some(ss) = submit_selector {
                         cmd["submitSelector"] = json!(ss);
+                    }
+                    if let Some(otp_op) = otp_op_ref {
+                        cmd["otpOpRef"] = json!(otp_op);
+                    }
+                    if let Some(otp_sel) = otp_selector {
+                        cmd["otpSelector"] = json!(otp_sel);
+                    }
+                    if let Some(otp_submit_sel) = otp_submit_selector {
+                        cmd["otpSubmitSelector"] = json!(otp_submit_sel);
                     }
                     Ok(cmd)
                 }
@@ -4025,6 +4146,152 @@ mod tests {
         let cmd = parse_command(&args("eval document.title"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "evaluate");
         assert_eq!(cmd["script"], "document.title");
+    }
+
+    #[test]
+    fn test_auth_save_with_password_op_and_otp() {
+        let input: Vec<String> = vec![
+            "auth".to_string(),
+            "save".to_string(),
+            "github".to_string(),
+            "--url".to_string(),
+            "https://github.com/login".to_string(),
+            "--username-op".to_string(),
+            "op://work/github/username".to_string(),
+            "--password-op".to_string(),
+            "op://work/github/password".to_string(),
+            "--otp-op".to_string(),
+            "op://work/github/one-time password?attribute=otp".to_string(),
+            "--otp-selector".to_string(),
+            "#otp".to_string(),
+            "--otp-submit-selector".to_string(),
+            "button.verify".to_string(),
+        ];
+
+        let cmd = parse_command(&input, &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "auth_save");
+        assert_eq!(cmd["usernameOpRef"], "op://work/github/username");
+        assert_eq!(cmd["passwordOpRef"], "op://work/github/password");
+        assert_eq!(
+            cmd["otpOpRef"],
+            "op://work/github/one-time password?attribute=otp"
+        );
+        assert_eq!(cmd["otpSelector"], "#otp");
+        assert_eq!(cmd["otpSubmitSelector"], "button.verify");
+        assert!(cmd.get("password").is_none());
+    }
+
+    #[test]
+    fn test_auth_save_with_username_op_and_password_stdin() {
+        let cmd = parse_command(
+            &args("auth save github --url https://github.com/login --username-op op://work/github/username --password-stdin"),
+            &default_flags(),
+        )
+        .unwrap();
+
+        assert_eq!(cmd["action"], "auth_save");
+        assert_eq!(cmd["usernameOpRef"], "op://work/github/username");
+        assert_eq!(cmd["passwordStdin"], true);
+        assert!(cmd.get("username").is_none());
+    }
+
+    #[test]
+    fn test_auth_save_with_onepassword_item() {
+        let cmd = parse_command(
+            &args("auth save github --url https://github.com/login --onepassword-item GitHub --onepassword-vault Work --otp-selector #otp"),
+            &default_flags(),
+        )
+        .unwrap();
+
+        assert_eq!(cmd["action"], "auth_save");
+        assert_eq!(cmd["onePasswordItem"], "GitHub");
+        assert_eq!(cmd["onePasswordVault"], "Work");
+        assert_eq!(cmd["otpSelector"], "#otp");
+        assert!(cmd.get("username").is_none());
+        assert!(cmd.get("password").is_none());
+    }
+
+    #[test]
+    fn test_auth_save_requires_password_source() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --username user"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_auth_save_requires_username_source() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --password-op op://work/github/password"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_auth_save_rejects_multiple_username_sources() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --username user --username-op op://work/github/username --password-op op://work/github/password"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err
+            .format()
+            .contains("Use exactly one of --username or --username-op"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_multiple_password_sources() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --username user --password pass --password-op op://work/github/password"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err
+            .format()
+            .contains("Use exactly one of --password, --password-stdin, or --password-op"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_otp_selectors_without_otp_reference() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --username user --password-op op://work/github/password --otp-selector #otp"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err
+            .format()
+            .contains("--otp-selector and --otp-submit-selector require --otp-op"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_onepassword_vault_without_item() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --onepassword-vault Work --username user --password pass"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err
+            .format()
+            .contains("--onepassword-vault requires --onepassword-item"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_mixing_onepassword_item_with_manual_sources() {
+        let result = parse_command(
+            &args("auth save github --url https://github.com/login --onepassword-item GitHub --username user --password pass"),
+            &default_flags(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.format().contains(
+            "Use either --onepassword-item or the individual username/password/otp flags"
+        ));
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7396,6 +7396,35 @@ async fn wait_for_any_selector(
     }
 }
 
+async fn wait_for_navigation_after_auth_submit(mgr: &BrowserManager, session_id: &str) {
+    let mut rx = mgr.client.subscribe();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(10);
+    let mut navigated = false;
+
+    loop {
+        let result = tokio::time::timeout_at(deadline, rx.recv()).await;
+        match result {
+            Ok(Ok(event)) => {
+                if event.session_id.as_deref() == Some(session_id) {
+                    match event.method.as_str() {
+                        "Page.frameNavigated" | "Page.loadEventFired" => {
+                            navigated = true;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Err(_)) => break,
+            Err(_) => break,
+        }
+    }
+
+    if !navigated {
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    }
+}
+
 async fn handle_auth_save(cmd: &Value) -> Result<Value, String> {
     let name = cmd
         .get("name")
@@ -7405,25 +7434,35 @@ async fn handle_auth_save(cmd: &Value) -> Result<Value, String> {
         .get("url")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'url'")?;
-    let username = cmd
-        .get("username")
-        .and_then(|v| v.as_str())
-        .ok_or("Missing 'username'")?;
-    let password = cmd
-        .get("password")
-        .and_then(|v| v.as_str())
-        .ok_or("Missing 'password'")?;
+    let one_password_item = cmd.get("onePasswordItem").and_then(|v| v.as_str());
+    let one_password_vault = cmd.get("onePasswordVault").and_then(|v| v.as_str());
+    let username = cmd.get("username").and_then(|v| v.as_str());
+    let username_op_ref = cmd.get("usernameOpRef").and_then(|v| v.as_str());
+    let password = cmd.get("password").and_then(|v| v.as_str());
+    let password_op_ref = cmd.get("passwordOpRef").and_then(|v| v.as_str());
     let username_selector = cmd.get("usernameSelector").and_then(|v| v.as_str());
     let password_selector = cmd.get("passwordSelector").and_then(|v| v.as_str());
     let submit_selector = cmd.get("submitSelector").and_then(|v| v.as_str());
+    let otp_op_ref = cmd.get("otpOpRef").and_then(|v| v.as_str());
+    let otp_selector = cmd.get("otpSelector").and_then(|v| v.as_str());
+    let otp_submit_selector = cmd.get("otpSubmitSelector").and_then(|v| v.as_str());
     auth::auth_save(
         name,
         url,
-        username,
-        password,
-        username_selector,
-        password_selector,
-        submit_selector,
+        auth::AuthSaveOptions {
+            one_password_item,
+            one_password_vault,
+            username,
+            username_op_ref,
+            password,
+            password_op_ref,
+            username_selector,
+            password_selector,
+            submit_selector,
+            otp_op_ref,
+            otp_selector,
+            otp_submit_selector,
+        },
     )
 }
 
@@ -7437,8 +7476,36 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         return Err("Credential has no URL".to_string());
     }
     let url = cred.url;
-    let username = cred.username;
-    let password = cred.password;
+    let one_password_item = if let Some(item) = cred.one_password_item.as_deref() {
+        Some(auth::resolve_1password_item(
+            item,
+            cred.one_password_vault.as_deref(),
+        )?)
+    } else {
+        None
+    };
+    let username = if let Some(ref item) = one_password_item {
+        item.username.clone()
+    } else if let Some(username_op_ref) = cred.username_op_ref.as_deref() {
+        auth::resolve_1password_reference(username_op_ref)?
+    } else if !cred.username.is_empty() {
+        cred.username.clone()
+    } else {
+        return Err(
+            "Credential has no username, 1Password item, or 1Password secret reference".to_string(),
+        );
+    };
+    let password = if let Some(ref item) = one_password_item {
+        item.password.clone()
+    } else if let Some(password_op_ref) = cred.password_op_ref.as_deref() {
+        auth::resolve_1password_reference(password_op_ref)?
+    } else if !cred.password.is_empty() {
+        cred.password.clone()
+    } else {
+        return Err(
+            "Credential has no password, 1Password item, or 1Password secret reference".to_string(),
+        );
+    };
 
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     mgr.navigate(&url, AUTH_LOGIN_WAIT_UNTIL).await?;
@@ -7469,6 +7536,14 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         "button[type=submit]",
         "input[type=submit]",
         "button:not([type])",
+    ];
+    let auto_otp_selectors = [
+        "input[autocomplete='one-time-code']",
+        "input[name*=otp i]",
+        "input[id*=otp i]",
+        "input[name*=code i]",
+        "input[id*=code i]",
+        "input[inputmode='numeric']",
     ];
 
     let username_sel = cmd
@@ -7597,32 +7672,68 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
     )
     .await?;
 
-    // Wait for navigation after submit (with fallback timeout)
-    let mut rx = mgr.client.subscribe();
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(10);
-    let mut navigated = false;
+    let otp_code = if let Some(ref item) = one_password_item {
+        item.otp.clone()
+    } else if let Some(otp_op_ref) = cred.otp_op_ref.as_deref() {
+        Some(auth::resolve_1password_reference(otp_op_ref)?)
+    } else {
+        None
+    };
 
-    loop {
-        let result = tokio::time::timeout_at(deadline, rx.recv()).await;
-        match result {
-            Ok(Ok(event)) => {
-                if event.session_id.as_deref() == Some(&session_id) {
-                    match event.method.as_str() {
-                        "Page.frameNavigated" | "Page.loadEventFired" => {
-                            navigated = true;
-                            break;
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Ok(Err(_)) => break,
-            Err(_) => break,
+    if let Some(otp_code) = otp_code {
+        let otp_selector = if let Some(selector) = cmd
+            .get("otpSelector")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or(cred.otp_selector.clone())
+        {
+            wait_for_selector(&mgr.client, &session_id, &selector, "visible", 15_000).await?;
+            selector
+        } else {
+            let selector =
+                wait_for_any_selector(&mgr.client, &session_id, &auto_otp_selectors, 15_000)
+                    .await?;
+            wait_for_selector(&mgr.client, &session_id, &selector, "visible", 15_000).await?;
+            selector
+        };
+        interaction::fill(
+            &mgr.client,
+            &session_id,
+            &state.ref_map,
+            &otp_selector,
+            &otp_code,
+            &state.iframe_sessions,
+        )
+        .await?;
+
+        let otp_submit_selector = if let Some(selector) = cmd
+            .get("otpSubmitSelector")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or(cred.otp_submit_selector.clone())
+        {
+            Some(selector)
+        } else {
+            wait_for_any_selector(&mgr.client, &session_id, &auto_submit_selectors, 2_000)
+                .await
+                .ok()
+        };
+
+        if let Some(otp_submit_selector) = otp_submit_selector {
+            interaction::click(
+                &mgr.client,
+                &session_id,
+                &state.ref_map,
+                &otp_submit_selector,
+                "left",
+                1,
+                &state.iframe_sessions,
+            )
+            .await?;
+            wait_for_navigation_after_auth_submit(mgr, &session_id).await;
         }
-    }
-
-    if !navigated {
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    } else {
+        wait_for_navigation_after_auth_submit(mgr, &session_id).await;
     }
 
     Ok(json!({ "loggedIn": true, "name": name }))

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7672,18 +7672,15 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
     )
     .await?;
 
-    let otp_code = if let Some(ref item) = one_password_item {
-        item.otp_reference
-            .as_deref()
-            .map(auth::resolve_1password_reference)
-            .transpose()?
+    let otp_reference = if let Some(ref item) = one_password_item {
+        item.otp_reference.clone()
     } else if let Some(otp_op_ref) = cred.otp_op_ref.as_deref() {
-        Some(auth::resolve_1password_reference(otp_op_ref)?)
+        Some(otp_op_ref.to_string())
     } else {
         None
     };
 
-    if let Some(otp_code) = otp_code {
+    if let Some(otp_reference) = otp_reference {
         let otp_selector = if let Some(selector) = cmd
             .get("otpSelector")
             .and_then(|v| v.as_str())
@@ -7699,6 +7696,7 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
             wait_for_selector(&mgr.client, &session_id, &selector, "visible", 15_000).await?;
             selector
         };
+        let otp_code = auth::resolve_1password_reference(&otp_reference)?;
         interaction::fill(
             &mgr.client,
             &session_id,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7673,7 +7673,10 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
     .await?;
 
     let otp_code = if let Some(ref item) = one_password_item {
-        item.otp.clone()
+        item.otp_reference
+            .as_deref()
+            .map(auth::resolve_1password_reference)
+            .transpose()?
     } else if let Some(otp_op_ref) = cred.otp_op_ref.as_deref() {
         Some(auth::resolve_1password_reference(otp_op_ref)?)
     } else {

--- a/cli/src/native/auth.rs
+++ b/cli/src/native/auth.rs
@@ -374,7 +374,7 @@ struct OnePasswordItem {
 pub struct ResolvedOnePasswordItem {
     pub username: String,
     pub password: String,
-    pub otp: Option<String>,
+    pub otp_reference: Option<String>,
 }
 
 fn value_as_string(value: &Value) -> Option<String> {
@@ -447,7 +447,7 @@ fn resolve_1password_item_with_op_bin(
         .and_then(value_as_string)
         .ok_or("1Password item is missing a password field")?;
 
-    let otp = item_json
+    let otp_reference = item_json
         .fields
         .iter()
         .find(|field| {
@@ -458,14 +458,12 @@ fn resolve_1password_item_with_op_bin(
                 .unwrap_or(false)
         })
         .and_then(|field| field.reference.as_deref())
-        .map(|reference| append_query_parameter(reference, "attribute=otp"))
-        .map(|reference| resolve_1password_reference_with_op_bin(op_bin, &reference))
-        .transpose()?;
+        .map(|reference| append_query_parameter(reference, "attribute=otp"));
 
     Ok(ResolvedOnePasswordItem {
         username,
         password,
-        otp,
+        otp_reference,
     })
 }
 
@@ -1052,8 +1050,6 @@ mod tests {
             r##"#!/bin/sh
 if [ "$1" = "item" ] && [ "$2" = "get" ]; then
   printf '%s' '{"fields":[{"id":"username","label":"username","purpose":"USERNAME","type":"STRING","value":"octocat"},{"id":"password","label":"password","purpose":"PASSWORD","type":"CONCEALED","value":"s3cret"},{"id":"otp","label":"one-time password","type":"OTP","reference":"op://work/github/one-time password"}]}'
-elif [ "$1" = "read" ] && [ "$2" = "--no-newline" ] && [ "$3" = "op://work/github/one-time password?attribute=otp" ]; then
-  printf '654321'
 else
   echo 'unexpected args' >&2
   exit 1
@@ -1075,7 +1071,7 @@ fi
             ResolvedOnePasswordItem {
                 username: "octocat".to_string(),
                 password: "s3cret".to_string(),
-                otp: Some("654321".to_string()),
+                otp_reference: Some("op://work/github/one-time password?attribute=otp".to_string()),
             }
         );
 

--- a/cli/src/native/auth.rs
+++ b/cli/src/native/auth.rs
@@ -5,6 +5,7 @@ use serde_json::{json, Value};
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+use std::process::Command;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -12,13 +13,32 @@ pub struct AuthProfile {
     pub name: String,
     pub url: String,
     pub username: String,
+    /// Optional 1Password item specifier for resolving login credentials at runtime.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub one_password_item: Option<String>,
+    /// Optional vault hint used together with `one_password_item`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub one_password_vault: Option<String>,
+    /// Optional 1Password secret reference for resolving the username at login time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username_op_ref: Option<String>,
     pub password: String,
+    /// Optional 1Password secret reference for resolving the password at login time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password_op_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username_selector: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password_selector: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub submit_selector: Option<String>,
+    /// Optional 1Password secret reference for resolving a one-time password code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otp_op_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otp_selector: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otp_submit_selector: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -27,6 +47,22 @@ pub struct AuthProfile {
 
 // Keep legacy Credential alias for backward compatibility
 pub type Credential = AuthProfile;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AuthSaveOptions<'a> {
+    pub one_password_item: Option<&'a str>,
+    pub one_password_vault: Option<&'a str>,
+    pub username: Option<&'a str>,
+    pub username_op_ref: Option<&'a str>,
+    pub password: Option<&'a str>,
+    pub password_op_ref: Option<&'a str>,
+    pub username_selector: Option<&'a str>,
+    pub password_selector: Option<&'a str>,
+    pub submit_selector: Option<&'a str>,
+    pub otp_op_ref: Option<&'a str>,
+    pub otp_selector: Option<&'a str>,
+    pub otp_submit_selector: Option<&'a str>,
+}
 
 fn validate_profile_name(name: &str) -> Result<(), String> {
     if name.is_empty()
@@ -52,6 +88,25 @@ fn get_auth_dir() -> PathBuf {
 
 fn get_profile_path(name: &str) -> PathBuf {
     get_auth_dir().join(format!("{}.json", name))
+}
+
+fn validate_1password_reference(reference: &str) -> Result<(), String> {
+    if reference.trim().starts_with("op://") {
+        Ok(())
+    } else {
+        Err(format!(
+            "Invalid 1Password secret reference '{}'. Expected a value starting with op://",
+            reference
+        ))
+    }
+}
+
+fn validate_1password_item_specifier(item: &str) -> Result<(), String> {
+    if item.trim().is_empty() {
+        Err("1Password item specifier cannot be empty".to_string())
+    } else {
+        Ok(())
+    }
 }
 
 const ENCRYPTION_KEY_ENV: &str = "AGENT_BROWSER_ENCRYPTION_KEY";
@@ -262,6 +317,190 @@ fn load_profile(name: &str) -> Result<AuthProfile, String> {
     decrypt_profile(&data)
 }
 
+fn run_op_command(op_bin: &str, args: &[&str]) -> Result<Vec<u8>, String> {
+    let output = Command::new(op_bin)
+        .args(args)
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                format!(
+                    "1Password CLI ('{}') was not found. Install the 'op' CLI and sign in before using 1Password-backed auth profiles.",
+                    op_bin
+                )
+            } else {
+                format!("Failed to execute 1Password CLI: {}", e)
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("op exited with status {}", output.status)
+        };
+        return Err(detail);
+    }
+
+    Ok(output.stdout)
+}
+
+#[derive(Debug, Deserialize)]
+struct OnePasswordItemField {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    label: String,
+    #[serde(default)]
+    purpose: Option<String>,
+    #[serde(rename = "type", default)]
+    field_type: Option<String>,
+    #[serde(default)]
+    value: Option<Value>,
+    #[serde(default)]
+    reference: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OnePasswordItem {
+    #[serde(default)]
+    fields: Vec<OnePasswordItemField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedOnePasswordItem {
+    pub username: String,
+    pub password: String,
+    pub otp: Option<String>,
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    value.as_str().map(ToString::to_string)
+}
+
+fn is_purpose(field: &OnePasswordItemField, purpose: &str) -> bool {
+    field
+        .purpose
+        .as_deref()
+        .map(|p| p.eq_ignore_ascii_case(purpose))
+        .unwrap_or(false)
+}
+
+fn is_field_name(field: &OnePasswordItemField, name: &str) -> bool {
+    field.id.eq_ignore_ascii_case(name) || field.label.eq_ignore_ascii_case(name)
+}
+
+fn append_query_parameter(reference: &str, query: &str) -> String {
+    if reference.contains('?') {
+        format!("{}&{}", reference, query)
+    } else {
+        format!("{}?{}", reference, query)
+    }
+}
+
+fn read_1password_item_json_with_op_bin(
+    op_bin: &str,
+    item: &str,
+    vault: Option<&str>,
+) -> Result<OnePasswordItem, String> {
+    validate_1password_item_specifier(item)?;
+
+    let mut args = vec!["item", "get", item];
+    if let Some(vault) = vault {
+        args.push("--vault");
+        args.push(vault);
+    }
+    args.push("--reveal");
+    args.push("--format");
+    args.push("json");
+
+    let stdout = run_op_command(op_bin, &args)
+        .map_err(|detail| format!("Failed to retrieve 1Password item details: {}", detail))?;
+
+    serde_json::from_slice::<OnePasswordItem>(&stdout)
+        .map_err(|e| format!("Failed to parse 1Password item JSON: {}", e))
+}
+
+fn resolve_1password_item_with_op_bin(
+    op_bin: &str,
+    item: &str,
+    vault: Option<&str>,
+) -> Result<ResolvedOnePasswordItem, String> {
+    let item_json = read_1password_item_json_with_op_bin(op_bin, item, vault)?;
+
+    let username = item_json
+        .fields
+        .iter()
+        .find(|field| is_purpose(field, "username") || is_field_name(field, "username"))
+        .and_then(|field| field.value.as_ref())
+        .and_then(value_as_string)
+        .ok_or("1Password item is missing a username field")?;
+
+    let password = item_json
+        .fields
+        .iter()
+        .find(|field| is_purpose(field, "password") || is_field_name(field, "password"))
+        .and_then(|field| field.value.as_ref())
+        .and_then(value_as_string)
+        .ok_or("1Password item is missing a password field")?;
+
+    let otp = item_json
+        .fields
+        .iter()
+        .find(|field| {
+            field
+                .field_type
+                .as_deref()
+                .map(|field_type| field_type.eq_ignore_ascii_case("otp"))
+                .unwrap_or(false)
+        })
+        .and_then(|field| field.reference.as_deref())
+        .map(|reference| append_query_parameter(reference, "attribute=otp"))
+        .map(|reference| resolve_1password_reference_with_op_bin(op_bin, &reference))
+        .transpose()?;
+
+    Ok(ResolvedOnePasswordItem {
+        username,
+        password,
+        otp,
+    })
+}
+
+fn resolve_1password_reference_with_op_bin(
+    op_bin: &str,
+    reference: &str,
+) -> Result<String, String> {
+    validate_1password_reference(reference)?;
+
+    let stdout = run_op_command(op_bin, &["read", "--no-newline", reference])
+        .map_err(|detail| format!("Failed to resolve 1Password secret reference: {}", detail))?;
+
+    let value = String::from_utf8(stdout)
+        .map_err(|e| format!("1Password CLI returned invalid UTF-8: {}", e))?;
+
+    if value.is_empty() {
+        return Err("1Password CLI returned an empty secret value".to_string());
+    }
+
+    Ok(value)
+}
+
+/// Resolve a 1Password secret reference using the local `op` CLI.
+pub fn resolve_1password_reference(reference: &str) -> Result<String, String> {
+    resolve_1password_reference_with_op_bin("op", reference)
+}
+
+/// Resolve username, password, and optional OTP from a 1Password Login item.
+pub fn resolve_1password_item(
+    item: &str,
+    vault: Option<&str>,
+) -> Result<ResolvedOnePasswordItem, String> {
+    resolve_1password_item_with_op_bin("op", item, vault)
+}
+
 pub fn credentials_set(
     name: &str,
     username: &str,
@@ -273,40 +512,97 @@ pub fn credentials_set(
         name: name.to_string(),
         url: url.unwrap_or("").to_string(),
         username: username.to_string(),
+        one_password_item: None,
+        one_password_vault: None,
+        username_op_ref: None,
         password: password.to_string(),
+        password_op_ref: None,
         username_selector: None,
         password_selector: None,
         submit_selector: None,
+        otp_op_ref: None,
+        otp_selector: None,
+        otp_submit_selector: None,
         created_at: None,
         last_login_at: None,
     };
     save_profile(&profile)?;
-    Ok(json!({ "saved": name }))
+    Ok(json!({ "saved": true, "name": name }))
 }
 
-pub fn auth_save(
-    name: &str,
-    url: &str,
-    username: &str,
-    password: &str,
-    username_selector: Option<&str>,
-    password_selector: Option<&str>,
-    submit_selector: Option<&str>,
-) -> Result<Value, String> {
+pub fn auth_save(name: &str, url: &str, options: AuthSaveOptions<'_>) -> Result<Value, String> {
     validate_profile_name(name)?;
+    let using_one_password_item = options.one_password_item.is_some();
+    if options.one_password_vault.is_some() && !using_one_password_item {
+        return Err("--onepassword-vault requires --onepassword-item".to_string());
+    }
+    if let Some(item) = options.one_password_item {
+        validate_1password_item_specifier(item)?;
+    }
+    if using_one_password_item {
+        let has_other_secret_sources = options.username.is_some()
+            || options.username_op_ref.is_some()
+            || options.password.is_some()
+            || options.password_op_ref.is_some()
+            || options.otp_op_ref.is_some();
+        if has_other_secret_sources {
+            return Err(
+                "Use either --onepassword-item or individual username/password/otp sources"
+                    .to_string(),
+            );
+        }
+    }
+    let username_source_count =
+        usize::from(options.username.is_some()) + usize::from(options.username_op_ref.is_some());
+    if !using_one_password_item && username_source_count == 0 {
+        return Err("Auth profile requires either a username or --username-op".to_string());
+    }
+    if !using_one_password_item && username_source_count > 1 {
+        return Err("Auth profile accepts only one username source".to_string());
+    }
+    let password_source_count =
+        usize::from(options.password.is_some()) + usize::from(options.password_op_ref.is_some());
+    if !using_one_password_item && password_source_count == 0 {
+        return Err("Auth profile requires either a password or --password-op".to_string());
+    }
+    if !using_one_password_item && password_source_count > 1 {
+        return Err("Auth profile accepts only one password source".to_string());
+    }
+    if let Some(reference) = options.username_op_ref {
+        validate_1password_reference(reference)?;
+    }
+    if let Some(reference) = options.password_op_ref {
+        validate_1password_reference(reference)?;
+    }
+    if let Some(reference) = options.otp_op_ref {
+        validate_1password_reference(reference)?;
+    }
+    if !using_one_password_item
+        && options.otp_op_ref.is_none()
+        && (options.otp_selector.is_some() || options.otp_submit_selector.is_some())
+    {
+        return Err("OTP selectors require an --otp-op reference".to_string());
+    }
     let profile = AuthProfile {
         name: name.to_string(),
         url: url.to_string(),
-        username: username.to_string(),
-        password: password.to_string(),
-        username_selector: username_selector.map(String::from),
-        password_selector: password_selector.map(String::from),
-        submit_selector: submit_selector.map(String::from),
+        one_password_item: options.one_password_item.map(String::from),
+        one_password_vault: options.one_password_vault.map(String::from),
+        username: options.username.unwrap_or("").to_string(),
+        username_op_ref: options.username_op_ref.map(String::from),
+        password: options.password.unwrap_or("").to_string(),
+        password_op_ref: options.password_op_ref.map(String::from),
+        username_selector: options.username_selector.map(String::from),
+        password_selector: options.password_selector.map(String::from),
+        submit_selector: options.submit_selector.map(String::from),
+        otp_op_ref: options.otp_op_ref.map(String::from),
+        otp_selector: options.otp_selector.map(String::from),
+        otp_submit_selector: options.otp_submit_selector.map(String::from),
         created_at: None,
         last_login_at: None,
     };
     save_profile(&profile)?;
-    Ok(json!({ "saved": name }))
+    Ok(json!({ "saved": true, "name": name }))
 }
 
 pub fn credentials_get(name: &str) -> Result<Value, String> {
@@ -315,7 +611,12 @@ pub fn credentials_get(name: &str) -> Result<Value, String> {
         "name": profile.name,
         "username": profile.username,
         "url": profile.url,
-        "hasPassword": true,
+        "hasPassword": !profile.password.is_empty()
+            || profile.password_op_ref.is_some()
+            || profile.one_password_item.is_some(),
+        "hasUsername": !profile.username.is_empty()
+            || profile.username_op_ref.is_some()
+            || profile.one_password_item.is_some(),
     }))
 }
 
@@ -330,7 +631,7 @@ pub fn credentials_delete(name: &str) -> Result<Value, String> {
         return Err(format!("Auth profile '{}' not found", name));
     }
     fs::remove_file(&path).map_err(|e| format!("Failed to delete profile: {}", e))?;
-    Ok(json!({ "deleted": name }))
+    Ok(json!({ "deleted": true, "name": name }))
 }
 
 pub fn credentials_list() -> Result<Value, String> {
@@ -374,14 +675,39 @@ pub fn credentials_list() -> Result<Value, String> {
 pub fn auth_show(name: &str) -> Result<Value, String> {
     validate_profile_name(name)?;
     let profile = load_profile(name)?;
+    let username_source = if profile.one_password_item.is_some() {
+        "1password-item"
+    } else if profile.username_op_ref.is_some() {
+        "1password"
+    } else if !profile.username.is_empty() {
+        "stored"
+    } else {
+        "missing"
+    };
+    let password_source = if profile.one_password_item.is_some() {
+        "1password-item"
+    } else if profile.password_op_ref.is_some() {
+        "1password"
+    } else if !profile.password.is_empty() {
+        "stored"
+    } else {
+        "missing"
+    };
     Ok(json!({
         "profile": {
             "name": profile.name,
             "url": profile.url,
             "username": profile.username,
+            "onePasswordItem": profile.one_password_item,
+            "onePasswordVault": profile.one_password_vault,
+            "usernameSource": username_source,
             "usernameSelector": profile.username_selector,
             "passwordSelector": profile.password_selector,
             "submitSelector": profile.submit_selector,
+            "passwordSource": password_source,
+            "otpEnabled": profile.otp_op_ref.is_some() || profile.one_password_item.is_some(),
+            "otpSelector": profile.otp_selector,
+            "otpSubmitSelector": profile.otp_submit_selector,
         }
     }))
 }
@@ -423,11 +749,18 @@ mod tests {
         let profile = AuthProfile {
             name: "test".to_string(),
             url: "https://example.com".to_string(),
-            username: "user".to_string(),
+            one_password_item: None,
+            one_password_vault: None,
+            username: "".to_string(),
+            username_op_ref: Some("op://vault/item/username".to_string()),
             password: "pass".to_string(),
+            password_op_ref: Some("op://vault/item/password".to_string()),
             username_selector: None,
             password_selector: None,
             submit_selector: Some("button[type=submit]".to_string()),
+            otp_op_ref: Some("op://vault/item/otp".to_string()),
+            otp_selector: Some("#otp".to_string()),
+            otp_submit_selector: Some("button.verify".to_string()),
             created_at: None,
             last_login_at: None,
         };
@@ -435,9 +768,18 @@ mod tests {
         let parsed: AuthProfile = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.name, "test");
         assert_eq!(
+            parsed.username_op_ref,
+            Some("op://vault/item/username".to_string())
+        );
+        assert_eq!(
+            parsed.password_op_ref,
+            Some("op://vault/item/password".to_string())
+        );
+        assert_eq!(
             parsed.submit_selector,
             Some("button[type=submit]".to_string())
         );
+        assert_eq!(parsed.otp_selector, Some("#otp".to_string()));
         assert!(parsed.username_selector.is_none());
     }
 
@@ -447,11 +789,18 @@ mod tests {
             let profile = AuthProfile {
                 name: "roundtrip".to_string(),
                 url: "https://example.com".to_string(),
+                one_password_item: None,
+                one_password_vault: None,
                 username: "user".to_string(),
+                username_op_ref: None,
                 password: "s3cret!".to_string(),
+                password_op_ref: None,
                 username_selector: None,
                 password_selector: None,
                 submit_selector: None,
+                otp_op_ref: None,
+                otp_selector: None,
+                otp_submit_selector: None,
                 created_at: None,
                 last_login_at: None,
             };
@@ -493,11 +842,18 @@ mod tests {
             let profile = AuthProfile {
                 name: "json-test".to_string(),
                 url: "https://example.com/login".to_string(),
+                one_password_item: None,
+                one_password_vault: None,
                 username: "admin".to_string(),
+                username_op_ref: None,
                 password: "hunter2".to_string(),
+                password_op_ref: None,
                 username_selector: Some("#email".to_string()),
                 password_selector: None,
                 submit_selector: None,
+                otp_op_ref: None,
+                otp_selector: None,
+                otp_submit_selector: None,
                 created_at: None,
                 last_login_at: None,
             };
@@ -536,11 +892,18 @@ mod tests {
             let profile = AuthProfile {
                 name: "format-check".to_string(),
                 url: "https://example.com".to_string(),
+                one_password_item: None,
+                one_password_vault: None,
                 username: "user".to_string(),
+                username_op_ref: None,
                 password: "pass".to_string(),
+                password_op_ref: None,
                 username_selector: None,
                 password_selector: None,
                 submit_selector: None,
+                otp_op_ref: None,
+                otp_selector: None,
+                otp_submit_selector: None,
                 created_at: None,
                 last_login_at: None,
             };
@@ -552,5 +915,170 @@ mod tests {
             assert!(parsed["authTag"].is_string());
             assert!(parsed["data"].is_string());
         });
+    }
+
+    #[test]
+    fn test_validate_1password_reference() {
+        assert!(validate_1password_reference("op://work/github/password").is_ok());
+        assert!(validate_1password_reference("https://example.com").is_err());
+    }
+
+    #[test]
+    fn test_auth_save_rejects_multiple_password_sources() {
+        let result = auth_save(
+            "github",
+            "https://github.com/login",
+            AuthSaveOptions {
+                username: Some("user"),
+                password: Some("pass"),
+                password_op_ref: Some("op://work/github/password"),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("only one password source"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_onepassword_vault_without_item() {
+        let result = auth_save(
+            "github",
+            "https://github.com/login",
+            AuthSaveOptions {
+                one_password_vault: Some("Work"),
+                username: Some("user"),
+                password: Some("pass"),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("--onepassword-vault requires"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_mixed_onepassword_item_and_manual_sources() {
+        let result = auth_save(
+            "github",
+            "https://github.com/login",
+            AuthSaveOptions {
+                one_password_item: Some("GitHub"),
+                username: Some("user"),
+                password: Some("pass"),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("either --onepassword-item"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_otp_selectors_without_reference() {
+        let result = auth_save(
+            "github",
+            "https://github.com/login",
+            AuthSaveOptions {
+                username: Some("user"),
+                password: Some("pass"),
+                otp_selector: Some("#otp"),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("OTP selectors require"));
+    }
+
+    #[test]
+    fn test_auth_save_rejects_multiple_username_sources() {
+        let result = auth_save(
+            "github",
+            "https://github.com/login",
+            AuthSaveOptions {
+                username: Some("user"),
+                username_op_ref: Some("op://work/github/username"),
+                password: Some("pass"),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("only one username source"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_1password_reference_with_stub_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script_path = std::env::temp_dir().join(format!(
+            "agent-browser-op-stub-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        fs::write(
+            &script_path,
+            "#!/bin/sh\nif [ \"$1\" = \"read\" ] && [ \"$2\" = \"--no-newline\" ]; then\n  printf '654321'\nelse\n  echo 'unexpected args' >&2\n  exit 1\nfi\n",
+        )
+        .unwrap();
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = resolve_1password_reference_with_op_bin(
+            script_path.to_str().unwrap(),
+            "op://work/github/one-time password?attribute=otp",
+        )
+        .unwrap();
+
+        assert_eq!(result, "654321");
+
+        let _ = fs::remove_file(&script_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_1password_item_with_stub_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script_path = std::env::temp_dir().join(format!(
+            "agent-browser-op-item-stub-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        fs::write(
+            &script_path,
+            r##"#!/bin/sh
+if [ "$1" = "item" ] && [ "$2" = "get" ]; then
+  printf '%s' '{"fields":[{"id":"username","label":"username","purpose":"USERNAME","type":"STRING","value":"octocat"},{"id":"password","label":"password","purpose":"PASSWORD","type":"CONCEALED","value":"s3cret"},{"id":"otp","label":"one-time password","type":"OTP","reference":"op://work/github/one-time password"}]}'
+elif [ "$1" = "read" ] && [ "$2" = "--no-newline" ] && [ "$3" = "op://work/github/one-time password?attribute=otp" ]; then
+  printf '654321'
+else
+  echo 'unexpected args' >&2
+  exit 1
+fi
+"##,
+        )
+        .unwrap();
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = resolve_1password_item_with_op_bin(
+            script_path.to_str().unwrap(),
+            "GitHub",
+            Some("Work"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            ResolvedOnePasswordItem {
+                username: "octocat".to_string(),
+                password: "s3cret".to_string(),
+                otp: Some("654321".to_string()),
+            }
+        );
+
+        let _ = fs::remove_file(&script_path);
     }
 }

--- a/cli/src/native/auth.rs
+++ b/cli/src/native/auth.rs
@@ -394,6 +394,14 @@ fn is_field_name(field: &OnePasswordItemField, name: &str) -> bool {
 }
 
 fn append_query_parameter(reference: &str, query: &str) -> String {
+    if reference
+        .split_once('?')
+        .map(|(_, existing_query)| existing_query.split('&').any(|part| part == query))
+        .unwrap_or(false)
+    {
+        return reference.to_string();
+    }
+
     if reference.contains('?') {
         format!("{}&{}", reference, query)
     } else {
@@ -919,6 +927,28 @@ mod tests {
     fn test_validate_1password_reference() {
         assert!(validate_1password_reference("op://work/github/password").is_ok());
         assert!(validate_1password_reference("https://example.com").is_err());
+    }
+
+    #[test]
+    fn test_append_query_parameter_is_idempotent() {
+        assert_eq!(
+            append_query_parameter("op://work/github/one-time password", "attribute=otp"),
+            "op://work/github/one-time password?attribute=otp"
+        );
+        assert_eq!(
+            append_query_parameter(
+                "op://work/github/one-time password?attribute=otp",
+                "attribute=otp"
+            ),
+            "op://work/github/one-time password?attribute=otp"
+        );
+        assert_eq!(
+            append_query_parameter(
+                "op://work/github/one-time password?foo=bar",
+                "attribute=otp"
+            ),
+            "op://work/github/one-time password?foo=bar&attribute=otp"
+        );
     }
 
     #[test]

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -477,23 +477,36 @@ async fn test_auth_save_and_show() {
     let result = auth::auth_save(
         "parity-roundtrip",
         "https://example.com",
-        "user",
-        "pass",
-        Some("input#user"),
-        None,
-        None,
+        auth::AuthSaveOptions {
+            one_password_item: Some("Example Login"),
+            one_password_vault: Some("Work"),
+            username_selector: Some("input#user"),
+            otp_selector: Some("input#otp"),
+            otp_submit_selector: Some("button.verify"),
+            ..Default::default()
+        },
     );
     assert!(result.is_ok());
 
     let show = auth::auth_show("parity-roundtrip");
     assert!(show.is_ok());
     let data = show.unwrap();
-    assert_eq!(data["profile"]["username"], "user");
+    assert_eq!(data["profile"]["username"], "");
+    assert_eq!(data["profile"]["onePasswordItem"], "Example Login");
+    assert_eq!(data["profile"]["onePasswordVault"], "Work");
+    assert_eq!(data["profile"]["usernameSource"], "1password-item");
     assert_eq!(data["profile"]["usernameSelector"], "input#user");
+    assert_eq!(data["profile"]["passwordSource"], "1password-item");
+    assert_eq!(data["profile"]["otpEnabled"], true);
+    assert_eq!(data["profile"]["otpSelector"], "input#otp");
 
     let full = auth::credentials_get_full("parity-roundtrip");
     assert!(full.is_ok());
-    assert_eq!(full.unwrap().password, "pass");
+    let full = full.unwrap();
+    assert_eq!(full.one_password_item.as_deref(), Some("Example Login"));
+    assert_eq!(full.one_password_vault.as_deref(), Some("Work"));
+    assert_eq!(full.password, "");
+    assert!(full.password_op_ref.is_none());
 
     // Cleanup
     let _ = auth::credentials_delete("parity-roundtrip");

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -930,6 +930,20 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 .get("username")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+            let one_password_item = profile.get("onePasswordItem").and_then(|v| v.as_str());
+            let one_password_vault = profile.get("onePasswordVault").and_then(|v| v.as_str());
+            let username_source = profile
+                .get("usernameSource")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let password_source = profile
+                .get("passwordSource")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let otp_enabled = profile
+                .get("otpEnabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             let created = profile
                 .get("createdAt")
                 .and_then(|v| v.as_str())
@@ -938,6 +952,15 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             println!("Name: {}", name);
             println!("URL: {}", url);
             println!("Username: {}", user);
+            if let Some(item) = one_password_item {
+                println!("1Password item: {}", item);
+            }
+            if let Some(vault) = one_password_vault {
+                println!("1Password vault: {}", vault);
+            }
+            println!("Username source: {}", username_source);
+            println!("Password source: {}", password_source);
+            println!("OTP enabled: {}", if otp_enabled { "yes" } else { "no" });
             println!("Created: {}", created);
             if let Some(ll) = last_login {
                 println!("Last login: {}", ll);
@@ -2135,12 +2158,20 @@ Subcommands:
 
 Save Options:
   --url <url>              Login page URL (required)
-  --username <user>        Username (required)
-  --password <pass>        Password (required unless --password-stdin)
-  --password-stdin          Read password from stdin (recommended)
+  --onepassword-item <i>   1Password Login item name or ID for username/password and optional OTP
+  --onepassword-vault <v>  Optional 1Password vault for --onepassword-item
+  --username <user>        Username (required unless using 1Password)
+  --username-op <ref>      Advanced: 1Password secret reference for the username (op://...)
+  --password <pass>        Password (required unless --password-stdin, --password-op, or using 1Password)
+  --password-stdin         Read password from stdin (recommended for local secrets)
+  --password-op <ref>      Advanced: 1Password secret reference for the password (op://...)
   --username-selector <s>  Custom CSS selector for username field
   --password-selector <s>  Custom CSS selector for password field
   --submit-selector <s>    Custom CSS selector for submit button
+  --otp-op <ref>           Advanced: 1Password secret reference for a TOTP/OTP code
+  --otp-selector <s>       Custom CSS selector for the OTP input
+  --otp-submit-selector <s>
+                           Custom CSS selector for the OTP submit button
 
 Login behavior:
   auth login waits for form selectors to appear before filling/clicking.
@@ -2153,6 +2184,8 @@ Global Options:
 Examples:
   echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
   agent-browser auth save github --url https://github.com/login --username user --password pass
+  agent-browser auth save github --url https://github.com/login --onepassword-item GitHub --onepassword-vault Work
+  agent-browser auth save github --url https://github.com/login --username-op op://Work/GitHub/username --password-op op://Work/GitHub/password --otp-op 'op://Work/GitHub/one-time password?attribute=otp'
   agent-browser auth login github
   agent-browser auth list
   agent-browser auth show github
@@ -3030,7 +3063,7 @@ Batch:
                               --bail stops on first error (default: continue all)
 
 Auth Vault:
-  auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)
+  auth save <name> [opts]    Save auth profile (--url, --onepassword-item/--onepassword-vault or manual/advanced secret flags)
   auth login <name>          Login using saved credentials (waits for form fields)
   auth list                  List saved auth profiles
   auth show <name>           Show auth profile metadata

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -313,17 +313,26 @@ agent-browser auth delete <name>         # Delete a saved profile
 Save options:
 
 - `--url <url>` -- login page URL (required)
-- `--username <user>` -- username (required)
-- `--password <pass>` -- password (required unless `--password-stdin`)
+- `--onepassword-item <item>` -- 1Password Login item name or ID for username/password and optional OTP
+- `--onepassword-vault <vault>` -- optional 1Password vault for `--onepassword-item`
+- `--username <user>` -- username (required unless using 1Password)
+- `--username-op <ref>` -- advanced 1Password secret reference for the username
+- `--password <pass>` -- password (required unless using `--password-stdin`, `--password-op`, or 1Password)
 - `--password-stdin` -- read password from stdin (recommended to avoid shell history exposure)
+- `--password-op <ref>` -- advanced 1Password secret reference for the password
 - `--username-selector <sel>` -- custom CSS selector for username field
 - `--password-selector <sel>` -- custom CSS selector for password field
 - `--submit-selector <sel>` -- custom CSS selector for submit button
+- `--otp-op <ref>` -- advanced 1Password secret reference for a TOTP/OTP code
+- `--otp-selector <sel>` -- custom CSS selector for the OTP input
+- `--otp-submit-selector <sel>` -- custom CSS selector for the OTP submit button
 
-`auth login` navigates with `load` and then waits for the username/password/submit selectors to appear before interacting. This improves reliability on SPA login pages where fields render after initial page load.
+`auth login` navigates with `load` and then waits for the username/password/submit selectors to appear before interacting. This improves reliability on SPA login pages where fields render after initial page load. When an OTP source is configured, `auth login` waits for the OTP input before resolving the current TOTP value from 1Password.
 
 ```bash
 echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
+agent-browser auth save github --url https://github.com/login --onepassword-item GitHub --onepassword-vault Work
+agent-browser auth save github --url https://github.com/login --username-op op://Work/GitHub/username --password-op op://Work/GitHub/password --otp-op 'op://Work/GitHub/one-time password?attribute=otp'
 agent-browser auth login github
 agent-browser auth list
 ```

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -8,7 +8,7 @@ All security features are opt-in. By default, agent-browser imposes no restricti
 
 These features are designed to mitigate the following threats when an LLM-based agent drives a browser:
 
-- **Credential exposure** -- Passwords stored in the auth vault are never included in LLM context. The CLI handles vault operations locally; credentials do not pass through the daemon's IPC channel.
+- **Credential exposure** -- Secrets stored in the auth vault are never included in LLM context. The CLI handles vault operations locally; credentials do not pass through the daemon's IPC channel. When using 1Password-backed profiles, agent-browser stores only the item name or secret reference in the profile and resolves the username, password, or OTP locally through the `op` CLI at login time.
 - **Prompt injection via page content** -- Malicious pages can embed text that looks like tool output or system instructions. Content boundary markers (`--content-boundaries`) let the orchestrator distinguish trusted tool output from untrusted page content.
 - **Unauthorized navigation / data exfiltration** -- A compromised or manipulated agent could navigate to attacker-controlled domains to exfiltrate data. The domain allowlist (`--allowed-domains`) blocks navigations, sub-resource requests, WebSocket connections, EventSource streams, and `sendBeacon` calls to non-allowed domains.
 - **Unauthorized destructive actions** -- Action policy (`--action-policy`) and confirmation gating (`--confirm-actions`) prevent the agent from performing dangerous operations (eval, downloads, uploads) without explicit approval.
@@ -24,7 +24,7 @@ These features are designed to mitigate the following threats when an LLM-based 
 
 ## Authentication Vault
 
-Store credentials locally and reference them by name. The LLM never sees passwords.
+Store credentials locally and reference them by name. The LLM never sees secrets. Profiles can store encrypted values directly, keep only a 1Password Login item name, or use field-level 1Password references that resolve at login time.
 
 ```bash
 # Save credentials (encrypted if AGENT_BROWSER_ENCRYPTION_KEY is set)
@@ -33,6 +33,12 @@ echo "pass" | agent-browser auth save github --url https://github.com/login --us
 
 # Or pass directly (a warning will be shown)
 agent-browser auth save github --url https://github.com/login --username user --password pass
+
+# Or resolve secrets from a single 1Password Login item at login time
+agent-browser auth save github \
+  --url https://github.com/login \
+  --onepassword-item GitHub \
+  --onepassword-vault Work
 
 # Login using saved credentials
 agent-browser auth login github
@@ -61,6 +67,8 @@ agent-browser auth save myapp \
 ```
 
 Profiles are stored in `~/.agent-browser/auth/` and always encrypted with AES-256-GCM. If `AGENT_BROWSER_ENCRYPTION_KEY` is not set, a key is auto-generated at `~/.agent-browser/.encryption-key` on first use. Back up this file or set the environment variable explicitly for portability.
+
+For 1Password-backed profiles, the saved JSON contains only the item name or `op://...` references; the actual username, password, or OTP is fetched locally from the signed-in `op` CLI during `auth login`.
 
 File permissions are enforced on both Unix (`chmod 600`/`700`) and Windows (`icacls` restricted to the current user) to prevent other users from reading encryption keys or auth profiles.
 

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -27,7 +27,7 @@ These features are designed to mitigate the following threats when an LLM-based 
 Store credentials locally and reference them by name. The LLM never sees secrets. Profiles can store encrypted values directly, keep only a 1Password Login item name, or use field-level 1Password references that resolve at login time.
 
 ```bash
-# Save credentials (encrypted if AGENT_BROWSER_ENCRYPTION_KEY is set)
+# Save credentials (always encrypted)
 # Recommended: pipe password via stdin to avoid shell history / process listing exposure
 echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
 
@@ -68,7 +68,7 @@ agent-browser auth save myapp \
 
 Profiles are stored in `~/.agent-browser/auth/` and always encrypted with AES-256-GCM. If `AGENT_BROWSER_ENCRYPTION_KEY` is not set, a key is auto-generated at `~/.agent-browser/.encryption-key` on first use. Back up this file or set the environment variable explicitly for portability.
 
-For 1Password-backed profiles, the saved JSON contains only the item name or `op://...` references; the actual username, password, or OTP is fetched locally from the signed-in `op` CLI during `auth login`.
+For 1Password-backed profiles, the saved JSON contains only the item name or `op://...` references; the username, password, and OTP are fetched locally from the signed-in `op` CLI during `auth login`. OTP values are resolved after the OTP input is visible so slow MFA pages do not consume most of a TOTP window before the code can be entered.
 
 File permissions are enforced on both Unix (`chmod 600`/`700`) and Windows (`icacls` restricted to the current user) to prevent other users from reading encryption keys or auth profiles.
 

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -86,7 +86,7 @@ The profile directory stores:
 
 ## Import auth from your browser
 
-If you are already logged in to a site in Chrome, you can grab that auth state and reuse it in agent-browser. This is the fastest way to bypass login flows, OAuth, SSO, or 2FA.
+If you are already logged in to a site in Chrome, you can grab that auth state and reuse it in agent-browser. This is the fastest way to bypass complex login flows, OAuth, SSO, passkeys, or 2FA.
 
 **Step 1:** Start Chrome with remote debugging:
 
@@ -127,6 +127,21 @@ agent-browser --session-name myapp state load ./my-auth.json
 ```
 
 State files contain session tokens in plaintext. Add them to `.gitignore` and delete when no longer needed. For encryption at rest, see [State encryption](#state-encryption) below.
+
+## Auth vault with 1Password-backed login
+
+If the site uses a standard username/password form and an OTP field, you can also save an auth profile and let agent-browser resolve the username, password, and optional OTP from a single 1Password Login item at login time.
+
+```bash
+agent-browser auth save myapp \
+  --url https://app.example.com/login \
+  --onepassword-item MyApp \
+  --onepassword-vault Work
+
+agent-browser auth login myapp
+```
+
+This is a good fit for password + TOTP flows. If you need non-standard fields, agent-browser still supports advanced `--username-op`, `--password-op`, and `--otp-op` references. For OAuth, SSO, passkeys, CAPTCHAs, or unusual multi-step authentication, importing browser state is still the more reliable option.
 
 ## Session persistence
 

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -199,7 +199,20 @@ agent-browser state save ./oauth-state.json
 
 ## Two-Factor Authentication
 
-Handle 2FA with manual intervention:
+For sites that use a standard OTP field, you can keep the username, password, and optional TOTP in a single 1Password Login item and let `auth login` resolve them at runtime:
+
+```bash
+agent-browser auth save myapp \
+   --url https://app.example.com/login \
+   --onepassword-item MyApp \
+   --onepassword-vault Work
+
+agent-browser auth login myapp
+```
+
+If you need field-level control, you can still use `--username-op`, `--password-op`, and `--otp-op` directly.
+
+If the site uses a non-standard flow, passkeys, push approvals, CAPTCHAs, or external MFA challenges, handle 2FA with manual intervention:
 
 ```bash
 # Login with credentials

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -199,7 +199,7 @@ agent-browser state save ./oauth-state.json
 
 ## Two-Factor Authentication
 
-For sites that use a standard OTP field, you can keep the username, password, and optional TOTP in a single 1Password Login item and let `auth login` resolve them at runtime:
+For sites that use a standard OTP field, you can keep the username, password, and optional TOTP in a single 1Password Login item and let `auth login` resolve them at runtime. OTP values are resolved after the OTP input is visible so slow MFA pages do not consume most of a TOTP window before the code can be entered:
 
 ```bash
 agent-browser auth save myapp \


### PR DESCRIPTION
Summary
- add 1Password-backed auth vault profiles with a recommended item-based flow via the onepassword-item and onepassword-vault flags
- resolve username, password, and optional OTP values locally at auth login time through the 1Password CLI
- keep username-op, password-op, and otp-op as advanced fallbacks for partial or custom 1Password setups and second factors handled outside 1Password such as SMS or email
- update CLI help, docs, skills, and tests to cover the new auth flow

Testing
- cargo fmt -- --check
- cargo test -q
- cargo clippy -q

Closes #711.