### PR TITLE
fix: detect click listeners registered via addEventListener in snapshots

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2750,6 +2750,7 @@ async fn poll_until_true(
                     expression: expression.to_string(),
                     return_by_value: Some(true),
                     await_promise: Some(true),
+                    ..Default::default()
                 },
                 Some(session_id),
             )
@@ -4514,6 +4515,7 @@ async fn handle_waitforfunction(cmd: &Value, state: &DaemonState) -> Result<Valu
                 expression: format!("({})", expression),
                 return_by_value: Some(true),
                 await_promise: Some(true),
+                ..Default::default()
             },
             Some(&session_id),
         )
@@ -4815,6 +4817,7 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
                 expression: js,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(&session_id),
         )
@@ -4945,6 +4948,7 @@ async fn handle_semantic_locator(
                 expression: query,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(&session_id),
         )
@@ -5031,6 +5035,7 @@ async fn handle_nth(cmd: &Value, state: &mut DaemonState) -> Result<Value, Strin
                 expression: js,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(&session_id),
         )
@@ -5104,6 +5109,7 @@ async fn handle_evalhandle(cmd: &Value, state: &DaemonState) -> Result<Value, St
                 expression: script.to_string(),
                 return_by_value: Some(false),
                 await_promise: Some(true),
+                ..Default::default()
             },
             Some(&session_id),
         )
@@ -6397,6 +6403,7 @@ async fn wait_for_any_selector(
                         expression,
                         return_by_value: Some(true),
                         await_promise: Some(true),
+                        ..Default::default()
                     },
                     Some(session_id),
                 )

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -573,6 +573,7 @@ impl BrowserManager {
                     expression: script.to_string(),
                     return_by_value: Some(true),
                     await_promise: Some(true),
+                    ..Default::default()
                 },
                 Some(&session_id),
             )
@@ -1040,6 +1041,7 @@ impl BrowserManager {
                     ),
                     return_by_value: Some(false),
                     await_promise: Some(false),
+                    ..Default::default()
                 },
                 Some(session_id),
             )

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -232,7 +232,7 @@ pub struct HandleJavaScriptDialogParams {
 // Runtime domain
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateParams {
     pub expression: String,
@@ -240,6 +240,8 @@ pub struct EvaluateParams {
     pub return_by_value: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub await_promise: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_command_line_api: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -2498,6 +2498,78 @@ async fn e2e_snapshot_cursor_interactive() {
     assert_success(&resp);
 }
 
+/// Issue #1016 – Elements with click listeners registered via addEventListener
+/// (without onclick attribute or cursor:pointer) must be detected as clickable.
+/// Also verifies that <a> tags without href are detected.
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_addeventlistener_detection() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Page with elements that use addEventListener only (no onclick attr, no cursor:pointer):
+    //  - <span> with addEventListener('click', ...)
+    //  - <a> without href, with addEventListener('click', ...)
+    //  - <div> with addEventListener('click', ...) but no text (should be skipped)
+    let html = concat!(
+        "<html><body>",
+        "<span id='dl1'>report.pdf</span>",
+        "<a id='dl2'>invoice.xlsx</a>",
+        "<div id='empty'></div>",
+        "<script>",
+        "document.getElementById('dl1').addEventListener('click', function() { });",
+        "document.getElementById('dl2').addEventListener('click', function() { });",
+        "document.getElementById('empty').addEventListener('click', function() { });",
+        "</script>",
+        "</body></html>",
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "setcontent", "html": html }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+
+    // The span and <a> with addEventListener should be detected as clickable with click-listener hint
+    assert!(
+        snapshot.lines().any(|l| l.contains("report.pdf") && l.contains("clickable") && l.contains("click-listener")),
+        "Expected 'report.pdf' to be marked clickable with click-listener hint:\n{}",
+        snapshot,
+    );
+    assert!(
+        snapshot.lines().any(|l| l.contains("invoice.xlsx") && l.contains("clickable") && l.contains("click-listener")),
+        "Expected 'invoice.xlsx' to be marked clickable with click-listener hint:\n{}",
+        snapshot,
+    );
+
+    // Empty div with addEventListener should NOT appear (no text content guard)
+    let clickable_count = snapshot.lines().filter(|l| l.contains("clickable")).count();
+    assert_eq!(
+        clickable_count, 2,
+        "Expected exactly 2 clickable elements (empty div should be excluded):\n{}",
+        snapshot,
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// Verifies that `screenshot --annotate` completes in bounded time even with
 /// many interactive elements. Guards against the sequential CDP round-trip
 /// regression that caused hangs over high-latency WSS (Issue #841).

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -284,6 +284,7 @@ pub async fn resolve_element_object_id(
                 expression: js,
                 return_by_value: Some(false),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )
@@ -448,6 +449,7 @@ async fn resolve_by_selector(
                 expression: js,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )
@@ -907,6 +909,7 @@ pub async fn get_element_count(
                 expression: js,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -382,6 +382,7 @@ pub async fn scroll(
                     expression: js,
                     return_by_value: Some(true),
                     await_promise: Some(false),
+                    ..Default::default()
                 },
                 Some(session_id),
             )

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -456,6 +456,7 @@ async fn inject_annotation_overlay(
                 expression,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )
@@ -482,6 +483,7 @@ async fn remove_annotation_overlay(client: &CdpClient, session_id: &str) -> Resu
                 expression,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )
@@ -498,6 +500,7 @@ async fn get_scroll_offsets(client: &CdpClient, session_id: &str) -> Result<(f64
                 expression: "({x: window.scrollX || 0, y: window.scrollY || 0})".to_string(),
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -215,6 +215,7 @@ pub async fn take_snapshot(
                         expression: js,
                         return_by_value: Some(false),
                         await_promise: Some(false),
+                        ..Default::default()
                     },
                     Some(session_id),
                 )
@@ -531,8 +532,9 @@ async fn find_cursor_interactive_elements(
         'slider':1, 'spinbutton':1, 'switch':1, 'tab':1, 'treeitem':1
     };
     var interactiveTags = {
-        'a':1, 'button':1, 'input':1, 'select':1, 'textarea':1, 'details':1, 'summary':1
+        'button':1, 'input':1, 'select':1, 'textarea':1, 'details':1, 'summary':1
     };
+    var hasGetEventListeners = typeof getEventListeners === 'function';
 
     var allElements = document.body.querySelectorAll('*');
     for (var i = 0; i < allElements.length; i++) {
@@ -543,8 +545,16 @@ async fn find_cursor_interactive_elements(
         var tagName = el.tagName.toLowerCase();
         if (interactiveTags[tagName]) continue;
 
+        // Skip <a> tags that have href (they get 'link' role in the AX tree).
+        // <a> without href gets 'generic' role and would be missed by both
+        // the AX tree and this detection, so we let it through.
+        if (tagName === 'a' && el.hasAttribute('href')) continue;
+
         var role = el.getAttribute('role');
         if (role && interactiveRoles[role.toLowerCase()]) continue;
+
+        var rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) continue;
 
         var computedStyle = getComputedStyle(el);
         var hasCursorPointer = computedStyle.cursor === 'pointer';
@@ -553,8 +563,20 @@ async fn find_cursor_interactive_elements(
         var hasTabIndex = tabIndex !== null && tabIndex !== '-1';
         var ce = el.getAttribute('contenteditable');
         var isEditable = ce === '' || ce === 'true';
+        var text = (el.textContent || '').trim();
+        var hasClickListener = false;
 
-        if (!hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) continue;
+        if (!hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) {
+            // Fallback: detect click listeners registered via addEventListener.
+            // Only check visible elements with text content to limit overhead.
+            if (hasGetEventListeners && text) {
+                var listeners = getEventListeners(el);
+                if (listeners.click && listeners.click.length > 0) {
+                    hasClickListener = true;
+                }
+            }
+            if (!hasClickListener) continue;
+        }
 
         // Skip elements that only inherit cursor:pointer from an ancestor
         if (hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) {
@@ -562,16 +584,12 @@ async fn find_cursor_interactive_elements(
             if (parent && getComputedStyle(parent).cursor === 'pointer') continue;
         }
 
-        var text = (el.textContent || '').trim().slice(0, 100);
-
-        var rect = el.getBoundingClientRect();
-        if (rect.width === 0 || rect.height === 0) continue;
-
         el.setAttribute('data-__ab-ci', String(results.length));
         results.push({
-            text: text,
+            text: text.slice(0, 100),
             tagName: tagName,
             hasOnClick: hasOnClick,
+            hasClickListener: hasClickListener,
             hasCursorPointer: hasCursorPointer,
             hasTabIndex: hasTabIndex,
             isEditable: isEditable
@@ -588,6 +606,7 @@ async fn find_cursor_interactive_elements(
                 expression: js.to_string(),
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                include_command_line_api: Some(true),
             },
             Some(session_id),
         )
@@ -686,6 +705,7 @@ async fn find_cursor_interactive_elements(
                 expression: cleanup_js,
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )
@@ -709,6 +729,10 @@ async fn find_cursor_interactive_elements(
             .get("hasOnClick")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let has_click_listener = elem
+            .get("hasClickListener")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let has_tab_index = elem
             .get("hasTabIndex")
             .and_then(|v| v.as_bool())
@@ -718,7 +742,7 @@ async fn find_cursor_interactive_elements(
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let kind = if has_cursor_pointer || has_on_click {
+        let kind = if has_cursor_pointer || has_on_click || has_click_listener {
             "clickable"
         } else if is_editable {
             "editable"
@@ -732,6 +756,9 @@ async fn find_cursor_interactive_elements(
         }
         if has_on_click {
             hints.push("onclick".to_string());
+        }
+        if has_click_listener {
+            hints.push("click-listener".to_string());
         }
         if has_tab_index {
             hints.push("tabindex".to_string());

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -66,6 +66,7 @@ pub async fn save_state(
                 expression: origin_js.to_string(),
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )
@@ -204,6 +205,7 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
                         expression: js,
                         return_by_value: Some(true),
                         await_promise: Some(false),
+                        ..Default::default()
                     },
                     Some(session_id),
                 )
@@ -223,6 +225,7 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
                         expression: js,
                         return_by_value: Some(true),
                         await_promise: Some(false),
+                        ..Default::default()
                     },
                     Some(session_id),
                 )

--- a/cli/src/native/storage.rs
+++ b/cli/src/native/storage.rs
@@ -81,6 +81,7 @@ async fn eval_simple(client: &CdpClient, session_id: &str, js: &str) -> Result<V
                 expression: js.to_string(),
                 return_by_value: Some(true),
                 await_promise: Some(false),
+                ..Default::default()
             },
             Some(session_id),
         )


### PR DESCRIPTION
## Summary

Closes #1016

Elements with click handlers added via `addEventListener` (without `onclick` attribute or `cursor:pointer` CSS) were invisible in accessibility snapshots. This caused download links rendered as **StaticText** to be unclickable by agents.

## Problem

`find_cursor_interactive_elements` in `snapshot.rs` only detected interactivity through 4 signals:

| Signal | Detection | Limitation |
|--------|-----------|------------|
| `cursor: pointer` | `getComputedStyle(el).cursor` | Misses `:hover`-only styles |
| `onclick` attribute | `el.hasAttribute('onclick') \|\| el.onclick` | Misses `addEventListener` |
| `tabindex` | `el.getAttribute('tabindex')` | Most custom click elements lack this |
| `contenteditable` | `el.getAttribute('contenteditable')` | Unrelated to downloads |

Additionally, `<a>` tags without `href` were unconditionally skipped by the `interactiveTags` check, while Chrome's AX tree assigns them `generic` role (not `link`) — making them invisible to both detection paths.

## Solution

### 1. `getEventListeners()` via Chrome DevTools Console API
- Added `includeCommandLineAPI: true` to the `Runtime.evaluate` call in `find_cursor_interactive_elements`
- This enables access to `getEventListeners(el)`, which returns all event listeners registered on an element (including via `addEventListener`)
- Only called on **visible elements with text content** to limit performance overhead
- Gracefully falls back to existing behavior when unavailable (e.g., Lightpanda) via `typeof getEventListeners === 'function'` guard

### 2. `<a>` without `href` handling
- Removed `'a'` from the `interactiveTags` skip-list
- Added explicit `if (tagName === 'a' && el.hasAttribute('href')) continue;` — `<a href="...">` elements are still skipped (handled by AX tree as `link` role)
- `<a>` without `href` now passes through cursor-interactive detection

### 3. Performance optimizations
- Hoisted `getBoundingClientRect` before `getComputedStyle`/`getEventListeners` to reject zero-size elements early
- Hoisted `textContent` computation to avoid double access for listener-detected elements

### 4. Infrastructure
- Added `include_command_line_api: Option<bool>` field to `EvaluateParams`
- Added `#[derive(Default)]` to `EvaluateParams`, using `..Default::default()` at existing call sites to avoid boilerplate across 20+ files
- Added distinct `"click-listener"` hint (separate from `"onclick"`) for diagnostic clarity

## Test plan

- [x] 542 unit tests pass (0 failures)
- [x] New e2e test covers: `<span>` with addEventListener, `<a>` without href with addEventListener, empty `<div>` excluded
- [ ] Manual test on page with download links rendered as StaticText

