### PR TITLE
feat: return errors for missing/zero-dimension elements in selector screenshots

### DIFF
--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -208,16 +208,29 @@ async fn capture_screenshot_base64(
             });
         }
     } else if let Some(ref selector) = options.selector {
-        if let Some(rect) =
-            get_rect_for_selector(client, session_id, ref_map, selector, iframe_sessions).await?
-        {
-            params.clip = Some(Viewport {
-                x: rect.x,
-                y: rect.y,
-                width: rect.width,
-                height: rect.height,
-                scale: 1.0,
-            });
+        match get_rect_for_selector(client, session_id, ref_map, selector, iframe_sessions).await? {
+            Some(rect) => {
+                if rect.width <= 0.0 || rect.height <= 0.0 {
+                    return Err(format!(
+                        "Element '{}' has zero dimensions ({}x{})",
+                        selector, rect.width, rect.height
+                    ));
+                }
+
+                params.clip = Some(Viewport {
+                    x: rect.x,
+                    y: rect.y,
+                    width: rect.width,
+                    height: rect.height,
+                    scale: 1.0,
+                });
+            }
+            None => {
+                return Err(format!(
+                    "Element '{}' not found or not visible on the page",
+                    selector
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

When `screenshot @ref output.png` targets an element that can't be found or has zero dimensions, return a clear error instead of silently falling back to a full-page screenshot.

## Changes

In `cli/src/native/screenshot.rs`, the selector branch now uses a `match` instead of `if let Some`:

- `None` from `get_rect_for_selector` returns: `"Element '{selector}' not found or not visible on the page"`
- Zero or negative width/height returns: `"Element '{selector}' has zero dimensions ({width}x{height})"`
- Full-page and viewport screenshot behavior unchanged

## Why this matters

The element screenshot clipping already works correctly when the element is found ([screenshot.rs:202-218](https://github.com/vercel-labs/agent-browser/blob/main/cli/src/native/screenshot.rs#L202)). The gap is that a missing element silently produces a full-page screenshot, which is confusing in automation pipelines where you expect either the element's screenshot or an error.

[#587](https://github.com/vercel-labs/agent-browser/issues/587) - 5 reactions, highest of any open feature request.

## Testing

- `screenshot output.png` - full page (unchanged)
- `screenshot @e3 element.png` - captures element bounding box (unchanged, already worked)
- `screenshot @nonexistent out.png` - now returns error instead of full-page fallback

Closes #587

This contribution was developed with AI assistance (Claude Code).