### PR TITLE
Fix CDP attach hang on real browser sessions (Chrome 144+)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -556,6 +556,13 @@ impl DaemonState {
             if let Some(ref mgr) = self.browser {
                 let _ = mgr
                     .client
+                    .send_command_no_params(
+                        "Runtime.runIfWaitingForDebugger",
+                        Some(iframe_sid.as_str()),
+                    )
+                    .await;
+                let _ = mgr
+                    .client
                     .send_command_no_params("DOM.enable", Some(iframe_sid.as_str()))
                     .await;
                 let _ = mgr

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -479,6 +479,13 @@ impl BrowserManager {
         self.client
             .send_command_no_params("Runtime.enable", Some(session_id))
             .await?;
+        // Resume the target if it is paused waiting for the debugger.
+        // This is needed for real browser sessions (Chrome 144+) where targets
+        // are paused after attach until explicitly resumed. No-op otherwise.
+        let _ = self
+            .client
+            .send_command_no_params("Runtime.runIfWaitingForDebugger", Some(session_id))
+            .await;
         self.client
             .send_command_no_params("Network.enable", Some(session_id))
             .await?;
@@ -508,6 +515,10 @@ impl BrowserManager {
         self.client
             .send_command_no_params("Runtime.enable", None)
             .await?;
+        let _ = self
+            .client
+            .send_command_no_params("Runtime.runIfWaitingForDebugger", None)
+            .await;
         self.client
             .send_command_no_params("Network.enable", None)
             .await?;


### PR DESCRIPTION
## Summary

- Call `Runtime.runIfWaitingForDebugger` after `Runtime.enable` in all target attachment paths to resume targets paused by approval-based remote debugging in Chrome 144+
- Place the call before `Network.enable` to avoid the [documented CDP deadlock](https://chromedevtools.github.io/devtools-protocol/tot/Network/) when `Network.enable` precedes the resume
- Cover all three attach paths: `enable_domains` (initial attach, `tab_new`, `tab_switch`), `enable_domains_direct` (provider proxies), and the iframe auto-attach handler in `process_drained_events`

The call is a no-op for targets that are not paused, so it does not affect normal launched-browser flows.

Fixes #1130

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes (no warnings)
- [x] `cargo test` passes (572 tests, 0 failures)
- [x] E2E: launched Chrome with `--remote-debugging-port=9222`, connected via `--cdp ws://...`, verified `open`, `get url`, `get title` all complete without hanging
- [x] E2E: normal browser launch flow (`open`, `get title`, `get url`, `close`) still works
- [ ] Manual: connect to a real desktop Chrome 144+ session with approval prompt and verify commands complete after approval (requires macOS/desktop environment)