### PR TITLE
fix: fall back to /json/list when /json/version is unavailable

### DIFF
--- a/cli/src/native/cdp/discovery.rs
+++ b/cli/src/native/cdp/discovery.rs
@@ -24,19 +24,26 @@ pub async fn discover_cdp_url_with_timeout(
     timeout: Duration,
 ) -> Result<String, String> {
     // Primary: /json/version (standard path)
-    if let Ok(info) = fetch_cdp_info(host, port, timeout).await {
-        if let Some(ws_url) = info.web_socket_debugger_url {
-            return Ok(rewrite_ws_host(&ws_url, host, port));
+    let version_err = match fetch_cdp_info(host, port, timeout).await {
+        Ok(info) => {
+            if let Some(ws_url) = info.web_socket_debugger_url {
+                return Ok(rewrite_ws_host(&ws_url, host, port));
+            }
+            format!(
+                "No webSocketDebuggerUrl in /json/version at {}:{}",
+                host, port
+            )
         }
-    }
+        Err(e) => e,
+    };
 
     // Fallback: /json/list (returns target list; look for the browser target)
     match fetch_cdp_list(host, port, timeout).await {
         Ok(ws_url) => Ok(rewrite_ws_host(&ws_url, host, port)),
-        Err(list_err) => Err(format!(
-            "CDP discovery failed at {}:{}: /json/version unavailable and /json/list fallback failed: {}",
-            host, port, list_err
-        )),
+        Err(_) => {
+            // Return the original /json/version error since that's the primary path
+            Err(version_err)
+        }
     }
 }
 
@@ -154,9 +161,9 @@ mod tests {
         let (port, server) = spawn_json_server("not-json").await;
 
         let err = discover_cdp_url("127.0.0.1", port).await.unwrap_err();
-        // /json/version returns invalid JSON, so discovery falls through to
-        // /json/list which also fails (server closed after one request)
-        assert!(err.contains("CDP discovery failed"));
+        // /json/version returns invalid JSON; /json/list also fails (server
+        // closed), so the original /json/version error is returned
+        assert!(err.contains("Invalid /json/version response"));
         server.await.unwrap();
     }
 


### PR DESCRIPTION
## Summary

When Chrome's UI-based remote debugging is enabled (the permission dialog flow), it only exposes a WebSocket endpoint - the `/json/version` HTTP endpoint returns 404. Discovery now tries `/json/version` first, then falls back to `/json/list` to find the browser target's WebSocket URL.

## Changes

- `discovery.rs`: `discover_cdp_url_with_timeout` now catches `/json/version` failures and falls back to `/json/list`
- Added `fetch_cdp_list` function that queries `/json/list` and extracts the `webSocketDebuggerUrl` from the browser target
- Updated existing test to reflect the fallback behavior
- Added test for the 404-to-list fallback path

## Testing

- `cargo test -- discovery` passes all 5 tests
- `cargo fmt --check` and `cargo clippy` clean

Fixes #628

This contribution was developed with AI assistance (Claude Code).