### PR TITLE
fix: inline VS Code webviews in snapshots

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1624,6 +1624,74 @@ fn handle_cdp_url(state: &DaemonState) -> Result<Value, String> {
     Ok(json!({ "cdpUrl": mgr.get_cdp_url() }))
 }
 
+fn is_vscode_webview_url(url: &str) -> bool {
+    url.starts_with("vscode-webview://")
+}
+
+fn find_frame_id(tree: &Value, name: Option<&str>, url: Option<&str>) -> Option<String> {
+    let frame = tree.get("frame")?;
+    let frame_name = frame.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let frame_url = frame.get("url").and_then(|v| v.as_str()).unwrap_or("");
+    let frame_id = frame.get("id").and_then(|v| v.as_str())?;
+
+    if let Some(n) = name {
+        if frame_name == n {
+            return Some(frame_id.to_string());
+        }
+    }
+    if let Some(u) = url {
+        if frame_url.contains(u) {
+            return Some(frame_id.to_string());
+        }
+    }
+
+    if let Some(children) = tree.get("childFrames").and_then(|v| v.as_array()) {
+        for child in children {
+            if let Some(id) = find_frame_id(child, name, url) {
+                return Some(id);
+            }
+        }
+    }
+
+    None
+}
+
+async fn resolve_vscode_active_frame_id(
+    mgr: &BrowserManager,
+    session_id: &str,
+    url: &str,
+) -> Result<Option<String>, String> {
+    // VS Code webview targets expose the rendered extension UI inside a nested
+    // iframe named `active-frame`, not on the wrapper target itself.
+    if !is_vscode_webview_url(url) {
+        return Ok(None);
+    }
+
+    let tree_result = mgr
+        .client
+        .send_command_no_params("Page.getFrameTree", Some(session_id))
+        .await?;
+    Ok(find_frame_id(
+        &tree_result["frameTree"],
+        Some("active-frame"),
+        None,
+    ))
+}
+
+fn sync_iframe_sessions_from_pages(state: &mut DaemonState) {
+    let Some(mgr) = state.browser.as_ref() else {
+        return;
+    };
+
+    for page in mgr.pages_list() {
+        if page.target_type == "iframe" {
+            state
+                .iframe_sessions
+                .insert(page.target_id, page.session_id);
+        }
+    }
+}
+
 async fn handle_inspect(state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
 
@@ -1771,8 +1839,15 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
 // ---------------------------------------------------------------------------
 
 async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    sync_iframe_sessions_from_pages(state);
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
+    let url = mgr.get_url().await.unwrap_or_default();
+    let frame_id = if state.active_frame_id.is_some() {
+        state.active_frame_id.clone()
+    } else {
+        resolve_vscode_active_frame_id(mgr, &session_id, &url).await?
+    };
 
     let options = SnapshotOptions {
         selector: cmd
@@ -1799,12 +1874,10 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &session_id,
         &options,
         &mut state.ref_map,
-        state.active_frame_id.as_deref(),
+        frame_id.as_deref(),
         &state.iframe_sessions,
     )
     .await?;
-
-    let url = mgr.get_url().await.unwrap_or_default();
 
     let refs: serde_json::Map<String, Value> = state
         .ref_map
@@ -4150,6 +4223,7 @@ async fn handle_waitforfunction(cmd: &Value, state: &DaemonState) -> Result<Valu
 // ---------------------------------------------------------------------------
 
 async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    sync_iframe_sessions_from_pages(state);
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -4165,33 +4239,6 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         .client
         .send_command_no_params("Page.getFrameTree", Some(&session_id))
         .await?;
-
-    fn find_frame(tree: &Value, name: Option<&str>, url: Option<&str>) -> Option<String> {
-        let frame = tree.get("frame")?;
-        let frame_name = frame.get("name").and_then(|v| v.as_str()).unwrap_or("");
-        let frame_url = frame.get("url").and_then(|v| v.as_str()).unwrap_or("");
-        let frame_id = frame.get("id").and_then(|v| v.as_str())?;
-
-        if let Some(n) = name {
-            if frame_name == n {
-                return Some(frame_id.to_string());
-            }
-        }
-        if let Some(u) = url {
-            if frame_url.contains(u) {
-                return Some(frame_id.to_string());
-            }
-        }
-
-        if let Some(children) = tree.get("childFrames").and_then(|v| v.as_array()) {
-            for child in children {
-                if let Some(id) = find_frame(child, name, url) {
-                    return Some(id);
-                }
-            }
-        }
-        None
-    }
 
     let frame_tree = &tree_result["frameTree"];
 
@@ -4275,13 +4322,13 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         );
         let result = mgr.evaluate(&js, None).await?;
         let frame_name = result.as_str().ok_or("Could not find frame for selector")?;
-        if let Some(frame_id) = find_frame(frame_tree, Some(frame_name), None) {
+        if let Some(frame_id) = find_frame_id(frame_tree, Some(frame_name), None) {
             state.active_frame_id = Some(frame_id);
             return Ok(json!({ "frame": frame_name }));
         }
     }
 
-    if let Some(frame_id) = find_frame(frame_tree, name, url) {
+    if let Some(frame_id) = find_frame_id(frame_tree, name, url) {
         let label = name.or(url).unwrap_or("frame");
         state.active_frame_id = Some(frame_id);
         return Ok(json!({ "frame": label }));
@@ -6761,6 +6808,40 @@ mod tests {
         assert_eq!(resp["id"], "cmd-2");
         assert_eq!(resp["success"], false);
         assert_eq!(resp["error"], "Something went wrong");
+    }
+
+    #[test]
+    fn test_find_frame_id_finds_vscode_active_frame() {
+        let tree = json!({
+            "frame": {
+                "id": "root",
+                "name": "",
+                "url": "vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html"
+            },
+            "childFrames": [
+                {
+                    "frame": {
+                        "id": "wrapper",
+                        "name": "webview-host",
+                        "url": "vscode-webview://1l4q6f4e6i2l8rb3q0r4d0v6kq2b6jgg/index.html?id=webview-element-uuid"
+                    },
+                    "childFrames": [
+                        {
+                            "frame": {
+                                "id": "active",
+                                "name": "active-frame",
+                                "url": "vscode-webview://1l4q6f4e6i2l8rb3q0r4d0v6kq2b6jgg/index.html?id=webview-element-uuid&origin=tabby"
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(
+            find_frame_id(&tree, Some("active-frame"), None),
+            Some("active".to_string())
+        );
     }
 
     #[tokio::test]

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -95,8 +95,14 @@ fn is_internal_chrome_target(url: &str) -> bool {
         || url.starts_with("devtools://")
 }
 
+fn is_vscode_webview_target(url: &str) -> bool {
+    url.starts_with("vscode-webview://")
+}
+
 pub(crate) fn should_track_target(target: &TargetInfo) -> bool {
-    (target.target_type == "page" || target.target_type == "webview")
+    (target.target_type == "page"
+        || target.target_type == "webview"
+        || (target.target_type == "iframe" && is_vscode_webview_target(&target.url)))
         && (target.url.is_empty() || !is_internal_chrome_target(&target.url))
 }
 
@@ -141,7 +147,7 @@ pub struct PageInfo {
     pub session_id: String,
     pub url: String,
     pub title: String,
-    pub target_type: String, // "page" or "webview"
+    pub target_type: String, // "page", "webview", "iframe", or another CDP target type
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1365,6 +1371,36 @@ mod tests {
             target_type: "page".to_string(),
             title: "New Tab".to_string(),
             url: "chrome://newtab/".to_string(),
+            attached: None,
+            browser_context_id: None,
+        };
+
+        assert!(!should_track_target(&target));
+    }
+
+    #[test]
+    fn test_should_track_vscode_webview_iframe_target() {
+        let target = TargetInfo {
+            target_id: "vscode-webview-iframe".to_string(),
+            target_type: "iframe".to_string(),
+            title: "Example".to_string(),
+            url: "vscode-webview://123/index.html?id=webview-1&extensionId=publisher.example"
+                .to_string(),
+            attached: None,
+            browser_context_id: None,
+        };
+
+        assert!(should_track_target(&target));
+    }
+
+    #[test]
+    fn test_should_not_track_vscode_service_worker_target() {
+        let target = TargetInfo {
+            target_id: "vscode-webview-sw".to_string(),
+            target_type: "service_worker".to_string(),
+            title: "Service Worker".to_string(),
+            url: "vscode-webview://123/service-worker.js?v=4&extensionId=publisher.example"
+                .to_string(),
             attached: None,
             browser_context_id: None,
         };

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -184,6 +184,72 @@ impl RoleNameTracker {
     }
 }
 
+fn is_vscode_webview_url(url: &str) -> bool {
+    url.starts_with("vscode-webview://")
+}
+
+fn find_frame_id(tree: &Value, name: Option<&str>, url: Option<&str>) -> Option<String> {
+    let frame = tree.get("frame")?;
+    let frame_name = frame.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let frame_url = frame.get("url").and_then(|v| v.as_str()).unwrap_or("");
+    let frame_id = frame.get("id").and_then(|v| v.as_str())?;
+
+    if let Some(n) = name {
+        if frame_name == n {
+            return Some(frame_id.to_string());
+        }
+    }
+    if let Some(u) = url {
+        if frame_url.contains(u) {
+            return Some(frame_id.to_string());
+        }
+    }
+
+    if let Some(children) = tree.get("childFrames").and_then(|v| v.as_array()) {
+        for child in children {
+            if let Some(id) = find_frame_id(child, name, url) {
+                return Some(id);
+            }
+        }
+    }
+
+    None
+}
+
+async fn resolve_vscode_active_frame_id(
+    client: &CdpClient,
+    session_id: &str,
+) -> Result<Option<String>, String> {
+    let location: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: "location.href".to_string(),
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await?;
+    let url = location
+        .result
+        .value
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_default();
+    if !is_vscode_webview_url(&url) {
+        return Ok(None);
+    }
+
+    let tree_result = client
+        .send_command_no_params("Page.getFrameTree", Some(session_id))
+        .await?;
+    Ok(find_frame_id(
+        &tree_result["frameTree"],
+        Some("active-frame"),
+        None,
+    ))
+}
+
 pub async fn take_snapshot(
     client: &CdpClient,
     session_id: &str,
@@ -254,7 +320,7 @@ pub async fn take_snapshot(
             None
         };
 
-    let (ax_params, effective_session_id) =
+    let (mut ax_params, effective_session_id) =
         resolve_ax_session(frame_id, session_id, iframe_sessions);
     // Ensure domains are enabled on the iframe session (defensive fallback
     // in case the attach-time enable in execute_command was missed).
@@ -265,6 +331,13 @@ pub async fn take_snapshot(
         let _ = client
             .send_command_no_params("Accessibility.enable", Some(effective_session_id))
             .await;
+    }
+    if frame_id.is_none() || frame_id.is_some_and(|fid| iframe_sessions.contains_key(fid)) {
+        if let Some(active_frame_id) =
+            resolve_vscode_active_frame_id(client, effective_session_id).await?
+        {
+            ax_params = serde_json::json!({ "frameId": active_frame_id });
+        }
     }
     let ax_tree: GetFullAXTreeResult = client
         .send_command_typed(


### PR DESCRIPTION
## Summary
- track VS Code webview iframe targets so their sessions are available to snapshotting
- resolve the nested active-frame inside VS Code webviews when taking snapshots
- reuse the same frame lookup helper in frame selection and add focused VS Code regression coverage

## Testing
- cargo test vscode --manifest-path cli/Cargo.toml
- cargo fmt --manifest-path cli/Cargo.toml -- --check