### PR TITLE
fix: `state show` always fails with "Missing 'path' parameter"

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1223,7 +1223,7 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                         context: "state show".to_string(),
                         usage: "state show <filename>",
                     })?;
-                    Ok(json!({ "id": id, "action": "state_show", "filename": filename }))
+                    Ok(json!({ "id": id, "action": "state_show", "path": filename }))
                 }
                 Some("clean") => {
                     let mut days: Option<i64> = None;


### PR DESCRIPTION
`agent-browser state show <filename>` unconditionally errored with `✗ Missing 'path' parameter` regardless of input due to a key name mismatch between the CLI parser and the command dispatcher.

## Root Cause

- `commands.rs` serialized the filename argument under the key `"filename"`
- `state.rs` dispatcher looked it up as `"path"` → always `None` → always errored

## Fix

- **`cli/src/commands.rs`**: change the JSON key from `"filename"` to `"path"` in the `state_show` command object

```rust
// Before
Ok(json!({ "id": id, "action": "state_show", "filename": filename }))

// After
Ok(json!({ "id": id, "action": "state_show", "path": filename }))
```

Note: existing tests didn't catch this because they bypass `commands.rs` and construct the dispatch JSON directly with the correct `"path"` key.