### PR TITLE
chore: patch release - ### Bug Fixes

- **Stale accessibility tree refere...

### DIFF
--- a/.changeset/release-mmr3qgkj.md
+++ b/.changeset/release-mmr3qgkj.md
@@ -1,0 +1,7 @@
+---
+"agent-browser": patch
+---
+
+### Bug Fixes
+
+- **Stale accessibility tree reference fallback** - Fixed an issue where interacting with an element whose **`backend_node_id`** had become stale (e.g. after the DOM was replaced) would fail with a `Could not compute box model` CDP error. Element resolution now re-queries the accessibility tree using role/name lookup to obtain a fresh node ID before retrying the operation (#806)


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
### Bug Fixes

- **Stale accessibility tree reference fallback** - Fixed an issue where interacting with an element whose **`backend_node_id`** had become stale (e.g. after the DOM was replaced) would fail with a `Could not compute box model` CDP error. Element resolution now re-queries the accessibility tree using role/name lookup to obtain a fresh node ID before retrying the operation (#806)

---
*This PR was created automatically by the release automation tool*