### PR TITLE
fix: add font packages to `install --with-deps` for CJK and emoji support

### DIFF
--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -430,6 +430,11 @@ fn install_linux_deps() {
             ("libcups2", Some("libcups2t64")),
             ("libxshmfence1", None),
             ("libgbm1", None),
+            // Fonts: without actual font files, pages render with missing glyphs
+            // (tofu). This is especially visible for CJK and emoji characters.
+            ("fonts-noto-color-emoji", None),
+            ("fonts-noto-cjk", None),
+            ("fonts-freefont-ttf", None),
         ]
         .into_iter()
         .map(|(base, t64_variant)| {
@@ -469,6 +474,10 @@ fn install_linux_deps() {
                 "libXi",
                 "gtk3",
                 "cairo-gobject",
+                // Fonts
+                "google-noto-cjk-fonts",
+                "google-noto-emoji-color-fonts",
+                "liberation-fonts",
             ],
         )
     } else if which_exists("yum") {
@@ -488,6 +497,9 @@ fn install_linux_deps() {
                 "pango",
                 "alsa-lib",
                 "libxkbcommon",
+                // Fonts
+                "google-noto-cjk-fonts",
+                "liberation-fonts",
             ],
         )
     } else {


### PR DESCRIPTION
## Summary

- Fixes #1001 — `install --with-deps` installed font *rendering* libraries but no actual font *files*, causing CJK (Chinese, Japanese, Korean) characters and emoji to render as invisible/tofu on headless Linux systems
- Adds font file packages for all three supported package managers:
  - **apt**: `fonts-noto-color-emoji`, `fonts-noto-cjk`, `fonts-freefont-ttf`
  - **dnf**: `google-noto-cjk-fonts`, `google-noto-emoji-color-fonts`, `liberation-fonts`
  - **yum**: `google-noto-cjk-fonts`, `liberation-fonts`

## Test plan

- [x] Verified CJK/emoji text is invisible in headless Chrome **before** installing font packages (screenshot confirmed)
- [x] Verified CJK/emoji text renders correctly **after** installing font packages (screenshot confirmed)
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (527 passed; 2 pre-existing failures unrelated to this change)