### PR TITLE
fix: resolve false timeouts during Fetch interception

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -319,11 +319,24 @@ impl DaemonState {
                             request_headers,
                         };
 
-                        let df = domain_filter.read().await;
-                        let rt = routes.read().await;
-                        let oh = origin_headers.read().await;
-
-                        resolve_fetch_paused(&client, df.as_ref(), &rt, &oh, &paused).await;
+                        // Spawn each resolution concurrently so that paused
+                        // requests are continued without blocking the event
+                        // loop.  Previously this was awaited inline, which
+                        // meant a burst of Fetch.requestPaused events during
+                        // page load would queue up — Chrome stalls the page
+                        // until each paused request is resolved, so the
+                        // sequential processing could cause the page to never
+                        // finish loading within the navigation timeout.
+                        let c = client.clone();
+                        let df = domain_filter.clone();
+                        let rt = routes.clone();
+                        let oh = origin_headers.clone();
+                        tokio::spawn(async move {
+                            let df = df.read().await;
+                            let rt = rt.read().await;
+                            let oh = oh.read().await;
+                            resolve_fetch_paused(&c, df.as_ref(), &rt, &oh, &paused).await;
+                        });
                     }
                     Ok(_) => continue,
                     Err(broadcast::error::RecvError::Lagged(_)) => continue,

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -502,7 +502,16 @@ impl BrowserManager {
             WaitUntil::NetworkIdle => return self.wait_for_network_idle(session_id, rx).await,
         };
 
+        // The ready-state value that indicates the target lifecycle
+        // milestone has already been reached (used for lag recovery).
+        let ready_state_target = match wait_until {
+            WaitUntil::Load => "complete",
+            WaitUntil::DomContentLoaded => "interactive",
+            _ => unreachable!(),
+        };
+
         let timeout = tokio::time::Duration::from_millis(self.default_timeout_ms);
+        let client = &self.client;
 
         tokio::time::timeout(timeout, async {
             loop {
@@ -514,7 +523,33 @@ impl BrowserManager {
                             return Ok(());
                         }
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        // Events were dropped — the lifecycle event may have
+                        // already fired.  Check document.readyState to see
+                        // if the page has already reached the target state.
+                        if let Ok(result) = client
+                            .send_command(
+                                "Runtime.evaluate",
+                                Some(serde_json::json!({
+                                    "expression": "document.readyState",
+                                    "returnByValue": true,
+                                })),
+                                Some(session_id),
+                            )
+                            .await
+                        {
+                            let state = result
+                                .pointer("/result/value")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("");
+                            if state == "complete"
+                                || (ready_state_target == "interactive" && state == "interactive")
+                            {
+                                return Ok(());
+                            }
+                        }
+                        continue;
+                    }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
             }
@@ -1171,7 +1206,16 @@ async fn poll_network_idle(
                     }
                 }
                 Ok(Ok(_)) => {}
-                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
+                    // Events were dropped — our pending-request tracking is
+                    // now unreliable.  Clear the set and start the idle timer
+                    // so we don't get stuck waiting for completion events
+                    // that were already dropped.
+                    let mut p = pending.lock().await;
+                    p.clear();
+                    idle_start = Some(tokio::time::Instant::now());
+                    continue;
+                }
                 Ok(Err(_)) => break,
                 Err(_) => {
                     // Timeout on recv -- if no pending requests, start (or

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -70,7 +70,7 @@ impl CdpClient {
         let ws_tx = Arc::new(Mutex::new(ws_tx));
 
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
-        let (event_tx, _) = broadcast::channel(256);
+        let (event_tx, _) = broadcast::channel(1024);
         let (raw_tx, _) = broadcast::channel(512);
 
         let pending_clone = pending.clone();


### PR DESCRIPTION
## Summary

Fixes #978 — false "Operation Timed Out" errors when network interception (domain filter, routes, or origin-scoped headers) is active.

**Root cause:** The `Fetch.requestPaused` event handler in `start_fetch_handler` processed paused requests sequentially — each `resolve_fetch_paused` call was `await`ed inline before the event loop could handle the next event. During page loads with many sub-resources, this caused head-of-line blocking: Chrome stalls every paused request until the handler responds with `Fetch.continueRequest`/`fulfillRequest`/`failRequest`, so the serial processing could delay page load past the navigation timeout even though individual requests were completing successfully in the background.

**Changes:**
- **Concurrent fetch resolution** (`actions.rs`): Spawn each `resolve_fetch_paused` as an independent `tokio::spawn` task instead of awaiting inline, so all paused requests are resolved concurrently
- **Lifecycle lag recovery** (`browser.rs`): When the broadcast channel lags in `wait_for_lifecycle`, check `document.readyState` to detect if the page already finished loading (prevents false timeout when the lifecycle event was dropped)
- **Network idle lag recovery** (`browser.rs`): Clear stale pending-request tracking in `poll_network_idle` on channel lag so the idle timer isn't stuck waiting for completion events that were already dropped
- **Larger event buffer** (`client.rs`): Increase CDP event broadcast channel from 256 to 1024 to reduce event drops under heavy interception load

## Test plan

- [x] `cargo build` / `cargo build --release` pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy` clean
- [x] `cargo test` — 512 passed (2 pre-existing env-specific failures unrelated to this change)
- [x] `cargo test network_idle` — 4/4 pass
- [x] `cargo test ai_friendly` — 8/8 pass
- [x] `cargo test domain_filter` — 6/6 pass
- [x] e2e: navigations with `--domain` filter work, including repeated rapid navigations
- [ ] Ideally test with a remote CDP connection (e.g. Browserless) where CDP round-trip latency is 5-50ms — this is the scenario where the sequential processing causes real timeouts. Not reproducible in local-only sandbox since localhost CDP RTT is <0.1ms.