### PR TITLE
Fix daemon hang on Linux caused by waitpid(-1) race condition

### DIFF
--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -495,10 +495,7 @@ mod tests {
     fn test_no_waitpid_minus_one_in_daemon() {
         let source = include_str!("daemon.rs");
         // Only check production code (everything before `#[cfg(test)]`)
-        let production_code = source
-            .split("#[cfg(test)]")
-            .next()
-            .unwrap_or(source);
+        let production_code = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
             !production_code.contains("waitpid(-1"),
             "daemon.rs production code must not call waitpid(-1, ...). \


### PR DESCRIPTION
Fixes #1035

The SIGCHLD handler added in v0.22.3 called `waitpid(-1, WNOHANG)` to reap zombie Chrome processes. This races with Rust's `Child::try_wait()` / `Child::wait()` because `waitpid(-1)` reaps *any* child in the process, stealing the exit status before the `Child` handle can collect it. The result is `ECHILD` errors in `BrowserManager::has_process_exited()` and `ChromeProcess::kill()`, leaving the daemon in a broken state that manifests as indefinite hangs on Linux servers.

The fix removes the global SIGCHLD handler and `reap_children()` function entirely. Instead, the existing 500ms drain interval now checks `mgr.has_process_exited()` (which delegates to `Child::try_wait()`) for targeted, race-free crash detection. When Chrome is detected as crashed, the `BrowserManager` is closed and daemon state is reset.

## Changes

- Removed `SIGCHLD` signal handler and `reap_children()` from the Unix daemon event loop
- Enhanced the drain interval to detect Chrome crashes via `has_process_exited()` and clean up state
- Added 3 regression tests:
  - Static source scan that fails if `waitpid(-1)` is re-introduced in production code
  - `try_wait()` correctness test for exit detection without a SIGCHLD handler
  - Kill detection test simulating a Chrome crash