### PR TITLE
fix: include root package in pnpm workspace for changesets

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
+  - '.'
   - 'packages/*'
   - 'docs'


### PR DESCRIPTION
## Summary

- The dashboard PR (#1034) introduced `pnpm-workspace.yaml` listing only `packages/*` and `docs`
- This caused the changesets release CI to fail with: `Found changeset release-v0230 for package agent-browser which is not in the workspace`
- Adding `'.'` to the workspace packages list makes the root `agent-browser` package visible to changesets again