### PR TITLE
fix: support xpath= selector prefix in element resolution

### DIFF
--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -359,6 +359,21 @@ fn build_find_element_js(selector: &str) -> String {
     }
 }
 
+/// Build a JS expression that counts matching DOM elements by CSS selector or XPath.
+fn build_count_elements_js(selector: &str) -> String {
+    if let Some(xpath) = selector.strip_prefix("xpath=") {
+        format!(
+            "document.evaluate({}, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength",
+            serde_json::to_string(xpath).unwrap_or_default()
+        )
+    } else {
+        format!(
+            "document.querySelectorAll({}).length",
+            serde_json::to_string(selector).unwrap_or_default()
+        )
+    }
+}
+
 fn build_selector_js(selector: &str) -> String {
     let find_expr = build_find_element_js(selector);
     format!(
@@ -755,17 +770,7 @@ pub async fn get_element_count(
     session_id: &str,
     selector: &str,
 ) -> Result<i64, String> {
-    let js = if let Some(xpath) = selector.strip_prefix("xpath=") {
-        format!(
-            "document.evaluate({}, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength",
-            serde_json::to_string(xpath).unwrap_or_default()
-        )
-    } else {
-        format!(
-            "document.querySelectorAll({}).length",
-            serde_json::to_string(selector).unwrap_or_default()
-        )
-    };
+    let js = build_count_elements_js(selector);
 
     let result: EvaluateResult = client
         .send_command_typed(
@@ -897,6 +902,20 @@ mod tests {
         // "xpath" without "=" should be treated as CSS selector
         let js = build_selector_js("xpath//div");
         assert!(js.contains("document.querySelector"));
+    }
+
+    #[test]
+    fn test_build_count_elements_js_css() {
+        let js = build_count_elements_js(".item");
+        assert!(js.contains("document.querySelectorAll(\".item\").length"));
+        assert!(!js.contains("document.evaluate"));
+    }
+
+    #[test]
+    fn test_build_count_elements_js_xpath() {
+        let js = build_count_elements_js("xpath=//li");
+        assert!(js.contains("document.evaluate(\"//li\", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength"));
+        assert!(!js.contains("querySelectorAll"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes #907 — `xpath=` prefixed selectors (e.g. `xpath=//button`) were passed directly to `document.querySelector()` / `document.querySelectorAll()`, which only support CSS selectors, causing element-not-found errors.
- When a selector starts with `xpath=`, the prefix is stripped and `document.evaluate()` is used instead.
- Applied to all three selector resolution paths:
  - `resolve_by_selector` (used by `click`)
  - `resolve_element_object_id` (used by `type`, `fill`, `hover`, `focus`, `check`, `select`, `screenshot`, etc.)
  - `get_element_count` (used by `wait` and element counting)
- Extracted `build_find_element_js()` shared helper to avoid duplicating the xpath/css branching logic.
- 4 regression tests covering CSS selectors, XPath selectors, empty XPath, and `xpath` without `=` delimiter.

## Test plan
- [x] `cargo test -- test_build_selector_js` — 4 tests pass
- [x] Verified `main` branch fails: `click "xpath=//a"` → `Element not found`
- [x] Verified PR branch succeeds: `click "xpath=//a"` → `Done`
- [x] Manual: `agent-browser click "xpath=//h1"` works on example.com
- [x] CSS selectors (`agent-browser click "#id"`) still work as before