### PR TITLE
fix: send JSON body in Browserbase session creation request

### DIFF
--- a/.changeset/fix-browserbase-415.md
+++ b/.changeset/fix-browserbase-415.md
@@ -1,0 +1,7 @@
+---
+"agent-browser": patch
+---
+
+### Bug Fixes
+
+- **Browserbase session creation** - Fixed 415 "Unsupported Media Type" error when using `-p browserbase` by sending an empty JSON body with the session creation request. Regression introduced in #625 which removed the JSON body along with the `projectId` field.

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -92,6 +92,7 @@ async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), Stri
     let response = client
         .post("https://api.browserbase.com/v1/sessions")
         .header("X-BB-API-Key", &api_key)
+        .json(&json!({}))
         .send()
         .await
         .map_err(|e| format!("Browserbase request failed: {}", e))?;


### PR DESCRIPTION
## Summary

Fixes #912

PR #625 (cc82dd1) removed the `BROWSERBASE_PROJECT_ID` requirement from session creation, but also removed the `Content-Type: application/json` header and JSON body from the POST request. The Browserbase API (Fastify) requires `Content-Type: application/json`, returning a 415 "Unsupported Media Type" error without it.

This adds `.json(&json!({}))` to the session creation request in `connect_browserbase()`, matching the pattern used by every other provider (Browserless, Browser Use, Kernel) in the same file.

## Changes

- `cli/src/native/providers.rs`: Add empty JSON body to Browserbase session creation POST request

## Test plan

- [x] Built the CLI locally (`cargo build --release`)
- [x] Verified `-p browserbase` now creates sessions successfully
- [x] Tested against a Cloudflare-protected site (ricardo.ch) — page loads and snapshot works
- [x] Confirmed the fix matches the pattern used by all other providers in `providers.rs`