### PR TITLE
docs: fix desktop browser list in iOS comparison table

### DIFF
--- a/docs/src/app/ios/page.mdx
+++ b/docs/src/app/ios/page.mdx
@@ -176,7 +176,7 @@ agent-browser -p ios --device "John's iPhone" open https://example.com
     <tr><th>Feature</th><th>Desktop</th><th>iOS</th></tr>
   </thead>
   <tbody>
-    <tr><td>Browser</td><td>Chromium/Firefox/WebKit</td><td>Safari only</td></tr>
+    <tr><td>Browser</td><td>Chrome, Lightpanda</td><td>Safari only</td></tr>
     <tr><td>Tabs</td><td>Supported</td><td>Single tab only</td></tr>
     <tr><td>PDF export</td><td>Supported</td><td>Not supported</td></tr>
     <tr><td>Screencast</td><td>Supported</td><td>Not supported</td></tr>


### PR DESCRIPTION
## Summary
- Fixes the "Differences from desktop" table in `ios/page.mdx`: `Chromium/Firefox/WebKit` → `Chrome, Lightpanda`
- The codebase only has CDP launchers for Chrome (`cdp/chrome.rs`) and Lightpanda (`cdp/lightpanda.rs`). Firefox and WebKit have no launcher and are not supported.

Part of #774 (item 2 in the [incremental PR plan](https://github.com/vercel-labs/agent-browser/issues/774#issuecomment-2988053657))

## Test plan
- [x] Verify `ios/page.mdx` renders correctly with updated browser names

<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/df6c4c5e-e6cb-409f-a367-159c7297719c" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)