### PR TITLE
fix: keep new tabs in tab_list even before URL is populated

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -392,9 +392,8 @@ impl DaemonState {
                             if let Ok(te) =
                                 serde_json::from_value::<TargetCreatedEvent>(event.params.clone())
                             {
-                                if (te.target_info.target_type == "page"
-                                    || te.target_info.target_type == "webview")
-                                    && !te.target_info.url.is_empty()
+                                if te.target_info.target_type == "page"
+                                    || te.target_info.target_type == "webview"
                                 {
                                     let already_tracked = self
                                         .browser

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -336,7 +336,6 @@ impl BrowserManager {
             .into_iter()
             .filter(|t| {
                 (t.target_type == "page" || t.target_type == "webview")
-                    && !t.url.is_empty()
                     && !is_internal_chrome_target(&t.url)
             })
             .collect();


### PR DESCRIPTION
## Summary
- stop filtering out page/webview targets when `target_info.url` is empty
- apply this in both initial target discovery and runtime `Target.targetCreated` event handling

## Why
When a page click opens a new tab, Chromium can emit the target before URL/title are populated.
If we drop empty-URL targets, `tab` may continue to report only one tab even though the browser switched to a new tab.

## Regression source
This behavior appears to have been introduced by commit `8348b77` (`fix: filter chrome:// internal targets from auto-connect discovery`), which added `!url.is_empty()` filtering in target collection paths.
That change accidentally excluded valid newly-created tabs whose URL is not populated yet.

## Repro
1. Open a page with `<a target="_blank">`
2. Trigger click via `find text "..." click`
3. Run `tab`

Before: sometimes only one tab is reported.
After: new tab is tracked immediately (may start with empty URL/title, later updated).

## Validation
- `cargo check` in `cli/` passes
- local manual repro confirms `tab` returns the second tab after new-tab click
