### PR TITLE
Make refs strict across snapshots

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2144,16 +2144,20 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
             .map(|d| d as usize),
     };
 
-    state.ref_map.clear();
+    let previous_ref_map = state.ref_map.clone();
+    let mut next_ref_map = RefMap::new();
+    next_ref_map.set_next_ref_num(previous_ref_map.next_ref_num());
     let tree = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &previous_ref_map,
+        &mut next_ref_map,
         state.active_frame_id.as_deref(),
         &state.iframe_sessions,
     )
     .await?;
+    state.ref_map = next_ref_map;
 
     let url = mgr.get_url().await.unwrap_or_default();
 
@@ -2247,7 +2251,9 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     };
 
     if annotate {
-        state.ref_map.clear();
+        let previous_ref_map = state.ref_map.clone();
+        let mut annotate_ref_map = RefMap::new();
+        annotate_ref_map.set_next_ref_num(previous_ref_map.next_ref_num());
         let _ = snapshot::take_snapshot(
             &mgr.client,
             &session_id,
@@ -2255,11 +2261,28 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
                 interactive: true,
                 ..SnapshotOptions::default()
             },
-            &mut state.ref_map,
+            &previous_ref_map,
+            &mut annotate_ref_map,
             state.active_frame_id.as_deref(),
             &state.iframe_sessions,
         )
         .await?;
+        let result = screenshot::take_screenshot(
+            &mgr.client,
+            &session_id,
+            &annotate_ref_map,
+            &options,
+            &state.iframe_sessions,
+        )
+        .await?;
+
+        let mut response = json!({ "path": result.path });
+        if !result.annotations.is_empty() {
+            response["annotations"] = serde_json::to_value(&result.annotations)
+                .map_err(|e| format!("Failed to serialize annotations: {}", e))?;
+        }
+
+        return Ok(response);
     }
 
     let result = screenshot::take_screenshot(
@@ -3154,11 +3177,15 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         selector,
         ..SnapshotOptions::default()
     };
+    let previous_ref_map = state.ref_map.clone();
+    let mut diff_ref_map = RefMap::new();
+    diff_ref_map.set_next_ref_num(previous_ref_map.next_ref_num());
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &previous_ref_map,
+        &mut diff_ref_map,
         state.active_frame_id.as_deref(),
         &state.iframe_sessions,
     )
@@ -3206,11 +3233,15 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     mgr.navigate(url1, wait_until).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let options = SnapshotOptions::default();
+    let previous_ref_map = state.ref_map.clone();
+    let mut first_ref_map = RefMap::new();
+    first_ref_map.set_next_ref_num(previous_ref_map.next_ref_num());
     let snap1 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &previous_ref_map,
+        &mut first_ref_map,
         None,
         &state.iframe_sessions,
     )
@@ -3218,12 +3249,13 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
 
     // Navigate to URL2 and snapshot
     mgr.navigate(url2, wait_until).await?;
-    state.ref_map.clear();
+    let mut second_ref_map = RefMap::new();
     let snap2 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &first_ref_map,
+        &mut second_ref_map,
         None,
         &state.iframe_sessions,
     )

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -2411,13 +2411,13 @@ async fn e2e_inspect() {
 }
 
 // ---------------------------------------------------------------------------
-// Stale ref fallback (#805): clicking a ref after the DOM has been replaced
-// should fall back to role/name lookup instead of failing.
+// Strict refs: clicking a ref after the DOM has been replaced should fail
+// rather than silently rebinding to a different element.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[ignore]
-async fn e2e_click_stale_ref_falls_back_to_role_name() {
+async fn e2e_click_stale_ref_requires_new_snapshot() {
     let mut state = DaemonState::new();
 
     let resp = execute_command(
@@ -2478,24 +2478,64 @@ async fn e2e_click_stale_ref_falls_back_to_role_name() {
     assert_success(&resp);
     assert_eq!(get_data(&resp)["title"], "replaced");
 
-    // Now click the stale "Target" ref. Before the fix this returned:
-    //   "CDP error (DOM.getBoxModel): Could not compute box model."
-    // After the fix it falls back to role/name lookup and succeeds.
+    // Now click the stale "Target" ref. Strict refs should fail and require
+    // the caller to capture a fresh snapshot.
     let resp = execute_command(
         &json!({ "id": "6", "action": "click", "selector": "e2" }),
         &mut state,
     )
     .await;
-    assert_success(&resp);
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+    let error = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(
+        error,
+        "Ref e2 is stale because the page changed. Capture a new snapshot before interacting again."
+    );
 
-    // Verify the fallback click hit the right (recreated) button.
     let resp = execute_command(&json!({ "id": "7", "action": "title" }), &mut state).await;
     assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "replaced");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_preserves_refs_for_same_dom_nodes() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let html = r##"data:text/html,<body>
+        <button>Images</button>
+        <button>Videos</button>
+        <a href="#cats">Cats</a>
+    </body>"##;
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": html }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let refs_before = get_data(&resp)["refs"].clone();
+
+    let resp = execute_command(&json!({ "id": "4", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let refs_after = get_data(&resp)["refs"].clone();
+
     assert_eq!(
-        get_data(&resp)["title"],
-        "clicked",
-        "Stale ref should have been resolved via role/name fallback"
+        refs_after, refs_before,
+        "Repeated snapshots should keep the same ref ids for surviving DOM nodes"
     );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -15,6 +15,7 @@ pub struct RefEntry {
     pub frame_id: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct RefMap {
     map: HashMap<String, RefEntry>,
     next_ref: usize,
@@ -84,6 +85,22 @@ impl RefMap {
 
     pub fn get(&self, ref_id: &str) -> Option<&RefEntry> {
         self.map.get(ref_id)
+    }
+
+    pub fn ref_id_for_backend_node(
+        &self,
+        backend_node_id: i64,
+        frame_id: Option<&str>,
+    ) -> Option<String> {
+        self.map.iter().find_map(|(ref_id, entry)| {
+            let same_backend_node = entry.backend_node_id == Some(backend_node_id);
+            let same_frame = entry.frame_id.as_deref() == frame_id;
+            if same_backend_node && same_frame {
+                Some(ref_id.clone())
+            } else {
+                None
+            }
+        })
     }
 
     pub fn entries_sorted(&self) -> Vec<(String, RefEntry)> {
@@ -175,33 +192,10 @@ pub async fn resolve_element_center(
                 let (x, y) = box_model_center(&r.model);
                 return Ok((x, y, effective_session_id.to_string()));
             }
-            // backend_node_id is stale; re-query the accessibility tree below
+            return Err(stale_ref_error(&ref_id));
         }
 
-        // Fallback: re-query the accessibility tree to find a fresh node by role/name
-        let fresh_id = find_node_id_by_role_name(
-            client,
-            session_id,
-            &entry.role,
-            &entry.name,
-            entry.nth,
-            entry.frame_id.as_deref(),
-            iframe_sessions,
-        )
-        .await?;
-        let result: DomGetBoxModelResult = client
-            .send_command_typed(
-                "DOM.getBoxModel",
-                &DomGetBoxModelParams {
-                    backend_node_id: Some(fresh_id),
-                    node_id: None,
-                    object_id: None,
-                },
-                Some(effective_session_id),
-            )
-            .await?;
-        let (x, y) = box_model_center(&result.model);
-        return Ok((x, y, effective_session_id.to_string()));
+        return Err(stale_ref_error(&ref_id));
     }
 
     // CSS selector
@@ -243,36 +237,10 @@ pub async fn resolve_element_object_id(
                     return Ok((object_id, effective_session_id.to_string()));
                 }
             }
-            // backend_node_id is stale; re-query the accessibility tree below
+            return Err(stale_ref_error(&ref_id));
         }
 
-        // Fallback: re-query the accessibility tree to find a fresh node by role/name
-        let fresh_id = find_node_id_by_role_name(
-            client,
-            session_id,
-            &entry.role,
-            &entry.name,
-            entry.nth,
-            entry.frame_id.as_deref(),
-            iframe_sessions,
-        )
-        .await?;
-        let result: DomResolveNodeResult = client
-            .send_command_typed(
-                "DOM.resolveNode",
-                &DomResolveNodeParams {
-                    backend_node_id: Some(fresh_id),
-                    node_id: None,
-                    object_group: Some("agent-browser".to_string()),
-                },
-                Some(effective_session_id),
-            )
-            .await?;
-        let object_id = result
-            .object
-            .object_id
-            .ok_or_else(|| format!("No objectId for ref {}", ref_id))?;
-        return Ok((object_id, effective_session_id.to_string()));
+        return Err(stale_ref_error(&ref_id));
     }
 
     // Selector fallback (CSS or XPath)
@@ -329,55 +297,11 @@ fn resolve_frame_session<'a>(
         .unwrap_or(session_id)
 }
 
-/// Re-query the accessibility tree to find a node matching role+name+nth,
-/// returning its fresh backendDOMNodeId. This uses the same data source
-/// (Accessibility.getFullAXTree) that built the ref map during snapshot,
-/// so role/name matching is guaranteed to be consistent.
-async fn find_node_id_by_role_name(
-    client: &CdpClient,
-    session_id: &str,
-    role: &str,
-    name: &str,
-    nth: Option<usize>,
-    frame_id: Option<&str>,
-    iframe_sessions: &HashMap<String, String>,
-) -> Result<i64, String> {
-    let (ax_params, effective_session_id) =
-        resolve_ax_session(frame_id, session_id, iframe_sessions);
-    let ax_tree: GetFullAXTreeResult = client
-        .send_command_typed(
-            "Accessibility.getFullAXTree",
-            &ax_params,
-            Some(effective_session_id),
-        )
-        .await?;
-
-    let nth_index = nth.unwrap_or(0);
-    let mut match_count: usize = 0;
-
-    for node in &ax_tree.nodes {
-        if node.ignored.unwrap_or(false) {
-            continue;
-        }
-        let node_role = extract_ax_string(&node.role);
-        let node_name = extract_ax_string(&node.name);
-        if node_role == role && node_name == name {
-            if match_count == nth_index {
-                return node.backend_d_o_m_node_id.ok_or_else(|| {
-                    format!(
-                        "AX node has no backendDOMNodeId for role={} name={}",
-                        role, name
-                    )
-                });
-            }
-            match_count += 1;
-        }
-    }
-
-    Err(format!(
-        "Could not locate element with role={} name={}",
-        role, name
-    ))
+fn stale_ref_error(ref_id: &str) -> String {
+    format!(
+        "Ref {} is stale because the page changed. Capture a new snapshot before interacting again.",
+        ref_id
+    )
 }
 
 fn extract_ax_string(value: &Option<AXValue>) -> String {

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -188,7 +188,8 @@ pub async fn take_snapshot(
     client: &CdpClient,
     session_id: &str,
     options: &SnapshotOptions,
-    ref_map: &mut RefMap,
+    previous_ref_map: &RefMap,
+    next_ref_map: &mut RefMap,
     frame_id: Option<&str>,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<String, String> {
@@ -310,7 +311,7 @@ pub async fn take_snapshot(
     };
 
     let mut tracker = RoleNameTracker::new();
-    let mut next_ref: usize = ref_map.next_ref_num();
+    let mut next_ref: usize = next_ref_map.next_ref_num();
 
     let mut nodes_with_refs: Vec<(usize, usize)> = Vec::new();
 
@@ -356,10 +357,18 @@ pub async fn take_snapshot(
             None
         };
 
-        let ref_id = format!("e{}", next_ref);
-        next_ref += 1;
+        let ref_id = tree_nodes[*idx]
+            .backend_node_id
+            .and_then(|backend_node_id| {
+                previous_ref_map.ref_id_for_backend_node(backend_node_id, frame_id)
+            })
+            .unwrap_or_else(|| {
+                let ref_id = format!("e{}", next_ref);
+                next_ref += 1;
+                ref_id
+            });
 
-        ref_map.add_with_frame(
+        next_ref_map.add_with_frame(
             ref_id.clone(),
             tree_nodes[*idx].backend_node_id,
             &tree_nodes[*idx].role,
@@ -381,7 +390,7 @@ pub async fn take_snapshot(
         }
     }
 
-    ref_map.set_next_ref_num(next_ref);
+    next_ref_map.set_next_ref_num(next_ref);
 
     let mut output = String::new();
     for &root_idx in &effective_roots {
@@ -409,7 +418,8 @@ pub async fn take_snapshot(
                     client,
                     session_id,
                     options,
-                    ref_map,
+                    previous_ref_map,
+                    next_ref_map,
                     Some(&child_fid),
                     iframe_sessions,
                 ))


### PR DESCRIPTION
Fail stale refs instead of silently rebinding them after DOM changes, and preserve ref ids for surviving nodes across repeated snapshots so exact refs stay stable until the page really changes.