### PR TITLE
feat: add assert commands for test assertions with exit codes

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1306,6 +1306,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         // === Is (state checks) ===
         "is" => parse_is(&rest, &id),
 
+        // === Assert (state/value checks) ===
+        "assert" => parse_assert(&rest, &id),
+
         // === Find (locators) ===
         "find" => parse_find(&rest, &id),
 
@@ -2592,6 +2595,92 @@ fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         None => Err(ParseError::MissingArguments {
             context: "is".to_string(),
             usage: "is <visible|enabled|checked> <selector>",
+        }),
+    }
+}
+
+// Assert commands reuse existing daemon actions and attach assert metadata so
+// the CLI can evaluate pass/fail locally (including in batch mode).
+fn parse_assert(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+    const VALID: &[&str] = &[
+        "visible", "hidden", "enabled", "checked", "text", "url", "title",
+    ];
+
+    match rest.first().copied() {
+        Some("visible") => {
+            let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert visible".to_string(),
+                usage: "assert visible <selector>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "isvisible", "selector": sel, "assert": true, "assert_type": "visible" }),
+            )
+        }
+        Some("hidden") => {
+            let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert hidden".to_string(),
+                usage: "assert hidden <selector>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "isvisible", "selector": sel, "assert": true, "assert_type": "hidden", "assert_negate": true }),
+            )
+        }
+        Some("enabled") => {
+            let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert enabled".to_string(),
+                usage: "assert enabled <selector>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "isenabled", "selector": sel, "assert": true, "assert_type": "enabled" }),
+            )
+        }
+        Some("checked") => {
+            let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert checked".to_string(),
+                usage: "assert checked <selector>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "ischecked", "selector": sel, "assert": true, "assert_type": "checked" }),
+            )
+        }
+        Some("text") => {
+            let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert text".to_string(),
+                usage: "assert text <selector> <expected>",
+            })?;
+            let expected = rest.get(2).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert text".to_string(),
+                usage: "assert text <selector> <expected>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "gettext", "selector": sel, "assert": true, "assert_type": "text", "assert_expected": expected }),
+            )
+        }
+        Some("url") => {
+            let expected = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert url".to_string(),
+                usage: "assert url <pattern>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "url", "assert": true, "assert_type": "url", "assert_expected": expected }),
+            )
+        }
+        Some("title") => {
+            let expected = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
+                context: "assert title".to_string(),
+                usage: "assert title <expected>",
+            })?;
+            Ok(
+                json!({ "id": id, "action": "title", "assert": true, "assert_type": "title", "assert_expected": expected }),
+            )
+        }
+        Some(sub) => Err(ParseError::UnknownSubcommand {
+            subcommand: sub.to_string(),
+            valid_options: VALID,
+        }),
+        None => Err(ParseError::MissingArguments {
+            context: "assert".to_string(),
+            usage: "assert <visible|hidden|enabled|checked|text|url|title> [args...]",
         }),
     }
 }
@@ -4855,6 +4944,89 @@ mod tests {
         let err = result.unwrap_err();
         assert!(matches!(err, ParseError::MissingArguments { .. }));
         assert!(err.format().contains("get text"));
+    }
+
+    #[test]
+    fn test_assert_visible() {
+        let cmd = parse_command(&args("assert visible @e1"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "isvisible");
+        assert_eq!(cmd["selector"], "@e1");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "visible");
+    }
+
+    #[test]
+    fn test_assert_hidden() {
+        let cmd = parse_command(&args("assert hidden #modal"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "isvisible");
+        assert_eq!(cmd["selector"], "#modal");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "hidden");
+        assert_eq!(cmd["assert_negate"], true);
+    }
+
+    #[test]
+    fn test_assert_enabled() {
+        let cmd = parse_command(&args("assert enabled #submit"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "isenabled");
+        assert_eq!(cmd["selector"], "#submit");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "enabled");
+    }
+
+    #[test]
+    fn test_assert_checked() {
+        let cmd = parse_command(&args("assert checked #agree"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "ischecked");
+        assert_eq!(cmd["selector"], "#agree");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "checked");
+    }
+
+    #[test]
+    fn test_assert_text() {
+        let cmd = parse_command(&args("assert text @e3 Welcome"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "gettext");
+        assert_eq!(cmd["selector"], "@e3");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "text");
+        assert_eq!(cmd["assert_expected"], "Welcome");
+    }
+
+    #[test]
+    fn test_assert_url() {
+        let cmd = parse_command(&args("assert url **/dashboard"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "url");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "url");
+        assert_eq!(cmd["assert_expected"], "**/dashboard");
+    }
+
+    #[test]
+    fn test_assert_title() {
+        let cmd = parse_command(&args("assert title Dashboard"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "title");
+        assert_eq!(cmd["assert"], true);
+        assert_eq!(cmd["assert_type"], "title");
+        assert_eq!(cmd["assert_expected"], "Dashboard");
+    }
+
+    #[test]
+    fn test_assert_missing_subcommand() {
+        let result = parse_command(&args("assert"), &default_flags());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ParseError::MissingArguments { .. }));
+        assert!(err.format().contains("assert"));
+    }
+
+    #[test]
+    fn test_assert_text_missing_expected() {
+        let result = parse_command(&args("assert text @e3"), &default_flags());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ParseError::MissingArguments { .. }));
+        assert!(err.format().contains("assert text"));
     }
 
     // === Protocol alignment tests ===

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -640,6 +640,138 @@ fn run_session_info(session: &str, json_mode: bool) {
     }
 }
 
+/// Match patterns where `*` means any non-slash chars and `**` means any chars.
+fn matches_glob_pattern(pattern: &str, value: &str) -> bool {
+    fn rec(
+        pi: usize,
+        vi: usize,
+        pattern: &[char],
+        value: &[char],
+        memo: &mut [Vec<Option<bool>>],
+    ) -> bool {
+        if let Some(cached) = memo[pi][vi] {
+            return cached;
+        }
+
+        let result = if pi == pattern.len() {
+            vi == value.len()
+        } else if pattern[pi] == '*' {
+            let is_double_star = pi + 1 < pattern.len() && pattern[pi + 1] == '*';
+            if is_double_star {
+                rec(pi + 2, vi, pattern, value, memo)
+                    || (vi < value.len() && rec(pi, vi + 1, pattern, value, memo))
+            } else {
+                rec(pi + 1, vi, pattern, value, memo)
+                    || (vi < value.len()
+                        && value[vi] != '/'
+                        && rec(pi, vi + 1, pattern, value, memo))
+            }
+        } else {
+            vi < value.len()
+                && pattern[pi] == value[vi]
+                && rec(pi + 1, vi + 1, pattern, value, memo)
+        };
+
+        memo[pi][vi] = Some(result);
+        result
+    }
+
+    let pattern_chars: Vec<char> = pattern.chars().collect();
+    let value_chars: Vec<char> = value.chars().collect();
+    let mut memo = vec![vec![None; value_chars.len() + 1]; pattern_chars.len() + 1];
+    rec(0, 0, &pattern_chars, &value_chars, &mut memo)
+}
+
+fn evaluate_assert(
+    cmd: &serde_json::Value,
+    resp: &connection::Response,
+) -> Option<Result<String, String>> {
+    if cmd.get("assert").and_then(|v| v.as_bool()) != Some(true) || !resp.success {
+        return None;
+    }
+
+    let data = resp.data.as_ref()?;
+    let assert_type = cmd
+        .get("assert_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let selector = cmd.get("selector").and_then(|v| v.as_str()).unwrap_or("");
+    let target = if selector.is_empty() {
+        assert_type.to_string()
+    } else {
+        format!("{} {}", assert_type, selector)
+    };
+
+    let fail = |expected: String, actual: String| {
+        format!(
+            "FAIL: assert {} (expected: {}, got: {})",
+            target, expected, actual
+        )
+    };
+    let pass = || format!("PASS: assert {}", target);
+
+    match assert_type {
+        "visible" | "hidden" => {
+            let expected = !cmd
+                .get("assert_negate")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            match data.get("visible").and_then(|v| v.as_bool()) {
+                Some(actual) if actual == expected => Some(Ok(pass())),
+                Some(actual) => Some(Err(fail(expected.to_string(), actual.to_string()))),
+                None => Some(Err(fail(expected.to_string(), "<missing>".to_string()))),
+            }
+        }
+        "enabled" => match data.get("enabled").and_then(|v| v.as_bool()) {
+            Some(true) => Some(Ok(pass())),
+            Some(actual) => Some(Err(fail("true".to_string(), actual.to_string()))),
+            None => Some(Err(fail("true".to_string(), "<missing>".to_string()))),
+        },
+        "checked" => match data.get("checked").and_then(|v| v.as_bool()) {
+            Some(true) => Some(Ok(pass())),
+            Some(actual) => Some(Err(fail("true".to_string(), actual.to_string()))),
+            None => Some(Err(fail("true".to_string(), "<missing>".to_string()))),
+        },
+        "text" => {
+            let expected = cmd
+                .get("assert_expected")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match data.get("text").and_then(|v| v.as_str()) {
+                Some(actual) if actual.contains(expected) => Some(Ok(pass())),
+                Some(actual) => Some(Err(fail(expected.to_string(), actual.to_string()))),
+                None => Some(Err(fail(expected.to_string(), "<missing>".to_string()))),
+            }
+        }
+        "url" => {
+            let expected = cmd
+                .get("assert_expected")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match data.get("url").and_then(|v| v.as_str()) {
+                Some(actual) if matches_glob_pattern(expected, actual) => Some(Ok(pass())),
+                Some(actual) => Some(Err(fail(expected.to_string(), actual.to_string()))),
+                None => Some(Err(fail(expected.to_string(), "<missing>".to_string()))),
+            }
+        }
+        "title" => {
+            let expected = cmd
+                .get("assert_expected")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match data.get("title").and_then(|v| v.as_str()) {
+                Some(actual) if actual == expected => Some(Ok(pass())),
+                Some(actual) => Some(Err(fail(expected.to_string(), actual.to_string()))),
+                None => Some(Err(fail(expected.to_string(), "<missing>".to_string()))),
+            }
+        }
+        _ => Some(Err(fail(
+            "known assert type".to_string(),
+            assert_type.to_string(),
+        ))),
+    }
+}
+
 fn run_session(args: &[String], session: &str, json_mode: bool) {
     let subcommand = args.get(1).map(|s| s.as_str());
 
@@ -1668,6 +1800,24 @@ fn main() {
             let success = resp.success;
             // Extract action for context-specific output handling
             let action = cmd.get("action").and_then(|v| v.as_str());
+            if let Some(assert_result) = evaluate_assert(&cmd, &resp) {
+                match assert_result {
+                    Ok(msg) => {
+                        if !flags.json {
+                            println!("{}", msg);
+                            return;
+                        }
+                    }
+                    Err(msg) => {
+                        if flags.json {
+                            print_json_error(msg);
+                        } else {
+                            println!("{}", msg);
+                        }
+                        exit(1);
+                    }
+                }
+            }
             print_response_with_opts(&resp, action, &output_opts);
             if !success {
                 exit(1);
@@ -1798,14 +1948,22 @@ fn run_batch(
 
         attach_pin_tab_to_command(&mut parsed, flags);
 
-        match send_command_with_respawn(parsed, &flags.session, daemon_opts) {
+        // `parsed` is still needed below for `evaluate_assert`, so hand the
+        // sender a clone rather than moving it.
+        match send_command_with_respawn(parsed.clone(), &flags.session, daemon_opts) {
             Ok(resp) => {
+                let assert_result = evaluate_assert(&parsed, &resp);
+                let assert_failure = assert_result
+                    .as_ref()
+                    .and_then(|r| r.as_ref().err().cloned());
+                let effective_success = resp.success && assert_failure.is_none();
+
                 if flags.json {
                     let mut result = json!({
                         "command": cmd_args,
-                        "success": resp.success,
+                        "success": effective_success,
                         "result": resp.data,
-                        "error": resp.error,
+                        "error": assert_failure.clone().or(resp.error),
                     });
                     // Match the single-command `Response` serialization,
                     // which only emits `code` when set (e.g. `tab_gone`).
@@ -1824,9 +1982,13 @@ fn run_batch(
                     if i > 0 {
                         println!();
                     }
-                    print_response_with_opts(&resp, action.as_deref(), &output_opts);
+                    match assert_result {
+                        Some(Ok(msg)) => println!("{}", msg),
+                        Some(Err(msg)) => println!("{}", msg),
+                        None => print_response_with_opts(&resp, action.as_deref(), &output_opts),
+                    }
                 }
-                if !resp.success {
+                if !effective_success {
                     had_error = true;
                     if bail {
                         if !flags.json {
@@ -2272,5 +2434,18 @@ mod tests {
         assert_eq!(prompt.action, "plugin:stealth:launch.mutate");
         assert_eq!(prompt.description, "plugin:stealth:launch.mutate");
         assert_eq!(prompt.confirmation_id, "original-command");
+    }
+
+    #[test]
+    fn test_matches_glob_pattern_single_star() {
+        assert!(matches_glob_pattern("*/dashboard", "app/dashboard"));
+        assert!(!matches_glob_pattern("*/dashboard", "app/admin/dashboard"));
+    }
+
+    #[test]
+    fn test_matches_glob_pattern_double_star() {
+        assert!(matches_glob_pattern("**/dashboard", "app/admin/dashboard"));
+        assert!(matches_glob_pattern("**/dashboard", "dashboard"));
+        assert!(!matches_glob_pattern("**/dashboard", "app/admin/settings"));
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -658,7 +658,13 @@ fn matches_glob_pattern(pattern: &str, value: &str) -> bool {
         } else if pattern[pi] == '*' {
             let is_double_star = pi + 1 < pattern.len() && pattern[pi + 1] == '*';
             if is_double_star {
-                rec(pi + 2, vi, pattern, value, memo)
+                // Skip ** and optional trailing /
+                let skip = if pi + 2 < pattern.len() && pattern[pi + 2] == '/' {
+                    3
+                } else {
+                    2
+                };
+                rec(pi + skip, vi, pattern, value, memo)
                     || (vi < value.len() && rec(pi, vi + 1, pattern, value, memo))
             } else {
                 rec(pi + 1, vi, pattern, value, memo)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2174,6 +2174,37 @@ Examples:
 "##
         }
 
+        // === Assert ===
+        "assert" => {
+            r##"
+agent-browser assert - Assert page or element state
+
+Usage: agent-browser assert <subcommand> [args]
+
+Asserts conditions and exits with code 1 when a condition is not met.
+
+Subcommands:
+  visible <selector>         Assert element is visible (exit 1 if not)
+  hidden <selector>          Assert element is hidden
+  text <selector> <txt>      Assert element contains text
+  url <pattern>              Assert URL matches pattern (* and ** globs)
+  title <expected>           Assert page title matches
+  enabled <selector>         Assert element is enabled
+  checked <selector>         Assert element is checked
+
+Global Options:
+  --json               Output as JSON
+  --session <name>     Use specific session
+
+Examples:
+  agent-browser assert visible "#modal"
+  agent-browser assert hidden "#loading"
+  agent-browser assert text "@e3" "Welcome"
+  agent-browser assert url "**/dashboard"
+  agent-browser assert title "Dashboard"
+"##
+        }
+
         // === Find ===
         "find" => {
             r##"
@@ -3549,6 +3580,10 @@ Get Info:  agent-browser get <what> [selector]
 
 Check State:  agent-browser is <what> <selector>
   visible, enabled, checked
+
+Assert:  agent-browser assert <what> [args]
+  visible <selector>, hidden <selector>, text <selector> <txt>
+  url <pattern>, title <expected>, enabled <selector>, checked <selector>
 
 Find Elements:  agent-browser find <locator> <value> <action> [text]
   role, text, label, placeholder, alt, title, testid, first, last, nth


### PR DESCRIPTION
## Summary

Adds an `assert` command family for verifying expected state in automation pipelines. Each command reuses existing daemon actions and exits with code 1 on failure.

## Commands

| Command | Description |
|---------|-------------|
| `assert visible @ref` | Assert element is visible |
| `assert hidden @ref` | Assert element is NOT visible |
| `assert text @ref "expected"` | Assert element contains text |
| `assert url "**/dashboard"` | Assert URL matches glob pattern |
| `assert title "Page Title"` | Assert page title matches |
| `assert enabled @ref` | Assert element is enabled |
| `assert checked @ref` | Assert element is checked |

## Why this matters

The `batch` command ([#865](https://github.com/vercel-labs/agent-browser/pull/865)) enables multi-step workflows, but there's no way to verify expected state between steps. The `is` commands ([commands.rs:1690](https://github.com/vercel-labs/agent-browser/blob/main/cli/src/commands.rs#L1690)) return true/false as JSON but don't fail the process. Assertions with exit codes are the missing piece for CI/CD and agent pipelines.

Every testing framework (Playwright, Cypress, Selenium) has assertion primitives. This brings the same capability to agent-browser's CLI.

## Changes

- `cli/src/commands.rs`: New `parse_assert` function (follows `parse_is` pattern). Sends same daemon actions with `assert: true` metadata. Unit tests included.
- `cli/src/main.rs`: Assert evaluator intercepts responses before normal output. Prints PASS/FAIL. Glob matcher for URL patterns (`*` = non-slash, `**` = any chars). Exits 1 on failure. Works in batch mode with `--bail`.
- `cli/src/output.rs`: Help text for assert commands.

No new daemon code - reuses isvisible, isenabled, ischecked, gettext, url, and title actions.

## Usage

```bash
agent-browser open https://example.com/login
agent-browser type @username "admin"
agent-browser click @submit
agent-browser assert url "**/dashboard"
agent-browser assert visible @welcome-banner
agent-browser assert text @greeting "Welcome"
```

## Testing

- `cargo check` passes
- Unit tests for all parse_assert subcommands
- Glob matcher tested for `*` and `**` patterns

This contribution was developed with AI assistance (Claude Code).