### PR TITLE
docs: migrate page metadata from MDX to layout.tsx

### DIFF
--- a/docs/src/app/cdp-mode/layout.tsx
+++ b/docs/src/app/cdp-mode/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("cdp-mode");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("cdp-mode")
-
 # CDP Mode
 
 Connect to an existing browser via Chrome DevTools Protocol:

--- a/docs/src/app/changelog/layout.tsx
+++ b/docs/src/app/changelog/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("changelog");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("changelog")
-
 # Changelog
 
 ## v0.21.0

--- a/docs/src/app/commands/layout.tsx
+++ b/docs/src/app/commands/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("commands");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("commands")
-
 # Commands
 
 ## Core

--- a/docs/src/app/configuration/layout.tsx
+++ b/docs/src/app/configuration/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("configuration");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("configuration")
-
 # Configuration
 
 Create an `agent-browser.json` file to set persistent defaults instead of repeating flags on every command.

--- a/docs/src/app/diffing/layout.tsx
+++ b/docs/src/app/diffing/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("diffing");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/diffing/page.mdx
+++ b/docs/src/app/diffing/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("diffing")
-
 import { DiffDemo } from "@/components/diff-demo"
 
 # Diffing

--- a/docs/src/app/engines/chrome/layout.tsx
+++ b/docs/src/app/engines/chrome/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("engines/chrome");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/engines/chrome/page.mdx
+++ b/docs/src/app/engines/chrome/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("engines/chrome")
-
 # Chrome
 
 Chrome (and Chromium) is the default browser engine. agent-browser discovers, launches, and manages the Chrome process automatically via the Chrome DevTools Protocol (CDP).

--- a/docs/src/app/engines/lightpanda/layout.tsx
+++ b/docs/src/app/engines/lightpanda/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("engines/lightpanda");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/engines/lightpanda/page.mdx
+++ b/docs/src/app/engines/lightpanda/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("engines/lightpanda")
-
 # Lightpanda
 
 [Lightpanda](https://lightpanda.io/) is a headless browser engine built from scratch in Zig for machines. It starts instantly, uses 10x less memory than Chrome, and executes 10x faster.

--- a/docs/src/app/installation/layout.tsx
+++ b/docs/src/app/installation/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("installation");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("installation")
-
 # Installation
 
 ## Global installation (recommended)

--- a/docs/src/app/ios/layout.tsx
+++ b/docs/src/app/ios/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("ios");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/ios/page.mdx
+++ b/docs/src/app/ios/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("ios")
-
 # iOS Simulator
 
 Control real Mobile Safari in the iOS Simulator for authentic mobile

--- a/docs/src/app/native-mode/layout.tsx
+++ b/docs/src/app/native-mode/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("native-mode");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/native-mode/page.mdx
+++ b/docs/src/app/native-mode/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("native-mode")
-
 # Native Mode
 
 agent-browser is now 100% native Rust by default. The Node.js/Playwright daemon has been removed.

--- a/docs/src/app/next/layout.tsx
+++ b/docs/src/app/next/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("next");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/next/page.mdx
+++ b/docs/src/app/next/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("next")
-
 # Next.js + Vercel
 
 Run agent-browser from a Next.js app on Vercel using Vercel Sandbox.

--- a/docs/src/app/page.mdx
+++ b/docs/src/app/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("")
-
 # agent-browser
 
 Browser automation CLI designed for AI agents. Compact text output minimizes context usage. 100% native Rust.

--- a/docs/src/app/profiler/layout.tsx
+++ b/docs/src/app/profiler/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("profiler");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/profiler/page.mdx
+++ b/docs/src/app/profiler/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("profiler")
-
 # Profiler
 
 Capture Chrome DevTools performance profiles during browser automation.

--- a/docs/src/app/quick-start/layout.tsx
+++ b/docs/src/app/quick-start/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("quick-start");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/quick-start/page.mdx
+++ b/docs/src/app/quick-start/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("quick-start")
-
 # Quick Start
 
 ## Core workflow

--- a/docs/src/app/security/layout.tsx
+++ b/docs/src/app/security/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("security");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -1,6 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-export const metadata = pageMetadata("security")
-
 # Security
 
 agent-browser includes security features to protect against credential exposure, prompt injection via untrusted page content, and unauthorized browser actions.

--- a/docs/src/app/selectors/layout.tsx
+++ b/docs/src/app/selectors/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("selectors");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/selectors/page.mdx
+++ b/docs/src/app/selectors/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("selectors")
-
 # Selectors
 
 ## Refs (recommended)

--- a/docs/src/app/sessions/layout.tsx
+++ b/docs/src/app/sessions/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("sessions");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("sessions")
-
 # Sessions
 
 Run multiple isolated browser instances:

--- a/docs/src/app/skills/layout.tsx
+++ b/docs/src/app/skills/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("skills");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/skills/page.mdx
+++ b/docs/src/app/skills/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("skills")
-
 # Skills
 
 agent-browser ships with skills that teach AI coding agents how to use it for specific workflows. Install a skill and your agent in Cursor, Claude Code, or Codex can automate browser tasks without manual guidance.

--- a/docs/src/app/snapshots/layout.tsx
+++ b/docs/src/app/snapshots/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("snapshots");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/snapshots/page.mdx
+++ b/docs/src/app/snapshots/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("snapshots")
-
 # Snapshots
 
 The `snapshot` command returns a compact accessibility tree with refs for element interaction.

--- a/docs/src/app/streaming/layout.tsx
+++ b/docs/src/app/streaming/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("streaming");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -1,7 +1,3 @@
-import { pageMetadata } from "@/lib/page-metadata"
-
-export const metadata = pageMetadata("streaming")
-
 # Streaming
 
 Stream the browser viewport via WebSocket for live preview or "pair browsing"


### PR DESCRIPTION
## Summary

- Move JS metadata exports (`import`/`export const metadata`) out of all 20 `page.mdx` files into per-directory `layout.tsx` files
- MDX files now contain pure markdown — render cleanly on GitHub without visible JS code
- Zero content changes; only the metadata mechanism is relocated

Part 1 of the incremental fix for #774.

## Details

- **19 new `layout.tsx` files** created (one per page directory), each exporting `pageMetadata("slug")`
- **20 `page.mdx` files** modified — only the 3-4 line JS header removed
- Root page uses existing root layout metadata (already correct)

## Test plan

- [x] `npm run build` in `docs/` — succeeds, all 20 routes present
- [x] Dev server spot-check — verified 6 pages (/, /quick-start, /installation, /engines/chrome, /cdp-mode, /security) all render correct `<title>` tags and content
- [x] Vercel preview deployment — visual confirmation

test with portless

<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/77827841-fc73-4cf0-b8e7-89b39e0f38d5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)