### PR TITLE
feat: add element screenshot error handling for selector clipping

### DIFF
--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -200,15 +200,27 @@ async fn capture_screenshot_base64(
             });
         }
     } else if let Some(ref selector) = options.selector {
-        if let Some(rect) = get_rect_for_selector(client, session_id, ref_map, selector).await? {
-            params.clip = Some(Viewport {
-                x: rect.x,
-                y: rect.y,
-                width: rect.width,
-                height: rect.height,
-                scale: 1.0,
-            });
+        let rect = get_rect_for_selector(client, session_id, ref_map, selector)
+            .await?
+            .ok_or_else(|| {
+                format!(
+                    "Element '{}' not found or not visible on the page",
+                    selector
+                )
+            })?;
+        if rect.width <= 0.0 || rect.height <= 0.0 {
+            return Err(format!(
+                "Element '{}' has zero dimensions ({}x{})",
+                selector, rect.width, rect.height
+            ));
         }
+        params.clip = Some(Viewport {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+            scale: 1.0,
+        });
     }
 
     let result: CaptureScreenshotResult = client


### PR DESCRIPTION
## Summary
- When `screenshot @ref output.png` includes a selector, the element's bounding box was already computed via `getBoundingClientRect()` and passed as the `clip` parameter to `Page.captureScreenshot`
- This PR adds proper error handling: if the element is not found or has zero dimensions, a clear error is returned instead of silently falling back to a full-page capture
- Full-page screenshot behavior is unchanged when no selector is provided

Closes #587

## Test plan
- [x] `cargo check` compiles cleanly
- [x] All 22 existing screenshot tests pass (`cargo test screenshot` - 22 passed, 0 failed)
- [ ] `screenshot output.png` - full page (unchanged behavior)
- [ ] `screenshot @e3 element.png` - captures only the element's bounding box
- [ ] `screenshot @nonexistent out.png` - returns error about element not found
- [ ] `screenshot` with a hidden zero-size element - returns error about zero dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)