### PR TITLE
fix: prevent CDP connect hang on browsers with discarded/frozen tabs

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -425,9 +425,54 @@ impl BrowserManager {
                 });
             }
 
+            // Try to enable domains on the first page with a timeout.
+            // Discarded/frozen tabs (Chrome Memory Saver) have no renderer,
+            // so Page.enable hangs forever. Fall back to a new tab if needed.
             self.active_page_index = 0;
             let session_id = self.pages[0].session_id.clone();
-            self.enable_domains(&session_id).await?;
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(3),
+                self.enable_domains(&session_id),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                _ => {
+                    // First tab is likely discarded — create a new tab
+                    let result: CreateTargetResult = self
+                        .client
+                        .send_command_typed(
+                            "Target.createTarget",
+                            &CreateTargetParams {
+                                url: "about:blank".to_string(),
+                            },
+                            None,
+                        )
+                        .await?;
+
+                    let attach_result: AttachToTargetResult = self
+                        .client
+                        .send_command_typed(
+                            "Target.attachToTarget",
+                            &AttachToTargetParams {
+                                target_id: result.target_id.clone(),
+                                flatten: true,
+                            },
+                            None,
+                        )
+                        .await?;
+
+                    self.pages.push(PageInfo {
+                        target_id: result.target_id,
+                        session_id: attach_result.session_id.clone(),
+                        url: "about:blank".to_string(),
+                        title: String::new(),
+                        target_type: "page".to_string(),
+                    });
+                    self.active_page_index = self.pages.len() - 1;
+                    self.enable_domains(&attach_result.session_id).await?;
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Fix CDP connect hanging indefinitely on browsers with discarded/frozen tabs (Chrome Memory Saver).

Fixes #1036

## Changes

- Add 3-second timeout to `enable_domains()` call during initial CDP connection in `discover_and_attach_targets()`
- If the first tab fails to respond (likely discarded/frozen with no renderer process), fall back to creating a new `about:blank` tab
- All existing tabs remain visible in `tab list` (attached but not enabled); they get enabled lazily on `tab switch`

## Test plan

- `cargo fmt --check` ✅
- `cargo clippy` ✅
- `cargo test` — 565 passed, 0 failed ✅
- Manual test: `chrome://discards` → Urgent Discard multiple tabs → `agent-browser --cdp 9222 get title`
  - Before: hangs indefinitely
  - After: completes in ~3s with fallback to new tab
 
## Design decision

Fallback to a new tab after the first timeout rather than trying all tabs because:

1. **`Target.getTargets` order is not sorted by activity** — there's no way to know which tab is more likely to be active, so trying them sequentially doesn't improve the odds
2. **Each timeout costs 3 seconds** — with many discarded tabs, sequential retries would add up (e.g. 10 discarded tabs = 30s wait)
3. **Creating a new tab is instant and guaranteed to work** — it always has a live renderer

A future improvement could use the `/json/list` HTTP endpoint (which returns tabs sorted by most recently active) to pick a better first candidate.