### PR TITLE
feat(click): add --js-click flag for DOM-level element.click()

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -138,18 +138,22 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
         // === Core Actions ===
         "click" => {
             let new_tab = rest.contains(&"--new-tab");
+            let js_click = rest.contains(&"--js-click");
             let sel = rest
                 .iter()
-                .find(|arg| **arg != "--new-tab")
+                .find(|arg| **arg != "--new-tab" && **arg != "--js-click")
                 .ok_or_else(|| ParseError::MissingArguments {
                     context: "click".to_string(),
-                    usage: "click <selector> [--new-tab]",
+                    usage: "click <selector> [--new-tab] [--js-click]",
                 })?;
+            let mut cmd = json!({ "id": id, "action": "click", "selector": sel });
             if new_tab {
-                Ok(json!({ "id": id, "action": "click", "selector": sel, "newTab": true }))
-            } else {
-                Ok(json!({ "id": id, "action": "click", "selector": sel }))
+                cmd["newTab"] = json!(true);
             }
+            if js_click {
+                cmd["jsClick"] = json!(true);
+            }
+            Ok(cmd)
         }
         "dblclick" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2186,6 +2186,19 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     let session_id = mgr.active_session_id()?.to_string();
 
     let new_tab = cmd.get("newTab").and_then(|v| v.as_bool()).unwrap_or(false);
+    let js_click = cmd.get("jsClick").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    if js_click {
+        interaction::js_click(
+            &mgr.client,
+            &session_id,
+            &state.ref_map,
+            selector,
+            &state.iframe_sessions,
+        )
+        .await?;
+        return Ok(json!({ "clicked": selector, "method": "js" }));
+    }
 
     if new_tab {
         use super::element::resolve_element_object_id;

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -538,6 +538,50 @@ pub async fn uncheck(
     Ok(())
 }
 
+/// DOM-level click via `element.click()`. Bypasses CDP coordinate-based
+/// input, working around pointer-events:none, viewport issues, and SPA
+/// routers that don't respond to Input.dispatchMouseEvent.
+///
+/// This mirrors the fallback path used by `check()`/`uncheck()` via
+/// `js_click_checkbox()`, generalized for any clickable element.
+pub async fn js_click(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    selector_or_ref: &str,
+    iframe_sessions: &HashMap<String, String>,
+) -> Result<(), String> {
+    let (object_id, effective_session_id) = resolve_element_object_id(
+        client,
+        session_id,
+        ref_map,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await?;
+
+    let js = r#"function() {
+            this.scrollIntoView({ block: 'center', behavior: 'instant' });
+            this.click();
+        }"#;
+
+    client
+        .send_command_typed::<_, Value>(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: js.to_string(),
+                object_id: Some(object_id),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(&effective_session_id),
+        )
+        .await?;
+
+    Ok(())
+}
+
 /// Fallback for when the coordinate-based CDP click did not toggle the
 /// checkbox/radio state. This mirrors how Playwright dispatches clicks
 /// through the DOM rather than via raw Input.dispatchMouseEvent coordinates.


### PR DESCRIPTION
## Problem

\`click\` uses CDP \`Input.dispatchMouseEvent\` which dispatches coordinate-based mouse events. This silently fails when:

- **\`pointer-events: none\`** — coordinates pass through to underlying elements (e.g., vercel.com navigation links)
- **Viewport-obscured elements** — \`getBoundingClientRect()\` returns incorrect coordinates for elements outside the visible area

The command reports success, but the intended element is not actually clicked. Related: #1011, #1044.

**Note:** SPA router click issues observed in v0.22.x appear to be resolved in v0.23.0. This PR addresses the remaining cases where coordinate-based clicking is fundamentally insufficient.

## Root Cause

\`Input.dispatchMouseEvent\` operates at the browser input pipeline level (coordinates → hit-test → element). CSS properties like \`pointer-events: none\` cause the hit-test to resolve to a different element than intended, and viewport-obscured elements produce unreliable coordinates.

\`element.click()\` (DOM API) bypasses the coordinate system entirely and invokes the element's click handler directly, which is immune to CSS pointer restrictions and viewport position.

## Changes

- **\`cli/src/native/interaction.rs\`**: Added \`pub async fn js_click()\` — calls \`element.scrollIntoView()\` + \`element.click()\` via \`Runtime.callFunctionOn\`. Mirrors the existing \`js_click_checkbox()\` fallback (used by \`check()\`/\`uncheck()\`), generalized for any clickable element.
- **\`cli/src/native/actions.rs\`**: \`handle_click()\` reads \`jsClick\` flag, dispatches to \`js_click()\` when set.
- **\`cli/src/commands.rs\`**: Parses \`--js-click\` CLI flag into \`{ "jsClick": true }\` JSON field, following the \`--new-tab\` pattern.

## Behavior

| Site | Issue | \`click @ref\` | \`click @ref --js-click\` |
|------|-------|-------------|------------------------|
| vercel.com | \`pointer-events: none\` | ❌ silent fail | ✅ navigates |
| namu.wiki | virtual rendering | ❌ (element at wrong coords) | ✅ navigates |
| example.com | (none) | ✅ works | ✅ works |

## Testing

\`\`\`bash
cargo test --manifest-path cli/Cargo.toml          # 542 passed, 0 failed
cargo fmt --manifest-path cli/Cargo.toml -- --check

# Manual verification (pointer-events: none):
agent-browser open https://vercel.com
agent-browser snapshot -i
agent-browser click @e91             # Docs link — URL unchanged
agent-browser click @e91 --js-click  # URL → /docs ✅
\`\`\`