### PR TITLE
feat: add --context flag for CDP BrowserContext isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ agent-browser --session-name secure open example.com
 
 | Variable                          | Description                                        |
 | --------------------------------- | -------------------------------------------------- |
+| `AGENT_BROWSER_CONTEXT`           | BrowserContext name for shared CDP isolation       |
 | `AGENT_BROWSER_SESSION_NAME`      | Auto-save/load state persistence name              |
 | `AGENT_BROWSER_ENCRYPTION_KEY`    | 64-char hex key for AES-256-GCM encryption         |
 | `AGENT_BROWSER_STATE_EXPIRE_DAYS` | Auto-delete states older than N days (default: 30) |
@@ -566,6 +567,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | Option | Description |
 |--------|-------------|
 | `--session <name>` | Use isolated session (or `AGENT_BROWSER_SESSION` env) |
+| `--context <name>` | Create isolated BrowserContext for shared CDP connections (or `AGENT_BROWSER_CONTEXT` env) |
 | `--session-name <name>` | Auto-save/restore session state (or `AGENT_BROWSER_SESSION_NAME` env) |
 | `--profile <path>` | Persistent browser profile directory (or `AGENT_BROWSER_PROFILE` env) |
 | `--state <path>` | Load storage state from JSON file (or `AGENT_BROWSER_STATE` env) |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -764,7 +764,11 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 || endpoint.starts_with("http://")
                 || endpoint.starts_with("https://")
             {
-                Ok(json!({ "id": id, "action": "launch", "cdpUrl": endpoint }))
+                let mut cmd = json!({ "id": id, "action": "launch", "cdpUrl": endpoint });
+                if let Some(ref ctx) = flags.context {
+                    cmd["contextName"] = json!(ctx);
+                }
+                Ok(cmd)
             } else {
                 // It's a port number - validate and use cdpPort field
                 let port: u16 = match endpoint.parse::<u32>() {
@@ -794,7 +798,11 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                         });
                     }
                 };
-                Ok(json!({ "id": id, "action": "launch", "cdpPort": port }))
+                let mut cmd = json!({ "id": id, "action": "launch", "cdpPort": port });
+                if let Some(ref ctx) = flags.context {
+                    cmd["contextName"] = json!(ctx);
+                }
+                Ok(cmd)
             }
         }
 
@@ -2297,6 +2305,7 @@ mod tests {
             allow_file_access: false,
             device: None,
             auto_connect: false,
+            context: None,
             session_name: None,
             cli_executable_path: false,
             cli_extensions: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -72,6 +72,7 @@ pub struct Config {
     pub allow_file_access: Option<bool>,
     pub cdp: Option<String>,
     pub auto_connect: Option<bool>,
+    pub context: Option<String>,
     pub headers: Option<String>,
     pub annotate: Option<bool>,
     pub color_scheme: Option<String>,
@@ -118,6 +119,7 @@ impl Config {
             allow_file_access: other.allow_file_access.or(self.allow_file_access),
             cdp: other.cdp.or(self.cdp),
             auto_connect: other.auto_connect.or(self.auto_connect),
+            context: other.context.or(self.context),
             headers: other.headers.or(self.headers),
             annotate: other.annotate.or(self.annotate),
             color_scheme: other.color_scheme.or(self.color_scheme),
@@ -208,6 +210,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--provider",
         "--device",
         "--session-name",
+        "--context",
         "--color-scheme",
         "--download-path",
         "--max-output",
@@ -285,6 +288,7 @@ pub struct Flags {
     pub allow_file_access: bool,
     pub device: Option<String>,
     pub auto_connect: bool,
+    pub context: Option<String>,
     pub session_name: Option<String>,
     pub annotate: bool,
     pub color_scheme: Option<String>,
@@ -382,6 +386,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         device: env::var("AGENT_BROWSER_IOS_DEVICE").ok().or(config.device),
         auto_connect: env_var_is_truthy("AGENT_BROWSER_AUTO_CONNECT")
             || config.auto_connect.unwrap_or(false),
+        context: env::var("AGENT_BROWSER_CONTEXT").ok().or(config.context),
         session_name: env::var("AGENT_BROWSER_SESSION_NAME")
             .ok()
             .or(config.session_name),
@@ -476,6 +481,12 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--session" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.session = s.clone();
+                    i += 1;
+                }
+            }
+            "--context" => {
+                if let Some(c) = args.get(i + 1) {
+                    flags.context = c.clone().into();
                     i += 1;
                 }
             }
@@ -760,6 +771,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--provider",
         "--device",
         "--session-name",
+        "--context",
         "--color-scheme",
         "--download-path",
         "--max-output",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -869,6 +869,10 @@ fn main() {
             launch_cmd["downloadPath"] = json!(dp);
         }
 
+        if let Some(ref ctx) = flags.context {
+            launch_cmd["contextName"] = json!(ctx);
+        }
+
         let err = match send_command(launch_cmd, &flags.session) {
             Ok(resp) if resp.success => None,
             Ok(resp) => Some(
@@ -965,6 +969,10 @@ fn main() {
                 launch_cmd["downloadPath"] = json!(dp);
             }
 
+            if let Some(ref ctx) = flags.context {
+                launch_cmd["contextName"] = json!(ctx);
+            }
+
             let err = match send_command(launch_cmd, &flags.session) {
                 Ok(resp) if resp.success => None,
                 Ok(resp) => Some(
@@ -997,6 +1005,10 @@ fn main() {
 
             if let Some(ref cs) = flags.color_scheme {
                 launch_cmd["colorScheme"] = json!(cs);
+            }
+
+            if let Some(ref ctx) = flags.context {
+                launch_cmd["contextName"] = json!(ctx);
             }
 
             let err = match send_command(launch_cmd, &flags.session) {
@@ -1117,6 +1129,10 @@ fn main() {
 
         if let Some(ref engine) = flags.engine {
             launch_cmd["engine"] = json!(engine);
+        }
+
+        if let Some(ref ctx) = flags.context {
+            launch_cmd["contextName"] = json!(ctx);
         }
 
         match send_command(launch_cmd, &flags.session) {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1394,6 +1394,25 @@ async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
     Ok(mgr)
 }
 
+async fn maybe_create_browser_context(cmd: &Value, state: &mut DaemonState) -> Result<(), String> {
+    if let Some(context_name) = cmd.get("contextName").and_then(|v| v.as_str()) {
+        if let Some(mgr) = state.browser.as_mut() {
+            match mgr.create_browser_context().await {
+                Ok(ctx_id) => {
+                    eprintln!(
+                        "Created BrowserContext: {} (name: {})",
+                        ctx_id, context_name
+                    );
+                }
+                Err(e) => {
+                    return Err(format!("Failed to create BrowserContext: {}", e));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
     let options = launch_options_from_env();
     let engine = env::var("AGENT_BROWSER_ENGINE").ok();
@@ -1582,6 +1601,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     if let Some(url) = cdp_url {
         state.reset_input_state();
         state.browser = Some(BrowserManager::connect_cdp(url).await?);
+        maybe_create_browser_context(cmd, state).await?;
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1592,6 +1612,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     if let Some(port) = cdp_port {
         state.reset_input_state();
         state.browser = Some(BrowserManager::connect_cdp(&port.to_string()).await?);
+        maybe_create_browser_context(cmd, state).await?;
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1602,6 +1623,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     if auto_connect {
         state.reset_input_state();
         state.browser = Some(connect_auto_with_fresh_tab().await?);
+        maybe_create_browser_context(cmd, state).await?;
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1628,6 +1650,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                     Ok(mgr) => {
                         state.reset_input_state();
                         state.browser = Some(mgr);
+                        maybe_create_browser_context(cmd, state).await?;
                         state.subscribe_to_browser_events();
                         state.start_fetch_handler();
                         state.start_dialog_handler();

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -194,6 +194,7 @@ impl BrowserProcess {
 
 pub struct BrowserManager {
     pub client: Arc<CdpClient>,
+    pub browser_context_id: Option<String>,
     browser_process: Option<BrowserProcess>,
     ws_url: String,
     pages: Vec<PageInfo>,
@@ -266,6 +267,7 @@ impl BrowserManager {
             let client = Arc::new(CdpClient::connect(&ws_url).await?);
             let mut manager = Self {
                 client,
+                browser_context_id: None,
                 browser_process: Some(process),
                 ws_url,
                 pages: Vec::new(),
@@ -342,6 +344,7 @@ impl BrowserManager {
         let client = Arc::new(CdpClient::connect(&ws_url).await?);
         let mut manager = Self {
             client,
+            browser_context_id: None,
             browser_process: None,
             ws_url,
             pages: Vec::new(),
@@ -400,6 +403,7 @@ impl BrowserManager {
                     "Target.createTarget",
                     &CreateTargetParams {
                         url: "about:blank".to_string(),
+                        browser_context_id: self.browser_context_id.clone(),
                     },
                     None,
                 )
@@ -661,6 +665,18 @@ impl BrowserManager {
     }
 
     pub async fn close(&mut self) -> Result<(), String> {
+        // Dispose BrowserContext if one was created.
+        if let Some(ref ctx_id) = self.browser_context_id {
+            let _ = self
+                .client
+                .send_command_typed::<_, Value>(
+                    "Target.disposeBrowserContext",
+                    &json!({ "browserContextId": ctx_id }),
+                    None,
+                )
+                .await;
+        }
+
         if self.browser_process.is_some() {
             // Only send Browser.close when we launched the browser ourselves.
             // For external connections (--auto-connect, --cdp) we just disconnect
@@ -744,6 +760,24 @@ impl BrowserManager {
         self.browser_process.is_none()
     }
 
+    pub async fn create_browser_context(&mut self) -> Result<String, String> {
+        let result = self
+            .client
+            .send_command_typed::<_, Value>(
+                "Target.createBrowserContext",
+                &json!({ "disposeOnDetach": true }),
+                None,
+            )
+            .await?;
+        let ctx_id = result
+            .get("browserContextId")
+            .and_then(|v| v.as_str())
+            .ok_or("Failed to get browserContextId")?
+            .to_string();
+        self.browser_context_id = Some(ctx_id.clone());
+        Ok(ctx_id)
+    }
+
     /// Ensures the browser has at least one page. If `pages` is empty, creates a new
     /// about:blank page and attaches to it.
     pub async fn ensure_page(&mut self) -> Result<(), String> {
@@ -757,6 +791,7 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: "about:blank".to_string(),
+                    browser_context_id: self.browser_context_id.clone(),
                 },
                 None,
             )
@@ -828,6 +863,7 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: target_url.to_string(),
+                    browser_context_id: self.browser_context_id.clone(),
                 },
                 None,
             )
@@ -1330,6 +1366,7 @@ async fn initialize_lightpanda_manager(
 
         let mut manager = BrowserManager {
             client: Arc::new(client),
+            browser_context_id: None,
             browser_process: None,
             ws_url: ws_url.clone(),
             pages: Vec::new(),

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -141,6 +141,8 @@ pub struct SetDiscoverTargetsParams {
 #[serde(rename_all = "camelCase")]
 pub struct CreateTargetParams {
     pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_context_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -119,6 +119,7 @@ async fn collect_storage_via_temp_target(
             "Target.createTarget",
             &CreateTargetParams {
                 url: "about:blank".to_string(),
+                browser_context_id: None,
             },
             None,
         )

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -985,6 +985,7 @@ Aliases: goto, navigate
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
+  --context <name>     Create isolated BrowserContext in shared Chrome
   --headers <json>     Set HTTP headers (scoped to this origin)
   --headed             Show browser window
 
@@ -2797,6 +2798,7 @@ Authentication:
 
 Options:
   --session <name>           Isolated session (or AGENT_BROWSER_SESSION env)
+  --context <name>           Create isolated BrowserContext (cookie/storage isolation)
   --executable-path <path>   Custom browser executable (or AGENT_BROWSER_EXECUTABLE_PATH)
   --extension <path>         Load browser extensions (repeatable)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
@@ -2853,6 +2855,7 @@ Configuration:
 Environment:
   AGENT_BROWSER_CONFIG           Path to config file (or use --config)
   AGENT_BROWSER_SESSION          Session name (default: "default")
+  AGENT_BROWSER_CONTEXT          BrowserContext name for cookie/storage isolation
   AGENT_BROWSER_SESSION_NAME     Auto-save/restore state persistence name
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM state encryption
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete states older than N days (default: 30)

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -90,6 +90,7 @@ This enables control of:
   </thead>
   <tbody>
     <tr><td><code>--session &lt;name&gt;</code></td><td>Use isolated session</td></tr>
+    <tr><td><code>--context &lt;name&gt;</code></td><td>Create isolated BrowserContext in shared Chrome (cookies and storage isolation)</td></tr>
     <tr><td><code>--profile &lt;path&gt;</code></td><td>Persistent browser profile directory</td></tr>
     <tr><td><code>-p &lt;provider&gt;</code></td><td>Cloud browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>)</td></tr>
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -350,6 +350,7 @@ agent-browser reload                  # Reload page
 
 ```bash
 --session <name>         # Isolated browser session
+--context <name>         # Isolated BrowserContext for shared CDP connections
 --session-name <name>    # Auto-save/restore session state (cookies, localStorage)
 --profile <path>         # Persistent browser profile directory
 --state <path>           # Load storage state from JSON file

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -53,6 +53,7 @@ Every CLI flag can be set in the config file using its camelCase equivalent:
     <tr><td><code>full</code></td><td><code>--full, -f</code></td><td>boolean</td></tr>
     <tr><td><code>debug</code></td><td><code>--debug</code></td><td>boolean</td></tr>
     <tr><td><code>session</code></td><td><code>--session</code></td><td>string</td></tr>
+    <tr><td><code>context</code></td><td><code>--context</code></td><td>string</td></tr>
     <tr><td><code>sessionName</code></td><td><code>--session-name</code></td><td>string</td></tr>
     <tr><td><code>executablePath</code></td><td><code>--executable-path</code></td><td>string</td></tr>
     <tr><td><code>extensions</code></td><td><code>--extension</code></td><td>string[]</td></tr>
@@ -165,6 +166,7 @@ These environment variables configure additional daemon and runtime behavior:
   </thead>
   <tbody>
     <tr><td><code>AGENT_BROWSER_AUTO_CONNECT</code></td><td>Auto-discover and connect to a running Chrome instance.</td><td>(disabled)</td></tr>
+    <tr><td><code>AGENT_BROWSER_CONTEXT</code></td><td>BrowserContext name for cookie and storage isolation in shared CDP connections.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_ALLOW_FILE_ACCESS</code></td><td>Allow <code>file://</code> URLs to access local files.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_COLOR_SCHEME</code></td><td>Color scheme preference (<code>dark</code>, <code>light</code>, <code>no-preference</code>).</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_DOWNLOAD_PATH</code></td><td>Default directory for browser downloads.</td><td>(temp directory)</td></tr>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -229,6 +229,7 @@ agent-browser set headers '{"X-Custom-Header": "value"}'
   </thead>
   <tbody>
     <tr><td><code>AGENT_BROWSER_SESSION</code></td><td>Browser session ID (default: "default")</td></tr>
+    <tr><td><code>AGENT_BROWSER_CONTEXT</code></td><td>BrowserContext name for cookie/storage isolation in shared CDP connections</td></tr>
     <tr><td><code>AGENT_BROWSER_SESSION_NAME</code></td><td>Auto-save/load state persistence name</td></tr>
     <tr><td><code>AGENT_BROWSER_ENCRYPTION_KEY</code></td><td>64-char hex key for AES-256-GCM encryption</td></tr>
     <tr><td><code>AGENT_BROWSER_STATE_EXPIRE_DAYS</code></td><td>Auto-delete states older than N days (default: 30)</td></tr>

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -55,6 +55,8 @@ When automating a site that requires login, choose the approach that fits:
 ```bash
 # Connect to the user's running Chrome (they're already logged in)
 agent-browser --auto-connect state save ./auth.json
+# Optional: isolate automation in a dedicated BrowserContext while sharing the same Chrome process
+agent-browser --auto-connect --context my-task open https://app.example.com
 # Use that auth state
 agent-browser --state ./auth.json open https://app.example.com/dashboard
 ```


### PR DESCRIPTION
## Summary

Adds `--context <name>` flag that creates an isolated CDP BrowserContext when connecting to a shared Chrome instance. Tabs within that context get full cookie/storage isolation without launching a separate Chrome process.

Thank you to @nathanvale for the thorough design in #1068. The CLI surface, CDP approach, and comparison table in that issue were the blueprint for this implementation.

## Why this matters

When multiple agents share one Chrome via `--auto-connect` or `connect <port>`, cookies and storage leak between sessions. The `--session` flag isolates tab namespaces but not storage. Users running agents against the same domain with different credentials hit cookie collisions.

| Source | Evidence |
|--------|----------|
| [#1068](https://github.com/vercel-labs/agent-browser/issues/1068) | Detailed proposal with CDP calls, CLI surface, comparison table |
| [#326](https://github.com/vercel-labs/agent-browser/issues/326) | Multiple agents hijacking each other |
| [#896](https://github.com/vercel-labs/agent-browser/issues/896) | --session daemons sharing same --profile |
| [#86](https://github.com/vercel-labs/agent-browser/issues/86) | Original multi-session request |

CDP BrowserContexts are the same mechanism Playwright and Puppeteer use for parallel isolated sessions. Context creation takes ~5ms vs launching a full Chrome process (~100-200MB).

## Changes

- `cli/src/flags.rs` -- New `--context <name>` flag + `AGENT_BROWSER_CONTEXT` env var
- `cli/src/native/browser.rs` -- `create_browser_context()` method, `browser_context_id` field on BrowserManager, dispose on close, pass context ID to all `Target.createTarget` calls
- `cli/src/native/actions.rs` -- `maybe_create_browser_context()` called after every connection path in handle_launch
- `cli/src/native/cdp/types.rs` -- `browser_context_id` field on `CreateTargetParams`
- `cli/src/commands.rs`, `cli/src/main.rs` -- Pass `contextName` through to daemon
- Docs: README, output.rs help, SKILL.md, 4 MDX doc pages

Default behavior (no `--context`) is unchanged.

## Demo

![context-isolation-demo](https://files.catbox.moe/3yha0r.gif)

Cookie `secret=work-only` set in `--context work` is not visible in `--context personal`. Each context gets its own CDP BrowserContext with full storage isolation.

## Testing

- 568 unit tests pass (`cargo test`)
- `cargo fmt --check` clean
- Built from source, ran two contexts against example.com, confirmed cookie isolation

Fixes #1068, relates to #326, #896, #86

This contribution was developed with AI assistance (Claude Code).