### PR TITLE
feat(cli): add --tab flag for tab-scoped commands

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2210,6 +2210,7 @@ mod tests {
             screenshot_quality: None,
             screenshot_format: None,
             idle_timeout: None,
+            tab_index: None,
         }
     }
 

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -219,6 +219,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--screenshot-quality",
         "--screenshot-format",
         "--idle-timeout",
+        "--tab",
     ];
     let mut i = 0;
     while i < args.len() {
@@ -301,6 +302,7 @@ pub struct Flags {
     pub screenshot_quality: Option<u32>,
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>, // Canonical milliseconds string for AGENT_BROWSER_IDLE_TIMEOUT_MS
+    pub tab_index: Option<usize>,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -435,6 +437,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_annotate: false,
         cli_download_path: false,
         cli_headed: false,
+        tab_index: None,
     };
 
     let mut i = 0;
@@ -484,6 +487,20 @@ pub fn parse_flags(args: &[String]) -> Flags {
                             color::warning_indicator(),
                             e
                         ),
+                    }
+                    i += 1;
+                }
+            }
+            "--tab" => {
+                if let Some(s) = args.get(i + 1) {
+                    if let Ok(idx) = s.parse::<usize>() {
+                        flags.tab_index = Some(idx);
+                    } else {
+                        eprintln!(
+                            "{} Invalid --tab value: {} (expected a number)",
+                            color::warning_indicator(),
+                            s
+                        );
                     }
                     i += 1;
                 }
@@ -761,6 +778,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--screenshot-quality",
         "--screenshot-format",
         "--idle-timeout",
+        "--tab",
     ];
 
     let mut i = 0;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -282,6 +282,11 @@ fn main() {
         }
     }
 
+    // Inject --tab index into command JSON if specified
+    if let Some(tab_idx) = flags.tab_index {
+        cmd["tabIndex"] = json!(tab_idx);
+    }
+
     // Validate session name before starting daemon
     if let Some(ref name) = flags.session_name {
         if !validation::is_valid_session_name(name) {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -709,15 +709,20 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         .get("tabIndex")
         .and_then(|v| v.as_u64())
         .map(|v| v as usize);
-    let prev_page_index = tab_override.and_then(|idx| {
-        state.browser.as_mut().map(|mgr| {
-            let prev = mgr.active_page();
-            if let Err(e) = mgr.set_active_page(idx) {
-                eprintln!("Warning: --tab override failed: {}", e);
+    let prev_page_index = if let Some(idx) = tab_override {
+        match state.browser.as_mut() {
+            Some(mgr) => {
+                let prev = mgr.active_page();
+                if let Err(e) = mgr.set_active_page(idx) {
+                    return error_response(&id, &format!("--tab override failed: {}", e));
+                }
+                Some(prev)
             }
-            prev
-        })
-    });
+            None => None,
+        }
+    } else {
+        None
+    };
 
     let result = match action {
         "launch" => handle_launch(cmd, state).await,
@@ -874,10 +879,16 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         _ => Err(format!("Not yet implemented: {}", action)),
     };
 
-    // Restore original active page index after --tab override
-    if let Some(prev) = prev_page_index {
-        if let Some(ref mut mgr) = state.browser {
-            let _ = mgr.set_active_page(prev);
+    // Restore original active page index after --tab override.
+    // Skip restore for tab-mutating commands: after tab_close the saved
+    // index may be out of range (or point to the wrong tab), and tab_new /
+    // tab_switch intentionally change the active tab.
+    let is_tab_mutating = matches!(action, "tab_close" | "tab_new" | "tab_switch");
+    if !is_tab_mutating {
+        if let Some(prev) = prev_page_index {
+            if let Some(ref mut mgr) = state.browser {
+                let _ = mgr.set_active_page(prev);
+            }
         }
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -704,6 +704,21 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         );
     }
 
+    // If --tab N was specified, temporarily override the active page index
+    let tab_override = cmd
+        .get("tabIndex")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize);
+    let prev_page_index = tab_override.and_then(|idx| {
+        state.browser.as_mut().map(|mgr| {
+            let prev = mgr.active_page();
+            if let Err(e) = mgr.set_active_page(idx) {
+                eprintln!("Warning: --tab override failed: {}", e);
+            }
+            prev
+        })
+    });
+
     let result = match action {
         "launch" => handle_launch(cmd, state).await,
         "navigate" => handle_navigate(cmd, state).await,
@@ -858,6 +873,13 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "mouseup" => handle_mouseup(cmd, state).await,
         _ => Err(format!("Not yet implemented: {}", action)),
     };
+
+    // Restore original active page index after --tab override
+    if let Some(prev) = prev_page_index {
+        if let Some(ref mut mgr) = state.browser {
+            let _ = mgr.set_active_page(prev);
+        }
+    }
 
     match result {
         Ok(data) => success_response(&id, data),

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -430,6 +430,25 @@ impl BrowserManager {
             .ok_or_else(|| "No active page".to_string())
     }
 
+    /// Get the current active page index.
+    pub fn active_page(&self) -> usize {
+        self.active_page_index
+    }
+
+    /// Temporarily override the active page index. Returns an error if the
+    /// index is out of range.
+    pub fn set_active_page(&mut self, index: usize) -> Result<(), String> {
+        if index >= self.pages.len() {
+            return Err(format!(
+                "Tab index {} out of range (0-{})",
+                index,
+                self.pages.len().saturating_sub(1)
+            ));
+        }
+        self.active_page_index = index;
+        Ok(())
+    }
+
     pub async fn navigate(&mut self, url: &str, wait_until: WaitUntil) -> Result<Value, String> {
         let session_id = self.active_session_id()?.to_string();
         let mut lifecycle_rx = self.client.subscribe();

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2621,6 +2621,7 @@ Options:
   --action-policy <path>     Action policy JSON file (or AGENT_BROWSER_ACTION_POLICY)
   --confirm-actions <list>   Categories requiring confirmation (or AGENT_BROWSER_CONFIRM_ACTIONS)
   --confirm-interactive      Interactive confirmation prompts; auto-denies if stdin is not a TTY (or AGENT_BROWSER_CONFIRM_INTERACTIVE)
+  --tab <index>              Run command against a specific tab without switching
   --engine <name>            Browser engine: chrome (default), lightpanda (or AGENT_BROWSER_ENGINE)
   --config <path>            Use a custom config file (or AGENT_BROWSER_CONFIG env)
   --debug                    Debug output


### PR DESCRIPTION
## Summary

Add a `--tab N` global flag that runs a command against a specific tab without switching the active tab. Useful for multi-tab scraping workflows where you need to interact with background tabs without losing your current context.

```bash
# Take screenshot of tab 2 without switching to it
agent-browser --tab 2 screenshot

# Get the URL of tab 1
agent-browser --tab 1 url

# Click an element in tab 0
agent-browser --tab 0 click @e1
```

Related: #853

## Evidence

| Signal | Source |
|--------|--------|
| Issue #853 | "SPA Scraping Pattern: Preserving accessibility refs with tab isolation" |
| Issue #74 | Tab management friction (tab list didn't show all tabs) |
| Gap | Must currently switch tabs to run commands, losing active tab context |
| [Reddit r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/comments/1rr0pyr/) | "Whats your reliable browser setup for Claude Code?" - parallel tab management is a pain point | 3 upvotes |
| [Reddit r/AI_Agents](https://www.reddit.com/r/AI_Agents/comments/1rtlzmy/) | "Built a fully autonomous system to coordinate 100+ browser automation agents" | 8 upvotes |
| [NxCode](https://www.nxcode.io/resources/news/stagehand-vs-browser-use-vs-playwright-ai-browser-automation-2026) | "Parallel browser session management" identified as universal unsolved gap | Industry report |

## Implementation

The `--tab` flag is parsed in `flags.rs` and injected as `tabIndex` into the command JSON in `main.rs`. The daemon's `handle_action` in `actions.rs` temporarily overrides the `active_page_index` on `BrowserManager` for the duration of the command, then restores the original index afterward. This means all existing handlers work with `--tab` without modification.

### Files changed
- `cli/src/flags.rs` - parse `--tab N` flag, add to clean_args skip list
- `cli/src/main.rs` - inject `tabIndex` into command JSON
- `cli/src/native/actions.rs` - temporarily swap active page index before/after dispatch
- `cli/src/native/browser.rs` - add `active_page()` and `set_active_page()` methods
- `cli/src/commands.rs` - add `tab_index` to test default_flags
- `cli/src/output.rs` - add `--tab` to help text

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (473 tests, 0 failures)
- [ ] Manual: `agent-browser --tab 1 url` returns URL of tab 1 without switching active tab
- [ ] Manual: `agent-browser --tab 0 screenshot` takes screenshot of tab 0

This contribution was developed with AI assistance (Claude Code).