### PR TITLE
fix: escape text of cursor-interactive elements

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -843,16 +843,17 @@ fn render_tree(
     let mut line = format!("{}- {}", prefix, role);
 
     // Use ARIA name if available, otherwise fall back to cursor-interactive textContent
-    let display_name = if !node.name.is_empty() {
-        node.name.clone()
+    let unescaped_display_name = if !node.name.is_empty() {
+        &node.name
     } else if let Some(ref ci) = node.cursor_info {
-        ci.text
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"")
-            .replace(['\n', '\r'], " ")
+        &ci.text
     } else {
-        node.name.clone()
+        &node.name
     };
+    let display_name = unescaped_display_name
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace(['\n', '\r'], " ");
     if !display_name.is_empty() {
         line.push_str(&format!(" \"{}\"", display_name));
     }


### PR DESCRIPTION
# Summary
This PR addresses an issue where special characters in cursor-interactive elements were not properly escaped, which could cause parsing errors or display issues in the snapshot output.

# Changes
   - Added proper escaping for backslashes (\) by replacing them with double backslashes (\\)
   - Added proper escaping for double quotes (") by replacing them with escaped quotes (\")
   - Replaced newline (\n) and carriage return (\r) characters with spaces to ensure clean single-line text representation