### PR TITLE
feat: add --use-system-keychain flag for enterprise SSO

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -205,6 +205,7 @@ pub struct DaemonOptions<'a> {
     pub auto_connect: bool,
     pub idle_timeout: Option<&'a str>,
     pub cdp: Option<&'a str>,
+    pub use_system_keychain: bool,
 }
 
 fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
@@ -246,6 +247,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if opts.allow_file_access {
         cmd.env("AGENT_BROWSER_ALLOW_FILE_ACCESS", "1");
+    }
+    if opts.use_system_keychain {
+        cmd.env("AGENT_BROWSER_USE_SYSTEM_KEYCHAIN", "1");
     }
     if let Some(prof) = opts.profile {
         cmd.env("AGENT_BROWSER_PROFILE", prof);

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -87,6 +87,7 @@ pub struct Config {
     pub screenshot_quality: Option<u32>,
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>,
+    pub use_system_keychain: Option<bool>,
 }
 
 impl Config {
@@ -132,6 +133,7 @@ impl Config {
             screenshot_quality: other.screenshot_quality.or(self.screenshot_quality),
             screenshot_format: other.screenshot_format.or(self.screenshot_format),
             idle_timeout: other.idle_timeout.or(self.idle_timeout),
+            use_system_keychain: other.use_system_keychain.or(self.use_system_keychain),
         }
     }
 }
@@ -298,6 +300,7 @@ pub struct Flags {
     pub screenshot_quality: Option<u32>,
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>, // Canonical milliseconds string for AGENT_BROWSER_IDLE_TIMEOUT_MS
+    pub use_system_keychain: bool,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -429,6 +432,8 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "AGENT_BROWSER_IDLE_TIMEOUT_MS",
         )
         .or(config.idle_timeout),
+        use_system_keychain: env_var_is_truthy("AGENT_BROWSER_USE_SYSTEM_KEYCHAIN")
+            || config.use_system_keychain.unwrap_or(false),
         cli_executable_path: false,
         cli_extensions: false,
         cli_profile: false,
@@ -572,6 +577,13 @@ pub fn parse_flags(args: &[String]) -> Flags {
                 let (val, consumed) = parse_bool_arg(args, i);
                 flags.allow_file_access = val;
                 flags.cli_allow_file_access = true;
+                if consumed {
+                    i += 1;
+                }
+            }
+            "--use-system-keychain" => {
+                let (val, consumed) = parse_bool_arg(args, i);
+                flags.use_system_keychain = val;
                 if consumed {
                     i += 1;
                 }
@@ -729,6 +741,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--annotate",
         "--content-boundaries",
         "--confirm-interactive",
+        "--use-system-keychain",
     ];
     // Global flags that always take a value (need to skip the next arg too)
     const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -396,6 +396,7 @@ fn main() {
         auto_connect: flags.auto_connect,
         idle_timeout: flags.idle_timeout.as_deref(),
         cdp: flags.cdp.as_deref(),
+        use_system_keychain: flags.use_system_keychain,
     };
     let daemon_result = match ensure_daemon(&flags.session, &daemon_opts) {
         Ok(result) => result,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1323,6 +1323,9 @@ fn launch_options_from_env() -> LaunchOptions {
             .unwrap_or(false),
         color_scheme: env::var("AGENT_BROWSER_COLOR_SCHEME").ok(),
         download_path: env::var("AGENT_BROWSER_DOWNLOAD_PATH").ok(),
+        use_system_keychain: env::var("AGENT_BROWSER_USE_SYSTEM_KEYCHAIN")
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false),
     }
 }
 
@@ -1534,6 +1537,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             .get("downloadPath")
             .and_then(|v| v.as_str())
             .map(String::from),
+        use_system_keychain: cmd
+            .get("useSystemKeychain")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
     };
 
     // Store proxy credentials for Fetch.authRequired handling

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -78,6 +78,9 @@ pub struct LaunchOptions {
     pub ignore_https_errors: bool,
     pub color_scheme: Option<String>,
     pub download_path: Option<String>,
+    /// Use the real OS keychain instead of a mock. Enables enterprise SSO
+    /// (macOS Platform SSO, Intune, Azure AD Conditional Access).
+    pub use_system_keychain: bool,
 }
 
 impl Default for LaunchOptions {
@@ -98,6 +101,7 @@ impl Default for LaunchOptions {
             ignore_https_errors: false,
             color_scheme: None,
             download_path: None,
+            use_system_keychain: false,
         }
     }
 }
@@ -124,9 +128,12 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         "--disable-features=Translate".to_string(),
         "--enable-features=NetworkService,NetworkServiceInProcess".to_string(),
         "--metrics-recording-only".to_string(),
-        "--password-store=basic".to_string(),
-        "--use-mock-keychain".to_string(),
     ];
+
+    if !options.use_system_keychain {
+        args.push("--password-store=basic".to_string());
+        args.push("--use-mock-keychain".to_string());
+    }
 
     let has_extensions = options
         .extensions

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2690,6 +2690,7 @@ Options:
                              e.g., --proxy-bypass "localhost,*.internal.com"
   --ignore-https-errors      Ignore HTTPS certificate errors
   --allow-file-access        Allow file:// URLs to access local files (Chromium only)
+  --use-system-keychain      Use real OS keychain for enterprise SSO (Intune, Azure AD)
   -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
   --json                     JSON output
@@ -2747,6 +2748,7 @@ Environment:
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
+  AGENT_BROWSER_USE_SYSTEM_KEYCHAIN Use real OS keychain (enables enterprise SSO/Intune)
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)
   AGENT_BROWSER_DOWNLOAD_PATH    Default download directory for browser downloads
   AGENT_BROWSER_DEFAULT_TIMEOUT  Default action timeout in ms (default: 25000)


### PR DESCRIPTION
## Summary

- Add `--use-system-keychain` CLI flag and `AGENT_BROWSER_USE_SYSTEM_KEYCHAIN` env var
- When enabled, skips `--use-mock-keychain` and `--password-store=basic` Chrome args
- Enables enterprise SSO (macOS Platform SSO, Intune, Azure AD Conditional Access) to work headlessly

### Problem

Enterprise sites protected by Azure AD Conditional Access + Intune device compliance require the real OS keychain for SSO. The hardcoded `--use-mock-keychain` and `--password-store=basic` flags prevent macOS Platform SSO Extension from accessing device certificates, causing authentication to fail even with `--profile`.

This is the same issue described in #422 — `--executable-path` alone doesn't help because the mock keychain blocks SSO regardless of which Chrome binary is used.

### Solution

Make the mock keychain flags conditional on a new `--use-system-keychain` flag. Default behavior is unchanged.

```bash
# Enterprise SSO setup
agent-browser --profile ~/.ab-profile --use-system-keychain open https://internal-sso-site.example.com
agent-browser text

# Or via env vars
export AGENT_BROWSER_PROFILE=~/.ab-profile
export AGENT_BROWSER_USE_SYSTEM_KEYCHAIN=1
```

Also works via JSON config and the daemon launch command (`"useSystemKeychain": true`).

### How it works

Google's Chrome DevTools MCP uses the same approach (Puppeteer with mock keychain disabled) to enable enterprise auth. The key insight: macOS Platform SSO Extension is a system-level hook that injects device certificates during authentication, but only when `--use-mock-keychain` is absent.

### Changes

| File | Change |
|------|--------|
| `cli/src/native/cdp/chrome.rs` | Conditional mock keychain args based on `use_system_keychain` |
| `cli/src/native/actions.rs` | Parse from env var and JSON launch command |
| `cli/src/flags.rs` | Config, Flags, CLI parsing, resolve |
| `cli/src/connection.rs` | Pass to daemon via env var |
| `cli/src/main.rs` | Wire flag into DaemonStartOpts |
| `cli/src/output.rs` | Help text |

## Test plan

- [ ] Default: `--use-mock-keychain` and `--password-store=basic` still present (no regression)
- [ ] With `--use-system-keychain`: both flags absent from Chrome args
- [ ] With `AGENT_BROWSER_USE_SYSTEM_KEYCHAIN=1`: same effect
- [ ] Enterprise SSO site accessible with `--profile + --use-system-keychain`
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)