### PR TITLE
fix: only bundle core agent-browser skill in npm package

### DIFF
--- a/.changeset/fix-skill-bundling.md
+++ b/.changeset/fix-skill-bundling.md
@@ -1,0 +1,5 @@
+---
+"agent-browser": patch
+---
+
+fix: only bundle core agent-browser skill in npm package

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bin",
     "scripts",
     "skill-data",
-    "skills"
+    "skills/agent-browser"
   ],
   "bin": {
     "agent-browser": "./bin/agent-browser.js"


### PR DESCRIPTION
## Summary

Changes the `files` array in `package.json` from `"skills"` to `"skills/agent-browser"` so only the core skill is included in the npm tarball.

## Problem

`npx skills add vercel-labs/agent-browser` installs all 5 skills (agent-browser, dogfood, electron, slack, vercel-sandbox) because `package.json` includes the entire `skills/` directory. Most users only want the core browser automation skill.

The `.claude-plugin/marketplace.json` already references only `./skills/agent-browser`. This change aligns the npm package with that behavior.

## Changes

`package.json`: `"skills"` -> `"skills/agent-browser"` in the `files` array.

Companion skills remain in the repo for users who want them via `--skill` flag.

This contribution was developed with AI assistance (Claude Code).

Fixes #963