### PR TITLE
Enhance Chrome launch process with user-data-dir and timeout

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -346,31 +346,6 @@ fn wait_for_ws_url_until(
     ))
 }
 
-fn wait_for_ws_url(reader: BufReader<std::process::ChildStderr>) -> Result<String, String> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    let prefix = "DevTools listening on ";
-    let mut stderr_lines: Vec<String> = Vec::new();
-
-    for line in reader.lines() {
-        if std::time::Instant::now() > deadline {
-            return Err(chrome_launch_error(
-                "Timeout waiting for Chrome DevTools URL",
-                &stderr_lines,
-            ));
-        }
-        let line = line.map_err(|e| format!("Failed to read Chrome stderr: {}", e))?;
-        if let Some(url) = line.strip_prefix(prefix) {
-            return Ok(url.trim().to_string());
-        }
-        stderr_lines.push(line);
-    }
-
-    Err(chrome_launch_error(
-        "Chrome exited before providing DevTools URL",
-        &stderr_lines,
-    ))
-}
-
 fn chrome_launch_error(message: &str, stderr_lines: &[String]) -> String {
     let relevant: Vec<&String> = stderr_lines
         .iter()


### PR DESCRIPTION
<img width="1916" height="118" alt="image" src="https://github.com/user-attachments/assets/e2460950-c4cb-4c49-b72b-67b97dc34846" />

# Pull Request: Fix flaky Chrome auto-launch on Windows (DevTools URL discovery)

## Summary
This PR fixes a flaky Chrome auto-launch issue where `agent-browser open ...` could fail with:

> `Auto-launch failed: Chrome exited before providing DevTools URL (no stderr output from Chrome)`

On Windows, Chrome does not reliably emit `DevTools listening on ...` to **stderr**. The previous launch flow depended on scraping stderr for that line, which caused intermittent failures and a user-visible workaround: running `close` before `open`.

## What changed
### ✅ Prefer `DevToolsActivePort` over stderr scraping
We now treat `DevToolsActivePort` in the selected `--user-data-dir` as the primary source of truth for the DevTools WebSocket URL.

- Chrome is launched with `--remote-debugging-port=0` and a known `--user-data-dir`.
- Chrome writes `DevToolsActivePort` into that directory once the debug endpoint is ready.
- We poll that file (up to 30s) and build the WebSocket URL as:

`ws://127.0.0.1:<port><ws_path>`

### 🔁 Keep stderr parsing as a fallback
If `DevToolsActivePort` is not observed within the timeout, we fall back to the legacy behavior of parsing stderr for:

`DevTools listening on ...`

This preserves compatibility and still provides helpful diagnostics.

## Files changed
- `cli/src/native/cdp/chrome.rs`
  - Added `wait_for_devtools_active_port(...)`
  - Updated `try_launch_chrome(...)` to:
    1. Poll `DevToolsActivePort`
    2. Fallback to stderr scraping

## Why this fixes the “must close first” behavior
The failure mode was not that Chrome *must* be closed first, but that the tool’s launch handshake relied on stderr output that is sometimes missing. Using `DevToolsActivePort` makes readiness detection deterministic and independent of Chrome’s stderr behavior.

## Testing
- Built successfully: `cargo build` (Windows)
- Manual verification:
  - Repeated runs of `agent-browser open <url>` should no longer require an explicit `agent-browser close` beforehand.

## Notes / Follow-ups
- If desired, we can further improve error reporting by including the chosen `--user-data-dir` path and whether `DevToolsActivePort` ever appeared (helpful for diagnosing profile permission/lock issues).

