### PR TITLE
fix: resolve typecheck errors - add DOM lib and HTMLElement cast

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -631,7 +631,7 @@ async function handleScroll(command: ScrollCommand, browser: BrowserManager): Pr
     if (command.x !== undefined || command.y !== undefined) {
       await element.evaluate(
         (el, { x, y }) => {
-          el.scrollBy(x ?? 0, y ?? 0);
+          (el as HTMLElement).scrollBy(x ?? 0, y ?? 0);
         },
         { x: command.x, y: command.y }
       );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": [
-      "ES2022"
+      "ES2022",
+      "DOM"
     ],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
- Add "DOM" to tsconfig lib for HTMLElement.scrollBy support
- Cast element to HTMLElement in scrollBy call (not available on SVGElement)
-   git fetch vercel-labs
  git checkout fix/typecheck-scrollby
  git rebase vercel-labs/main
  git push -f fork fix/typecheck-scrollby

