### PR TITLE
Fix modifier chord parsing for press

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ agent-browser dblclick <sel>          # Double-click element
 agent-browser focus <sel>             # Focus element
 agent-browser type <sel> <text>       # Type into element
 agent-browser fill <sel> <text>       # Clear and fill
-agent-browser press <key>             # Press key (Enter, Tab, Control+a) (alias: key)
+agent-browser press <key>             # Press key (Enter, Tab, Control+a, Meta+,) (alias: key)
 agent-browser keyboard type <text>    # Type with real keystrokes (no selector, current focus)
 agent-browser keyboard inserttext <text>  # Insert text without key events (no selector)
 agent-browser keydown <key>           # Hold key down

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2093,8 +2093,49 @@ async fn handle_press(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         .and_then(|v| v.as_str())
         .ok_or("Missing 'key' parameter")?;
 
-    interaction::press_key(&mgr.client, &session_id, key).await?;
+    let (base_key, modifiers) = split_key_chord(key);
+    match modifiers {
+        Some(bits) => {
+            interaction::press_key_with_modifiers(&mgr.client, &session_id, base_key, Some(bits))
+                .await?
+        }
+        None => interaction::press_key(&mgr.client, &session_id, base_key).await?,
+    }
     Ok(json!({ "pressed": key }))
+}
+
+fn split_key_chord(input: &str) -> (&str, Option<i32>) {
+    let mut modifiers = 0;
+    let mut remainder = input;
+    let mut consumed_modifier = false;
+
+    // CLI chord syntax is "Modifier+Key", e.g. "Control+a" or "Meta+,".
+    // Consume only leading modifier segments so plain "+" and unknown names
+    // keep their existing concrete behavior.
+    while let Some((candidate, tail)) = remainder.split_once('+') {
+        let Some(bit) = modifier_bit(candidate) else {
+            break;
+        };
+        modifiers |= bit;
+        remainder = if tail.is_empty() { "+" } else { tail };
+        consumed_modifier = true;
+    }
+
+    if consumed_modifier {
+        (remainder, Some(modifiers))
+    } else {
+        (input, None)
+    }
+}
+
+fn modifier_bit(token: &str) -> Option<i32> {
+    match token.to_ascii_lowercase().as_str() {
+        "alt" => Some(1),
+        "control" | "ctrl" => Some(2),
+        "meta" | "cmd" | "command" => Some(4),
+        "shift" => Some(8),
+        _ => None,
+    }
 }
 
 async fn handle_hover(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -6718,6 +6759,22 @@ mod tests {
         assert_eq!(resp["id"], "cmd-2");
         assert_eq!(resp["success"], false);
         assert_eq!(resp["error"], "Something went wrong");
+    }
+
+    #[test]
+    fn test_split_key_chord_without_modifiers() {
+        assert_eq!(split_key_chord("Enter"), ("Enter", None));
+        assert_eq!(split_key_chord(","), (",", None));
+        assert_eq!(split_key_chord("+"), ("+", None));
+    }
+
+    #[test]
+    fn test_split_key_chord_with_modifiers() {
+        assert_eq!(split_key_chord("Control+a"), ("a", Some(2)));
+        assert_eq!(split_key_chord("Ctrl+Shift+s"), ("s", Some(10)));
+        assert_eq!(split_key_chord("Meta+,"), (",", Some(4)));
+        assert_eq!(split_key_chord("Command+Comma"), ("Comma", Some(4)));
+        assert_eq!(split_key_chord("Control++"), ("+", Some(2)));
     }
 
     #[tokio::test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1230,6 +1230,7 @@ Examples:
   agent-browser press Tab
   agent-browser press Control+a
   agent-browser press Control+Shift+s
+  agent-browser press 'Meta+,'
   agent-browser press Escape
 "##
         }
@@ -2521,7 +2522,7 @@ Core Commands:
   dblclick <sel>             Double-click element
   type <sel> <text>          Type into element
   fill <sel> <text>          Clear and fill
-  press <key>                Press key (Enter, Tab, Control+a)
+  press <key>                Press key (Enter, Tab, Control+a, Meta+,)
   keyboard type <text>       Type text with real keystrokes (no selector)
   keyboard inserttext <text> Insert text without key events
   hover <sel>                Hover element

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -8,7 +8,7 @@ agent-browser click <sel>             # Click element (--new-tab to open in new 
 agent-browser dblclick <sel>          # Double-click
 agent-browser fill <sel> <text>       # Clear and fill
 agent-browser type <sel> <text>       # Type into element
-agent-browser press <key>             # Press key (Enter, Tab, Control+a) (alias: key)
+agent-browser press <key>             # Press key (Enter, Tab, Control+a, Meta+,) (alias: key)
 agent-browser keyboard type <text>    # Type at current focus (no selector needed)
 agent-browser keyboard inserttext <text>  # Insert text without key events
 agent-browser keydown <key>           # Hold key down

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -123,6 +123,7 @@ agent-browser type @e2 "text"         # Type without clearing
 agent-browser select @e1 "option"     # Select dropdown option
 agent-browser check @e1               # Check checkbox
 agent-browser press Enter             # Press key
+agent-browser press 'Meta+,'          # Press punctuation combo
 agent-browser keyboard type "text"    # Type at current focus (no selector)
 agent-browser keyboard inserttext "text"  # Insert without key events
 agent-browser scroll down 500         # Scroll page


### PR DESCRIPTION
## Summary

Fix `press <key>` so documented modifier chords like `Control+a`, `Control+Shift+s`, and `Meta+,` are parsed into CDP modifier bits before dispatch.

This keeps the change at the CLI action seam and reuses the existing `press_key_with_modifiers(...)` interaction primitive rather than adding a second input abstraction.

Closes #983.

## What changed

- parse leading modifier segments in `handle_press()`
- pass the remaining key plus combined modifier bitmask into `press_key_with_modifiers(...)`
- keep plain keys and unknown names on their existing concrete path
- add unit coverage for plain keys, modifier chords, punctuation chords, and `Control++`
- update help/docs/skill examples to include a punctuation combo example (`'Meta+,'`)

## Why this shape

The bug was in CLI chord parsing, not in the lower CDP dispatch primitive.

So the fix stays where the user-facing syntax is interpreted:

- no new input subsystem
- no change to existing lower-level key dispatch behavior beyond using the already-present modifier-aware helper
- no duplicate source of truth for key semantics

## Verification

- `cd cli && cargo fmt`
- `cd cli && cargo test`
- live repro against a running Electron app over CDP:
  - before the fix, `press 'Meta+,'` did not open Settings
  - after the fix, the patched binary opened `#/settings`
  - plain `press ','` still behaved as a plain comma key
