### PR TITLE
Add Lightpanda Cloud provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1456,6 +1456,35 @@ Optional configuration via environment variables:
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
 
+### Lightpanda Cloud
+
+[Lightpanda Cloud](https://lightpanda.io) provides cloud-hosted Lightpanda browser instances accessible via CDP. Use it when running agent-browser in environments where a local browser isn't available.
+
+To enable Lightpanda Cloud, use the `-p` flag:
+
+```bash
+export LIGHTPANDA_CLOUD_TOKEN="your-api-token"
+agent-browser -p lightpanda-cloud open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=lightpanda-cloud
+export LIGHTPANDA_CLOUD_TOKEN="your-api-token"
+agent-browser open https://example.com
+```
+
+Optional configuration via environment variables:
+
+| Variable                   | Description                                         | Default  |
+| -------------------------- | --------------------------------------------------- | -------- |
+| `LIGHTPANDA_CLOUD_REGION`  | Cloud region (`euwest` or `uswest`)                 | `euwest` |
+
+When enabled, agent-browser connects to a Lightpanda Cloud session instead of launching a local browser. All commands work identically to the local Lightpanda engine.
+
+Get your API token from the [Lightpanda Console](https://console.lightpanda.io).
+
 ## License
 
 Apache-2.0

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1935,6 +1935,8 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                     Ok(mgr) => {
                         state.reset_input_state();
                         state.browser = Some(mgr);
+                        state.engine = conn.engine.as_str().to_string();
+                        write_engine_file(&state.session_id, &state.engine);
                         state.subscribe_to_browser_events();
                         state.start_fetch_handler();
                         state.start_dialog_handler();

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -1,10 +1,26 @@
 //! Browser provider connections for remote CDP sessions.
 //!
-//! Supports AgentCore, Browserbase, Browserless, Browser Use, and Kernel providers.
+//! Supports AgentCore, Browserbase, Browserless, Browser Use, Kernel, and Lightpanda Cloud  providers.
 //! Each provider returns a CDP WebSocket URL for connecting via BrowserManager.
 
 use serde_json::{json, Value};
 use std::env;
+
+/// Browser engine backing the provider connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProviderEngine {
+    Chrome,
+    Lightpanda,
+}
+
+impl ProviderEngine {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProviderEngine::Chrome => "chrome",
+            ProviderEngine::Lightpanda => "lightpanda",
+        }
+    }
+}
 
 /// Provider session info for cleanup on failure.
 #[derive(Debug)]
@@ -19,6 +35,8 @@ pub struct ProviderConnection {
     pub session: Option<ProviderSession>,
     /// If true, the WebSocket IS the page session (no Target.* commands).
     pub direct_page: bool,
+    /// Engine for action-level branching between Chrome and Lightpanda behavior.
+    pub engine: ProviderEngine,
 }
 
 /// Connects to the specified browser provider and returns a CDP WebSocket URL
@@ -31,6 +49,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                engine: ProviderEngine::Chrome,
             })
         }
         "browserless" => {
@@ -39,6 +58,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                engine: ProviderEngine::Chrome,
             })
         }
         "browser-use" | "browseruse" => {
@@ -47,6 +67,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                engine: ProviderEngine::Chrome,
             })
         }
         "kernel" => {
@@ -55,6 +76,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                engine: ProviderEngine::Chrome,
             })
         }
         "agentcore" => {
@@ -63,10 +85,20 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                engine: ProviderEngine::Chrome,
+            })
+        }
+        "lightpanda-cloud" => {
+            let url = connect_lightpanda_cloud().await?;
+            Ok(ProviderConnection {
+                ws_url: url,
+                session: None,
+                direct_page: false,
+                engine: ProviderEngine::Lightpanda,
             })
         }
         _ => Err(format!(
-            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore",
+            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, lightpanda-cloud",
             provider_name
         )),
     }
@@ -813,4 +845,16 @@ mod tests {
         let taken_again = take_agentcore_ws_headers();
         assert!(taken_again.is_none());
     }
+}
+
+async fn connect_lightpanda_cloud() -> Result<String, String> {
+    let api_key = env::var("LIGHTPANDA_CLOUD_TOKEN")
+        .map_err(|_| "LIGHTPANDA_CLOUD_TOKEN environment variable is not set")?;
+
+    let region = env::var("LIGHTPANDA_CLOUD_REGION").unwrap_or_else(|_| "euwest".to_string());
+
+    Ok(format!(
+        "wss://{}.cloud.lightpanda.io/ws?token={}",
+        region, api_key
+    ))
 }

--- a/docs/src/app/providers/lightpanda-cloud/layout.tsx
+++ b/docs/src/app/providers/lightpanda-cloud/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("providers/lightpanda-cloud");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/providers/lightpanda-cloud/page.mdx
+++ b/docs/src/app/providers/lightpanda-cloud/page.mdx
@@ -1,0 +1,36 @@
+# Lightpanda Cloud
+
+[Lightpanda Cloud](https://lightpanda.io) provides cloud-hosted Lightpanda browser instances accessible via CDP. Use it when running agent-browser in environments where a local browser isn't available.
+
+## Setup
+
+```bash
+export LIGHTPANDA_CLOUD_TOKEN="your-api-token"
+agent-browser -p lightpanda-cloud open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=lightpanda-cloud
+export LIGHTPANDA_CLOUD_TOKEN="your-api-token"
+agent-browser open https://example.com
+```
+
+The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
+
+## Configuration
+
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Description</th><th>Default</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>LIGHTPANDA_CLOUD_TOKEN</code></td><td>API token (required)</td><td></td></tr>
+    <tr><td><code>LIGHTPANDA_CLOUD_REGION</code></td><td>Cloud region (<code>euwest</code> or <code>uswest</code>)</td><td><code>euwest</code></td></tr>
+  </tbody>
+</table>
+
+When enabled, agent-browser connects to a Lightpanda Cloud session instead of launching a local browser. All commands work identically to the local Lightpanda engine.
+
+Get your API token from the [Lightpanda Console](https://console.lightpanda.io).

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -50,6 +50,7 @@ export const navigation: NavSection[] = [
       { name: "Browserbase", href: "/providers/browserbase" },
       { name: "Browserless", href: "/providers/browserless" },
       { name: "Kernel", href: "/providers/kernel" },
+      { name: "Lightpanda Cloud", href: "/providers/lightpanda-cloud" },
     ],
   },
   {

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -24,6 +24,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "providers/browserbase": "Browserbase",
   "providers/browserless": "Browserless",
   "providers/kernel": "Kernel",
+  "providers/lightpanda-cloud": "Lightpanda Cloud",
   changelog: "Changelog",
 };
 


### PR DESCRIPTION
## Summary

- Add `lightpanda-cloud` as a new cloud browser provider, connecting to Lightpanda's hosted CDP
  endpoint via `wss://{region}.cloud.lightpanda.io/ws?token=TOKEN`
- Introduce `ProviderEngine` enum (`Chrome` | `Lightpanda`) on `ProviderConnection` so the
  provider path correctly sets `state.engine` to `"lightpanda"`, ensuring action-level branching
  between Chrome and Lightpanda behavior works for cloud sessions
- Existing providers (Browserbase, Browserless, Browser Use, Kernel) are tagged `ProviderEngine::Chrome`

## Configuration

| Variable                  | Description                         | Default  |
| ------------------------- | ----------------------------------- | -------- |
| `LIGHTPANDA_CLOUD_TOKEN`  | API token (required)                | —        |
| `LIGHTPANDA_CLOUD_REGION` | Cloud region (`euwest` or `uswest`) | `euwest` |

Usage: `agent-browser -p lightpanda-cloud open https://example.com`
