### PR TITLE
fix: console command returns only Done due to JSON field name mismatch

### DIFF
--- a/cli/src/native/network.rs
+++ b/cli/src/native/network.rs
@@ -321,12 +321,12 @@ impl EventTracker {
     }
 
     pub fn get_console_json(&self) -> Value {
-        let entries: Vec<Value> = self
+        let messages: Vec<Value> = self
             .console_entries
             .iter()
-            .map(|e| json!({ "level": e.level, "text": e.text }))
+            .map(|e| json!({ "type": e.level, "text": e.text }))
             .collect();
-        json!({ "entries": entries })
+        json!({ "messages": messages })
     }
 
     pub fn get_errors_json(&self) -> Value {


### PR DESCRIPTION
## Problem

The `agent-browser console` command was returning only `[Done]` without displaying any console log content.

## Root Cause

Field name mismatch between the data producer and the output formatter:

- `get_console_json()` in `network.rs` produced: `{"entries": [{"level": ..., "text": ...}]}`
- `output.rs` expected: `{"messages": [{"type": ..., "text": ...}]}`

This caused the console data to fall through all the output format checks in `print_response_with_opts`, resulting in the default `[Done]` output.

## Fix

Updated `get_console_json()` to produce JSON matching the output formatter:
- Renamed top-level key from `entries` to `messages`
- Renamed entry field from `level` to `type`

## Testing

All 498 unit tests pass.