### PR TITLE
Fix Chrome instance collision by scoping profiles to session IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ On Linux, install system dependencies:
 agent-browser install --with-deps
 ```
 
+### Updating
+
+Upgrade to the latest version:
+
+```bash
+agent-browser upgrade
+```
+
+Detects your installation method (npm, Homebrew, or Cargo) and runs the appropriate update command automatically.
+
 ### Requirements
 
 - **Chrome** - Run `agent-browser install` to download Chrome from [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) (Google's official automation channel). No Playwright or Node.js required for the daemon.
@@ -339,6 +349,7 @@ agent-browser reload                  # Reload page
 ```bash
 agent-browser install                 # Download Chrome from Chrome for Testing (Google's official automation channel)
 agent-browser install --with-deps     # Also install system deps (Linux)
+agent-browser upgrade                 # Upgrade agent-browser to the latest version
 ```
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -58,16 +58,6 @@ On Linux, install system dependencies:
 agent-browser install --with-deps
 ```
 
-### Updating
-
-Upgrade to the latest version:
-
-```bash
-agent-browser upgrade
-```
-
-Detects your installation method (npm, Homebrew, or Cargo) and runs the appropriate update command automatically.
-
 ### Requirements
 
 - **Chrome** - Run `agent-browser install` to download Chrome from [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) (Google's official automation channel). No Playwright or Node.js required for the daemon.
@@ -349,7 +339,6 @@ agent-browser reload                  # Reload page
 ```bash
 agent-browser install                 # Download Chrome from Chrome for Testing (Google's official automation channel)
 agent-browser install --with-deps     # Also install system deps (Linux)
-agent-browser upgrade                 # Upgrade agent-browser to the latest version
 ```
 
 ## Authentication
@@ -447,6 +436,8 @@ The profile directory stores:
 - Login sessions
 
 **Tip**: Use different profile paths for different projects to keep their browser state isolated.
+
+**Sessions with profiles**: When `--session` is combined with `--profile`, each session stores its Chrome data in a separate subdirectory: `<profile>/<session>/`. This ensures that concurrent sessions using the same base profile path each get their own isolated Chrome instance. For example, `--profile ~/.myapp-profile --session work` uses `~/.myapp-profile/work/` and `--session personal` uses `~/.myapp-profile/personal/`.
 
 ## Session Persistence
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -973,9 +973,10 @@ fn launch_options_from_env() -> LaunchOptions {
         proxy: env::var("AGENT_BROWSER_PROXY").ok(),
         proxy_bypass: env::var("AGENT_BROWSER_PROXY_BYPASS").ok(),
         profile: env::var("AGENT_BROWSER_PROFILE").ok().map(|p| {
-            let session =
-                env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string());
-            session_scoped_profile(&p, &session)
+            match env::var("AGENT_BROWSER_SESSION").ok() {
+                Some(session) => session_scoped_profile(&p, &session),
+                None => p,
+            }
         }),
         allow_file_access: env::var("AGENT_BROWSER_ALLOW_FILE_ACCESS")
             .map(|v| v == "1" || v == "true")
@@ -5939,15 +5940,15 @@ mod tests {
     }
 
     #[test]
-    fn test_launch_options_from_env_profile_default_session_fallback() {
+    fn test_launch_options_from_env_profile_without_session() {
         let _guard = EnvGuard::new(&["AGENT_BROWSER_PROFILE", "AGENT_BROWSER_SESSION"]);
         _guard.set("AGENT_BROWSER_PROFILE", "/tmp/test-profile");
-        _guard.remove("AGENT_BROWSER_SESSION"); // ensure fallback to "default"
+        _guard.remove("AGENT_BROWSER_SESSION"); // no session set
         let opts = launch_options_from_env();
         assert_eq!(
             opts.profile.as_deref(),
-            Some("/tmp/test-profile/default"),
-            "profile should append 'default' when session is unset"
+            Some("/tmp/test-profile"),
+            "profile should be unchanged when session is unset"
         );
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -942,6 +942,19 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
     Ok(())
 }
 
+/// Returns the effective Chrome user-data-dir path for a session.
+///
+/// Appends the session ID as a subdirectory under the base profile path so
+/// that each `--session` daemon gets its own independent Chrome instance even
+/// when `--profile` is shared across sessions. Chrome enforces a singleton
+/// constraint per `--user-data-dir`, so without this isolation the second
+/// daemon silently connects to the first daemon's Chrome instance instead of
+/// launching a new one.
+fn session_scoped_profile(profile: &str, session_id: &str) -> String {
+    let profile = profile.trim_end_matches('/');
+    format!("{}/{}", profile, session_id)
+}
+
 fn launch_options_from_env() -> LaunchOptions {
     let headed = env::var("AGENT_BROWSER_HEADED")
         .map(|v| v == "1" || v == "true")
@@ -959,7 +972,11 @@ fn launch_options_from_env() -> LaunchOptions {
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH").ok(),
         proxy: env::var("AGENT_BROWSER_PROXY").ok(),
         proxy_bypass: env::var("AGENT_BROWSER_PROXY_BYPASS").ok(),
-        profile: env::var("AGENT_BROWSER_PROFILE").ok(),
+        profile: env::var("AGENT_BROWSER_PROFILE").ok().map(|p| {
+            let session =
+                env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string());
+            session_scoped_profile(&p, &session)
+        }),
         allow_file_access: env::var("AGENT_BROWSER_ALLOW_FILE_ACCESS")
             .map(|v| v == "1" || v == "true")
             .unwrap_or(false),
@@ -1148,7 +1165,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         profile: cmd
             .get("profile")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(|s| session_scoped_profile(s, &state.session_id)),
         allow_file_access: cmd
             .get("allowFileAccess")
             .and_then(|v| v.as_bool())
@@ -5881,6 +5898,56 @@ mod tests {
         assert!(
             !opts.headless,
             "AGENT_BROWSER_HEADED=1 should set headless=false"
+        );
+    }
+
+    #[test]
+    fn test_session_scoped_profile_basic() {
+        assert_eq!(
+            session_scoped_profile("/tmp/my-profile", "first"),
+            "/tmp/my-profile/first"
+        );
+    }
+
+    #[test]
+    fn test_session_scoped_profile_default_session() {
+        assert_eq!(
+            session_scoped_profile("/tmp/my-profile", "default"),
+            "/tmp/my-profile/default"
+        );
+    }
+
+    #[test]
+    fn test_session_scoped_profile_strips_trailing_slash() {
+        assert_eq!(
+            session_scoped_profile("/tmp/my-profile/", "second"),
+            "/tmp/my-profile/second"
+        );
+    }
+
+    #[test]
+    fn test_launch_options_from_env_profile_with_session() {
+        let _guard = EnvGuard::new(&["AGENT_BROWSER_PROFILE", "AGENT_BROWSER_SESSION"]);
+        _guard.set("AGENT_BROWSER_PROFILE", "/tmp/test-profile");
+        _guard.set("AGENT_BROWSER_SESSION", "my-session");
+        let opts = launch_options_from_env();
+        assert_eq!(
+            opts.profile.as_deref(),
+            Some("/tmp/test-profile/my-session"),
+            "profile should include session subdirectory"
+        );
+    }
+
+    #[test]
+    fn test_launch_options_from_env_profile_default_session_fallback() {
+        let _guard = EnvGuard::new(&["AGENT_BROWSER_PROFILE", "AGENT_BROWSER_SESSION"]);
+        _guard.set("AGENT_BROWSER_PROFILE", "/tmp/test-profile");
+        _guard.remove("AGENT_BROWSER_SESSION"); // ensure fallback to "default"
+        let opts = launch_options_from_env();
+        assert_eq!(
+            opts.profile.as_deref(),
+            Some("/tmp/test-profile/default"),
+            "profile should append 'default' when session is unset"
         );
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2266,6 +2266,22 @@ Examples:
 "##
         }
 
+        // === Upgrade ===
+        "upgrade" => {
+            r##"
+agent-browser upgrade - Upgrade to the latest version
+
+Usage: agent-browser upgrade
+
+Detects the current installation method (npm, Homebrew, or Cargo) and runs
+the appropriate update command. Displays the version change on success, or
+informs you if you are already on the latest version.
+
+Examples:
+  agent-browser upgrade
+"##
+        }
+
         // === Connect ===
         "connect" => {
             r##"
@@ -2572,6 +2588,7 @@ Sessions:
 Setup:
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
+  upgrade                    Upgrade to the latest version
 
 Snapshot Options:
   -i, --interactive          Only interactive elements

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2266,22 +2266,6 @@ Examples:
 "##
         }
 
-        // === Upgrade ===
-        "upgrade" => {
-            r##"
-agent-browser upgrade - Upgrade to the latest version
-
-Usage: agent-browser upgrade
-
-Detects the current installation method (npm, Homebrew, or Cargo) and runs
-the appropriate update command. Displays the version change on success, or
-informs you if you are already on the latest version.
-
-Examples:
-  agent-browser upgrade
-"##
-        }
-
         // === Connect ===
         "connect" => {
             r##"
@@ -2588,7 +2572,6 @@ Sessions:
 Setup:
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
-  upgrade                    Upgrade to the latest version
 
 Snapshot Options:
   -i, --interactive          Only interactive elements
@@ -2599,6 +2582,7 @@ Snapshot Options:
 Authentication:
   --profile <path>           Persist login sessions across restarts (cookies, IndexedDB, cache)
                              (or AGENT_BROWSER_PROFILE env)
+                             When used with --session, data is stored in <path>/<session>/
   --session-name <name>      Auto-save/restore cookies and localStorage by name
                              (or AGENT_BROWSER_SESSION_NAME env)
   --state <path>             Load saved auth state (cookies + storage) from JSON file

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -57,6 +57,16 @@ The profile directory stores:
 - Browser cache
 - Login sessions
 
+**Using `--profile` with `--session`**: When combining `--profile` with `--session`, each session stores its Chrome data in a separate subdirectory (`<profile>/<session>/`). This ensures that concurrent sessions sharing the same base profile path each launch their own independent Chrome instance. For example:
+
+```bash
+# Two independent Chrome instances, each with their own persisted data
+agent-browser --profile ~/.myapp-profile --session work open app.example.com
+agent-browser --profile ~/.myapp-profile --session personal open app.example.com
+# work data -> ~/.myapp-profile/work/
+# personal data -> ~/.myapp-profile/personal/
+```
+
 ## Import auth from your browser
 
 If you are already logged in to a site in Chrome, you can grab that auth state and reuse it in agent-browser. This is the fastest way to bypass login flows, OAuth, SSO, or 2FA.

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx agent-browser:*), Bash(agent-browser:*)
 
 # Browser Automation with agent-browser
 
-The CLI uses Chrome/Chromium via CDP directly. Install via `npm i -g agent-browser`, `brew install agent-browser`, or `cargo install agent-browser`. Run `agent-browser install` to download Chrome.
+The CLI uses Chrome/Chromium via CDP directly. Install via `npm i -g agent-browser`, `brew install agent-browser`, or `cargo install agent-browser`. Run `agent-browser install` to download Chrome. Run `agent-browser upgrade` to update to the latest version.
 
 ## Core Workflow
 

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(npx agent-browser:*), Bash(agent-browser:*)
 
 # Browser Automation with agent-browser
 
-The CLI uses Chrome/Chromium via CDP directly. Install via `npm i -g agent-browser`, `brew install agent-browser`, or `cargo install agent-browser`. Run `agent-browser install` to download Chrome. Run `agent-browser upgrade` to update to the latest version.
+The CLI uses Chrome/Chromium via CDP directly. Install via `npm i -g agent-browser`, `brew install agent-browser`, or `cargo install agent-browser`. Run `agent-browser install` to download Chrome.
 
 ## Core Workflow
 
@@ -71,6 +71,8 @@ agent-browser --profile ~/.myapp open https://app.example.com/login
 # All future runs: already authenticated
 agent-browser --profile ~/.myapp open https://app.example.com/dashboard
 ```
+
+When using `--profile` with `--session`, each session stores its Chrome data in a separate subdirectory (`<profile>/<session>/`) so that concurrent sessions with the same base profile path run independent Chrome instances without conflict.
 
 **Option 3: Session name (auto-save/restore cookies + localStorage)**
 


### PR DESCRIPTION
## Summary

Fixes an issue where multiple `--session` daemons sharing the same `--profile` path would connect to a single Chrome instance instead of launching separate instances. This caused tab accumulation, navigation timeouts, and unexpected behavior because Chrome enforces a singleton constraint per `--user-data-dir`.

## Changes

- **Added session-scoped profile paths**: When both `--session` and `--profile` are specified, the effective Chrome user-data-dir becomes `<profile>/<session>/` instead of just `<profile>/`
- **Updated profile handling**: Modified `launch_options_from_env()` and `handle_launch()` to automatically append the session ID as a subdirectory under the base profile path
- **Added documentation**: Updated README, CLI help text, and docs to explain the new behavior
- **Added unit tests**: Created tests to verify the session-scoped profile path logic

This ensures each session gets its own isolated Chrome instance while preserving the benefits of persistent profiles. Sessions without `--profile` continue to work as before with unique temporary directories.

Fixes #896