### PR TITLE
feat: Browserbase proxy, stealth, and image blocking via env vars

### DIFF
--- a/.changeset/browserbase-proxy-stealth.md
+++ b/.changeset/browserbase-proxy-stealth.md
@@ -1,0 +1,13 @@
+---
+"agent-browser": patch
+---
+
+### New Features
+
+- **Browserbase proxy support** - Enable Browserbase's residential proxy via `BROWSERBASE_PROXY=1` environment variable to route traffic through residential IPs instead of datacenter IPs
+- **Browserbase advanced stealth** - Enable advanced stealth mode via `BROWSERBASE_ADVANCED_STEALTH=1` and configure OS fingerprint via `BROWSERBASE_OS` (windows, mac, linux, mobile, tablet)
+- **Image blocking for providers** - Block image loading to save proxy bandwidth via `BROWSERBASE_BLOCK_IMAGES=1` environment variable, using CDP Fetch interception to abort image requests (note: not recommended on sites with anti-bot protection)
+
+### Bug Fixes
+
+- **Browserbase session creation** - Fixed 415 "Unsupported Media Type" error when using `-p browserbase` by sending a JSON body with the session creation request (regression from #625)

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1112,6 +1112,43 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.browser = Some(mgr);
                         state.subscribe_to_browser_events();
                         state.update_stream_client().await;
+
+                        // Block image loading when BROWSERBASE_BLOCK_IMAGES=1
+                        if env::var("BROWSERBASE_BLOCK_IMAGES")
+                            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                            .unwrap_or(false)
+                        {
+                            let image_exts = [
+                                "**/*.png", "**/*.jpg", "**/*.jpeg", "**/*.gif",
+                                "**/*.webp", "**/*.svg", "**/*.ico", "**/*.avif",
+                            ];
+                            for ext in &image_exts {
+                                state.routes.push(RouteEntry {
+                                    url_pattern: ext.to_string(),
+                                    response: None,
+                                    abort: true,
+                                });
+                            }
+                            // Sync routes to Fetch interception
+                            if let Some(ref browser) = state.browser {
+                                if let Ok(session_id) = browser.active_session_id() {
+                                    let patterns: Vec<Value> = state
+                                        .routes
+                                        .iter()
+                                        .map(|r| json!({ "urlPattern": r.url_pattern }))
+                                        .collect();
+                                    let _ = browser
+                                        .client
+                                        .send_command(
+                                            "Fetch.enable",
+                                            Some(json!({ "patterns": patterns })),
+                                            Some(session_id),
+                                        )
+                                        .await;
+                                }
+                            }
+                        }
+
                         return Ok(json!({ "launched": true, "provider": provider }));
                     }
                     Err(e) => {

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -88,10 +88,53 @@ async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), Stri
     let api_key = env::var("BROWSERBASE_API_KEY")
         .map_err(|_| "BROWSERBASE_API_KEY environment variable is not set")?;
 
+    let mut session_body = json!({});
+    let mut browser_settings = json!({});
+
+    // Enable Browserbase proxy when BROWSERBASE_PROXY=1 or BROWSERBASE_PROXY=true
+    if env::var("BROWSERBASE_PROXY")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        session_body.as_object_mut().unwrap().insert(
+            "proxies".to_string(),
+            json!([{ "type": "browserbase" }]),
+        );
+    }
+
+    // Enable advanced stealth mode via BROWSERBASE_ADVANCED_STEALTH=1
+    // Basic stealth is enabled by default on Browserbase; advanced uses a
+    // custom Chromium build that mimics human-like environmental signals.
+    if env::var("BROWSERBASE_ADVANCED_STEALTH")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        browser_settings
+            .as_object_mut()
+            .unwrap()
+            .insert("advancedStealth".to_string(), json!(true));
+    }
+
+    // Set OS for stealth fingerprint via BROWSERBASE_OS (windows, mac, linux, mobile, tablet)
+    if let Ok(os) = env::var("BROWSERBASE_OS") {
+        browser_settings
+            .as_object_mut()
+            .unwrap()
+            .insert("os".to_string(), json!(os));
+    }
+
+    if browser_settings.as_object().map_or(false, |o| !o.is_empty()) {
+        session_body
+            .as_object_mut()
+            .unwrap()
+            .insert("browserSettings".to_string(), browser_settings);
+    }
+
     let client = reqwest::Client::new();
     let response = client
         .post("https://api.browserbase.com/v1/sessions")
         .header("X-BB-API-Key", &api_key)
+        .json(&session_body)
         .send()
         .await
         .map_err(|e| format!("Browserbase request failed: {}", e))?;


### PR DESCRIPTION
## Summary

Adds environment variable support for configuring Browserbase sessions with proxy, advanced stealth, and image blocking. Also includes the fix for #912 (415 error on session creation).

**New environment variables:**

| Variable | Description | Example |
|----------|-------------|---------|
| `BROWSERBASE_PROXY` | Enable residential proxy | `1` |
| `BROWSERBASE_ADVANCED_STEALTH` | Enable advanced stealth (custom Chromium) | `1` |
| `BROWSERBASE_OS` | OS fingerprint for stealth | `windows`, `mac`, `linux`, `mobile`, `tablet` |
| `BROWSERBASE_BLOCK_IMAGES` | Block image loading via CDP Fetch interception | `1` |

**Implementation:**
- `providers.rs`: Builds the session creation body from env vars (proxies, browserSettings with advancedStealth/os)
- `actions.rs`: After CDP connection, registers abort routes for image extensions and enables Fetch interception when `BROWSERBASE_BLOCK_IMAGES=1`

**Note on image blocking:** Per [Browserbase docs](https://docs.browserbase.com/guides/cost-optimization), blocking images via request interception is not recommended on sites with anti-bot protection, as image/font loading is used to verify legitimate browsers. This is best suited for non-visual automation on sites without such protections.

## Test plan

- [x] Built locally (`cargo build --release`)
- [x] Verified 415 fix: `-p browserbase` creates sessions successfully
- [x] Verified proxy: `BROWSERBASE_PROXY=1` routes through residential IP (confirmed different IP via httpbin.org/ip)
- [x] Verified image blocking: `BROWSERBASE_BLOCK_IMAGES=1` registers Fetch abort routes for image extensions
- [x] Confirmed image blocking + anti-bot sites conflict (as documented by Browserbase)