### PR TITLE
feat: add shell completion for bash and zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ agent-browser upgrade
 
 Detects your installation method (npm, Homebrew, or Cargo) and runs the appropriate update command automatically.
 
+### Shell Completion
+
+Enable tab completion for commands and flags:
+
+```bash
+# bash (~/.bashrc or ~/.bash_profile)
+eval "$(agent-browser completion bash)"
+
+# zsh (~/.zshrc)
+eval "$(agent-browser completion zsh)"
+```
+
 ### Requirements
 
 - **Chrome** - Run `agent-browser install` to download Chrome from [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) (Google's official automation channel). No Playwright or Node.js required for the daemon.

--- a/cli/completions/_agent_browser
+++ b/cli/completions/_agent_browser
@@ -1,0 +1,259 @@
+#compdef agent-browser
+# Shell completion for agent-browser
+# Source: cli/completions/_agent_browser
+# Keep in sync with: cli/src/commands.rs and cli/src/flags.rs
+#
+# To activate (add one of these to ~/.zshrc):
+#   eval "$(agent-browser completion zsh)"
+#   # or manually: fpath=(~/.zfunc $fpath) && agent-browser completion zsh > ~/.zfunc/_agent_browser
+
+_agent_browser() {
+    local state
+
+    _arguments \
+        '--json[Output in JSON format]' \
+        '--headed[Show browser window]' \
+        '--debug[Enable debug logging]' \
+        '--session[Session ID]:session:' \
+        '--headers[HTTP headers as JSON]:json:' \
+        '--executable-path[Browser executable path]:path:_files' \
+        '--cdp[CDP endpoint URL]:url:' \
+        '--extension[Browser extension path]:path:_dirs' \
+        '--profile[Browser profile directory]:path:_files' \
+        '--state[Browser state file]:path:_files' \
+        '--proxy[Proxy server URL]:url:' \
+        '--proxy-bypass[Domains to bypass proxy]:domains:' \
+        '--args[Extra browser arguments]:args:' \
+        '--user-agent[Custom user agent]:agent:' \
+        '--provider[Browser provider]:provider:(chromium firefox webkit ios android)' \
+        '-p[Browser provider]:provider:(chromium firefox webkit ios android)' \
+        '--device[Device emulation name]:device:' \
+        '--ignore-https-errors[Ignore HTTPS certificate errors]' \
+        '--allow-file-access[Allow file:// URL access]' \
+        '--auto-connect[Connect to running browser]' \
+        '--session-name[Named session for state persistence]:name:' \
+        '--annotate[Annotate elements in screenshots]' \
+        '--color-scheme[Color scheme]:scheme:(light dark)' \
+        '--download-path[Download directory]:path:_files' \
+        '--content-boundaries[Show content boundaries]' \
+        '--max-output[Max output size in bytes]:bytes:' \
+        '--allowed-domains[Allowed domains comma-separated]:domains:' \
+        '--action-policy[Action approval policy]:policy:' \
+        '--confirm-actions[Actions requiring confirmation]:actions:' \
+        '--confirm-interactive[Require interactive confirmation]' \
+        '--engine[Browser engine]:engine:(chrome lightpanda)' \
+        '--screenshot-dir[Default screenshot directory]:path:_files' \
+        '--screenshot-quality[JPEG quality 0-100]:quality:' \
+        '--screenshot-format[Screenshot format]:format:(png jpeg)' \
+        '--idle-timeout[Idle timeout e.g. 30s 5m]:duration:' \
+        '--config[Config file path]:path:_files' \
+        '1: :->cmd' \
+        '*: :->args' && return 0
+
+    case $state in
+        cmd)
+            local -a cmds=(
+                'open:Navigate to a URL'
+                'goto:Navigate to a URL'
+                'navigate:Navigate to a URL'
+                'back:Go back'
+                'forward:Go forward'
+                'reload:Reload the page'
+                'click:Click an element'
+                'dblclick:Double-click an element'
+                'fill:Clear and fill an element'
+                'type:Type into an element'
+                'hover:Hover over an element'
+                'focus:Focus an element'
+                'check:Check a checkbox'
+                'uncheck:Uncheck a checkbox'
+                'select:Select a dropdown option'
+                'drag:Drag and drop'
+                'upload:Upload files'
+                'download:Download a file'
+                'scroll:Scroll the page'
+                'scrollintoview:Scroll element into view'
+                'press:Press a key'
+                'key:Press a key'
+                'keyboard:Type with real keystrokes'
+                'get:Get element property'
+                'is:Check element state'
+                'find:Find elements'
+                'screenshot:Take a screenshot'
+                'pdf:Save as PDF'
+                'snapshot:Accessibility tree snapshot'
+                'eval:Run JavaScript'
+                'connect:Connect to browser via CDP'
+                'wait:Wait for element or time'
+                'inspect:Open Chrome DevTools'
+                'batch:Execute commands from stdin'
+                'cookies:Manage cookies'
+                'storage:Manage storage'
+                'state:Manage browser state'
+                'network:Manage network'
+                'trace:Record a trace'
+                'profiler:Record a profile'
+                'record:Record video'
+                'set:Configure browser settings'
+                'mouse:Mouse actions'
+                'tab:Manage tabs'
+                'window:Manage windows'
+                'frame:Switch frames'
+                'dialog:Handle dialogs'
+                'console:View console logs'
+                'errors:View page errors'
+                'highlight:Highlight an element'
+                'clipboard:Read/write clipboard'
+                'diff:Compare snapshots'
+                'auth:Auth vault'
+                'close:Close browser'
+                'install:Install browser binaries'
+                'upgrade:Upgrade to latest version'
+                'session:Manage sessions'
+                'confirm:Approve a pending action'
+                'deny:Deny a pending action'
+                'completion:Generate shell completion script'
+            )
+            _describe 'command' cmds
+            ;;
+        args)
+            case ${words[2]} in
+                auth)
+                    local -a sub=('save:Save credentials' 'login:Login with saved profile' 'list:List saved profiles' 'show:Show profile details' 'delete:Delete a profile')
+                    _describe 'subcommand' sub
+                    _arguments \
+                        '--url[Authentication URL]:url:' \
+                        '--username[Username]:username:' \
+                        '--password[Password]:password:' \
+                        '--password-stdin[Read password from stdin]' \
+                        '--username-selector[Username field selector]:selector:' \
+                        '--password-selector[Password field selector]:selector:' \
+                        '--submit-selector[Submit button selector]:selector:' ;;
+                cookies)
+                    local -a sub=('get:Get cookies' 'set:Set a cookie' 'clear:Clear cookies')
+                    _describe 'subcommand' sub
+                    _arguments \
+                        '--url[Cookie URL scope]:url:' \
+                        '--domain[Cookie domain]:domain:' \
+                        '--path[Cookie path]:path:' \
+                        '--httpOnly[HTTP-only cookie]' \
+                        '--secure[Secure cookie]' \
+                        '--sameSite[SameSite policy]:policy:(Strict Lax None)' \
+                        '--expires[Expiry timestamp (seconds)]:timestamp:' ;;
+                network)
+                    local -a sub=('route:Intercept a URL pattern' 'unroute:Remove intercept' 'requests:Show network requests' 'har:Record HAR file')
+                    _describe 'subcommand' sub
+                    _arguments \
+                        '--abort[Abort matching requests]' \
+                        '--body[Response body]:body:' ;;
+                get)
+                    local -a sub=('text:Get text content' 'html:Get HTML content' 'value:Get input value' 'attr:Get attribute' 'title:Get page title' 'url:Get page URL' 'count:Count elements' 'box:Get bounding box' 'styles:Get computed styles' 'cdp-url:Get CDP URL')
+                    _describe 'subcommand' sub ;;
+                is)
+                    local -a sub=('visible:Check if visible' 'enabled:Check if enabled' 'checked:Check if checked')
+                    _describe 'subcommand' sub ;;
+                find)
+                    local -a sub=('role:Find by ARIA role' 'text:Find by text' 'label:Find by label' 'placeholder:Find by placeholder' 'alt:Find by alt text' 'title:Find by title' 'testid:Find by test ID' 'first:Get first match' 'last:Get last match' 'nth:Get nth match')
+                    _describe 'subcommand' sub
+                    _arguments \
+                        '--exact[Exact match]' \
+                        '--name[Search by name]:name:' ;;
+                set)
+                    local -a sub=('viewport:Set viewport size' 'device:Emulate device' 'geo:Set geolocation' 'geolocation:Set geolocation' 'offline:Toggle offline mode' 'headers:Set HTTP headers' 'credentials:Set HTTP credentials' 'auth:Set HTTP auth credentials' 'media:Set media type')
+                    _describe 'subcommand' sub ;;
+                mouse)
+                    local -a sub=('move:Move mouse' 'down:Mouse button down' 'up:Mouse button up' 'wheel:Scroll wheel')
+                    _describe 'subcommand' sub ;;
+                tab)
+                    local -a sub=('new:Open new tab' 'list:List tabs' 'close:Close tab')
+                    _describe 'subcommand' sub ;;
+                keyboard)
+                    local -a sub=('type:Type text with keystrokes' 'inserttext:Insert text without key events')
+                    _describe 'subcommand' sub ;;
+                diff)
+                    local -a sub=('snapshot:Compare snapshots' 'screenshot:Compare screenshots' 'url:Compare URLs')
+                    _describe 'subcommand' sub
+                    _arguments \
+                        '-b[Baseline file]:path:_files' '--baseline[Baseline file]:path:_files' \
+                        '-s[Scope to selector]:selector:' '--selector[Scope to selector]:selector:' \
+                        '-c[Compact output]' '--compact[Compact output]' \
+                        '-d[Max depth]:depth:' '--depth[Max depth]:depth:' \
+                        '-o[Output diff image]:path:_files' '--output[Output diff image]:path:_files' \
+                        '-t[Pixel threshold 0-1]:threshold:' '--threshold[Pixel threshold]:threshold:' \
+                        '-f[Full page]' '--full[Full page]' \
+                        '--screenshot[Compare as screenshots]' \
+                        '--wait-until[Wait for load state]:state:(load domcontentloaded networkidle)' ;;
+                clipboard)
+                    local -a sub=('read:Read clipboard' 'write:Write clipboard' 'copy:Copy to clipboard' 'paste:Paste from clipboard')
+                    _describe 'subcommand' sub ;;
+                scroll)
+                    local -a sub=('up:Scroll up' 'down:Scroll down' 'left:Scroll left' 'right:Scroll right')
+                    _describe 'subcommand' sub ;;
+                storage)
+                    local -a sub=('local:Local storage' 'session:Session storage')
+                    _describe 'subcommand' sub ;;
+                state)
+                    local -a sub=('save:Save state' 'load:Load state' 'list:List states' 'clear:Clear state' 'show:Show state' 'clean:Clean states' 'rename:Rename state')
+                    _describe 'subcommand' sub
+                    _arguments \
+                        '-a[Apply to all]' '--all[Apply to all]' \
+                        '--older-than[Days threshold]:days:' ;;
+                trace)
+                    local -a sub=('start:Start recording' 'stop:Stop recording')
+                    _describe 'subcommand' sub ;;
+                record)
+                    local -a sub=('start:Start recording' 'stop:Stop recording' 'restart:Restart recording')
+                    _describe 'subcommand' sub ;;
+                profiler)
+                    local -a sub=('start:Start recording' 'stop:Stop recording')
+                    _describe 'subcommand' sub
+                    _arguments '--categories[Profiler categories]:categories:' ;;
+                dialog)
+                    local -a sub=('accept:Accept dialog' 'dismiss:Dismiss dialog')
+                    _describe 'subcommand' sub ;;
+                window)
+                    local -a sub=('new:Open new window')
+                    _describe 'subcommand' sub ;;
+                session)
+                    local -a sub=('list:List active sessions')
+                    _describe 'subcommand' sub ;;
+                completion)
+                    local -a shells=('bash:Bash completion script' 'zsh:Zsh completion script')
+                    _describe 'shell' shells ;;
+                snapshot)
+                    _arguments \
+                        '-i[Only interactive elements]' '--interactive[Only interactive elements]' \
+                        '-c[Remove empty structural elements]' '--compact[Remove empty structural elements]' \
+                        '-C[Include cursor position]' '--cursor[Include cursor position]' \
+                        '-d[Limit tree depth]:depth:' '--depth[Limit tree depth]:depth:' \
+                        '-s[Scope to CSS selector]:selector:' '--selector[Scope to CSS selector]:selector:' ;;
+                wait)
+                    _arguments \
+                        '-u[Wait for URL pattern]:pattern:' '--url[Wait for URL pattern]:pattern:' \
+                        '-l[Wait for load state]:state:(load domcontentloaded networkidle)' \
+                        '--load[Wait for load state]:state:(load domcontentloaded networkidle)' \
+                        '-f[Wait for JS function]:expression:' '--fn[Wait for JS function]:expression:' \
+                        '-t[Wait for text]:text:' '--text[Wait for text]:text:' \
+                        '-d[Wait for download]:path:_files' '--download[Wait for download]:path:_files' \
+                        '--timeout[Timeout in ms]:ms:' ;;
+                screenshot)
+                    _arguments \
+                        '-f[Capture full page]' '--full[Capture full page]' ;;
+                click|dblclick|hover)
+                    _arguments '--new-tab[Open link in new tab]' ;;
+                eval)
+                    _arguments \
+                        '-b[Script is base64 encoded]' '--base64[Script is base64 encoded]' \
+                        '--stdin[Read script from stdin]' ;;
+                batch)
+                    _arguments '--bail[Stop on first error]' ;;
+            esac
+            ;;
+    esac
+}
+
+if [ "$funcstack[1]" = "_agent_browser" ]; then
+    _agent_browser "$@"
+else
+    compdef _agent_browser agent-browser
+fi

--- a/cli/completions/agent-browser.bash
+++ b/cli/completions/agent-browser.bash
@@ -1,0 +1,180 @@
+# Shell completion for agent-browser
+# Source: cli/completions/agent-browser.bash
+# Keep in sync with: cli/src/commands.rs and cli/src/flags.rs
+#
+# To activate:
+#   eval "$(agent-browser completion bash)"
+#   # or add that line to ~/.bashrc
+
+_agent_browser() {
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    local global_flags="--json --headed --debug --session --headers --executable-path --cdp --extension --profile --state --proxy --proxy-bypass --args --user-agent --provider -p --device --ignore-https-errors --allow-file-access --auto-connect --session-name --annotate --color-scheme --download-path --content-boundaries --max-output --allowed-domains --action-policy --confirm-actions --confirm-interactive --engine --screenshot-dir --screenshot-quality --screenshot-format --idle-timeout --config"
+
+    # Flags that consume the next token as a value.
+    # Keep in sync with GLOBAL_FLAGS_WITH_VALUE in flags.rs.
+    local flags_with_value="--session --headers --executable-path --cdp --extension --profile --state --proxy --proxy-bypass --args --user-agent --provider -p --device --session-name --color-scheme --download-path --max-output --allowed-domains --action-policy --confirm-actions --config --engine --screenshot-dir --screenshot-quality --screenshot-format --idle-timeout"
+
+    # Complete values for flags that take a fixed set of options.
+    case "$prev" in
+        --provider|-p)
+            COMPREPLY=( $(compgen -W "chromium firefox webkit ios android" -- "$cur") )
+            return 0 ;;
+        --engine)
+            COMPREPLY=( $(compgen -W "chrome lightpanda" -- "$cur") )
+            return 0 ;;
+        --color-scheme)
+            COMPREPLY=( $(compgen -W "light dark" -- "$cur") )
+            return 0 ;;
+        --screenshot-format)
+            COMPREPLY=( $(compgen -W "png jpeg" -- "$cur") )
+            return 0 ;;
+        --wait-until|--load|-l)
+            COMPREPLY=( $(compgen -W "load domcontentloaded networkidle" -- "$cur") )
+            return 0 ;;
+        --sameSite)
+            COMPREPLY=( $(compgen -W "Strict Lax None" -- "$cur") )
+            return 0 ;;
+        --executable-path|--profile|--state|--screenshot-dir|--download-path|--config|-b|--baseline|-o|--output)
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0 ;;
+        --extension)
+            COMPREPLY=( $(compgen -d -- "$cur") )
+            return 0 ;;
+    esac
+
+    # If $prev is a value-consuming flag, $cur is its value — nothing to complete.
+    if [[ " $flags_with_value " == *" $prev "* ]]; then
+        return 0
+    fi
+
+    # Find the command word: first non-flag, non-flag-value word after argv[0].
+    local cmd="" cmd_pos=0 i word skip_next=0
+    for (( i=1; i<COMP_CWORD; i++ )); do
+        word="${COMP_WORDS[$i]}"
+        if (( skip_next )); then
+            skip_next=0
+            continue
+        fi
+        if [[ " $flags_with_value " == *" $word "* ]]; then
+            skip_next=1
+            continue
+        fi
+        if [[ "$word" != -* ]]; then
+            cmd="$word"
+            cmd_pos=$i
+            break
+        fi
+    done
+
+    # No command yet — complete commands or global flags.
+    if [[ -z "$cmd" ]]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "$global_flags" -- "$cur") )
+        else
+            local commands="open goto navigate back forward reload click dblclick fill type hover focus check uncheck select drag upload download scroll scrollintoview press key keyboard get is find screenshot pdf snapshot eval connect wait inspect batch cookies storage state network trace profiler record set mouse tab window frame dialog console errors highlight clipboard diff auth close install upgrade session confirm deny completion"
+            COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+        fi
+        return 0
+    fi
+
+    # Find subcommand: first non-flag word after the command.
+    local sub="" skip_next2=0
+    for (( i=cmd_pos+1; i<COMP_CWORD; i++ )); do
+        word="${COMP_WORDS[$i]}"
+        if (( skip_next2 )); then
+            skip_next2=0
+            continue
+        fi
+        if [[ "$word" == -* ]]; then
+            if [[ " $flags_with_value " == *" $word "* ]]; then
+                skip_next2=1
+            fi
+            continue
+        fi
+        sub="$word"
+        break
+    done
+
+    # Complete flags at any depth — context-aware using both $cmd and $sub.
+    if [[ "$cur" == -* ]]; then
+        local cmd_flags=""
+        case "$cmd" in
+            snapshot)
+                cmd_flags="-i --interactive -c --compact -C --cursor -d --depth -s --selector" ;;
+            wait)
+                cmd_flags="--url -u --load -l --fn -f --text -t --download -d --timeout" ;;
+            screenshot)
+                cmd_flags="--full -f" ;;
+            click|dblclick|hover)
+                cmd_flags="--new-tab" ;;
+            eval)
+                cmd_flags="-b --base64 --stdin" ;;
+            scroll|scrollintoview|highlight)
+                cmd_flags="-s --selector" ;;
+            batch)
+                cmd_flags="--bail" ;;
+            auth)
+                cmd_flags="--url --username --password --password-stdin --username-selector --password-selector --submit-selector" ;;
+            cookies)
+                cmd_flags="--url --domain --path --httpOnly --secure --sameSite --expires" ;;
+            diff)
+                case "$sub" in
+                    snapshot) cmd_flags="-b --baseline -s --selector -c --compact -d --depth" ;;
+                    screenshot) cmd_flags="-b --baseline -s --selector -o --output -t --threshold -f --full" ;;
+                    url) cmd_flags="-s --selector -c --compact -d --depth -f --full --screenshot --wait-until" ;;
+                    *) cmd_flags="-b --baseline -s --selector -c --compact -d --depth -o --output -t --threshold -f --full --screenshot --wait-until" ;;
+                esac ;;
+            state)
+                cmd_flags="--all -a --older-than" ;;
+            profiler)
+                cmd_flags="--categories" ;;
+            find)
+                cmd_flags="--exact --name" ;;
+            network)
+                case "$sub" in
+                    route) cmd_flags="--abort --body" ;;
+                esac ;;
+        esac
+        COMPREPLY=( $(compgen -W "$global_flags $cmd_flags" -- "$cur") )
+        return 0
+    fi
+
+    # Complete subcommand if we don't have one yet.
+    if [[ -z "$sub" ]]; then
+        case "$cmd" in
+            auth)       COMPREPLY=( $(compgen -W "save login list delete show" -- "$cur") ) ;;
+            cookies)    COMPREPLY=( $(compgen -W "get set clear" -- "$cur") ) ;;
+            network)    COMPREPLY=( $(compgen -W "route unroute requests har" -- "$cur") ) ;;
+            get)        COMPREPLY=( $(compgen -W "text html value attr title url count box styles cdp-url" -- "$cur") ) ;;
+            is)         COMPREPLY=( $(compgen -W "visible enabled checked" -- "$cur") ) ;;
+            find)       COMPREPLY=( $(compgen -W "role text label placeholder alt title testid first last nth" -- "$cur") ) ;;
+            set)        COMPREPLY=( $(compgen -W "viewport device geo geolocation offline headers credentials auth media" -- "$cur") ) ;;
+            mouse)      COMPREPLY=( $(compgen -W "move down up wheel" -- "$cur") ) ;;
+            tab)        COMPREPLY=( $(compgen -W "new list close" -- "$cur") ) ;;
+            keyboard)   COMPREPLY=( $(compgen -W "type inserttext" -- "$cur") ) ;;
+            diff)       COMPREPLY=( $(compgen -W "snapshot screenshot url" -- "$cur") ) ;;
+            clipboard)  COMPREPLY=( $(compgen -W "read write copy paste" -- "$cur") ) ;;
+            scroll)     COMPREPLY=( $(compgen -W "up down left right" -- "$cur") ) ;;
+            storage)    COMPREPLY=( $(compgen -W "local session" -- "$cur") ) ;;
+            state)      COMPREPLY=( $(compgen -W "save load list clear show clean rename" -- "$cur") ) ;;
+            trace|profiler)  COMPREPLY=( $(compgen -W "start stop" -- "$cur") ) ;;
+            record)          COMPREPLY=( $(compgen -W "start stop restart" -- "$cur") ) ;;
+            dialog)     COMPREPLY=( $(compgen -W "accept dismiss" -- "$cur") ) ;;
+            window)     COMPREPLY=( $(compgen -W "new" -- "$cur") ) ;;
+            session)    COMPREPLY=( $(compgen -W "list" -- "$cur") ) ;;
+            completion) COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") ) ;;
+        esac
+        return 0
+    fi
+
+    # Depth 3: network har start|stop
+    if [[ "$cmd" == "network" && "$sub" == "har" ]]; then
+        COMPREPLY=( $(compgen -W "start stop" -- "$cur") )
+        return 0
+    fi
+}
+complete -F _agent_browser agent-browser

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -71,6 +71,121 @@ pub fn gen_id() -> String {
     )
 }
 
+pub(crate) const AUTH_SUBCOMMANDS: &[&str] = &["save", "login", "list", "delete", "show"];
+pub(crate) const KEYBOARD_SUBCOMMANDS: &[&str] = &["type", "inserttext"];
+pub(crate) const WINDOW_SUBCOMMANDS: &[&str] = &["new"];
+pub(crate) const DIALOG_SUBCOMMANDS: &[&str] = &["accept", "dismiss"];
+pub(crate) const TRACE_SUBCOMMANDS: &[&str] = &["start", "stop"];
+pub(crate) const PROFILER_SUBCOMMANDS: &[&str] = &["start", "stop"];
+pub(crate) const RECORD_SUBCOMMANDS: &[&str] = &["start", "stop", "restart"];
+pub(crate) const CLIPBOARD_SUBCOMMANDS: &[&str] = &["read", "write", "copy", "paste"];
+pub(crate) const STATE_SUBCOMMANDS: &[&str] =
+    &["save", "load", "list", "clear", "show", "clean", "rename"];
+pub(crate) const SESSION_SUBCOMMANDS: &[&str] = &["list"];
+pub(crate) const DIFF_SUBCOMMANDS: &[&str] = &["snapshot", "screenshot", "url"];
+pub(crate) const GET_SUBCOMMANDS: &[&str] = &[
+    "text", "html", "value", "attr", "url", "title", "count", "box", "styles", "cdp-url",
+];
+pub(crate) const IS_SUBCOMMANDS: &[&str] = &["visible", "enabled", "checked"];
+pub(crate) const FIND_SUBCOMMANDS: &[&str] = &[
+    "role",
+    "text",
+    "label",
+    "placeholder",
+    "alt",
+    "title",
+    "testid",
+    "first",
+    "last",
+    "nth",
+];
+pub(crate) const MOUSE_SUBCOMMANDS: &[&str] = &["move", "down", "up", "wheel"];
+pub(crate) const SET_SUBCOMMANDS: &[&str] = &[
+    "viewport",
+    "device",
+    "geo",
+    "geolocation",
+    "offline",
+    "headers",
+    "credentials",
+    "auth",
+    "media",
+];
+pub(crate) const NETWORK_SUBCOMMANDS: &[&str] = &["route", "unroute", "requests", "har"];
+pub(crate) const HAR_SUBCOMMANDS: &[&str] = &["start", "stop"];
+pub(crate) const STORAGE_SUBCOMMANDS: &[&str] = &["local", "session"];
+
+/// Returns all recognized top-level command names.
+/// Used by completion tests to verify coverage stays complete.
+/// Update this list whenever a new command is added to parse_command's match arms
+/// or handled before parse_command in main.rs.
+#[cfg(test)]
+pub(crate) fn all_known_commands() -> &'static [&'static str] {
+    &[
+        "open",
+        "goto",
+        "navigate",
+        "back",
+        "forward",
+        "reload",
+        "click",
+        "dblclick",
+        "fill",
+        "type",
+        "hover",
+        "focus",
+        "check",
+        "uncheck",
+        "select",
+        "drag",
+        "upload",
+        "download",
+        "scroll",
+        "scrollintoview",
+        "press",
+        "key",
+        "keyboard",
+        "get",
+        "is",
+        "find",
+        "screenshot",
+        "pdf",
+        "snapshot",
+        "eval",
+        "connect",
+        "wait",
+        "inspect",
+        "batch",
+        "cookies",
+        "storage",
+        "state",
+        "network",
+        "trace",
+        "profiler",
+        "record",
+        "set",
+        "mouse",
+        "tab",
+        "window",
+        "frame",
+        "dialog",
+        "console",
+        "errors",
+        "highlight",
+        "clipboard",
+        "diff",
+        "auth",
+        "close",
+        "confirm",
+        "deny",
+        // pre-dispatch (handled in main.rs before parse_command)
+        "install",
+        "upgrade",
+        "session",
+        "completion",
+    ]
+}
+
 pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError> {
     if args.is_empty() {
         return Err(ParseError::MissingArguments {
@@ -298,7 +413,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 }
                 _ => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
-                    valid_options: &["type", "inserttext"],
+                    valid_options: KEYBOARD_SUBCOMMANDS,
                 }),
             }
         }
@@ -728,7 +843,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 }
                 _ => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.unwrap_or("(none)").to_string(),
-                    valid_options: &["save", "login", "list", "delete", "show"],
+                    valid_options: AUTH_SUBCOMMANDS,
                 }),
             }
         }
@@ -956,20 +1071,17 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
         },
 
         // === Window ===
-        "window" => {
-            const VALID: &[&str] = &["new"];
-            match rest.first().copied() {
-                Some("new") => Ok(json!({ "id": id, "action": "window_new" })),
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "window".to_string(),
-                    usage: "window <new>",
-                }),
-            }
-        }
+        "window" => match rest.first().copied() {
+            Some("new") => Ok(json!({ "id": id, "action": "window_new" })),
+            Some(sub) => Err(ParseError::UnknownSubcommand {
+                subcommand: sub.to_string(),
+                valid_options: WINDOW_SUBCOMMANDS,
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "window".to_string(),
+                usage: "window <new>",
+            }),
+        },
 
         // === Frame ===
         "frame" => {
@@ -985,97 +1097,87 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
         }
 
         // === Dialog ===
-        "dialog" => {
-            const VALID: &[&str] = &["accept", "dismiss"];
-            match rest.first().copied() {
-                Some("accept") => {
-                    let mut cmd = json!({ "id": id, "action": "dialog", "response": "accept" });
-                    if let Some(prompt_text) = rest.get(1) {
-                        cmd["promptText"] = json!(prompt_text);
-                    }
-                    Ok(cmd)
+        "dialog" => match rest.first().copied() {
+            Some("accept") => {
+                let mut cmd = json!({ "id": id, "action": "dialog", "response": "accept" });
+                if let Some(prompt_text) = rest.get(1) {
+                    cmd["promptText"] = json!(prompt_text);
                 }
-                Some("dismiss") => {
-                    let mut cmd = json!({ "id": id, "action": "dialog", "response": "dismiss" });
-                    if let Some(prompt_text) = rest.get(1) {
-                        cmd["promptText"] = json!(prompt_text);
-                    }
-                    Ok(cmd)
-                }
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "dialog".to_string(),
-                    usage: "dialog <accept|dismiss> [text]",
-                }),
+                Ok(cmd)
             }
-        }
+            Some("dismiss") => {
+                let mut cmd = json!({ "id": id, "action": "dialog", "response": "dismiss" });
+                if let Some(prompt_text) = rest.get(1) {
+                    cmd["promptText"] = json!(prompt_text);
+                }
+                Ok(cmd)
+            }
+            Some(sub) => Err(ParseError::UnknownSubcommand {
+                subcommand: sub.to_string(),
+                valid_options: DIALOG_SUBCOMMANDS,
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "dialog".to_string(),
+                usage: "dialog <accept|dismiss> [text]",
+            }),
+        },
 
         // === Debug ===
-        "trace" => {
-            const VALID: &[&str] = &["start", "stop"];
-            match rest.first().copied() {
-                Some("start") => Ok(json!({ "id": id, "action": "trace_start" })),
-                Some("stop") => {
-                    let mut cmd = json!({ "id": id, "action": "trace_stop" });
-                    if let Some(path) = rest.get(1) {
-                        cmd["path"] = json!(path);
-                    }
-                    Ok(cmd)
+        "trace" => match rest.first().copied() {
+            Some("start") => Ok(json!({ "id": id, "action": "trace_start" })),
+            Some("stop") => {
+                let mut cmd = json!({ "id": id, "action": "trace_stop" });
+                if let Some(path) = rest.get(1) {
+                    cmd["path"] = json!(path);
                 }
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "trace".to_string(),
-                    usage: "trace <start|stop> [path]",
-                }),
+                Ok(cmd)
             }
-        }
+            Some(sub) => Err(ParseError::UnknownSubcommand {
+                subcommand: sub.to_string(),
+                valid_options: TRACE_SUBCOMMANDS,
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "trace".to_string(),
+                usage: "trace <start|stop> [path]",
+            }),
+        },
 
         // === Profiler (CDP Tracing / Chromium profiling) ===
-        "profiler" => {
-            const VALID: &[&str] = &["start", "stop"];
-            match rest.first().copied() {
-                Some("start") => {
-                    let mut cmd = json!({ "id": id, "action": "profiler_start" });
-                    if let Some(idx) = rest.iter().position(|s| *s == "--categories") {
-                        if let Some(cats) = rest.get(idx + 1) {
-                            let categories: Vec<&str> = cats.split(',').collect();
-                            cmd["categories"] = json!(categories);
-                        } else {
-                            return Err(ParseError::MissingArguments {
-                                context: "profiler start --categories".to_string(),
-                                usage: "--categories <list>",
-                            });
-                        }
+        "profiler" => match rest.first().copied() {
+            Some("start") => {
+                let mut cmd = json!({ "id": id, "action": "profiler_start" });
+                if let Some(idx) = rest.iter().position(|s| *s == "--categories") {
+                    if let Some(cats) = rest.get(idx + 1) {
+                        let categories: Vec<&str> = cats.split(',').collect();
+                        cmd["categories"] = json!(categories);
+                    } else {
+                        return Err(ParseError::MissingArguments {
+                            context: "profiler start --categories".to_string(),
+                            usage: "--categories <list>",
+                        });
                     }
-                    Ok(cmd)
                 }
-                Some("stop") => {
-                    let mut cmd = json!({ "id": id, "action": "profiler_stop" });
-                    if let Some(path) = rest.get(1) {
-                        cmd["path"] = json!(path);
-                    }
-                    Ok(cmd)
-                }
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "profiler".to_string(),
-                    usage: "profiler <start|stop> [options]",
-                }),
+                Ok(cmd)
             }
-        }
+            Some("stop") => {
+                let mut cmd = json!({ "id": id, "action": "profiler_stop" });
+                if let Some(path) = rest.get(1) {
+                    cmd["path"] = json!(path);
+                }
+                Ok(cmd)
+            }
+            Some(sub) => Err(ParseError::UnknownSubcommand {
+                subcommand: sub.to_string(),
+                valid_options: PROFILER_SUBCOMMANDS,
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "profiler".to_string(),
+                usage: "profiler <start|stop> [options]",
+            }),
+        },
 
         // === Recording (browser video recording) ===
         "record" => {
-            const VALID: &[&str] = &["start", "stop", "restart"];
             match rest.first().copied() {
                 Some("start") => {
                     let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
@@ -1118,7 +1220,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 }
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
-                    valid_options: VALID,
+                    valid_options: RECORD_SUBCOMMANDS,
                 }),
                 None => Err(ParseError::MissingArguments {
                     context: "record".to_string(),
@@ -1159,129 +1261,126 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             Some("paste") => Ok(json!({ "id": id, "action": "clipboard", "operation": "paste" })),
             Some(sub) => Err(ParseError::UnknownSubcommand {
                 subcommand: sub.to_string(),
-                valid_options: &["read", "write", "copy", "paste"],
+                valid_options: CLIPBOARD_SUBCOMMANDS,
             }),
         },
 
         // === State ===
-        "state" => {
-            const VALID: &[&str] = &["save", "load", "list", "clear", "show", "clean", "rename"];
-            match rest.first().copied() {
-                Some("save") => {
-                    let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                        context: "state save".to_string(),
-                        usage: "state save <path>",
-                    })?;
-                    Ok(json!({ "id": id, "action": "state_save", "path": path }))
-                }
-                Some("load") => {
-                    let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                        context: "state load".to_string(),
-                        usage: "state load <path>",
-                    })?;
-                    Ok(json!({ "id": id, "action": "state_load", "path": path }))
-                }
-                Some("list") => Ok(json!({ "id": id, "action": "state_list" })),
-                Some("clear") => {
-                    let mut session_name: Option<&str> = None;
-                    let mut all = false;
-
-                    let mut i = 1;
-                    while i < rest.len() {
-                        match rest[i] {
-                            "--all" | "-a" => {
-                                all = true;
-                            }
-                            arg if !arg.starts_with('-') => {
-                                session_name = Some(arg);
-                            }
-                            _ => {}
-                        }
-                        i += 1;
-                    }
-
-                    if let Some(name) = session_name {
-                        if !is_valid_session_name(name) {
-                            return Err(ParseError::InvalidSessionName {
-                                name: name.to_string(),
-                            });
-                        }
-                    }
-
-                    let mut cmd = json!({ "id": id, "action": "state_clear" });
-                    if all {
-                        cmd["all"] = json!(true);
-                    }
-                    if let Some(name) = session_name {
-                        cmd["sessionName"] = json!(name);
-                    }
-                    Ok(cmd)
-                }
-                Some("show") => {
-                    let filename = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                        context: "state show".to_string(),
-                        usage: "state show <filename>",
-                    })?;
-                    Ok(json!({ "id": id, "action": "state_show", "filename": filename }))
-                }
-                Some("clean") => {
-                    let mut days: Option<i64> = None;
-
-                    let mut i = 1;
-                    while i < rest.len() {
-                        if rest[i] == "--older-than" {
-                            if let Some(d) = rest.get(i + 1) {
-                                days = d.parse().ok();
-                                i += 1;
-                            }
-                        }
-                        i += 1;
-                    }
-
-                    let days = days.ok_or_else(|| ParseError::MissingArguments {
-                        context: "state clean".to_string(),
-                        usage: "state clean --older-than <days>",
-                    })?;
-
-                    Ok(json!({ "id": id, "action": "state_clean", "days": days }))
-                }
-                Some("rename") => {
-                    let old_name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                        context: "state rename".to_string(),
-                        usage: "state rename <old-name> <new-name>",
-                    })?;
-                    let new_name = rest.get(2).ok_or_else(|| ParseError::MissingArguments {
-                        context: "state rename".to_string(),
-                        usage: "state rename <old-name> <new-name>",
-                    })?;
-                    let old_name = old_name.trim_end_matches(".json");
-                    let new_name = new_name.trim_end_matches(".json");
-
-                    if !is_valid_session_name(old_name) {
-                        return Err(ParseError::InvalidSessionName {
-                            name: old_name.to_string(),
-                        });
-                    }
-                    if !is_valid_session_name(new_name) {
-                        return Err(ParseError::InvalidSessionName {
-                            name: new_name.to_string(),
-                        });
-                    }
-
-                    Ok(
-                        json!({ "id": id, "action": "state_rename", "oldName": old_name, "newName": new_name }),
-                    )
-                }
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "state".to_string(),
-                    usage: "state <save|load|list|clear|show|clean|rename> ...",
-                }),
+        "state" => match rest.first().copied() {
+            Some("save") => {
+                let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                    context: "state save".to_string(),
+                    usage: "state save <path>",
+                })?;
+                Ok(json!({ "id": id, "action": "state_save", "path": path }))
             }
-        }
+            Some("load") => {
+                let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                    context: "state load".to_string(),
+                    usage: "state load <path>",
+                })?;
+                Ok(json!({ "id": id, "action": "state_load", "path": path }))
+            }
+            Some("list") => Ok(json!({ "id": id, "action": "state_list" })),
+            Some("clear") => {
+                let mut session_name: Option<&str> = None;
+                let mut all = false;
+
+                let mut i = 1;
+                while i < rest.len() {
+                    match rest[i] {
+                        "--all" | "-a" => {
+                            all = true;
+                        }
+                        arg if !arg.starts_with('-') => {
+                            session_name = Some(arg);
+                        }
+                        _ => {}
+                    }
+                    i += 1;
+                }
+
+                if let Some(name) = session_name {
+                    if !is_valid_session_name(name) {
+                        return Err(ParseError::InvalidSessionName {
+                            name: name.to_string(),
+                        });
+                    }
+                }
+
+                let mut cmd = json!({ "id": id, "action": "state_clear" });
+                if all {
+                    cmd["all"] = json!(true);
+                }
+                if let Some(name) = session_name {
+                    cmd["sessionName"] = json!(name);
+                }
+                Ok(cmd)
+            }
+            Some("show") => {
+                let filename = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                    context: "state show".to_string(),
+                    usage: "state show <filename>",
+                })?;
+                Ok(json!({ "id": id, "action": "state_show", "filename": filename }))
+            }
+            Some("clean") => {
+                let mut days: Option<i64> = None;
+
+                let mut i = 1;
+                while i < rest.len() {
+                    if rest[i] == "--older-than" {
+                        if let Some(d) = rest.get(i + 1) {
+                            days = d.parse().ok();
+                            i += 1;
+                        }
+                    }
+                    i += 1;
+                }
+
+                let days = days.ok_or_else(|| ParseError::MissingArguments {
+                    context: "state clean".to_string(),
+                    usage: "state clean --older-than <days>",
+                })?;
+
+                Ok(json!({ "id": id, "action": "state_clean", "days": days }))
+            }
+            Some("rename") => {
+                let old_name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                    context: "state rename".to_string(),
+                    usage: "state rename <old-name> <new-name>",
+                })?;
+                let new_name = rest.get(2).ok_or_else(|| ParseError::MissingArguments {
+                    context: "state rename".to_string(),
+                    usage: "state rename <old-name> <new-name>",
+                })?;
+                let old_name = old_name.trim_end_matches(".json");
+                let new_name = new_name.trim_end_matches(".json");
+
+                if !is_valid_session_name(old_name) {
+                    return Err(ParseError::InvalidSessionName {
+                        name: old_name.to_string(),
+                    });
+                }
+                if !is_valid_session_name(new_name) {
+                    return Err(ParseError::InvalidSessionName {
+                        name: new_name.to_string(),
+                    });
+                }
+
+                Ok(
+                    json!({ "id": id, "action": "state_rename", "oldName": old_name, "newName": new_name }),
+                )
+            }
+            Some(sub) => Err(ParseError::UnknownSubcommand {
+                subcommand: sub.to_string(),
+                valid_options: STATE_SUBCOMMANDS,
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "state".to_string(),
+                usage: "state <save|load|list|clear|show|clean|rename> ...",
+            }),
+        },
 
         // === iOS-specific commands ===
         "tap" => {
@@ -1322,7 +1421,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 }
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
-                    valid_options: &["list"],
+                    valid_options: SESSION_SUBCOMMANDS,
                 }),
             }
         }
@@ -1342,8 +1441,6 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
 }
 
 fn parse_diff(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["snapshot", "screenshot", "url"];
-
     match rest.first().copied() {
         Some("snapshot") => {
             let mut cmd = json!({ "id": id, "action": "diff_snapshot" });
@@ -1605,7 +1702,7 @@ fn parse_diff(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: DIFF_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "diff".to_string(),
@@ -1615,10 +1712,6 @@ fn parse_diff(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 }
 
 fn parse_get(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &[
-        "text", "html", "value", "attr", "url", "title", "count", "box", "styles", "cdp-url",
-    ];
-
     match rest.first().copied() {
         Some("text") => {
             let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
@@ -1678,7 +1771,7 @@ fn parse_get(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: GET_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "get".to_string(),
@@ -1688,8 +1781,6 @@ fn parse_get(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 }
 
 fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["visible", "enabled", "checked"];
-
     match rest.first().copied() {
         Some("visible") => {
             let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
@@ -1714,7 +1805,7 @@ fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: IS_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "is".to_string(),
@@ -1724,19 +1815,6 @@ fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 }
 
 fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &[
-        "role",
-        "text",
-        "label",
-        "placeholder",
-        "alt",
-        "title",
-        "testid",
-        "first",
-        "last",
-        "nth",
-    ];
-
     let locator = rest.first().ok_or_else(|| ParseError::MissingArguments {
         context: "find".to_string(),
         usage: "find <locator> <value> [action] [text]",
@@ -1855,14 +1933,12 @@ fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         _ => Err(ParseError::UnknownSubcommand {
             subcommand: locator.to_string(),
-            valid_options: VALID,
+            valid_options: FIND_SUBCOMMANDS,
         }),
     }
 }
 
 fn parse_mouse(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["move", "down", "up", "wheel"];
-
     match rest.first().copied() {
         Some("move") => {
             let x_str = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
@@ -1903,7 +1979,7 @@ fn parse_mouse(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: MOUSE_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "mouse".to_string(),
@@ -1913,18 +1989,6 @@ fn parse_mouse(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 }
 
 fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &[
-        "viewport",
-        "device",
-        "geo",
-        "geolocation",
-        "offline",
-        "headers",
-        "credentials",
-        "auth",
-        "media",
-    ];
-
     match rest.first().copied() {
         Some("viewport") => {
             let w_str = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
@@ -2039,7 +2103,7 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: SET_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "set".to_string(),
@@ -2050,8 +2114,6 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 
 /// Parse network interception, request inspection, and HAR recording commands.
 fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["route", "unroute", "requests", "har"];
-
     match rest.first().copied() {
         Some("route") => {
             let url = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
@@ -2080,30 +2142,27 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             }
             Ok(cmd)
         }
-        Some("har") => {
-            const HAR_VALID: &[&str] = &["start", "stop"];
-            match rest.get(1).copied() {
-                Some("start") => Ok(json!({ "id": id, "action": "har_start" })),
-                Some("stop") => {
-                    let mut cmd = json!({ "id": id, "action": "har_stop" });
-                    if let Some(path) = rest.get(2) {
-                        cmd["path"] = json!(path);
-                    }
-                    Ok(cmd)
+        Some("har") => match rest.get(1).copied() {
+            Some("start") => Ok(json!({ "id": id, "action": "har_start" })),
+            Some("stop") => {
+                let mut cmd = json!({ "id": id, "action": "har_stop" });
+                if let Some(path) = rest.get(2) {
+                    cmd["path"] = json!(path);
                 }
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: HAR_VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "network har".to_string(),
-                    usage: "network har <start|stop> [path]",
-                }),
+                Ok(cmd)
             }
-        }
+            Some(sub) => Err(ParseError::UnknownSubcommand {
+                subcommand: sub.to_string(),
+                valid_options: HAR_SUBCOMMANDS,
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "network har".to_string(),
+                usage: "network har <start|stop> [path]",
+            }),
+        },
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: NETWORK_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "network".to_string(),
@@ -2113,8 +2172,6 @@ fn parse_network(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 }
 
 fn parse_storage(rest: &[&str], id: &str) -> Result<Value, ParseError> {
-    const VALID: &[&str] = &["local", "session"];
-
     match rest.first().copied() {
         Some("local") | Some("session") => {
             let storage_type = rest.first().unwrap();
@@ -2154,7 +2211,7 @@ fn parse_storage(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
-            valid_options: VALID,
+            valid_options: STORAGE_SUBCOMMANDS,
         }),
         None => Err(ParseError::MissingArguments {
             context: "storage".to_string(),

--- a/cli/src/completion.rs
+++ b/cli/src/completion.rs
@@ -1,0 +1,276 @@
+// These three commands have no `valid_options` declared in commands.rs (their parsers use default/fallthrough
+// logic), so we define them here as the source of truth for completion coverage.
+#[cfg(test)]
+pub(crate) const COOKIES_SUBCOMMANDS: &[&str] = &["get", "set", "clear"];
+#[cfg(test)]
+pub(crate) const TAB_SUBCOMMANDS: &[&str] = &["new", "list", "close"];
+#[cfg(test)]
+pub(crate) const SCROLL_SUBCOMMANDS: &[&str] = &["up", "down", "left", "right"];
+
+pub fn run_completion(shell: &str) {
+    match shell {
+        "bash" => print!("{}", include_str!("../completions/agent-browser.bash")),
+        "zsh" => print!("{}", include_str!("../completions/_agent_browser")),
+        "" => {
+            eprintln!("Usage: agent-browser completion <shell>");
+            eprintln!("Supported shells: bash, zsh");
+            std::process::exit(1);
+        }
+        other => {
+            eprintln!("Unsupported shell: {other}");
+            eprintln!("Supported shells: bash, zsh");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{
+        all_known_commands, parse_command, ParseError, AUTH_SUBCOMMANDS, CLIPBOARD_SUBCOMMANDS,
+        DIALOG_SUBCOMMANDS, DIFF_SUBCOMMANDS, FIND_SUBCOMMANDS, GET_SUBCOMMANDS, HAR_SUBCOMMANDS,
+        IS_SUBCOMMANDS, KEYBOARD_SUBCOMMANDS, MOUSE_SUBCOMMANDS, NETWORK_SUBCOMMANDS,
+        PROFILER_SUBCOMMANDS, RECORD_SUBCOMMANDS, SESSION_SUBCOMMANDS, SET_SUBCOMMANDS,
+        STATE_SUBCOMMANDS, STORAGE_SUBCOMMANDS, TRACE_SUBCOMMANDS, WINDOW_SUBCOMMANDS,
+    };
+    use crate::flags::Flags;
+
+    fn default_flags() -> Flags {
+        Flags {
+            session: "test".to_string(),
+            json: false,
+            headed: false,
+            debug: false,
+            headers: None,
+            executable_path: None,
+            extensions: Vec::new(),
+            cdp: None,
+            profile: None,
+            state: None,
+            proxy: None,
+            proxy_bypass: None,
+            args: None,
+            user_agent: None,
+            provider: None,
+            ignore_https_errors: false,
+            allow_file_access: false,
+            device: None,
+            auto_connect: false,
+            session_name: None,
+            cli_executable_path: false,
+            cli_extensions: false,
+            cli_profile: false,
+            cli_state: false,
+            cli_args: false,
+            cli_user_agent: false,
+            cli_proxy: false,
+            cli_proxy_bypass: false,
+            cli_allow_file_access: false,
+            cli_annotate: false,
+            cli_download_path: false,
+            cli_headed: false,
+            annotate: false,
+            color_scheme: None,
+            download_path: None,
+            content_boundaries: false,
+            max_output: None,
+            allowed_domains: None,
+            action_policy: None,
+            confirm_actions: None,
+            confirm_interactive: false,
+            engine: None,
+            screenshot_dir: None,
+            screenshot_quality: None,
+            screenshot_format: None,
+            idle_timeout: None,
+        }
+    }
+
+    // Global flag coverage
+
+    #[test]
+    fn bash_contains_all_global_flags() {
+        let bash = include_str!("../completions/agent-browser.bash");
+        let failures: Vec<_> = crate::flags::GLOBAL_BOOL_FLAGS
+            .iter()
+            .chain(crate::flags::GLOBAL_FLAGS_WITH_VALUE.iter())
+            .filter(|flag| !bash.contains(*flag))
+            .map(|flag| format!("bash missing global flag: {flag}"))
+            .collect();
+        if !failures.is_empty() {
+            panic!("{}", failures.join("\n"));
+        }
+    }
+
+    #[test]
+    fn zsh_contains_all_global_flags() {
+        let zsh = include_str!("../completions/_agent_browser");
+        let failures: Vec<_> = crate::flags::GLOBAL_BOOL_FLAGS
+            .iter()
+            .chain(crate::flags::GLOBAL_FLAGS_WITH_VALUE.iter())
+            .filter(|flag| !zsh.contains(*flag))
+            .map(|flag| format!("zsh missing global flag: {flag}"))
+            .collect();
+        if !failures.is_empty() {
+            panic!("{}", failures.join("\n"));
+        }
+    }
+
+    // Shell autocompletion script coverage
+
+    #[test]
+    fn bash_contains_all_top_level_commands() {
+        let script = include_str!("../completions/agent-browser.bash");
+        for cmd in all_known_commands() {
+            assert!(
+                script.contains(cmd),
+                "bash completion missing command: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn zsh_contains_all_top_level_commands() {
+        let script = include_str!("../completions/_agent_browser");
+        for cmd in all_known_commands() {
+            assert!(
+                script.contains(cmd),
+                "zsh completion missing command: {cmd}"
+            );
+        }
+    }
+
+    // Validity check: every command in all_known_commands() is a real CLI command
+
+    /// Every parse_command-handled entry in all_known_commands() must be recognized by the CLI.
+    /// Catches typos in all_known_commands().
+    #[test]
+    fn completion_commands_are_all_valid_cli_commands() {
+        let flags = default_flags();
+        // These commands are handled before parse_command in main.rs
+        let pre_dispatch = ["completion", "install", "upgrade", "session"];
+        for cmd in all_known_commands() {
+            if pre_dispatch.contains(cmd) {
+                continue;
+            }
+            let args = vec![cmd.to_string()];
+            match parse_command(&args, &flags) {
+                Err(ParseError::UnknownCommand { .. }) => {
+                    panic!("'{cmd}' is in all_known_commands() but not recognized by CLI");
+                }
+                _ => {} // MissingArguments / Ok / other errors are fine — command exists
+            }
+        }
+    }
+
+    // Subcommand lists must appear in all autocompletion scripts
+
+    macro_rules! assert_subcommands_in_scripts {
+        ($list:expr, $label:expr) => {
+            let bash = include_str!("../completions/agent-browser.bash");
+            let zsh = include_str!("../completions/_agent_browser");
+            let mut failures = Vec::new();
+            for sub in $list {
+                if !bash.contains(sub) {
+                    failures.push(format!("bash missing {} subcommand: {}", $label, sub));
+                }
+                if !zsh.contains(sub) {
+                    failures.push(format!("zsh missing {} subcommand: {}", $label, sub));
+                }
+            }
+            if !failures.is_empty() {
+                panic!("{}", failures.join("\n"));
+            }
+        };
+    }
+
+    #[test]
+    fn auth_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(AUTH_SUBCOMMANDS, "auth");
+    }
+    #[test]
+    fn cookies_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(COOKIES_SUBCOMMANDS, "cookies");
+    }
+    #[test]
+    fn network_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(NETWORK_SUBCOMMANDS, "network");
+    }
+    #[test]
+    fn get_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(GET_SUBCOMMANDS, "get");
+    }
+    #[test]
+    fn is_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(IS_SUBCOMMANDS, "is");
+    }
+    #[test]
+    fn find_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(FIND_SUBCOMMANDS, "find");
+    }
+    #[test]
+    fn set_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(SET_SUBCOMMANDS, "set");
+    }
+    #[test]
+    fn mouse_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(MOUSE_SUBCOMMANDS, "mouse");
+    }
+    #[test]
+    fn tab_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(TAB_SUBCOMMANDS, "tab");
+    }
+    #[test]
+    fn keyboard_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(KEYBOARD_SUBCOMMANDS, "keyboard");
+    }
+    #[test]
+    fn diff_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(DIFF_SUBCOMMANDS, "diff");
+    }
+    #[test]
+    fn clipboard_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(CLIPBOARD_SUBCOMMANDS, "clipboard");
+    }
+    #[test]
+    fn scroll_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(SCROLL_SUBCOMMANDS, "scroll");
+    }
+    #[test]
+    fn storage_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(STORAGE_SUBCOMMANDS, "storage");
+    }
+    #[test]
+    fn state_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(STATE_SUBCOMMANDS, "state");
+    }
+    #[test]
+    fn dialog_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(DIALOG_SUBCOMMANDS, "dialog");
+    }
+    #[test]
+    fn session_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(SESSION_SUBCOMMANDS, "session");
+    }
+    #[test]
+    fn window_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(WINDOW_SUBCOMMANDS, "window");
+    }
+    #[test]
+    fn har_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(HAR_SUBCOMMANDS, "har");
+    }
+    #[test]
+    fn trace_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(TRACE_SUBCOMMANDS, "trace");
+    }
+    #[test]
+    fn profiler_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(PROFILER_SUBCOMMANDS, "profiler");
+    }
+    #[test]
+    fn record_subcommands_in_scripts() {
+        assert_subcommands_in_scripts!(RECORD_SUBCOMMANDS, "record");
+    }
+}

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -704,52 +704,55 @@ pub fn parse_flags(args: &[String]) -> Flags {
     flags
 }
 
+// Boolean flags that optionally take true/false.
+// Used by clean_args() and completion tests — keep in sync with parse_flags().
+pub(crate) const GLOBAL_BOOL_FLAGS: &[&str] = &[
+    "--json",
+    "--headed",
+    "--debug",
+    "--ignore-https-errors",
+    "--allow-file-access",
+    "--auto-connect",
+    "--annotate",
+    "--content-boundaries",
+    "--confirm-interactive",
+];
+
+// Global flags that always take a value (need to skip the next arg too).
+// Used by clean_args() and completion tests — keep in sync with parse_flags().
+pub(crate) const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
+    "--session",
+    "--headers",
+    "--executable-path",
+    "--cdp",
+    "--extension",
+    "--profile",
+    "--state",
+    "--proxy",
+    "--proxy-bypass",
+    "--args",
+    "--user-agent",
+    "-p",
+    "--provider",
+    "--device",
+    "--session-name",
+    "--color-scheme",
+    "--download-path",
+    "--max-output",
+    "--allowed-domains",
+    "--action-policy",
+    "--confirm-actions",
+    "--config",
+    "--engine",
+    "--screenshot-dir",
+    "--screenshot-quality",
+    "--screenshot-format",
+    "--idle-timeout",
+];
+
 pub fn clean_args(args: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     let mut skip_next = false;
-
-    // Boolean flags that optionally take true/false
-    const GLOBAL_BOOL_FLAGS: &[&str] = &[
-        "--json",
-        "--headed",
-        "--debug",
-        "--ignore-https-errors",
-        "--allow-file-access",
-        "--auto-connect",
-        "--annotate",
-        "--content-boundaries",
-        "--confirm-interactive",
-    ];
-    // Global flags that always take a value (need to skip the next arg too)
-    const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
-        "--session",
-        "--headers",
-        "--executable-path",
-        "--cdp",
-        "--extension",
-        "--profile",
-        "--state",
-        "--proxy",
-        "--proxy-bypass",
-        "--args",
-        "--user-agent",
-        "-p",
-        "--provider",
-        "--device",
-        "--session-name",
-        "--color-scheme",
-        "--download-path",
-        "--max-output",
-        "--allowed-domains",
-        "--action-policy",
-        "--confirm-actions",
-        "--config",
-        "--engine",
-        "--screenshot-dir",
-        "--screenshot-quality",
-        "--screenshot-format",
-        "--idle-timeout",
-    ];
 
     let mut i = 0;
     while i < args.len() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod color;
 mod commands;
+mod completion;
 mod connection;
 mod flags;
 mod install;
@@ -21,6 +22,7 @@ use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
 use commands::{gen_id, parse_command, ParseError};
+use completion::run_completion;
 use connection::{ensure_daemon, get_socket_dir, send_command, DaemonOptions};
 use flags::{clean_args, parse_flags, Flags};
 use install::run_install;
@@ -231,6 +233,13 @@ fn main() {
     // Handle upgrade separately
     if clean.first().map(|s| s.as_str()) == Some("upgrade") {
         run_upgrade();
+        return;
+    }
+
+    // Handle completion separately
+    if clean.first().map(|s| s.as_str()) == Some("completion") {
+        let shell = clean.get(1).map(|s| s.as_str()).unwrap_or("");
+        run_completion(shell);
         return;
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2475,6 +2475,25 @@ Examples:
 "##
         }
 
+        // === Completion ===
+        "completion" => {
+            r##"
+agent-browser completion - Generate shell completion scripts
+
+Usage: agent-browser completion <shell>
+
+Supported shells: bash, zsh
+
+To activate, add one of these lines to your shell config file:
+
+  bash (~/.bashrc or ~/.bash_profile):
+    eval "$(agent-browser completion bash)"
+
+  zsh (~/.zshrc):
+    eval "$(agent-browser completion zsh)"
+"##
+        }
+
         _ => return false,
     };
     println!("{}", help.trim());
@@ -2589,6 +2608,7 @@ Setup:
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
   upgrade                    Upgrade to the latest version
+  completion <shell>         Generate shell completion script (bash, zsh)
 
 Snapshot Options:
   -i, --interactive          Only interactive elements

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -348,6 +348,13 @@ agent-browser reload                  # Reload page
 --debug                  # Debug output
 ```
 
+## Shell completion
+
+```bash
+agent-browser completion bash        # Output bash completion script
+agent-browser completion zsh         # Output zsh completion script
+```
+
 ## Batch execution
 
 Execute multiple commands in a single invocation by piping a JSON array of string arrays to `batch`:

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -75,6 +75,18 @@ agent-browser upgrade
 
 Detects your installation method (npm, Homebrew, or Cargo) and runs the appropriate update command automatically. Displays the version change on success, or informs you if you are already on the latest version.
 
+## Shell completion
+
+Enable tab completion for commands and flags:
+
+```bash
+# bash (~/.bashrc or ~/.bash_profile)
+eval "$(agent-browser completion bash)"
+
+# zsh (~/.zshrc)
+eval "$(agent-browser completion zsh)"
+```
+
 ## Custom browser
 
 Use a custom browser executable instead of bundled Chromium:


### PR DESCRIPTION
Add `agent-browser completion <shell>` command that prints a shell completion script for bash or zsh. Introduce named module-level constants for every subcommand list (replacing local const blocks) so the new completion test suite can assert that each script covers all top-level commands, subcommands, and global flags.