### PR TITLE
feat(cli): add media commands for audio/video playback control

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1323,6 +1323,20 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             Ok(json!({ "id": id, "action": "batch", "bail": bail }))
         }
 
+        // === Media ===
+        "media" => {
+            const VALID: &[&str] = &["status", "pause", "play"];
+            match rest.first().copied() {
+                Some("status") | None => Ok(json!({ "id": id, "action": "media_status" })),
+                Some("pause") => Ok(json!({ "id": id, "action": "media_pause" })),
+                Some("play") => Ok(json!({ "id": id, "action": "media_play" })),
+                Some(sub) => Err(ParseError::UnknownSubcommand {
+                    subcommand: sub.to_string(),
+                    valid_options: VALID,
+                }),
+            }
+        }
+
         _ => Err(ParseError::UnknownCommand {
             command: cmd.to_string(),
         }),
@@ -4032,5 +4046,31 @@ mod tests {
         let cmd = parse_command(&args("batch --bail"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "batch");
         assert_eq!(cmd["bail"], true);
+    }
+
+    // === Media ===
+
+    #[test]
+    fn test_media_status() {
+        let cmd = parse_command(&args("media status"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "media_status");
+    }
+
+    #[test]
+    fn test_media_default_is_status() {
+        let cmd = parse_command(&args("media"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "media_status");
+    }
+
+    #[test]
+    fn test_media_pause() {
+        let cmd = parse_command(&args("media pause"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "media_pause");
+    }
+
+    #[test]
+    fn test_media_play() {
+        let cmd = parse_command(&args("media play"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "media_play");
     }
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -856,6 +856,9 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "mousemove" => handle_mousemove(cmd, state).await,
         "mousedown" => handle_mousedown(cmd, state).await,
         "mouseup" => handle_mouseup(cmd, state).await,
+        "media_status" => handle_media_status(state).await,
+        "media_pause" => handle_media_pause(state).await,
+        "media_play" => handle_media_play(state).await,
         _ => Err(format!("Not yet implemented: {}", action)),
     };
 
@@ -2562,6 +2565,109 @@ async fn handle_keyboard(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
         .await?;
 
     Ok(json!({ "dispatched": event_type }))
+}
+
+// ---------------------------------------------------------------------------
+// Media playback handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_media_status(state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let js = r#"(() => {
+        const elements = [...document.querySelectorAll('audio, video')];
+        return elements.map((el, i) => ({
+            index: i,
+            tagName: el.tagName.toLowerCase(),
+            src: el.currentSrc || el.src || '',
+            paused: el.paused,
+            currentTime: el.currentTime,
+            duration: el.duration,
+            muted: el.muted,
+            volume: el.volume,
+            loop: el.loop,
+        }));
+    })()"#;
+
+    let result = mgr
+        .client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({ "expression": js, "returnByValue": true })),
+            Some(&session_id),
+        )
+        .await?;
+
+    let media = result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    Ok(json!({ "media": media }))
+}
+
+async fn handle_media_pause(state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let js = r#"(() => {
+        const elements = [...document.querySelectorAll('audio, video')];
+        let count = 0;
+        elements.forEach(el => { if (!el.paused) { el.pause(); count++; } });
+        return count;
+    })()"#;
+
+    let result = mgr
+        .client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({ "expression": js, "returnByValue": true })),
+            Some(&session_id),
+        )
+        .await?;
+
+    let paused_count = result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    Ok(json!({ "paused": paused_count }))
+}
+
+async fn handle_media_play(state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let js = r#"(async () => {
+        const elements = [...document.querySelectorAll('audio, video')];
+        let count = 0;
+        for (const el of elements) {
+            if (el.paused) {
+                try { await el.play(); count++; } catch(e) {}
+            }
+        }
+        return count;
+    })()"#;
+
+    let result = mgr
+        .client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({ "expression": js, "returnByValue": true, "awaitPromise": true })),
+            Some(&session_id),
+        )
+        .await?;
+
+    let played_count = result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    Ok(json!({ "played": played_count }))
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -319,6 +319,52 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
+        // Media elements
+        if let Some(media) = data.get("media").and_then(|v| v.as_array()) {
+            if media.is_empty() {
+                println!("No media elements found");
+            } else {
+                for el in media {
+                    let idx = el.get("index").and_then(|v| v.as_i64()).unwrap_or(0);
+                    let tag = el
+                        .get("tagName")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let paused = el.get("paused").and_then(|v| v.as_bool()).unwrap_or(true);
+                    let state_str = if paused { "paused" } else { "playing" };
+                    let current = el
+                        .get("currentTime")
+                        .and_then(|v| v.as_f64())
+                        .unwrap_or(0.0);
+                    let duration = el.get("duration").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                    let src = el.get("src").and_then(|v| v.as_str()).unwrap_or("");
+                    println!(
+                        "[{}] <{}> {} {:.1}s/{:.1}s {}",
+                        idx, tag, state_str, current, duration, src
+                    );
+                }
+            }
+            return;
+        }
+        // Media pause/play result
+        if let Some(count) = data.get("paused").and_then(|v| v.as_i64()) {
+            println!(
+                "{} Paused {} media element{}",
+                color::success_indicator(),
+                count,
+                if count == 1 { "" } else { "s" }
+            );
+            return;
+        }
+        if let Some(count) = data.get("played").and_then(|v| v.as_i64()) {
+            println!(
+                "{} Resumed {} media element{}",
+                color::success_indicator(),
+                count,
+                if count == 1 { "" } else { "s" }
+            );
+            return;
+        }
         // Console logs
         if let Some(logs) = data.get("messages").and_then(|v| v.as_array()) {
             if opts.content_boundaries {
@@ -2459,6 +2505,32 @@ Examples:
 "##
         }
 
+        // === Media ===
+        "media" => {
+            r##"
+agent-browser media - Control audio/video playback
+
+Usage: agent-browser media [operation]
+
+Detect and control audio/video media elements on the page.
+
+Operations:
+  status               List all media elements with playback state (default)
+  pause                Pause all playing media
+  play                 Resume all paused media
+
+Global Options:
+  --json               Output as JSON
+  --session <name>     Use specific session
+
+Examples:
+  agent-browser media
+  agent-browser media status
+  agent-browser media pause
+  agent-browser media play
+"##
+        }
+
         _ => return false,
     };
     println!("{}", help.trim());
@@ -2533,6 +2605,9 @@ Storage:
 
 Tabs:
   tab [new|list|close|<n>]   Manage tabs
+
+Media:
+  media [status|pause|play]  Control audio/video playback
 
 Diff:
   diff snapshot              Compare current vs last snapshot


### PR DESCRIPTION
## Summary

Add `media` commands to detect and control audio/video playback state on the page.

- `agent-browser media status` - list all media elements with playing/paused state, currentTime, duration
- `agent-browser media pause` - pause all playing media
- `agent-browser media play` - resume all paused media

Closes #644

## Evidence

| Signal | Source |
|--------|--------|
| Issue #644 | "Feature request: add audio/sound support for media playback verification" - 11 reactions, maintainer said "we'll definitely consider this" |
| No prior PR | First focused implementation |
| [YouTube](https://www.youtube.com/watch?v=GPb4woYA_8s) | "Agent Browser: The CLI That Gives AI Agents Eyes on the Web" - media testing noted as gap | 15K views |
| [Issue #66](https://github.com/vercel-labs/agent-browser/issues/66) | Video recording support request | 11 reactions |

## Implementation

Uses `Runtime.evaluate` with JavaScript that queries all `<audio>` and `<video>` elements. For status, reads `paused`, `currentTime`, `duration`, `volume`, `muted`, `loop`, and `src`. For play/pause, calls the native `.play()` / `.pause()` methods.

### Files changed
- `cli/src/commands.rs` - `media` command parser with `status`/`pause`/`play` subcommands
- `cli/src/native/actions.rs` - three CDP handlers using Runtime.evaluate
- `cli/src/output.rs` - human-readable output for media status and play/pause results

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (477 tests, 0 failures)
- [ ] Manual: `agent-browser media status` on page with video
- [ ] Manual: `agent-browser media pause` pauses playback
- [ ] Manual: `agent-browser media play` resumes playback

This contribution was developed with AI assistance (Claude Code).