### PR TITLE
fix(native): auto_launch() honours AGENT_BROWSER_PROVIDER for cloud providers

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1435,6 +1435,48 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
         return Ok(());
     }
 
+    // Cloud provider: when AGENT_BROWSER_PROVIDER is set, connect via the
+    // provider API instead of launching a local Chrome instance.  This mirrors
+    // the logic in handle_launch() so that auto_launch (triggered by any
+    // command arriving before an explicit "launch") honours the provider env.
+    if let Ok(provider) = env::var("AGENT_BROWSER_PROVIDER") {
+        let p = provider.to_lowercase();
+        // ios/safari are device providers handled via explicit launch command
+        if !p.is_empty() && p != "ios" && p != "safari" {
+            let conn = providers::connect_provider(&p).await?;
+            let ws_headers = if p == "agentcore" {
+                providers::take_agentcore_ws_headers()
+            } else {
+                None
+            };
+            let connect_result = if conn.direct_page {
+                BrowserManager::connect_cdp_direct(&conn.ws_url).await
+            } else if ws_headers.is_some() {
+                BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers).await
+            } else {
+                BrowserManager::connect_cdp(&conn.ws_url).await
+            };
+            match connect_result {
+                Ok(mgr) => {
+                    state.reset_input_state();
+                    state.browser = Some(mgr);
+                    state.subscribe_to_browser_events();
+                    state.start_fetch_handler();
+                    state.start_dialog_handler();
+                    state.update_stream_client().await;
+                    write_provider_file(&state.session_id, &p);
+                    try_auto_restore_state(state).await;
+                    return Ok(());
+                }
+                Err(e) => {
+                    if let Some(ref ps) = conn.session {
+                        providers::close_provider_session(ps).await;
+                    }
+                    return Err(format!("Provider '{}' connection failed: {}", p, e));
+                }
+            }
+        }
+    }
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
     state.browser = Some(mgr);

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -41,6 +41,22 @@ pub async fn run_daemon(session: &str) {
                 session
             );
         }
+    } else {
+        // Redirect stderr to /dev/null to prevent daemon crash when the
+        // parent CLI drops the piped stderr handle after startup.  Cloud
+        // providers (AgentCore, Browserbase, etc.) may write to stderr
+        // during connection setup; a broken pipe would kill the daemon.
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::IntoRawFd;
+            if let Ok(devnull) = fs::File::create("/dev/null") {
+                let fd = devnull.into_raw_fd();
+                unsafe {
+                    libc::dup2(fd, 2);
+                    libc::close(fd);
+                }
+            }
+        }
     }
 
     let pid_path = socket_dir.join(format!("{}.pid", session));


### PR DESCRIPTION
## Problem

When using `-p agentcore` (or any cloud provider via `-p` flag, `AGENT_BROWSER_PROVIDER` env var, or `config.json`), the daemon's `auto_launch()` function ignores the provider setting and always launches a local Chrome instance.

**Note:** Setting `provider` in `~/.agent-browser/config.json` does not fix this. The config value is read by the CLI and forwarded to the daemon as `AGENT_BROWSER_PROVIDER` env var via `apply_daemon_env()`, but `auto_launch()` never checks this env var.

### Root Cause

Two issues combine to cause this:

**1. `auto_launch()` does not check `AGENT_BROWSER_PROVIDER` (`cli/src/native/actions.rs`)**

`auto_launch()` checks `AGENT_BROWSER_CDP` and `AGENT_BROWSER_AUTO_CONNECT`, but not `AGENT_BROWSER_PROVIDER`. When a non-launch command triggers `auto_launch`, it always falls through to `BrowserManager::launch()` (local Chrome), even when the daemon has `AGENT_BROWSER_PROVIDER=agentcore` in its environment.

The provider connection logic only exists in `handle_launch()`, which handles the explicit `{"action": "launch", "provider": "agentcore"}` command from the CLI. But `auto_launch` can fire before `handle_launch` processes, because any command arriving at the daemon before an explicit `launch` triggers the `needs_launch` check in `execute_command()`:

```rust
// actions.rs execute_command()
let skip_launch = matches!(action, "" | "launch" | "close" | ...);
if !skip_launch {
    if needs_launch {
        auto_launch(state).await  // ignores AGENT_BROWSER_PROVIDER
    }
}
match action {
    "launch" => handle_launch(cmd, state).await,  // provider logic here
    ...
}
```

**2. Daemon crashes on stderr write after CLI drops pipe handle (`cli/src/native/daemon.rs`, related to #979)**

The CLI spawns the daemon with `stderr: Stdio::piped()` to capture startup errors. After `daemon_ready()` returns, the CLI drops the pipe handle. Cloud providers may write to stderr during connection setup. Without `AGENT_BROWSER_DEBUG` (which redirects stderr to a log file), the daemon crashes silently on the broken pipe, and the CLI retries with a new daemon that falls back to local Chrome via `auto_launch`.

### Reproduction (clean Docker environment)

```bash
docker run --rm \
  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
  ubuntu:22.04 bash -c '
apt-get update -qq && apt-get install -y -qq curl ca-certificates procps > /dev/null 2>&1
curl -fsSL https://deb.nodesource.com/setup_22.x | bash - > /dev/null 2>&1
apt-get install -y -qq nodejs > /dev/null 2>&1
npm install -g agent-browser@0.24.0 > /dev/null 2>&1
agent-browser install --with-deps > /dev/null 2>&1

export AGENTCORE_REGION=us-east-1
export AGENTCORE_BROWSER_ID=<your-browser-id>
export AGENT_BROWSER_PROVIDER=agentcore

agent-browser -p agentcore open "https://example.com" 2>&1 &
sleep 5

# Daemon has the env vars...
DPID=$(pgrep -f "agent-browser-linux" | head -1)
cat /proc/$DPID/environ | tr "\0" "\n" | grep AGENT_BROWSER_PROVIDER
# Output: AGENT_BROWSER_PROVIDER=agentcore

# ...but auto_launch() ignores them and launches local Chrome
agent-browser get url 2>&1
# Output: Auto-launch failed: Chrome exited early
'
```

Daemon `/proc/PID/environ` confirms `AGENT_BROWSER_PROVIDER=agentcore` is present, but `auto_launch()` still attempts to launch local Chrome instead of connecting to the provider.

### Environment

- agent-browser v0.24.0
- Linux x86_64 (Ubuntu 22.04, also reproduced in clean Docker)
- AWS CLI v2.34.21
- AWS SSO credentials (bedrock-agentcore)

### Proposed Fix

1. Add `AGENT_BROWSER_PROVIDER` check to `auto_launch()` before the local Chrome fallback, mirroring the provider connection logic in `handle_launch()`
2. Redirect daemon stderr to `/dev/null` when not in debug mode, preventing crashes from broken pipe after CLI drops the handle

I have a working patch with both fixes, all 572 unit tests pass, `cargo fmt` and `cargo clippy` clean. PR: #1126

### Architectural Note

The deeper issue is that browser launch logic is split between `auto_launch()` (local Chrome only) and `handle_launch()` (supports providers). `auto_launch` was designed when only local Chrome existed; provider support was added to `handle_launch` but not unified with `auto_launch`. This PR adds provider support to `auto_launch` to fix the immediate bug, but a cleaner long-term approach would be to unify the launch path so `auto_launch` is the single source of truth for "how to connect to a browser", reading provider/CDP/auto-connect/local-Chrome from env/config in one place. That would eliminate the duplication between `auto_launch` and `handle_launch` and prevent future drift if new providers are added.