### PR TITLE
Fix AgentCore EOF errors and orphaned READY sessions

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -629,17 +629,25 @@ fn is_transient_error(error: &str) -> bool {
         || error.contains("os error 10054") // Connection reset by peer (Windows)
 }
 
+/// Returns the read-timeout (in seconds) for a daemon command.
+/// Provider launch commands involve remote API calls and credential resolution
+/// that can exceed the default 30 s, so they get a longer timeout to avoid
+/// premature EOF retries that create orphaned remote sessions.
+fn read_timeout_secs(cmd: &Value) -> u64 {
+    let is_launch = cmd.get("action").and_then(|v| v.as_str()) == Some("launch");
+    let has_provider = cmd.get("provider").is_some();
+    if is_launch && has_provider {
+        120
+    } else {
+        30
+    }
+}
+
 fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
     let mut stream = connect(session)?;
 
-    // Provider launch commands (agentcore, browserbase, etc.) involve remote API
-    // calls and credential resolution that can exceed 30 s.  Use a longer timeout
-    // to avoid premature EOF retries that create orphaned remote sessions.
-    let is_launch = cmd.get("action").and_then(|v| v.as_str()) == Some("launch");
-    let has_provider = cmd.get("provider").is_some();
-    let read_timeout_secs = if is_launch && has_provider { 120 } else { 30 };
     stream
-        .set_read_timeout(Some(Duration::from_secs(read_timeout_secs)))
+        .set_read_timeout(Some(Duration::from_secs(read_timeout_secs(cmd))))
         .ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
@@ -835,32 +843,22 @@ mod tests {
 
     // === Provider launch timeout tests ===
 
-    fn read_timeout_for(cmd: &Value) -> u64 {
-        let is_launch = cmd.get("action").and_then(|v| v.as_str()) == Some("launch");
-        let has_provider = cmd.get("provider").is_some();
-        if is_launch && has_provider {
-            120
-        } else {
-            30
-        }
-    }
-
     #[test]
     fn test_provider_launch_gets_longer_timeout() {
         let cmd = serde_json::json!({"action": "launch", "provider": "agentcore"});
-        assert_eq!(read_timeout_for(&cmd), 120);
+        assert_eq!(read_timeout_secs(&cmd), 120);
     }
 
     #[test]
     fn test_regular_launch_gets_default_timeout() {
         let cmd = serde_json::json!({"action": "launch", "headless": true});
-        assert_eq!(read_timeout_for(&cmd), 30);
+        assert_eq!(read_timeout_secs(&cmd), 30);
     }
 
     #[test]
     fn test_navigate_gets_default_timeout() {
         let cmd = serde_json::json!({"action": "navigate", "url": "https://example.com"});
-        assert_eq!(read_timeout_for(&cmd), 30);
+        assert_eq!(read_timeout_secs(&cmd), 30);
     }
 
     #[test]

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -632,7 +632,15 @@ fn is_transient_error(error: &str) -> bool {
 fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
     let mut stream = connect(session)?;
 
-    stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+    // Provider launch commands (agentcore, browserbase, etc.) involve remote API
+    // calls and credential resolution that can exceed 30 s.  Use a longer timeout
+    // to avoid premature EOF retries that create orphaned remote sessions.
+    let is_launch = cmd.get("action").and_then(|v| v.as_str()) == Some("launch");
+    let has_provider = cmd.get("provider").is_some();
+    let read_timeout_secs = if is_launch && has_provider { 120 } else { 30 };
+    stream
+        .set_read_timeout(Some(Duration::from_secs(read_timeout_secs)))
+        .ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
     let mut json_str = serde_json::to_string(cmd).map_err(|e| e.to_string())?;
@@ -823,6 +831,36 @@ mod tests {
         assert!(!is_transient_error("Invalid JSON syntax"));
         assert!(!is_transient_error("Permission denied"));
         assert!(!is_transient_error("Daemon not found"));
+    }
+
+    // === Provider launch timeout tests ===
+
+    fn read_timeout_for(cmd: &Value) -> u64 {
+        let is_launch = cmd.get("action").and_then(|v| v.as_str()) == Some("launch");
+        let has_provider = cmd.get("provider").is_some();
+        if is_launch && has_provider {
+            120
+        } else {
+            30
+        }
+    }
+
+    #[test]
+    fn test_provider_launch_gets_longer_timeout() {
+        let cmd = serde_json::json!({"action": "launch", "provider": "agentcore"});
+        assert_eq!(read_timeout_for(&cmd), 120);
+    }
+
+    #[test]
+    fn test_regular_launch_gets_default_timeout() {
+        let cmd = serde_json::json!({"action": "launch", "headless": true});
+        assert_eq!(read_timeout_for(&cmd), 30);
+    }
+
+    #[test]
+    fn test_navigate_gets_default_timeout() {
+        let cmd = serde_json::json!({"action": "navigate", "url": "https://example.com"});
+        assert_eq!(read_timeout_for(&cmd), 30);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1727,8 +1727,9 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     // Hash comparison and fast process-exit check are evaluated before the
     // async is_connection_alive to skip the expensive CDP liveness probe
     // when a relaunch is already certain.
+    let has_provider = cmd.get("provider").and_then(|v| v.as_str()).is_some();
     let needs_relaunch = if let Some(ref mut mgr) = state.browser {
-        let is_external = cdp_url.is_some() || cdp_port.is_some() || auto_connect;
+        let is_external = cdp_url.is_some() || cdp_port.is_some() || auto_connect || has_provider;
         let was_external = mgr.is_cdp_connection();
         let hash_changed = !is_external && state.launch_hash != Some(new_hash);
         is_external != was_external


### PR DESCRIPTION
## Summary

Fixes #1138. Three interrelated bugs caused `open` with `-p agentcore` to fail with EOF / "daemon may be busy or unresponsive" errors and leave orphaned AWS `READY` sessions behind.

- **Socket timeout too short for provider launches**: The CLI used a 30 s read timeout on the daemon socket, but AgentCore session creation (AWS credential resolution + SigV4 signing + HTTP PUT + WebSocket signing) can exceed that. Premature timeouts were classified as transient EOF errors, triggering up to 5 retries — each sending a new `launch` command.
- **Relaunch guard missed provider connections**: `handle_launch` did not include provider connections in its `is_external` check, so retried `launch` commands tore down the working connection and created a new remote session each time — producing the orphaned `READY` sessions.
- **`auto_launch` ignored providers**: When the daemon was alive but the browser WebSocket was stale, `auto_launch` always tried to launch local Chrome instead of reconnecting via the configured provider.

## Changes

- `cli/src/connection.rs`: Increase socket read timeout from 30 s to 120 s for provider launch commands; add unit tests for the timeout logic
- `cli/src/native/actions.rs` (`handle_launch`): Include `has_provider` in the `is_external` flag so the relaunch guard correctly reuses alive provider connections
- `cli/src/native/actions.rs` (`auto_launch`): Add `AGENT_BROWSER_PROVIDER` env var handling so stale connections are re-established through the correct provider

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — 575 passed, 0 failed, 49 ignored
- [x] E2E: `AGENT_BROWSER_PROVIDER=agentcore agent-browser get url` routes through AgentCore (fails with credential error, not Chrome-not-found)
- [x] E2E: Normal Chrome launch/navigate/close flow unaffected
- [x] E2E: `-p browserbase open` without API key gives clean error (no EOF)
- [ ] Needs manual verification with live AWS credentials and AgentCore service to confirm full end-to-end fix