### PR TITLE
feat(cli): add network response subcommand for body capture

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2044,7 +2044,7 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 
 /// Parse network interception, request inspection, and HAR recording commands.
 fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["route", "unroute", "requests", "har"];
+    const VALID: &[&str] = &["route", "unroute", "requests", "response", "har"];
 
     match rest.first().copied() {
         Some("route") => {
@@ -2071,6 +2071,19 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             let mut cmd = json!({ "id": id, "action": "requests", "clear": clear });
             if let Some(f) = filter {
                 cmd["filter"] = json!(f);
+            }
+            Ok(cmd)
+        }
+        Some("response") => {
+            let url = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "network response".to_string(),
+                usage: "network response <url-pattern> [--timeout <ms>]",
+            })?;
+            let mut cmd = json!({ "id": id, "action": "responsebody", "url": url });
+            if let Some(idx) = rest.iter().position(|&s| s == "--timeout") {
+                if let Some(ms) = rest.get(idx + 1).and_then(|s| s.parse::<u64>().ok()) {
+                    cmd["timeout"] = json!(ms);
+                }
             }
             Ok(cmd)
         }
@@ -2101,7 +2114,7 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }),
         None => Err(ParseError::MissingArguments {
             context: "network".to_string(),
-            usage: "network <route|unroute|requests|har> [args...]",
+            usage: "network <route|unroute|requests|response|har> [args...]",
         }),
     }
 }
@@ -2706,6 +2719,31 @@ mod tests {
     #[test]
     fn test_network_har_requires_subcommand() {
         let result = parse_command(&args("network har"), &default_flags());
+        assert!(matches!(result, Err(ParseError::MissingArguments { .. })));
+    }
+
+    #[test]
+    fn test_network_response() {
+        let cmd = parse_command(&args("network response /api/data"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "responsebody");
+        assert_eq!(cmd["url"], "/api/data");
+    }
+
+    #[test]
+    fn test_network_response_with_timeout() {
+        let cmd = parse_command(
+            &args("network response /api/data --timeout 5000"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "responsebody");
+        assert_eq!(cmd["url"], "/api/data");
+        assert_eq!(cmd["timeout"], 5000);
+    }
+
+    #[test]
+    fn test_network_response_missing_url() {
+        let result = parse_command(&args("network response"), &default_flags());
         assert!(matches!(result, Err(ParseError::MissingArguments { .. })));
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -131,6 +131,14 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 return;
             }
         }
+        // Response body (network response)
+        if action == Some("responsebody") {
+            if let Some(body) = data.get("body").and_then(|v| v.as_str()) {
+                let origin = data.get("origin").and_then(|v| v.as_str());
+                print_with_boundaries(body, origin, opts);
+                return;
+            }
+        }
         // Inspect response (check before generic URL handler since it also has a "url" field)
         if action == Some("inspect") {
             let opened = data
@@ -1727,6 +1735,8 @@ Subcommands:
   requests [options]         List captured requests
     --clear                  Clear request log
     --filter <pattern>       Filter by URL pattern
+  response <url-pattern>     Wait for and return matching response body
+    --timeout <ms>           Timeout in milliseconds (default: 30000)
   har <start|stop> [path]    Record and export a HAR file
 
 Global Options:
@@ -1740,6 +1750,8 @@ Examples:
   agent-browser network requests
   agent-browser network requests --filter "api"
   agent-browser network requests --clear
+  agent-browser network response "/api/products"
+  agent-browser network response "/api/data" --timeout 10000
   agent-browser network har start
   agent-browser network har stop ./capture.har
 "##
@@ -2525,6 +2537,7 @@ Network:  agent-browser network <action>
   route <url> [--abort|--body <json>]
   unroute [url]
   requests [--clear] [--filter <pattern>]
+  response <url-pattern> [--timeout <ms>]
   har <start|stop> [path]
 
 Storage:


### PR DESCRIPTION
## Summary

Wire the existing `responsebody` daemon handler to a new CLI subcommand: `network response <url-pattern>`. This lets users capture response bodies from the command line, which was previously only available via batch/JSON mode.

```bash
# Wait for a matching response and print its body
agent-browser network response "/api/products"

# With custom timeout
agent-browser network response "/api/data" --timeout 10000
```

Closes #111

## Evidence

| Signal | Source |
|--------|--------|
| Issue #111 | "network requests --body: include response bodies for scraping workflows" |
| PR #464 | Prior attempt (too broad scope - response + dump + filters). Never merged. |
| Existing handler | `handle_responsebody` already implements CDP Network.getResponseBody but had no CLI command |
| [Reddit r/mcp](https://www.reddit.com/r/mcp/comments/1rw0egg/) | Benchmarked API costs of AI browser agents - reducing duplicate fetch calls saves tokens | Recent |
| [#555](https://github.com/vercel-labs/agent-browser/issues/555) | network requests does not capture navigations - agents need better network introspection | Open |
| [Firecrawl Analysis](https://www.firecrawl.dev/blog/best-browser-agents) | agent-browser listed among top 11 AI browser agents but noted CLI overhead | Industry report |

## Implementation

The daemon's `handle_responsebody` handler was already complete - it subscribes to `Network.responseReceived` events, matches URLs, and calls `Network.getResponseBody`. This PR adds:

- `network response` subcommand in `parse_network` (commands.rs)
- `--timeout` flag support (default 30s)
- Human-readable output for response body (output.rs)
- Help text and tests

### Files changed
- `cli/src/commands.rs` - add `response` to parse_network VALID list and parser
- `cli/src/output.rs` - response body output handler, help text updates

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (476 tests, 0 failures)
- [ ] Manual: `agent-browser network response "/api/*"` returns matching body

This contribution was developed with AI assistance (Claude Code).