### PR TITLE
docs: add troubleshooting note for Chrome remote debugging checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,9 @@ agent-browser --session-name myapp state load ./my-auth.json
 > - `--remote-debugging-port` exposes full browser control on localhost. Any local process can connect. Only use on trusted machines and close Chrome when done.
 > - State files contain session tokens in plaintext. Add them to `.gitignore` and delete when no longer needed. For encryption at rest, set `AGENT_BROWSER_ENCRYPTION_KEY` (see [State Encryption](#state-encryption)).
 
+> **Troubleshooting:**
+> If `--auto-connect` fails with "No running Chrome instance found" even when Chrome is open with `--remote-debugging-port`, make sure to check the **"Allow remote debugging for this browser instance"** checkbox at `chrome://inspect/#remote-debugging`. This is required for auto-discovery to work.
+
 For full details on login flows, OAuth, 2FA, cookie-based auth, and the auth vault, see the [Authentication](docs/src/app/sessions/page.mdx) docs.
 
 ## Sessions


### PR DESCRIPTION
## Summary

- Added troubleshooting note to README explaining that `--auto-connect` requires the "Allow remote debugging for this browser instance" checkbox in `chrome://inspect` to be enabled
- This addresses confusion where users launching Chrome with `--remote-debugging-port` still get "No running Chrome instance found" errors

## Test plan

- [x] Verify the note appears in the Authentication section of README