### PR TITLE
Make dashboard work from proxied origins via same-origin proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ agent-browser open example.com
 agent-browser dashboard stop
 ```
 
-The dashboard runs as a standalone background process on port 4848, independent of browser sessions. It stays available even when no sessions are running. All sessions automatically stream to the dashboard.
+The dashboard runs as a standalone background process on port 4848, independent of browser sessions. It stays available even when no sessions are running, and it works from `http://localhost:4848` or a proxied/forwarded URL that reaches the dashboard server, such as `https://dashboard.agent-browser.localhost` or a Coder workspace URL. The browser stays on the dashboard origin; session-specific tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.
 
 The dashboard displays:
 - **Live viewport** -- real-time JPEG frames from the browser

--- a/cli/src/native/stream/dashboard.rs
+++ b/cli/src/native/stream/dashboard.rs
@@ -1,13 +1,387 @@
+use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
-
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
 
 use crate::connection::get_socket_dir;
 
 use super::chat::{chat_status_json, handle_chat_request, handle_models_request};
 use super::discovery::discover_sessions;
 use super::http::{serve_embedded_file, CORS_HEADERS};
+
+/// Dashboard same-origin proxy endpoints for session metadata and streams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionProxyEndpoint {
+    Tabs,
+    Status,
+    Stream,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DashboardProxyError {
+    status: &'static str,
+    message: String,
+}
+
+impl DashboardProxyError {
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            status: "404 Not Found",
+            message: message.into(),
+        }
+    }
+
+    fn bad_gateway(message: impl Into<String>) -> Self {
+        Self {
+            status: "502 Bad Gateway",
+            message: message.into(),
+        }
+    }
+}
+
+const PROXY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const PROXY_MAX_RESPONSE_SIZE: u64 = 16 * 1024 * 1024;
+
+fn build_json_error_body(error: &str) -> String {
+    let escaped = serde_json::to_string(error).unwrap_or_else(|_| format!("\"{}\"", error));
+    format!(r#"{{"success":false,"error":{escaped}}}"#)
+}
+
+async fn write_http_response_inner(
+    stream: &mut tokio::net::TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+    include_cors: bool,
+) {
+    let cors_headers = if include_cors { CORS_HEADERS } else { "" };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n{cors_headers}\r\n",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.write_all(body).await;
+}
+
+async fn write_http_response(
+    stream: &mut tokio::net::TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+) {
+    write_http_response_inner(stream, status, content_type, body, true).await;
+}
+
+async fn write_http_response_no_cors(
+    stream: &mut tokio::net::TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+) {
+    write_http_response_inner(stream, status, content_type, body, false).await;
+}
+
+async fn write_json_error_response_no_cors(
+    stream: &mut tokio::net::TcpStream,
+    status: &'static str,
+    error: &str,
+) {
+    let body = build_json_error_body(error);
+    write_http_response_no_cors(
+        stream,
+        status,
+        "application/json; charset=utf-8",
+        body.as_bytes(),
+    )
+    .await;
+}
+
+fn parse_request_method_and_path(request: &str) -> (&str, &str) {
+    let first_line = request.lines().next().unwrap_or("");
+    let method = first_line.split_whitespace().next().unwrap_or("GET");
+    let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+    (method, path)
+}
+
+fn is_websocket_upgrade(request: &str) -> bool {
+    request.lines().any(|line| {
+        if let Some((name, value)) = line.split_once(':') {
+            name.trim().eq_ignore_ascii_case("upgrade")
+                && value.trim().eq_ignore_ascii_case("websocket")
+        } else {
+            false
+        }
+    })
+}
+
+fn request_header_value<'a>(request: &'a str, name: &str) -> Option<&'a str> {
+    request.lines().find_map(|line| {
+        let (header_name, value) = line.split_once(':')?;
+        if header_name.trim().eq_ignore_ascii_case(name) {
+            Some(value.trim())
+        } else {
+            None
+        }
+    })
+}
+
+fn normalize_origin_authority(origin: &str) -> Option<String> {
+    let url = url::Url::parse(origin).ok()?;
+    let host = url.host_str()?.to_ascii_lowercase();
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    Some(match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host,
+    })
+}
+
+/// Validates that a proxied WebSocket request either has no Origin header or
+/// presents an Origin whose authority matches the request Host header.
+fn is_same_origin_ws_request(request: &str) -> bool {
+    let origin_authority = request_header_value(request, "origin").map(normalize_origin_authority);
+    let host = request_header_value(request, "host").map(|value| value.trim().to_ascii_lowercase());
+
+    match (origin_authority, host) {
+        (None, _) => true,
+        (Some(None), _) => false,
+        (Some(Some(_)), None) => false,
+        (Some(Some(origin)), Some(host)) => origin == host,
+    }
+}
+
+/// Parse a dashboard route of the form `/api/session/<port>/<endpoint>`.
+fn parse_session_proxy_route(path: &str) -> Result<(u16, SessionProxyEndpoint), &'static str> {
+    if !path.starts_with("/api/session/") {
+        return Err("Invalid session proxy route.");
+    }
+
+    let mut parts = path.split('/');
+    if parts.next() != Some("") || parts.next() != Some("api") || parts.next() != Some("session") {
+        return Err("Invalid session proxy route.");
+    }
+
+    let port_str = parts.next().ok_or("Missing session proxy port.")?;
+    if port_str.is_empty() {
+        return Err("Missing session proxy port.");
+    }
+
+    let endpoint = match parts.next().ok_or("Missing session proxy endpoint.")? {
+        "tabs" => SessionProxyEndpoint::Tabs,
+        "status" => SessionProxyEndpoint::Status,
+        "stream" => SessionProxyEndpoint::Stream,
+        _ => return Err("Unknown session proxy endpoint."),
+    };
+
+    if parts.next().is_some() {
+        return Err("Unexpected path segments in session proxy route.");
+    }
+
+    let port = port_str
+        .parse::<u16>()
+        .map_err(|_| "Session proxy port must be a valid TCP port.")?;
+    if port == 0 {
+        return Err("Session proxy port must be a valid TCP port.");
+    }
+
+    Ok((port, endpoint))
+}
+
+fn sessions_json_has_active_port(sessions_json: &str, port: u16) -> Result<bool, String> {
+    let sessions: Vec<Value> = serde_json::from_str(sessions_json)
+        .map_err(|e| format!("Failed to parse active sessions: {e}"))?;
+    Ok(sessions.iter().any(|session| {
+        session
+            .get("port")
+            .and_then(|value| value.as_u64())
+            .map(|value| value == u64::from(port))
+            .unwrap_or(false)
+    }))
+}
+
+fn require_active_session_port(port: u16) -> Result<(), DashboardProxyError> {
+    let sessions_json = discover_sessions();
+    let is_active = sessions_json_has_active_port(&sessions_json, port)
+        .map_err(DashboardProxyError::bad_gateway)?;
+    if is_active {
+        Ok(())
+    } else {
+        Err(DashboardProxyError::not_found(format!(
+            "No active session is listening on port {port}."
+        )))
+    }
+}
+
+fn split_http_response(response: &[u8]) -> Result<(&[u8], &[u8]), String> {
+    if let Some(header_end) = response.windows(4).position(|window| window == b"\r\n\r\n") {
+        let body_start = header_end + 4;
+        return Ok((&response[..header_end], &response[body_start..]));
+    }
+
+    if let Some(header_end) = response.windows(2).position(|window| window == b"\n\n") {
+        let body_start = header_end + 2;
+        return Ok((&response[..header_end], &response[body_start..]));
+    }
+
+    Err("Upstream response was missing an HTTP header terminator.".to_string())
+}
+
+fn parse_upstream_http_response(response: &[u8]) -> Result<(String, String, Vec<u8>), String> {
+    let (header_bytes, body) = split_http_response(response)?;
+    let header_str = std::str::from_utf8(header_bytes)
+        .map_err(|e| format!("Upstream response headers were not valid UTF-8: {e}"))?;
+
+    let mut lines = header_str.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| "Upstream response was missing a status line.".to_string())?;
+    let status = status_line
+        .split_once(' ')
+        .map(|(_, status)| status.trim().to_string())
+        .filter(|status| !status.is_empty())
+        .ok_or_else(|| "Upstream response status line was malformed.".to_string())?;
+    let content_type = lines
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.trim().eq_ignore_ascii_case("content-type") {
+                Some(value.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "application/json; charset=utf-8".to_string());
+
+    Ok((status, content_type, body.to_vec()))
+}
+
+/// Proxy dashboard-origin HTTP requests for session tabs or status to the loopback session server.
+async fn proxy_session_http_route(
+    port: u16,
+    endpoint: SessionProxyEndpoint,
+) -> Result<(String, String, Vec<u8>), DashboardProxyError> {
+    debug_assert!(matches!(
+        endpoint,
+        SessionProxyEndpoint::Tabs | SessionProxyEndpoint::Status
+    ));
+
+    require_active_session_port(port)?;
+
+    let upstream_path = match endpoint {
+        SessionProxyEndpoint::Tabs => "/api/tabs",
+        SessionProxyEndpoint::Status => "/api/status",
+        SessionProxyEndpoint::Stream => unreachable!("stream routes use the WebSocket proxy"),
+    };
+    let request = format!(
+        "GET {upstream_path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
+    );
+
+    tokio::time::timeout(PROXY_TIMEOUT, async {
+        let mut upstream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .map_err(|e| {
+                DashboardProxyError::bad_gateway(format!(
+                    "Failed to connect to session {port}: {e}"
+                ))
+            })?;
+        upstream.write_all(request.as_bytes()).await.map_err(|e| {
+            DashboardProxyError::bad_gateway(format!(
+                "Failed to proxy request to session {port}: {e}"
+            ))
+        })?;
+
+        let mut response = Vec::new();
+        (&mut upstream)
+            .take(PROXY_MAX_RESPONSE_SIZE + 1)
+            .read_to_end(&mut response)
+            .await
+            .map_err(|e| {
+                DashboardProxyError::bad_gateway(format!(
+                    "Failed to read session {port} response: {e}"
+                ))
+            })?;
+        if response.len() as u64 > PROXY_MAX_RESPONSE_SIZE {
+            return Err(DashboardProxyError::bad_gateway(format!(
+                "Session {port} response exceeded {PROXY_MAX_RESPONSE_SIZE} bytes."
+            )));
+        }
+
+        parse_upstream_http_response(&response).map_err(DashboardProxyError::bad_gateway)
+    })
+    .await
+    .map_err(|_| {
+        DashboardProxyError::bad_gateway(format!(
+            "Session {port} proxy request timed out after {}s.",
+            PROXY_TIMEOUT.as_secs()
+        ))
+    })?
+}
+
+/// Bridge a dashboard-origin WebSocket upgrade to the loopback session stream.
+async fn proxy_session_stream(mut stream: tokio::net::TcpStream, port: u16) {
+    let upstream_url = format!("ws://127.0.0.1:{port}");
+    let (upstream_ws, _) = match tokio_tungstenite::connect_async(&upstream_url).await {
+        Ok(ws) => ws,
+        Err(error) => {
+            write_json_error_response_no_cors(
+                &mut stream,
+                "502 Bad Gateway",
+                &format!("Failed to connect to session {port}: {error}"),
+            )
+            .await;
+            return;
+        }
+    };
+    let client_ws = match tokio_tungstenite::accept_async(stream).await {
+        Ok(ws) => ws,
+        Err(_) => return,
+    };
+
+    let (mut client_tx, mut client_rx) = client_ws.split();
+    let (mut upstream_tx, mut upstream_rx) = upstream_ws.split();
+
+    loop {
+        tokio::select! {
+            message = client_rx.next() => {
+                match message {
+                    Some(Ok(message)) => {
+                        let is_close = matches!(message, Message::Close(_));
+                        if upstream_tx.send(message).await.is_err() {
+                            break;
+                        }
+                        if is_close {
+                            break;
+                        }
+                    }
+                    Some(Err(_)) | None => {
+                        let _ = upstream_tx.send(Message::Close(None)).await;
+                        break;
+                    }
+                }
+            }
+            message = upstream_rx.next() => {
+                match message {
+                    Some(Ok(message)) => {
+                        let is_close = matches!(message, Message::Close(_));
+                        if client_tx.send(message).await.is_err() {
+                            break;
+                        }
+                        if is_close {
+                            break;
+                        }
+                    }
+                    Some(Err(_)) | None => {
+                        let _ = client_tx.send(Message::Close(None)).await;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
 
 pub async fn run_dashboard_server(port: u16) {
     let addr = format!("127.0.0.1:{}", port);
@@ -30,25 +404,82 @@ pub async fn run_dashboard_server(port: u16) {
 }
 
 async fn handle_dashboard_connection(mut stream: tokio::net::TcpStream) {
-    use tokio::io::AsyncReadExt;
-
     let mut buf = vec![0u8; 8192];
+    let peeked_len = match stream.peek(&mut buf).await {
+        Ok(n) if n > 0 => n,
+        _ => return,
+    };
+    let peeked_request = String::from_utf8_lossy(&buf[..peeked_len]);
+    let (peeked_method, peeked_path) = parse_request_method_and_path(&peeked_request);
+
+    if peeked_path.starts_with("/api/session/") {
+        let (port, endpoint) = match parse_session_proxy_route(peeked_path) {
+            Ok(route) => route,
+            Err(error) => {
+                write_json_error_response_no_cors(&mut stream, "400 Bad Request", error).await;
+                return;
+            }
+        };
+
+        match endpoint {
+            SessionProxyEndpoint::Stream => {
+                if peeked_method != "GET" {
+                    write_json_error_response_no_cors(
+                        &mut stream,
+                        "400 Bad Request",
+                        "Session stream proxy only supports GET WebSocket upgrades.",
+                    )
+                    .await;
+                    return;
+                }
+                if !is_websocket_upgrade(&peeked_request) {
+                    write_json_error_response_no_cors(
+                        &mut stream,
+                        "400 Bad Request",
+                        "Session stream proxy requires a WebSocket upgrade request.",
+                    )
+                    .await;
+                    return;
+                }
+                if !is_same_origin_ws_request(&peeked_request) {
+                    write_json_error_response_no_cors(
+                        &mut stream,
+                        "403 Forbidden",
+                        "Origin does not match Host header.",
+                    )
+                    .await;
+                    return;
+                }
+                if let Err(error) = require_active_session_port(port) {
+                    write_json_error_response_no_cors(&mut stream, error.status, &error.message)
+                        .await;
+                    return;
+                }
+                proxy_session_stream(stream, port).await;
+                return;
+            }
+            SessionProxyEndpoint::Tabs | SessionProxyEndpoint::Status => {
+                if peeked_method != "GET" {
+                    write_json_error_response_no_cors(
+                        &mut stream,
+                        "400 Bad Request",
+                        "Session proxy routes only support GET requests.",
+                    )
+                    .await;
+                    return;
+                }
+            }
+        }
+    }
+
     let n = match stream.read(&mut buf).await {
         Ok(n) if n > 0 => n,
         _ => return,
     };
 
-    let header_str = std::str::from_utf8(&buf[..n]).unwrap_or("");
-    let first_line = header_str.lines().next().unwrap_or("").to_string();
-    let method = first_line.split_whitespace().next().unwrap_or("GET");
-    let path = first_line.split_whitespace().nth(1).unwrap_or("/");
-    let origin = header_str.lines().find_map(|line| {
-        if line.len() > 8 && line[..8].eq_ignore_ascii_case("origin: ") {
-            Some(line[8..].trim().to_string())
-        } else {
-            None
-        }
-    });
+    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+    let (method, path) = parse_request_method_and_path(&request);
+    let origin = request_header_value(&request, "origin").map(|value| value.to_string());
 
     if method == "OPTIONS" {
         let response = format!(
@@ -80,21 +511,55 @@ async fn handle_dashboard_connection(mut stream: tokio::net::TcpStream) {
         };
         let (status, resp_body) = match result {
             Ok(msg) => ("200 OK", msg),
-            Err(e) => (
-                "400 Bad Request",
-                format!(
-                    r#"{{"success":false,"error":{}}}"#,
-                    serde_json::to_string(&e).unwrap_or_else(|_| format!("\"{}\"", e))
-                ),
-            ),
+            Err(e) => ("400 Bad Request", build_json_error_body(&e)),
         };
-        let response = format!(
-            "HTTP/1.1 {status}\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n{CORS_HEADERS}\r\n",
-            resp_body.len()
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-        let _ = stream.write_all(resp_body.as_bytes()).await;
+        write_http_response(
+            &mut stream,
+            status,
+            "application/json; charset=utf-8",
+            resp_body.as_bytes(),
+        )
+        .await;
         return;
+    }
+
+    if path.starts_with("/api/session/") {
+        let (port, endpoint) = match parse_session_proxy_route(path) {
+            Ok(route) => route,
+            Err(error) => {
+                write_json_error_response_no_cors(&mut stream, "400 Bad Request", error).await;
+                return;
+            }
+        };
+
+        match endpoint {
+            SessionProxyEndpoint::Tabs | SessionProxyEndpoint::Status => {
+                match proxy_session_http_route(port, endpoint).await {
+                    Ok((status, content_type, body)) => {
+                        write_http_response_no_cors(&mut stream, &status, &content_type, &body)
+                            .await;
+                    }
+                    Err(error) => {
+                        write_json_error_response_no_cors(
+                            &mut stream,
+                            error.status,
+                            &error.message,
+                        )
+                        .await;
+                    }
+                }
+                return;
+            }
+            SessionProxyEndpoint::Stream => {
+                write_json_error_response_no_cors(
+                    &mut stream,
+                    "400 Bad Request",
+                    "Session stream proxy requires a WebSocket upgrade request.",
+                )
+                .await;
+                return;
+            }
+        }
     }
 
     let (status, content_type, body): (&str, &str, Vec<u8>) = if path == "/api/sessions" {
@@ -113,19 +578,10 @@ async fn handle_dashboard_connection(mut stream: tokio::net::TcpStream) {
         serve_embedded_file(path)
     };
 
-    let response = format!(
-        "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n{CORS_HEADERS}\r\n",
-        status,
-        content_type,
-        body.len()
-    );
-    let _ = stream.write_all(response.as_bytes()).await;
-    let _ = stream.write_all(&body).await;
+    write_http_response(&mut stream, status, content_type, &body).await;
 }
 
 async fn read_post_body(stream: &mut tokio::net::TcpStream, initial: &[u8], n: usize) -> String {
-    use tokio::io::AsyncReadExt;
-
     let header_end = initial[..n]
         .windows(4)
         .position(|w| w == b"\r\n\r\n")
@@ -145,12 +601,12 @@ async fn read_post_body(stream: &mut tokio::net::TcpStream, initial: &[u8], n: u
         .lines()
         .find_map(|l| {
             if l.len() > 16 && l[..16].eq_ignore_ascii_case("content-length: ") {
-                l[16..].trim().parse().ok()
+                l[16..].trim().parse::<usize>().ok()
             } else {
                 let lower = l.to_lowercase();
                 lower
                     .strip_prefix("content-length:")
-                    .and_then(|v| v.trim().parse().ok())
+                    .and_then(|v| v.trim().parse::<usize>().ok())
             }
         })
         .unwrap_or(0);
@@ -239,11 +695,15 @@ async fn kill_session(body: &str) -> Result<String, String> {
 
     #[cfg(unix)]
     {
+        // SAFETY: The PID came from the daemon-managed pidfile and is only used
+        // to send standard termination signals to that process.
         unsafe {
             libc::kill(pid as i32, libc::SIGTERM);
         }
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        // SAFETY: A signal value of 0 performs an existence check on the same pid.
         if unsafe { libc::kill(pid as i32, 0) } == 0 {
+            // SAFETY: The process still exists after SIGTERM, so escalate to SIGKILL.
             unsafe {
                 libc::kill(pid as i32, libc::SIGKILL);
             }
@@ -291,5 +751,131 @@ pub(super) async fn spawn_session(body: &str) -> Result<String, String> {
         ))
     } else {
         Err(format!("Session process exited with {}", status))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_same_origin_ws_request_matching() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: localhost:4848\r\nOrigin: http://localhost:4848\r\nUpgrade: websocket\r\n\r\n";
+        assert!(is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_same_origin_ws_request_proxied() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: dashboard.agent-browser.localhost\r\nOrigin: https://dashboard.agent-browser.localhost\r\nUpgrade: websocket\r\n\r\n";
+        assert!(is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_normalize_origin_authority_https_without_port() {
+        assert_eq!(
+            normalize_origin_authority("https://dashboard.agent-browser.localhost"),
+            Some("dashboard.agent-browser.localhost".to_string())
+        );
+    }
+
+    #[test]
+    fn test_same_origin_ws_request_coder() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: workspace.coder.com\r\nOrigin: https://workspace.coder.com\r\nUpgrade: websocket\r\n\r\n";
+        assert!(is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_cross_origin_ws_request_rejected() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: localhost:4848\r\nOrigin: https://evil.com\r\nUpgrade: websocket\r\n\r\n";
+        assert!(!is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_no_origin_header_allowed() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: localhost:4848\r\nUpgrade: websocket\r\n\r\n";
+        assert!(is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_parse_session_proxy_route_valid() {
+        assert_eq!(
+            parse_session_proxy_route("/api/session/9222/tabs"),
+            Ok((9222, SessionProxyEndpoint::Tabs))
+        );
+        assert_eq!(
+            parse_session_proxy_route("/api/session/1337/status"),
+            Ok((1337, SessionProxyEndpoint::Status))
+        );
+        assert_eq!(
+            parse_session_proxy_route("/api/session/65535/stream"),
+            Ok((65535, SessionProxyEndpoint::Stream))
+        );
+    }
+
+    #[test]
+    fn test_parse_session_proxy_route_invalid() {
+        assert!(parse_session_proxy_route("/api/session/0/tabs").is_err());
+        assert!(parse_session_proxy_route("/api/session/not-a-port/tabs").is_err());
+        assert!(parse_session_proxy_route("/api/session/70000/tabs").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222/unknown").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222/tabs/extra").is_err());
+    }
+
+    #[test]
+    fn test_parse_session_proxy_route_path_traversal() {
+        assert!(parse_session_proxy_route("/api/session/9222/tabs/..").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222/tabs/../status").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222/../../etc/passwd").is_err());
+        assert!(parse_session_proxy_route("/api/session/../session/9222/tabs").is_err());
+    }
+
+    #[test]
+    fn test_parse_session_proxy_route_double_slashes() {
+        assert!(parse_session_proxy_route("/api/session//9222/tabs").is_err());
+        assert!(parse_session_proxy_route("/api//session/9222/tabs").is_err());
+        assert!(parse_session_proxy_route("//api/session/9222/tabs").is_err());
+    }
+
+    #[test]
+    fn test_parse_session_proxy_route_trailing_slash() {
+        assert!(parse_session_proxy_route("/api/session/9222/tabs/").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222/status/").is_err());
+        assert!(parse_session_proxy_route("/api/session/9222/stream/").is_err());
+    }
+
+    #[test]
+    fn test_parse_session_proxy_route_encoded_paths() {
+        assert!(parse_session_proxy_route("/api/session/9222/tabs%20extra").is_err());
+        assert!(parse_session_proxy_route("/api/session/%39%32%32%32/tabs").is_err());
+    }
+
+    #[test]
+    fn test_sessions_json_has_active_port() {
+        let sessions_json = r#"[
+            {"session":"alpha","port":9222,"engine":"chrome"},
+            {"session":"beta","port":9333,"engine":"chrome"}
+        ]"#;
+
+        assert_eq!(sessions_json_has_active_port(sessions_json, 9222), Ok(true));
+        assert_eq!(
+            sessions_json_has_active_port(sessions_json, 9444),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn test_sessions_json_has_active_port_invalid_json() {
+        assert!(sessions_json_has_active_port("{", 9222).is_err());
+    }
+
+    #[test]
+    fn test_parse_upstream_http_response() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\nConnection: close\r\n\r\n{\"ok\":true}";
+        let parsed = parse_upstream_http_response(response).expect("response should parse");
+
+        assert_eq!(parsed.0, "200 OK");
+        assert_eq!(parsed.1, "application/json; charset=utf-8");
+        assert_eq!(parsed.2, b"{\"ok\":true}".to_vec());
     }
 }

--- a/cli/src/native/stream/dashboard.rs
+++ b/cli/src/native/stream/dashboard.rs
@@ -140,18 +140,57 @@ fn normalize_origin_authority(origin: &str) -> Option<String> {
     })
 }
 
+fn normalize_host_authority(host: &str) -> String {
+    let host = host.trim().to_ascii_lowercase();
+
+    if let Some(bracket_end) = host.rfind(']') {
+        if bracket_end == host.len() - 1 {
+            return host;
+        }
+
+        if host.as_bytes().get(bracket_end + 1) == Some(&b':') {
+            let port = &host[bracket_end + 2..];
+            if port == "80" || port == "443" {
+                return host[..=bracket_end].to_string();
+            }
+        }
+
+        return host;
+    }
+
+    if let Some((name, port)) = host.rsplit_once(':') {
+        if !name.contains(':') && (port == "80" || port == "443") {
+            return name.to_string();
+        }
+    }
+
+    host
+}
+
+fn header_matches_host(request: &str, header_name: &str) -> Option<bool> {
+    let authority =
+        request_header_value(request, header_name).and_then(normalize_origin_authority)?;
+    let host = request_header_value(request, "host").map(normalize_host_authority)?;
+    Some(authority == host)
+}
+
 /// Validates that a proxied WebSocket request either has no Origin header or
 /// presents an Origin whose authority matches the request Host header.
 fn is_same_origin_ws_request(request: &str) -> bool {
-    let origin_authority = request_header_value(request, "origin").map(normalize_origin_authority);
-    let host = request_header_value(request, "host").map(|value| value.trim().to_ascii_lowercase());
-
-    match (origin_authority, host) {
-        (None, _) => true,
-        (Some(None), _) => false,
-        (Some(Some(_)), None) => false,
-        (Some(Some(origin)), Some(host)) => origin == host,
+    match header_matches_host(request, "origin") {
+        Some(matches) => matches,
+        None => request_header_value(request, "origin").is_none(),
     }
+}
+
+/// Validates that an HTTP session-proxy request came from a same-origin page.
+///
+/// For GET requests we require either a same-origin `Origin` or a same-origin
+/// `Referer` so browsers cannot hit the proxy routes via side-channel tags or
+/// arbitrary cross-origin fetches.
+fn is_same_origin_http_request(request: &str) -> bool {
+    matches!(header_matches_host(request, "origin"), Some(true))
+        || matches!(header_matches_host(request, "referer"), Some(true))
 }
 
 /// Parse a dashboard route of the form `/api/session/<port>/<endpoint>`.
@@ -534,6 +573,16 @@ async fn handle_dashboard_connection(mut stream: tokio::net::TcpStream) {
 
         match endpoint {
             SessionProxyEndpoint::Tabs | SessionProxyEndpoint::Status => {
+                if !is_same_origin_http_request(&request) {
+                    write_json_error_response_no_cors(
+                        &mut stream,
+                        "403 Forbidden",
+                        "Origin or Referer does not match Host header.",
+                    )
+                    .await;
+                    return;
+                }
+
                 match proxy_session_http_route(port, endpoint).await {
                     Ok((status, content_type, body)) => {
                         write_http_response_no_cors(&mut stream, &status, &content_type, &body)
@@ -776,6 +825,36 @@ mod tests {
             normalize_origin_authority("https://dashboard.agent-browser.localhost"),
             Some("dashboard.agent-browser.localhost".to_string())
         );
+    }
+
+    #[test]
+    fn test_same_origin_ws_request_default_https_port() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: dashboard.agent-browser.localhost:443\r\nOrigin: https://dashboard.agent-browser.localhost\r\nUpgrade: websocket\r\n\r\n";
+        assert!(is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_same_origin_http_request_matching_origin() {
+        let req = "GET /api/session/9222/tabs HTTP/1.1\r\nHost: localhost:4848\r\nOrigin: http://localhost:4848\r\n\r\n";
+        assert!(is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn test_same_origin_http_request_matching_referer() {
+        let req = "GET /api/session/9222/tabs HTTP/1.1\r\nHost: dashboard.agent-browser.localhost:443\r\nReferer: https://dashboard.agent-browser.localhost/sessions\r\n\r\n";
+        assert!(is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn test_same_origin_http_request_rejects_missing_origin_and_referer() {
+        let req = "GET /api/session/9222/tabs HTTP/1.1\r\nHost: localhost:4848\r\n\r\n";
+        assert!(!is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn test_same_origin_http_request_rejects_cross_origin_referer() {
+        let req = "GET /api/session/9222/tabs HTTP/1.1\r\nHost: localhost:4848\r\nReferer: https://evil.com/path\r\n\r\n";
+        assert!(!is_same_origin_http_request(req));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2554,6 +2554,11 @@ Running 'agent-browser dashboard' with no subcommand is equivalent to 'dashboard
 
 The dashboard runs as a standalone background process, independent of
 browser sessions. All sessions automatically stream to the dashboard.
+It works from http://localhost:4848 or a proxied/forwarded URL that
+reaches the dashboard server, such as https://dashboard.agent-browser.localhost
+or a Coder workspace URL. The browser stays on the dashboard origin;
+session tabs, status, and stream traffic are proxied internally, so
+session ports do not need to be exposed.
 
 Options:
   --port <n>           Port for the dashboard server (default: 4848)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -381,6 +381,8 @@ agent-browser dashboard start --port <n>  # Start on a specific port
 agent-browser dashboard stop          # Stop the dashboard server
 ```
 
+Open the dashboard through `http://localhost:4848` or a proxied/forwarded dashboard URL such as `https://dashboard.agent-browser.localhost`. The browser stays on the dashboard origin; per-session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.
+
 ## Doctor
 
 Diagnose your install, auto-clean stale daemon files, and optionally repair common problems.

--- a/docs/src/app/dashboard/page.mdx
+++ b/docs/src/app/dashboard/page.mdx
@@ -11,9 +11,9 @@ agent-browser dashboard start
 agent-browser open example.com
 ```
 
-Then open `http://localhost:4848` in your browser to see the live dashboard.
+Then open `http://localhost:4848` or a proxied/forwarded dashboard URL such as `https://dashboard.agent-browser.localhost` in your browser to see the live dashboard.
 
-All sessions automatically stream to the dashboard. No extra flags are needed.
+All sessions automatically stream to the dashboard. No extra flags are needed. The browser stays on the dashboard origin while the server proxies per-session tabs, status, and stream traffic internally, so session ports do not need to be exposed.
 
 ### Custom stream port
 
@@ -122,7 +122,7 @@ The dashboard is a Next.js static export (`output: 'export'`) that produces plai
 pnpm build:dashboard
 ```
 
-The dashboard is embedded into the CLI binary at compile time using `rust-embed`. Plain HTTP requests serve the embedded dashboard assets, while WebSocket upgrade requests are handled as before.
+The dashboard is embedded into the CLI binary at compile time using `rust-embed`. Plain HTTP requests serve the embedded dashboard assets and same-origin API routes. Session-specific tabs, status, and stream WebSocket traffic are proxied through the dashboard server to loopback-only session ports.
 
 ## AI Chat
 

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -5,6 +5,7 @@ import { useAtomValue, useSetAtom } from "jotai/react";
 import { ArrowLeft, ArrowRight, Camera, Circle, FileCode, Maximize, Moon, RotateCw, Smartphone, Square, Sun, Wifi, WifiOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { execCommand, sessionArgs } from "@/lib/exec";
+import { getSessionStreamUrl } from "@/lib/dashboard-routes";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -550,7 +551,7 @@ export function Viewport() {
         </span>
         {browserConnected && (
           <span className="text-xs text-muted-foreground/60 font-mono">
-            ws://localhost:{streamPort}
+            {getSessionStreamUrl(streamPort)}
           </span>
         )}
         <div className="ml-auto flex items-center gap-2">

--- a/packages/dashboard/src/lib/dashboard-routes.ts
+++ b/packages/dashboard/src/lib/dashboard-routes.ts
@@ -1,0 +1,42 @@
+/**
+ * Centralized route building for dashboard API calls.
+ * All routes stay on the current dashboard origin so the UI also works
+ * behind forwarded or reverse-proxied URLs.
+ */
+
+/** Build a dashboard API path such as "/api/sessions". */
+export function getDashboardApiPath(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  assertDashboardApiPath(normalizedPath);
+  return normalizedPath;
+}
+
+/** Build the same-origin per-session tabs endpoint proxied through the dashboard. */
+export function getSessionTabsPath(port: number): string {
+  assertValidPort(port);
+  return `/api/session/${port}/tabs`;
+}
+
+/** Build the same-origin WebSocket URL for a session stream. */
+export function getSessionStreamUrl(port: number): string {
+  assertValidPort(port);
+  const streamPath = `/api/session/${port}/stream`;
+  if (typeof window === "undefined") {
+    return streamPath;
+  }
+
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}${streamPath}`;
+}
+
+function assertDashboardApiPath(path: string): asserts path is string {
+  if (!path.startsWith("/api/")) {
+    throw new Error(`Assertion failed: Expected dashboard API path, got: ${path}`);
+  }
+}
+
+function assertValidPort(port: number): asserts port is number {
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Assertion failed: Invalid session port: ${port}`);
+  }
+}

--- a/packages/dashboard/src/store/sessions.ts
+++ b/packages/dashboard/src/store/sessions.ts
@@ -5,20 +5,22 @@ import { useCallback, useEffect, useRef } from "react";
 import { useAtomCallback } from "jotai/utils";
 import type { SessionInfo } from "@/types";
 import { type ExecResult, execCommand, killSession, sessionArgs } from "@/lib/exec";
+import { getDashboardApiPath, getSessionTabsPath } from "@/lib/dashboard-routes";
 import { tabCacheAtom, engineCacheAtom } from "@/store/tabs";
 import { streamTabsAtom, streamEngineAtom } from "@/store/stream";
 
 function getPort(): number {
-  if (typeof window === "undefined") return 9223;
+  if (typeof window === "undefined") return 0;
   const params = new URLSearchParams(window.location.search);
-  const p = params.get("port");
-  return p ? parseInt(p, 10) || 9223 : 9223;
+  const portParam = params.get("port");
+  const port = portParam ? Number.parseInt(portParam, 10) : 0;
+  return Number.isInteger(port) && port > 0 ? port : 0;
 }
 
 export const newSessionDialogAtom = atom(false);
 
 function getSessionsUrl(): string {
-  return "/api/sessions";
+  return getDashboardApiPath("/api/sessions");
 }
 
 // ---------------------------------------------------------------------------
@@ -254,9 +256,9 @@ export function useSessionsSync(pollInterval = 5000) {
             // Poll tabs for all sessions
             for (const s of data) {
               try {
-                const tabsResp = await fetch(
-                  `http://localhost:${s.port}/api/tabs`,
-                ).catch(() => null);
+                const tabsResp = await fetch(getSessionTabsPath(s.port)).catch(
+                  () => null,
+                );
                 if (tabsResp?.ok) {
                   const tabs = await tabsResp.json();
                   if (tabs.length > 0) {

--- a/packages/dashboard/src/store/stream.ts
+++ b/packages/dashboard/src/store/stream.ts
@@ -9,7 +9,7 @@ import type {
   StreamMessage,
   TabInfo,
 } from "@/types";
-import { activePortAtom } from "@/store/sessions";
+import { getSessionStreamUrl } from "@/lib/dashboard-routes";
 import { tabCacheAtom, engineCacheAtom } from "@/store/tabs";
 
 const MAX_EVENTS = 500;
@@ -117,9 +117,10 @@ export function useStreamSync(port: number) {
   }, [port, setConnected, setBrowserConnected, setScreencasting, setRecording, setVpWidth, setVpHeight, setFrame, setEvents, setConsoleLogs, setTabs, setEngine]);
 
   const connect = useCallback(() => {
+    if (port <= 0) return;
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
 
-    const ws = new WebSocket(`ws://localhost:${port}`);
+    const ws = new WebSocket(getSessionStreamUrl(port));
     wsRef.current = ws;
     setWsRef(ws);
 

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -49,3 +49,7 @@ installed version.
 - Accessibility-tree snapshots with element refs for reliable interaction
 - Sessions, authentication vault, state persistence, video recording
 - Specialized skills for Electron apps, Slack, exploratory testing, cloud providers
+
+## Observability Dashboard
+
+The dashboard runs independently of browser sessions on port 4848 and can also be opened through a proxied or forwarded URL such as `https://dashboard.agent-browser.localhost`. Agents should stay on the dashboard origin: session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.


### PR DESCRIPTION
## Summary

- make the dashboard work from forwarded and proxied origins without exposing per-session localhost ports
- add validated same-origin HTTP and WebSocket proxy routes for per-session tabs, status, and stream traffic
- harden the proxy by removing CORS from proxy responses, enforcing WebSocket Origin-vs-Host checks, and adding timeout and response size limits
- update frontend routing, docs, and Portless guidance, with tests for route parsing and proxy security edge cases

## Validation

- `cargo test --manifest-path cli/Cargo.toml -- stream::tests`
- `cargo build --release --manifest-path cli/Cargo.toml`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `pnpm --dir packages/dashboard build`
- manual Portless dogfooding via `http://dashboard.localhost:1355`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: make the dashboard work from a forwarded / proxied workspace URL

## Goal

Make `agent-browser dashboard` work when the UI is opened through a forwarded HTTPS workspace URL (for example, a Coder app URL) **without** requiring the browser to reach raw `localhost` ports. Preserve existing local `http://localhost:4848` behavior, keep the session stream servers loopback-only, and fix the dashboard in a way that is robust for any same-origin reverse-proxy deployment.

## Context and verified evidence

- The frontend currently hardcodes dashboard API calls to `http://localhost:4848` in `packages/dashboard/src/lib/exec.ts`.
- `packages/dashboard/src/store/sessions.ts` only uses relative `/api/sessions` when `window.location.origin` literally contains `:4848`; otherwise it falls back to `http://localhost:4848/api/sessions`.
- `packages/dashboard/src/store/sessions.ts` polls tabs from `http://localhost:${s.port}/api/tabs`.
- `packages/dashboard/src/store/stream.ts` opens the live stream with `new WebSocket(`ws://localhost:${port}`)`.
- The standalone dashboard server in `cli/src/native/stream.rs` currently exposes static files plus `/api/sessions`, `/api/exec`, and `/api/kill`; it does **not** proxy per-session `/api/tabs` or WebSocket traffic.
- The per-session stream server in `cli/src/native/stream.rs` serves `/api/tabs`, `/api/status`, `/api/command`, and the WebSocket stream, and its `is_allowed_origin()` check only allows loopback/file origins today.

<details>
<summary>Why the fix should not be a new host flag or "hostname + :port" frontend logic</summary>

The browser-visible URL in forwarded environments is owned by the reverse proxy, not by the dashboard process. Building URLs like `${window.location.hostname}:4848` or `${window.location.hostname}:${sessionPort}` is brittle and does not match wildcard-subdomain forwarding setups.

The safer and smaller fix is to make the browser talk **only to the dashboard origin** and let the dashboard server proxy to loopback-only session ports on the workspace VM/container.
</details>

## Proposed design

### Core decision

Move the dashboard to a **single-origin browser model**:

1. The browser talks only to the dashboard origin:
   - `/api/sessions`
   - `/api/exec`
   - `/api/kill`
   - `/api/session/<port>/tabs`
   - `ws(s)://<dashboard-origin>/api/session/<port>/stream`
2. The dashboard server proxies session-specific HTTP and WebSocket traffic to `127.0.0.1:<session-port>`.
3. Session stream servers remain loopback-only and keep their stricter origin policy because browsers no longer connect to them directly.

This removes all browser-side `localhost` assumptions and avoids widening the per-session WebSocket trust boundary.

## Workstreams

### 1) Backend: add same-origin proxy routes on the dashboard server

**Primary file:** `cli/src/native/stream.rs`

Add explicit dashboard-only proxy routes inside `handle_dashboard_connection()` for session traffic:

- `GET /api/session/<port>/tabs`
- `GET /api/session/<port>/status` (optional but cheap to add while route parsing exists)
- `WS /api/session/<port>/stream`

Implementation notes:

- Add a small route parser/helper instead of stringly-typed path slicing all over the handler.
- Validate that `<port>` parses as a `u16`, is non-zero, and belongs to a currently active session before proxying.
- Reuse `discover_sessions()` data or add a small helper that returns a validated active-port set/map.
- For HTTP proxying, connect to `127.0.0.1:<port>` and relay the minimal request needed (initially `GET /api/tabs` and optionally `GET /api/status`).
- For WebSocket proxying, accept a browser WebSocket on the dashboard server, open an upstream WebSocket to `ws://127.0.0.1:<port>`, and pump frames/messages in both directions.
- Keep the per-session `is_allowed_origin()` behavior intact; the dashboard proxy should connect server-to-server, so the browser never hits the per-session WS endpoint directly.

Defensive programming requirements:

- Add assertions / explicit validation around parsed ports and route shape.
- Reject stale or unknown ports with a clear 404/400 JSON response rather than forwarding blindly.
- Document any assumptions in helper comments near the route parser / proxy entrypoints.

**Quality gate after this workstream**

- Add focused Rust unit tests for route parsing and active-port validation in `cli/src/native/stream.rs`.
- Add at least one test for rejecting malformed or inactive ports.
- Manually verify a local `GET /api/session/<port>/tabs` response before changing the frontend.

### 2) Frontend: remove functional `localhost` usage and centralize route building

**Primary files:**

- `packages/dashboard/src/lib/exec.ts`
- `packages/dashboard/src/store/sessions.ts`
- `packages/dashboard/src/store/stream.ts`
- `packages/dashboard/src/components/viewport.tsx`
- new helper, e.g. `packages/dashboard/src/lib/dashboard-routes.ts`

Refactor the frontend so functional traffic always targets the current dashboard origin:

- Create a small shared helper module for route construction instead of repeating URL logic inline.
- Convert dashboard API calls to relative paths:
  - `/api/sessions`
  - `/api/exec`
  - `/api/kill`
- Convert per-session tab polling to `/api/session/<port>/tabs`.
- Convert the stream connection to `ws:`/`wss:` based on `window.location.protocol`, pointing at `/api/session/<port>/stream` on `window.location.host`.
- Update the viewport/status label so it shows the same-origin stream endpoint, not `ws://localhost:<port>`.

Recommended helper surface:

```ts
getDashboardApiPath(path: string): string
getSessionTabsPath(port: number): string
getSessionStreamUrl(port: number): string
```

Keep the helper intentionally dumb and explicit; do not reintroduce environment guessing or host/port rewriting.

#### Active-session selection cleanup (small but worthwhile)

`packages/dashboard/src/store/sessions.ts` currently defaults the active port to `9223`, which causes early connection attempts to an arbitrary port before session discovery completes.

Fix this as part of the refactor by making the initial active port invalid/empty until either:

- `?port=<n>` is provided, or
- the first discovered session is selected.

Minimal implementation options:

- use `0` as the sentinel and guard `useStreamSync()` when `port <= 0`, or
- make the atom nullable if the type churn is acceptable.

This keeps the browser from making noisy / misleading connection attempts during startup.

**Quality gate after this workstream**

- `pnpm --dir packages/dashboard build`
- Search the functional frontend code for remaining `http://localhost:` / `ws://localhost:` callsites and remove them unless they are non-functional examples/tests.
- Smoke-test the dashboard locally before moving on to docs.

### 3) Security and compatibility hardening

**Primary file:** `cli/src/native/stream.rs`

Because the dashboard can now be opened through a forwarded origin, do not expand trust by broadening the per-session origin whitelist. The proxy route design avoids that need.

Hardening tasks:

- Reassess the current permissive dashboard CORS behavior (`Access-Control-Allow-Origin: *`). Same-origin usage means the dashboard does not need permissive cross-origin browser access for normal operation.
- At minimum, do not make CORS/origin behavior more permissive while adding the proxy routes.
- Prefer port validation against active sessions over blind localhost forwarding.
- If the route surface grows, factor JSON response helpers to keep error handling consistent.

**Quality gate after this workstream**

- Verify that a forwarded dashboard session works without widening `is_allowed_origin()`.
- Verify that invalid ports cannot be proxied.

### 4) Documentation and help text updates

Because this changes user-visible dashboard behavior, update all required docs/help surfaces called out in `AGENTS.md`.

**Files to update**

- `cli/src/output.rs`
- `README.md`
- `skills/agent-browser/SKILL.md`
- `docs/src/app/observe/page.mdx`
- `docs/src/app/commands/page.mdx` (if the dashboard behavior text/examples need matching updates)
- inline doc comments near the new proxy helpers / route builders

Doc changes should explain:

- the dashboard now works from the local URL **or** a forwarded workspace URL
- the browser talks only to the dashboard origin
- session ports remain internal implementation details
- `agent-browser dashboard install` still installs the static assets, but dogfooding local changes requires serving the locally built dashboard bundle instead of the released zip

**Quality gate after this workstream**

- Review help text and docs for any remaining claim that the UI must directly call `localhost:<session-port>`.

## Acceptance criteria

The change is done when all of the following are true:

1. Opening the dashboard at `http://localhost:4848` still works for local use.
2. Opening the dashboard through the forwarded workspace URL loads without mixed-content or CORS failures.
3. The frontend no longer makes functional requests from the browser to `http://localhost:*` or `ws://localhost:*`.
4. Session discovery, session creation, session kill, and exec-driven UI actions work through same-origin dashboard endpoints.
5. The live viewport connects through a same-origin `ws:`/`wss:` dashboard route and remains interactive.
6. Session tab lists still populate for all visible sessions.
7. Invalid or stale session ports are rejected by the dashboard proxy instead of being blindly forwarded.
8. Documentation/help text reflects the new deployment model.

## Dogfooding / self-verification plan

### Environment setup

1. Build the dashboard assets from the workspace copy of the repo:
   - `pnpm build:dashboard`
2. Install the **local** built assets into the dashboard serve location used by the CLI during testing (do not rely on `dashboard install`, which fetches the released bundle).
3. Build and run the CLI from the workspace checkout:
   - `cargo build --manifest-path cli/Cargo.toml`
   - start the dashboard from the built CLI on port `4848`
4. Start at least one browser session from the same checkout so the dashboard has a live stream source.
5. If available, install Portless as a **global external tool** (do not add it to this repo and do not make the fix depend on it).

### Portless-assisted rehearsal (recommended local preflight)

Use Portless as a local rehearsal layer before the real workspace test. The goal is to open the dashboard through a **named host-based URL** instead of `localhost:4848`, so we can catch the exact class of bugs that assume raw port URLs.

Suggested flow:

1. Start the Portless proxy with HTTPS enabled.
2. Register a static alias for the real dashboard server port (`4848`) under a stable name such as `dashboard`.
3. Open the dashboard via the resulting Portless URL instead of `http://localhost:4848`.
4. Run the same smoke checks as the forwarded-workspace scenario.

Example command sequence:

```bash
portless proxy start --https
portless alias dashboard 4848
portless list
```

Use the named Portless URL shown by `portless list` for the rehearsal run.

What this rehearsal should catch:

- mixed-content failures from any lingering `http://localhost:*` fetches
- secure-page WebSocket failures from any lingering `ws://localhost:*` usage
- frontend assumptions that the visible origin must literally include `:4848`

Important guardrail:

- If the implementation still requires exposing or aliasing **per-session** ports through Portless, the design is still wrong. Only the standalone dashboard origin should need exposure; session ports must stay behind same-origin dashboard proxy routes.

What Portless does **not** replace:

- final dogfooding in the real forwarded workspace URL
- proxy/header/cookie quirks specific to the actual workspace platform

### Dogfood scenarios

#### Scenario A: local regression check

- Open the dashboard at `http://localhost:4848`
- Verify sessions appear, the viewport connects, tabs populate, and one interactive action works (for example: create tab, switch tab, or close tab)

#### Scenario B: Portless host-based URL rehearsal

- Open the dashboard through the Portless HTTPS host-based URL rather than a raw localhost port URL
- Verify DevTools shows same-origin `/api/...` requests and a same-origin `wss:` stream URL
- Verify there are **no** mixed-content, CORS, or `localhost` connection errors
- Verify the viewport streams, session selection works, and at least one action path using `exec.ts` succeeds

#### Scenario C: forwarded workspace URL (primary target)

- Open the forwarded HTTPS URL for the dashboard port in the workspace environment
- Verify the page loads cleanly
- Verify DevTools shows same-origin `/api/...` requests and a same-origin `ws:`/`wss:` stream URL
- Verify there are **no** mixed-content, CORS, or `localhost` connection errors
- Verify the viewport streams, session selection works, and at least one action path using `exec.ts` succeeds

#### Scenario D: invalid-port handling

- Attempt to hit a proxy route with a non-existent / stale port
- Verify the dashboard returns a clean error and does not hang or forward blindly

### Required review artifacts

Capture and attach all of the following during dogfooding:

- Screenshot: dashboard loaded via the Portless host-based URL with a connected session visible
- Screenshot: dashboard loaded via the forwarded workspace URL with a connected session visible
- Screenshot: browser DevTools Network/Console showing same-origin API + WebSocket traffic and no mixed-content errors
- Video recording: end-to-end flow through the Portless URL (open dashboard, session appears, viewport connects, one interactive action succeeds)
- Video recording: end-to-end flow in the forwarded workspace environment (open dashboard, session appears, viewport connects, one interactive action succeeds)
- Optional extra screenshot/video for local `localhost:4848` regression proof

### Validation commands

Run these before declaring success:

- `pnpm --dir packages/dashboard build`
- `cargo test --manifest-path cli/Cargo.toml`
- any targeted test command added for the new proxy helpers/routes

## Risks and watchouts

- **WebSocket relay is the highest-risk change.** Keep the first version narrow: just proxy the existing stream channel; do not redesign the message format.
- **Local asset confusion:** `agent-browser dashboard install` pulls the released dashboard bundle, so manual testing can accidentally exercise stale assets unless the locally built bundle is installed into the serve directory.
- **Session-port direct browsing:** if the team still cares about opening the dashboard directly on a session stream port, explicitly regression-test that path or consciously document it as secondary behavior. The primary fix should optimize for the standalone dashboard origin.
- **Security drift:** avoid “just allow more origins” as the fix. The proxy design is better because it preserves loopback-only trust around the per-session servers.

## Recommended implementation order

1. Add backend route parsing + validated HTTP proxy for tabs/status.
2. Add backend WebSocket proxy for the stream path.
3. Refactor frontend to a shared same-origin route helper and remove functional localhost usage.
4. Clean up initial active-port selection so the UI does not guess `9223`.
5. Update docs/help text.
6. Dogfood in both local and forwarded workspace environments with screenshots + video.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.4` • Thinking: `xhigh`_
