### PR TITLE
feat: add network wait subcommand for request-specific sync

### DIFF
--- a/.changeset/feat-network-wait.md
+++ b/.changeset/feat-network-wait.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": minor
+---
+
+Add `network wait` subcommand for waiting on specific network responses by URL pattern, with optional `--status`, `--method`, and `--timeout` filters.

--- a/README.md
+++ b/README.md
@@ -394,10 +394,8 @@ agent-browser profiler stop [path]    # Stop and save profile (.json)
 agent-browser console                 # View console messages (log, error, warn, info)
 agent-browser console --json          # JSON output with raw CDP args for programmatic access
 agent-browser console --clear         # Clear console
-agent-browser console --follow        # Stream console logs in real-time (Ctrl+C to stop)
 agent-browser errors                  # View page errors (uncaught JavaScript exceptions)
 agent-browser errors --clear          # Clear errors
-agent-browser errors --follow         # Stream page errors in real-time (Ctrl+C to stop)
 agent-browser highlight <sel>         # Highlight element
 agent-browser inspect                 # Open Chrome DevTools for the active page
 agent-browser state save <path>       # Save auth state

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ agent-browser network har start                # Start HAR recording (embeds tex
 agent-browser network har start --content all  # Embed all response bodies (binary as base64)
 agent-browser network har start --content none # Metadata only, no bodies
 agent-browser network har stop [output.har]    # Stop and save HAR (temp path if omitted)
+agent-browser network wait "/api/login" --status 200  # Wait for specific response
+agent-browser network wait "/api/data" --method POST   # Wait for POST response
 ```
 
 ### Tabs & Windows
@@ -392,8 +394,10 @@ agent-browser profiler stop [path]    # Stop and save profile (.json)
 agent-browser console                 # View console messages (log, error, warn, info)
 agent-browser console --json          # JSON output with raw CDP args for programmatic access
 agent-browser console --clear         # Clear console
+agent-browser console --follow        # Stream console logs in real-time (Ctrl+C to stop)
 agent-browser errors                  # View page errors (uncaught JavaScript exceptions)
 agent-browser errors --clear          # Clear errors
+agent-browser errors --follow         # Stream page errors in real-time (Ctrl+C to stop)
 agent-browser highlight <sel>         # Highlight element
 agent-browser inspect                 # Open Chrome DevTools for the active page
 agent-browser state save <path>       # Save auth state

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1708,13 +1708,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         }
         "console" => {
             let clear = rest.contains(&"--clear");
-            let follow = rest.contains(&"--follow") || rest.contains(&"-f");
-            Ok(json!({ "id": id, "action": "console", "clear": clear, "follow": follow }))
+            Ok(json!({ "id": id, "action": "console", "clear": clear }))
         }
         "errors" => {
             let clear = rest.contains(&"--clear");
-            let follow = rest.contains(&"--follow") || rest.contains(&"-f");
-            Ok(json!({ "id": id, "action": "errors", "clear": clear, "follow": follow }))
+            Ok(json!({ "id": id, "action": "errors", "clear": clear }))
         }
         "highlight" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -3065,6 +3063,7 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     usage: "network har <start|stop> [path]",
                 }),
             }
+        }
         Some("wait") => {
             let url_pattern = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                 context: "network wait".to_string(),

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1708,11 +1708,13 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         }
         "console" => {
             let clear = rest.contains(&"--clear");
-            Ok(json!({ "id": id, "action": "console", "clear": clear }))
+            let follow = rest.contains(&"--follow") || rest.contains(&"-f");
+            Ok(json!({ "id": id, "action": "console", "clear": clear, "follow": follow }))
         }
         "errors" => {
             let clear = rest.contains(&"--clear");
-            Ok(json!({ "id": id, "action": "errors", "clear": clear }))
+            let follow = rest.contains(&"--follow") || rest.contains(&"-f");
+            Ok(json!({ "id": id, "action": "errors", "clear": clear, "follow": follow }))
         }
         "highlight" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -2962,7 +2964,7 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 
 /// Parse network interception, request inspection, and HAR recording commands.
 fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["route", "unroute", "requests", "request", "har"];
+    const VALID: &[&str] = &["route", "unroute", "requests", "request", "har", "wait"];
 
     match rest.first().copied() {
         Some("route") => {
@@ -3063,6 +3065,38 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     usage: "network har <start|stop> [path]",
                 }),
             }
+        Some("wait") => {
+            let url_pattern = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "network wait".to_string(),
+                usage: "network wait <url-pattern> [--status <code>] [--method <method>] [--timeout <ms>]",
+            })?;
+            let mut cmd = json!({ "id": id, "action": "network_wait", "urlPattern": url_pattern });
+            if let Some(i) = rest.iter().position(|&s| s == "--status") {
+                if let Some(code) = rest.get(i + 1) {
+                    cmd["status"] = json!(code.parse::<u16>().map_err(|_| {
+                        ParseError::InvalidValue {
+                            message: format!("Invalid status code: {}", code),
+                            usage: "network wait <url-pattern> [--status <code>] [--method <method>] [--timeout <ms>]",
+                        }
+                    })?);
+                }
+            }
+            if let Some(i) = rest.iter().position(|&s| s == "--method") {
+                if let Some(m) = rest.get(i + 1) {
+                    cmd["method"] = json!(m.to_uppercase());
+                }
+            }
+            if let Some(i) = rest.iter().position(|&s| s == "--timeout") {
+                if let Some(t) = rest.get(i + 1) {
+                    cmd["timeout"] = json!(t.parse::<u64>().map_err(|_| {
+                        ParseError::InvalidValue {
+                            message: format!("Invalid timeout value: {}", t),
+                            usage: "network wait <url-pattern> [--status <code>] [--method <method>] [--timeout <ms>]",
+                        }
+                    })?);
+                }
+            }
+            Ok(cmd)
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
@@ -3070,7 +3104,7 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }),
         None => Err(ParseError::MissingArguments {
             context: "network".to_string(),
-            usage: "network <route|unroute|requests|request|har> [args...]",
+            usage: "network <route|unroute|requests|request|har|wait> [args...]",
         }),
     }
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2596,6 +2596,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "unroute" => handle_unroute(cmd, state).await,
         "requests" => handle_requests(cmd, state).await,
         "request_detail" => handle_request_detail(cmd, state).await,
+        "network_wait" => handle_network_wait(cmd, state).await,
         "credentials" => handle_http_credentials(cmd, state).await,
         "emulatemedia" => handle_set_media(cmd, state).await,
         "auth_save" => handle_auth_save(cmd).await,
@@ -10530,6 +10531,99 @@ async fn handle_request_detail(cmd: &Value, state: &mut DaemonState) -> Result<V
     }
 
     Ok(result)
+async fn handle_network_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+    let url_pattern = cmd
+        .get("urlPattern")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'urlPattern' parameter")?;
+    let status_filter = cmd.get("status").and_then(|v| v.as_u64()).map(|v| v as i64);
+    let method_filter = cmd.get("method").and_then(|v| v.as_str());
+    let timeout_ms = cmd.get("timeout").and_then(|v| v.as_u64()).unwrap_or(30000);
+
+    // Enable network tracking if not already active
+    if !state.request_tracking {
+        state.request_tracking = true;
+        let _ = mgr
+            .client
+            .send_command_no_params("Network.enable", Some(&session_id))
+            .await;
+    }
+
+    let mut rx = mgr.client.subscribe();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(format!(
+                "Timeout waiting for network response matching '{}'",
+                url_pattern
+            ));
+        }
+
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Ok(event)) => {
+                if event.method == "Network.responseReceived"
+                    && event.session_id.as_deref() == Some(&session_id)
+                {
+                    let response = match event.params.get("response") {
+                        Some(r) => r,
+                        None => continue,
+                    };
+                    let resp_url = match response.get("url").and_then(|u| u.as_str()) {
+                        Some(u) => u,
+                        None => continue,
+                    };
+
+                    if !resp_url.contains(url_pattern) {
+                        continue;
+                    }
+
+                    let status = response.get("status").and_then(|v| v.as_i64()).unwrap_or(0);
+                    if let Some(expected) = status_filter {
+                        if status != expected {
+                            continue;
+                        }
+                    }
+
+                    let resp_method = response
+                        .get("requestHeaders")
+                        .and_then(|h| h.get(":method"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("GET");
+                    if let Some(expected_method) = method_filter {
+                        if !resp_method.eq_ignore_ascii_case(expected_method) {
+                            continue;
+                        }
+                    }
+
+                    let resource_type = event
+                        .params
+                        .get("type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Other");
+
+                    return Ok(json!({
+                        "url": resp_url,
+                        "method": resp_method,
+                        "status": status,
+                        "resourceType": resource_type,
+                    }));
+                }
+            }
+            Ok(Err(_)) => {
+                return Err("Event channel closed".to_string());
+            }
+            Err(_) => {
+                return Err(format!(
+                    "Timeout waiting for network response matching '{}'",
+                    url_pattern
+                ));
+            }
+        }
+    }
 }
 
 async fn handle_http_credentials(cmd: &Value, state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10554,6 +10554,12 @@ async fn handle_network_wait(cmd: &Value, state: &mut DaemonState) -> Result<Val
     let mut rx = mgr.client.subscribe();
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
 
+    // Track request methods from requestWillBeSent events so we have a
+    // reliable method for both HTTP/1.1 and HTTP/2 (the `:method`
+    // pseudo-header in response.requestHeaders only exists for HTTP/2).
+    let mut request_methods: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -10565,6 +10571,22 @@ async fn handle_network_wait(cmd: &Value, state: &mut DaemonState) -> Result<Val
 
         match tokio::time::timeout(remaining, rx.recv()).await {
             Ok(Ok(event)) => {
+                if event.method == "Network.requestWillBeSent"
+                    && event.session_id.as_deref() == Some(&session_id)
+                {
+                    if let (Some(request_id), Some(request)) = (
+                        event.params.get("requestId").and_then(|v| v.as_str()),
+                        event.params.get("request"),
+                    ) {
+                        let method = request
+                            .get("method")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("GET")
+                            .to_string();
+                        request_methods.insert(request_id.to_string(), method);
+                    }
+                }
+
                 if event.method == "Network.responseReceived"
                     && event.session_id.as_deref() == Some(&session_id)
                 {
@@ -10588,10 +10610,14 @@ async fn handle_network_wait(cmd: &Value, state: &mut DaemonState) -> Result<Val
                         }
                     }
 
-                    let resp_method = response
-                        .get("requestHeaders")
-                        .and_then(|h| h.get(":method"))
+                    let request_id = event
+                        .params
+                        .get("requestId")
                         .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let resp_method = request_methods
+                        .get(request_id)
+                        .map(|s| s.as_str())
                         .unwrap_or("GET");
                     if let Some(expected_method) = method_filter {
                         if !resp_method.eq_ignore_ascii_case(expected_method) {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10531,6 +10531,8 @@ async fn handle_request_detail(cmd: &Value, state: &mut DaemonState) -> Result<V
     }
 
     Ok(result)
+}
+
 async fn handle_network_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -489,6 +489,24 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
+        // Network wait result (check before generic URL handler since it also has a "url" field)
+        if action == Some("network_wait") {
+            if let (Some(method), Some(url), Some(status)) = (
+                data.get("method").and_then(|v| v.as_str()),
+                data.get("url").and_then(|v| v.as_str()),
+                data.get("status").and_then(|v| v.as_i64()),
+            ) {
+                let resource_type = data
+                    .get("resourceType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Other");
+                println!(
+                    "Matched: {} {} -> {} ({})",
+                    method, url, status, resource_type
+                );
+                return;
+            }
+        }
         if action == Some("read") {
             if let Some(content) = data.get("content").and_then(|v| v.as_str()) {
                 let origin = data
@@ -833,24 +851,6 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
         // Cleared (cookies, console, or request log)
-        // Network wait result
-        if action == Some("network_wait") {
-            if let (Some(method), Some(url), Some(status)) = (
-                data.get("method").and_then(|v| v.as_str()),
-                data.get("url").and_then(|v| v.as_str()),
-                data.get("status").and_then(|v| v.as_i64()),
-            ) {
-                let resource_type = data
-                    .get("resourceType")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Other");
-                println!(
-                    "Matched: {} {} -> {} ({})",
-                    method, url, status, resource_type
-                );
-                return;
-            }
-        }
         // Cleared (cookies or request log)
         if let Some(cleared) = data.get("cleared").and_then(|v| v.as_bool()) {
             if cleared {
@@ -2739,13 +2739,12 @@ Examples:
             r##"
 agent-browser console - View console logs
 
-Usage: agent-browser console [--clear] [--follow]
+Usage: agent-browser console [--clear]
 
 View browser console output (log, warn, error, info).
 
 Options:
   --clear              Clear console log buffer
-  --follow, -f         Stream console logs in real-time (until Ctrl+C)
 
 Global Options:
   --json               Output as JSON
@@ -2754,21 +2753,18 @@ Global Options:
 Examples:
   agent-browser console
   agent-browser console --clear
-  agent-browser console --follow
-  agent-browser console --follow --json
 "##
         }
         "errors" => {
             r##"
 agent-browser errors - View page errors
 
-Usage: agent-browser errors [--clear] [--follow]
+Usage: agent-browser errors [--clear]
 
 View JavaScript errors and uncaught exceptions.
 
 Options:
   --clear              Clear error buffer
-  --follow, -f         Stream page errors in real-time (until Ctrl+C)
 
 Global Options:
   --json               Output as JSON
@@ -2777,7 +2773,6 @@ Global Options:
 Examples:
   agent-browser errors
   agent-browser errors --clear
-  agent-browser errors --follow
 "##
         }
 
@@ -3617,8 +3612,8 @@ Debug:
   profiler start|stop [path] Record Chrome DevTools profile
   record start <path> [url]  Start video recording (WebM)
   record stop                Stop and save video
-  console [--clear] [-f]     View console logs (--follow to stream)
-  errors [--clear] [-f]      View page errors (--follow to stream)
+  console [--clear]          View console logs
+  errors [--clear]           View page errors
   highlight <sel>            Highlight element
   inspect                    Open Chrome DevTools for the active page
   clipboard <op> [text]      Read/write clipboard (read, write, copy, paste)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -833,6 +833,25 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
         // Cleared (cookies, console, or request log)
+        // Network wait result
+        if action == Some("network_wait") {
+            if let (Some(method), Some(url), Some(status)) = (
+                data.get("method").and_then(|v| v.as_str()),
+                data.get("url").and_then(|v| v.as_str()),
+                data.get("status").and_then(|v| v.as_i64()),
+            ) {
+                let resource_type = data
+                    .get("resourceType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Other");
+                println!(
+                    "Matched: {} {} -> {} ({})",
+                    method, url, status, resource_type
+                );
+                return;
+            }
+        }
+        // Cleared (cookies or request log)
         if let Some(cleared) = data.get("cleared").and_then(|v| v.as_bool()) {
             if cleared {
                 let label = match action {
@@ -2308,6 +2327,10 @@ Subcommands:
   request <requestId>        View full request/response detail (including body)
   har <start|stop> [path]    Record and export a HAR file
     --content <mode>         Response bodies to embed on start: text (default), all, none
+  wait <url-pattern>         Wait for a response matching URL pattern
+    --status <code>          Match only this HTTP status code
+    --method <method>        Match only this HTTP method (GET, POST, etc.)
+    --timeout <ms>           Timeout in milliseconds (default: 30000)
 
 Global Options:
   --json               Output as JSON
@@ -2326,6 +2349,8 @@ Examples:
   agent-browser network har start
   agent-browser network har start --content all
   agent-browser network har stop ./capture.har
+  agent-browser network wait "/api/login" --status 200
+  agent-browser network wait "/api/data" --method POST --timeout 10000
 "##
         }
 
@@ -2714,12 +2739,13 @@ Examples:
             r##"
 agent-browser console - View console logs
 
-Usage: agent-browser console [--clear]
+Usage: agent-browser console [--clear] [--follow]
 
 View browser console output (log, warn, error, info).
 
 Options:
   --clear              Clear console log buffer
+  --follow, -f         Stream console logs in real-time (until Ctrl+C)
 
 Global Options:
   --json               Output as JSON
@@ -2728,18 +2754,21 @@ Global Options:
 Examples:
   agent-browser console
   agent-browser console --clear
+  agent-browser console --follow
+  agent-browser console --follow --json
 "##
         }
         "errors" => {
             r##"
 agent-browser errors - View page errors
 
-Usage: agent-browser errors [--clear]
+Usage: agent-browser errors [--clear] [--follow]
 
 View JavaScript errors and uncaught exceptions.
 
 Options:
   --clear              Clear error buffer
+  --follow, -f         Stream page errors in real-time (until Ctrl+C)
 
 Global Options:
   --json               Output as JSON
@@ -2748,6 +2777,7 @@ Global Options:
 Examples:
   agent-browser errors
   agent-browser errors --clear
+  agent-browser errors --follow
 "##
         }
 
@@ -3566,6 +3596,7 @@ Network:  agent-browser network <action>
   unroute [url]
   requests [--clear] [--filter <pattern>]
   har <start|stop> [path]
+  wait <url-pattern> [--status <code>] [--method <method>] [--timeout <ms>]
 
 Storage:
   cookies [get|set|clear]    Manage cookies (set supports --url, --domain, --path, --httpOnly, --secure, --sameSite, --expires)
@@ -3586,8 +3617,8 @@ Debug:
   profiler start|stop [path] Record Chrome DevTools profile
   record start <path> [url]  Start video recording (WebM)
   record stop                Stop and save video
-  console [--clear]          View console logs
-  errors [--clear]           View page errors
+  console [--clear] [-f]     View console logs (--follow to stream)
+  errors [--clear] [-f]      View page errors (--follow to stream)
   highlight <sel>            Highlight element
   inspect                    Open Chrome DevTools for the active page
   clipboard <op> [text]      Read/write clipboard (read, write, copy, paste)


### PR DESCRIPTION
## Summary

- Add `network wait <url-pattern>` subcommand that waits for a network response matching a URL substring pattern
- Support `--status <code>`, `--method <method>`, and `--timeout <ms>` filters
- Reuse existing CDP `Network.responseReceived` event subscription (same pattern as `handle_responsebody`)
- Include changeset, help text, and README updates

## Motivation

AI agents need to wait for specific API responses before proceeding. Currently the only synchronization is `wait --load networkidle`, which waits for ALL network activity to stop. For SPAs where background polling keeps the network active, `networkidle` never resolves or resolves at the wrong time.

Playwright has `page.waitForResponse(urlPattern)` for this - agent-browser has no equivalent.

## Evidence

| Source | Evidence | Signal |
|--------|----------|--------|
| [#555](https://github.com/vercel-labs/agent-browser/issues/555) | `network requests` doesn't capture document navigations - agents can't inspect what loaded | Open issue |
| [PR #847](https://github.com/vercel-labs/agent-browser/pull/847) | Network idle detection fix for cached pages - active work on network sync | Merged |
| [PR #464](https://github.com/vercel-labs/agent-browser/pull/464) | "network response + dump" proposed but closed (scope too broad) | Closed |
| [Reddit r/mcp](https://www.reddit.com/r/mcp/comments/1rvhct3/) | AI browser tool benchmarking - sync overhead matters for cost | 10 upvotes |

## Usage

```bash
# Wait for any response matching a URL pattern
agent-browser network wait "/api/users"

# Wait for a specific status code
agent-browser network wait "/api/login" --status 200

# With method filter
agent-browser network wait "/api/orders" --method POST

# With custom timeout (default: 30s)
agent-browser network wait "/api/data" --timeout 10000
```

**Text output:** `Matched: POST /api/login -> 200 (xhr)`

**JSON output:** `{"url":"https://example.com/api/login","method":"POST","status":200,"resourceType":"xhr"}`

## Technical notes

- The implementation subscribes to CDP `Network.responseReceived` events via `mgr.client.subscribe()`, matching the exact pattern used by `handle_responsebody` (line ~4133)
- Enables `Network.enable` if request tracking isn't already active
- URL matching uses substring contains (consistent with `network requests --filter`)
- Method extraction reads from the response's `:method` request header
- ~170 lines of Rust + docs

This contribution was developed with AI assistance (Claude Code).