### PR TITLE
fix: retain radio/checkbox elements in compact snapshot tree

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -1030,7 +1030,7 @@ fn compact_tree(tree: &str, interactive: bool) -> String {
     let mut keep = vec![false; lines.len()];
 
     for (i, line) in lines.iter().enumerate() {
-        if line.contains("[ref=") || line.contains(": ") {
+        if line.contains("ref=") || line.contains(": ") {
             keep[i] = true;
             // Mark ancestors
             let my_indent = count_indent(line);
@@ -1198,6 +1198,26 @@ mod tests {
         assert!(result.contains("[ref=e1]"));
         assert!(result.contains("[ref=e2]"));
         assert!(result.contains("Hello"));
+    }
+
+    #[test]
+    fn test_compact_tree_radio_checkbox() {
+        // Radio/checkbox lines have attributes before ref (e.g. [checked=false, ref=e1])
+        // so "ref=" appears without a leading "[" — compact_tree must still keep them.
+        let tree = "- form\n  - radio \"Single unit\" [checked=false, ref=e1]\n  - checkbox \"I agree\" [checked=false, ref=e2]\n  - button \"Submit\" [ref=e3]\n";
+        let result = compact_tree(tree, true);
+        assert!(
+            result.contains("radio \"Single unit\""),
+            "radio should be kept"
+        );
+        assert!(
+            result.contains("checkbox \"I agree\""),
+            "checkbox should be kept"
+        );
+        assert!(
+            result.contains("button \"Submit\""),
+            "button should be kept"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `compact_tree()` checked for `"[ref="` to decide which lines to keep, but radio/checkbox elements render attributes before `ref` (e.g. `[checked=false, ref=e1]`), so `"[ref="` never matched — silently dropping them from `snapshot -i -c` output.
- Fixed by changing the check from `"[ref="` to `"ref="` (removed the leading bracket).
- Added a regression test `test_compact_tree_radio_checkbox` covering radio, checkbox, and button elements in compact mode.

Fixes #1006

## Test plan

- [x] `cargo test -- snapshot::tests::test_compact_tree` — 3/3 pass (including new test)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] E2E: reproduced the bug with unpatched binary (`snapshot -i -c` returned only the button)
- [x] E2E: confirmed the fix with patched binary (`snapshot -i -c` now returns radio, checkbox, and button)