### PR TITLE
fix: filter chrome:// internal targets from auto-connect discovery

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -87,6 +87,14 @@ fn validate_lightpanda_options(options: &LaunchOptions) -> Result<(), String> {
     Ok(())
 }
 
+/// Returns true for Chrome internal targets that should not be selected
+/// during auto-connect (e.g. chrome://, chrome-extension://, devtools://).
+fn is_internal_chrome_target(url: &str) -> bool {
+    url.starts_with("chrome://")
+        || url.starts_with("chrome-extension://")
+        || url.starts_with("devtools://")
+}
+
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
@@ -327,7 +335,9 @@ impl BrowserManager {
             .target_infos
             .into_iter()
             .filter(|t| {
-                (t.target_type == "page" || t.target_type == "webview") && !t.url.is_empty()
+                (t.target_type == "page" || t.target_type == "webview")
+                    && !t.url.is_empty()
+                    && !is_internal_chrome_target(&t.url)
             })
             .collect();
 
@@ -1441,5 +1451,22 @@ mod tests {
             "Timed out after 10000ms waiting for Lightpanda Target domain to initialize"
         ));
         assert!(err.contains("Target.setDiscoverTargets failed"));
+    }
+
+    #[test]
+    fn test_is_internal_chrome_target() {
+        assert!(is_internal_chrome_target("chrome://newtab/"));
+        assert!(is_internal_chrome_target(
+            "chrome://omnibox-popup.top-chrome/"
+        ));
+        assert!(is_internal_chrome_target(
+            "chrome-extension://abc123/popup.html"
+        ));
+        assert!(is_internal_chrome_target(
+            "devtools://devtools/bundled/inspector.html"
+        ));
+        assert!(!is_internal_chrome_target("https://example.com"));
+        assert!(!is_internal_chrome_target("http://localhost:3000"));
+        assert!(!is_internal_chrome_target("about:blank"));
     }
 }


### PR DESCRIPTION
## Summary

Filter out Chrome internal targets (`chrome://`, `chrome-extension://`, `devtools://`) during `--auto-connect` target discovery so follow-up commands operate on user-facing pages instead of internal Chrome pages.

## Problem

When using `--auto-connect`, `discover_and_attach_targets()` enumerates all browser targets and selects the first one with `target_type == "page"` and a non-empty URL. Chrome internal pages like `chrome://omnibox-popup.top-chrome/` satisfy both conditions and get selected as the active target.

This causes follow-up commands to return wrong data:
- `agent-browser --auto-connect get url` returns `chrome://omnibox-popup.top-chrome/`
- `agent-browser --auto-connect snapshot -i` returns `origin=about:blank` with no interactive elements

Reported by [@zbeyens](https://github.com/vercel-labs/agent-browser/issues/813#issuecomment-3041889247): "follow-up commands attach to the wrong target... It looks like `--auto-connect` is latching onto Chrome internal targets like `chrome://omnibox-popup.top-chrome/` instead of the actual app tab."

## Changes

- Add `is_internal_chrome_target()` helper that matches `chrome://`, `chrome-extension://`, and `devtools://` URL prefixes
- Add the filter to the target discovery pipeline in `discover_and_attach_targets()`
- If all targets are internal, the existing "create a new tab" fallback handles it correctly
- Add unit test covering both positive and negative cases

## Testing

- `cargo fmt --check` passes
- `cargo clippy -- -D warnings` passes
- All 436 existing tests pass, plus the new `test_is_internal_chrome_target` test

Fixes #813

This contribution was developed with AI assistance (Claude Code).