### PR TITLE
fix: pass --ignore-certificate-errors Chrome flag when --ignore-https-errors is set

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -1125,6 +1125,35 @@ mod tests {
     }
 
     #[test]
+    fn test_build_args_ignore_https_errors_includes_flag() {
+        let opts = LaunchOptions {
+            ignore_https_errors: true,
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--ignore-certificate-errors"));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_ignore_https_errors_default_no_flag() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(!result
+            .args
+            .iter()
+            .any(|a| a == "--ignore-certificate-errors"));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
     fn test_chrome_process_drop_cleans_temp_dir() {
         let dir = std::env::temp_dir().join(format!(
             "agent-browser-chrome-drop-test-{}",


### PR DESCRIPTION
## Summary

- Adds Chrome's `--ignore-certificate-errors` launch flag when `--ignore-https-errors` is used, complementing the existing CDP-level `Security.setIgnoreCertificateErrors`
- The CDP-only approach fails for some HTTPS setups (e.g. portless on localhost) where Chrome rejects the TLS connection at the network layer before CDP can intervene
- This two-layer approach (Chrome flag + CDP) matches how Puppeteer and Playwright handle the same scenario

Fixes #1124

## Test plan

- [x] `cargo test` — 572 passed, 0 failed
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] E2E: `agent-browser open --ignore-https-errors https://localhost:9443` with self-signed cert — page loads successfully
- [x] E2E: `agent-browser open https://localhost:9443` without flag — correctly fails with `ERR_CERT_AUTHORITY_INVALID`
- [x] Verified `--ignore-certificate-errors` present in Chrome process args only when flag is set