### PR TITLE
fix: wait for network idle before auth login form fill

### DIFF
--- a/.changeset/fix-auth-login-network-idle.md
+++ b/.changeset/fix-auth-login-network-idle.md
@@ -1,0 +1,7 @@
+---
+"agent-browser": patch
+---
+
+### Bug Fixes
+
+- **Auth login readiness** - `agent-browser auth login` now waits for `networkidle` before filling credentials, reducing failures on async/SPA login pages where form fields appear after the initial `load` event.

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -37,6 +37,11 @@ use super::webdriver::backend::{BrowserBackend, WebDriverBackend, WEBDRIVER_UNSU
 use super::webdriver::ios;
 use super::webdriver::safari;
 
+/// Wait strategy used by `auth_login` when navigating to the login page.
+/// NetworkIdle ensures all async JS (bundles, SPAs) has finished loading
+/// before we attempt to locate and fill form fields.
+pub const AUTH_LOGIN_WAIT_UNTIL: WaitUntil = WaitUntil::NetworkIdle;
+
 pub struct PendingConfirmation {
     pub action: String,
     pub cmd: Value,
@@ -5480,7 +5485,7 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
     let password = cred.password;
 
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-    mgr.navigate(&url, WaitUntil::Load).await?;
+    mgr.navigate(&url, AUTH_LOGIN_WAIT_UNTIL).await?;
 
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -6654,6 +6659,17 @@ mod tests {
             patterns.len(),
             1,
             "Should not add a second wildcard when routes already contain one"
+        );
+    }
+
+    #[test]
+    fn test_auth_login_waits_for_network_idle() {
+        use super::super::browser::WaitUntil;
+        assert_eq!(
+            super::AUTH_LOGIN_WAIT_UNTIL,
+            WaitUntil::NetworkIdle,
+            "auth_login must wait for NetworkIdle so async login pages \
+             finish loading before form fields are filled"
         );
     }
 }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -129,7 +129,7 @@ pub struct PageInfo {
     pub target_type: String, // "page" or "webview"
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WaitUntil {
     Load,
     DomContentLoaded,


### PR DESCRIPTION
## Summary
- Switch `auth login` navigation from `load` to `networkidle` so async/SPA login pages finish loading before credential fields are resolved and filled.
- Introduce `AUTH_LOGIN_WAIT_UNTIL` and add a regression test to lock the wait strategy to `NetworkIdle`.
- Add a patch changeset for release automation.

## Testing
- cargo fmt --manifest-path cli/Cargo.toml -- --check
- cargo clippy --manifest-path cli/Cargo.toml -- -D warnings
- cargo test --profile ci --manifest-path cli/Cargo.toml