### PR TITLE
chore: remove dead code and unused variables in actions.rs

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4277,7 +4277,7 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
 
     // Clean up the marker attribute
     if let Some(ref browser) = state.browser {
-        if let Ok(_) = browser.active_session_id() {
+        if browser.active_session_id().is_ok() {
             let _ = browser
                 .evaluate(
                     "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",


### PR DESCRIPTION
## Summary

- Remove `daemon_state_from_env` — zero call sites, logic already handled by `DaemonState::new()`
- Remove `resolve_semantic_locator` — zero call sites, superseded by `handle_semantic_locator`
- Remove unused `_session_id` bindings in `handle_find` and `handle_multiselect`
- Remove no-op `let _ = sid` in `handle_getbyrole`

Net: **-90 lines**, no behavioral change. `cargo check` and `cargo test` pass cleanly with zero warnings.

## Test plan

- [x] `cargo check` — no errors, no warnings
- [x] `cargo test` — 498 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)