### PR TITLE
fix: promote hidden radio/checkbox inputs in snapshot refs

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -832,7 +832,10 @@ fn promote_hidden_inputs(
         if !matches!(node.role.as_str(), "LabelText" | "generic") {
             continue;
         }
-        let cursor_info = match node.backend_node_id.and_then(|bid| cursor_elements.get(&bid)) {
+        let cursor_info = match node
+            .backend_node_id
+            .and_then(|bid| cursor_elements.get(&bid))
+        {
             Some(info) => info,
             None => continue,
         };
@@ -1503,5 +1506,4 @@ mod tests {
 
         assert_eq!(nodes[0].role, "LabelText"); // unchanged
     }
-
 }


### PR DESCRIPTION
## Summary

Fixes #1024

When a `<label>` wraps a `display:none` `<input type="radio">` (a common pattern in React/Vue/Tailwind UI), Chrome excludes the input from the accessibility tree entirely. The `<label>` appears as `role="LabelText"` with an empty name in `snapshot -i` output, making it impossible for AI agents to identify radio buttons via `data.refs`.

This PR detects hidden radio/checkbox inputs during cursor-interactive scanning and promotes their parent nodes to the correct role.

### Before

```json
{
  "e3": { "role": "LabelText", "name": "" },
  "e4": { "role": "LabelText", "name": "" },
  "e5": { "role": "LabelText", "name": "" }
}
```

### After

```json
{
  "e3": { "role": "radio", "name": "I've never scheduled an appointment at Oak Street Health" },
  "e4": { "role": "radio", "name": "I've previously scheduled an appointment with Oak Street Health" },
  "e5": { "role": "radio", "name": "None of these" }
}
```

## Reproduction

```html
<label class="styled-card" style="cursor: pointer">
  <input type="radio" name="visit" value="never" style="display: none">
  I've never scheduled an appointment
</label>
```

1. `agent-browser navigate <url>` to a page with this pattern
2. `agent-browser snapshot -i -c --json`
3. `data.refs` shows `role="LabelText"` with empty name instead of `role="radio"`

## How it works

1. **JS detection** — During cursor-interactive element scanning, `querySelector` checks if the element contains a hidden `<input type="radio|checkbox">` (`display:none`, `visibility:hidden`, or `hidden` attribute). Only these hiding methods are checked because `opacity:0` and sr-only inputs remain in Chrome's AX tree and already appear as `role="radio"` without promotion.

2. **`HiddenInputKind` enum** — The JS result is parsed into a `Radio`/`Checkbox` enum at the deserialization boundary, rejecting unexpected values before they reach `node.role`.

3. **`promote_hidden_inputs()`** — Before ref assignment, iterates tree nodes and promotes `LabelText`/`generic` nodes that have a matching hidden input:
   - Sets `node.role` to `"radio"` or `"checkbox"`
   - Falls back to DOM `textContent` for the name (only if AX tree name is empty)
   - Preserves the hidden input's `checked` state (supports `"true"`, `"false"`, `"mixed"` tristate)

## Test plan

- [x] `cargo check` / `cargo fmt` / `cargo clippy` pass
- [x] 17 unit tests pass (3 new tests for `promote_hidden_inputs`)
- [x] Manual browser test: hidden radio labels show `role="radio"` with correct name in `data.refs`
- [x] Manual browser test: clicking a promoted radio updates `checked=true`
- [x] Manual browser test: switching between radios correctly toggles checked state (mutual exclusion)
- [x] ARIA `role="radio"` (div-based) elements are unaffected (no `clickable` tag, native AX tree nodes)
- [x] Non-promotable roles (button, heading) are not modified
- [x] Issue reporter's Python filter code (`{k: v for k, v in refs.items() if v["role"] == "radio"}`) returns 6 results (was 0)