### PR TITLE
chore: patch release - ### Bug Fixes

- Fixed **video duration** being re...

### DIFF
--- a/.changeset/release-mmrrum4k.md
+++ b/.changeset/release-mmrrum4k.md
@@ -1,0 +1,13 @@
+---
+"agent-browser": patch
+---
+
+### Bug Fixes
+
+- Fixed **video duration** being reported incorrectly when using real-time ffmpeg encoding for screen recording (#812)
+- Removed obsolete **`BrowserManager` TypeScript API** references that no longer reflect the current CLI-based usage model (#821)
+
+### Documentation
+
+- Updated README to replace outdated **`BrowserManager` programmatic API** examples with the current CLI-based approach using `execSync` and `agent-browser` commands (#821)
+- Removed the **Programmatic API** section covering `BrowserManager` screencast and input injection methods, which are no longer part of the public API (#821)


### PR DESCRIPTION
## Release Changeset

**Type:** patch

**Changes:**
### Bug Fixes

- Fixed **video duration** being reported incorrectly when using real-time ffmpeg encoding for screen recording (#812)
- Removed obsolete **`BrowserManager` TypeScript API** references that no longer reflect the current CLI-based usage model (#821)

### Documentation

- Updated README to replace outdated **`BrowserManager` programmatic API** examples with the current CLI-based approach using `execSync` and `agent-browser` commands (#821)
- Removed the **Programmatic API** section covering `BrowserManager` screencast and input injection methods, which are no longer part of the public API (#821)

---
*This PR was created automatically by the release automation tool*