### PR TITLE
fix: handle --clear flag in console command

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1074,7 +1074,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "setcontent" => handle_setcontent(cmd, state).await,
         "headers" => handle_headers(cmd, state).await,
         "offline" => handle_offline(cmd, state).await,
-        "console" => handle_console(state).await,
+        "console" => handle_console(cmd, state).await,
         "errors" => handle_errors(state).await,
         "state_save" => handle_state_save(cmd, state).await,
         "state_load" => handle_state_load(cmd, state).await,
@@ -2884,8 +2884,15 @@ async fn handle_offline(cmd: &Value, state: &DaemonState) -> Result<Value, Strin
     Ok(json!({ "offline": offline }))
 }
 
-async fn handle_console(state: &DaemonState) -> Result<Value, String> {
-    Ok(state.event_tracker.get_console_json())
+async fn handle_console(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let clear = cmd.get("clear").and_then(|v| v.as_bool()).unwrap_or(false);
+    if clear {
+        state.event_tracker.clear_console();
+        Ok(json!({ "cleared": true }))
+    } else {
+        let result = state.event_tracker.get_console_json();
+        Ok(result)
+    }
 }
 
 async fn handle_errors(state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/network.rs
+++ b/cli/src/native/network.rs
@@ -322,6 +322,10 @@ impl EventTracker {
         });
     }
 
+    pub fn clear_console(&mut self) {
+        self.console_entries.clear();
+    }
+
     pub fn get_console_json(&self) -> Value {
         let messages: Vec<Value> = self
             .console_entries

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -430,11 +430,12 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
-        // Cleared (cookies or request log)
+        // Cleared (cookies, console, or request log)
         if let Some(cleared) = data.get("cleared").and_then(|v| v.as_bool()) {
             if cleared {
                 let label = match action {
                     Some("cookies_clear") => "Cookies cleared",
+                    Some("console") => "Console log cleared",
                     _ => "Request log cleared",
                 };
                 println!("{} {}", color::success_indicator(), label);


### PR DESCRIPTION
## Problem

`console --clear` was parsed correctly into `{ "action": "console", "clear": true }` by the CLI, but the action handler silently ignored the flag.

**Root cause:** `handle_console` did not accept a `cmd` parameter, so it had no way to read the `clear` field — the flag was a no-op.

## Changes

- **`cli/src/native/network.rs`**: Added `clear_console()` method to `EventTracker` that clears the console entry buffer.
- **`cli/src/native/actions.rs`**: Updated `handle_console` to accept `cmd: &Value` and `state: &mut DaemonState`, read the `clear` field, and clear the buffer when `--clear` is passed (returns `{ "cleared": true }`). Updated the call site in `execute_command` to pass `cmd`.

## Behavior

| Command | Before | After |
|---|---|---|
| `console` | Returns logs | Returns logs |
| `console --clear` | Returns logs, buffer **not** cleared | Clears buffer, returns `{ "cleared": true }` |
