### PR TITLE
docs: update cdp-mode — remove stale fallback line, add --full flag

### DIFF
--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -49,7 +49,7 @@ Auto-connect discovers Chrome by:
 
 1. Reading Chrome's `DevToolsActivePort` file from the default user data directory
 2. Falling back to probing common debugging ports (9222, 9229)
-3. If HTTP-based discovery (`/json/version`, `/json/list`) fails, falling back to a direct WebSocket connection
+3. Connecting via the discovered endpoint
 
 This is useful when:
 
@@ -105,6 +105,7 @@ This enables control of:
     <tr><td><code>{"--cdp <port|url>"}</code></td><td>CDP connection (port or WebSocket URL)</td></tr>
     <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to running Chrome</td></tr>
     <tr><td><code>--color-scheme &lt;scheme&gt;</code></td><td>Persistent color scheme (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
+    <tr><td><code>--full, -f</code></td><td>Capture full page screenshot (not just viewport)</td></tr>
     <tr><td><code>--debug</code></td><td>Debug output</td></tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- Remove outdated auto-connect step 3 ("If HTTP-based discovery fails, falling back to a direct WebSocket connection") — this behavior no longer exists
- Add `--full, -f` to the global options table (captures full page screenshot, not just viewport)

Part of #774 (item 4 in the [incremental PR plan](https://github.com/vercel-labs/agent-browser/issues/774#issuecomment-2988053657))

## Test plan
- [ ] `cd docs && npm run build` passes
- [ ] cdp-mode page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)