### PR TITLE
docs: add AGENT_BROWSER_CDP to --help environment variables list

### DIFF
--- a/.changeset/document-cdp-env-var.md
+++ b/.changeset/document-cdp-env-var.md
@@ -1,0 +1,5 @@
+---
+"@anthropic-ai/agent-browser-cli": patch
+---
+
+docs: add AGENT_BROWSER_CDP to --help environment variables list

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3158,6 +3158,7 @@ Environment:
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore)
+  AGENT_BROWSER_CDP              Connect to Chrome via remote debugging port (e.g. 9222)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)


### PR DESCRIPTION
Adds `AGENT_BROWSER_CDP` to the environment variables section of `--help` output (`cli/src/output.rs`).

The original issue reports this env var being ignored by the Node.js daemon (`daemon.ts`). That daemon was removed in the Rust rewrite. The Rust daemon reads `AGENT_BROWSER_CDP` correctly at `actions.rs:1415`, but the env var was missing from the help text.

This contribution was developed with AI assistance (Claude Code).

Closes #674