### PR TITLE
Add shell completions for bash, zsh, and fish

### DIFF
--- a/completions/agent-browser.bash
+++ b/completions/agent-browser.bash
@@ -1,0 +1,137 @@
+# Bash completion for agent-browser
+# https://github.com/vercel-labs/agent-browser
+
+_agent_browser() {
+  local cur prev words cword
+  _init_completion || return
+
+  local commands="open click dblclick type fill press keyboard hover focus check
+    uncheck select drag upload download scroll scrollintoview wait screenshot pdf
+    snapshot eval connect close back forward reload get is find mouse set network
+    storage cookies tab auth session dashboard stream diff state trace profiler
+    record console errors highlight inspect clipboard confirm deny tap swipe
+    device dialog frame window batch install upgrade"
+
+  local global_opts="--session --executable-path --extension --args --user-agent
+    --proxy --proxy-bypass --ignore-https-errors --allow-file-access -p --provider
+    --device --json --annotate --screenshot-dir --screenshot-quality
+    --screenshot-format --headed --cdp --color-scheme --download-path
+    --content-boundaries --max-output --allowed-domains --action-policy
+    --confirm-actions --confirm-interactive --engine --no-auto-dialog --config
+    --profile --session-name --state --auto-connect --headers --debug -V --version"
+
+  # if completing the first argument, show commands
+  if [[ $cword -eq 1 ]]; then
+    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+    return
+  fi
+
+  local cmd="${words[1]}"
+
+  case "$cmd" in
+    get)
+      COMPREPLY=($(compgen -W "text html value attr title url count box styles cdp-url" -- "$cur"))
+      ;;
+    is)
+      COMPREPLY=($(compgen -W "visible enabled checked" -- "$cur"))
+      ;;
+    find)
+      COMPREPLY=($(compgen -W "role text label placeholder alt title testid first last nth" -- "$cur"))
+      ;;
+    mouse)
+      COMPREPLY=($(compgen -W "move down up wheel" -- "$cur"))
+      ;;
+    set)
+      COMPREPLY=($(compgen -W "viewport device geo offline headers credentials media" -- "$cur"))
+      ;;
+    network)
+      COMPREPLY=($(compgen -W "route unroute requests har" -- "$cur"))
+      ;;
+    storage)
+      COMPREPLY=($(compgen -W "local session" -- "$cur"))
+      ;;
+    tab)
+      COMPREPLY=($(compgen -W "new list close" -- "$cur"))
+      ;;
+    cookies)
+      COMPREPLY=($(compgen -W "get set clear" -- "$cur"))
+      ;;
+    auth)
+      COMPREPLY=($(compgen -W "save login list show delete" -- "$cur"))
+      ;;
+    session)
+      COMPREPLY=($(compgen -W "list" -- "$cur"))
+      ;;
+    dashboard)
+      COMPREPLY=($(compgen -W "start stop install" -- "$cur"))
+      ;;
+    stream)
+      COMPREPLY=($(compgen -W "enable disable status" -- "$cur"))
+      ;;
+    diff)
+      COMPREPLY=($(compgen -W "snapshot screenshot url" -- "$cur"))
+      ;;
+    state)
+      COMPREPLY=($(compgen -W "save load list clear show clean rename" -- "$cur"))
+      ;;
+    trace)
+      COMPREPLY=($(compgen -W "start stop" -- "$cur"))
+      ;;
+    profiler)
+      COMPREPLY=($(compgen -W "start stop" -- "$cur"))
+      ;;
+    record)
+      COMPREPLY=($(compgen -W "start stop restart" -- "$cur"))
+      ;;
+    clipboard)
+      COMPREPLY=($(compgen -W "read write copy paste" -- "$cur"))
+      ;;
+    device)
+      COMPREPLY=($(compgen -W "list" -- "$cur"))
+      ;;
+    dialog)
+      COMPREPLY=($(compgen -W "accept dismiss status" -- "$cur"))
+      ;;
+    scroll)
+      COMPREPLY=($(compgen -W "up down left right" -- "$cur"))
+      ;;
+    snapshot)
+      COMPREPLY=($(compgen -W "-i --interactive -c --compact -d --depth -s --selector" -- "$cur"))
+      ;;
+    wait)
+      COMPREPLY=($(compgen -W "--url --load --fn --text --download" -- "$cur"))
+      ;;
+    close)
+      COMPREPLY=($(compgen -W "--all" -- "$cur"))
+      ;;
+    install)
+      COMPREPLY=($(compgen -W "--with-deps" -- "$cur"))
+      ;;
+    console|errors)
+      COMPREPLY=($(compgen -W "--clear" -- "$cur"))
+      ;;
+    batch)
+      COMPREPLY=($(compgen -W "--bail" -- "$cur"))
+      ;;
+    screenshot)
+      COMPREPLY=($(compgen -W "--full --annotate" -- "$cur"))
+      ;;
+    keyboard)
+      COMPREPLY=($(compgen -W "type inserttext" -- "$cur"))
+      ;;
+    window)
+      COMPREPLY=($(compgen -W "new" -- "$cur"))
+      ;;
+    har)
+      COMPREPLY=($(compgen -W "start stop" -- "$cur"))
+      ;;
+    *)
+      # for unknown subcommands, offer global options
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$global_opts" -- "$cur"))
+      fi
+      ;;
+  esac
+}
+
+complete -F _agent_browser agent-browser

--- a/completions/agent-browser.fish
+++ b/completions/agent-browser.fish
@@ -1,0 +1,235 @@
+# Fish completion for agent-browser
+# https://github.com/vercel-labs/agent-browser
+
+# disable file completions by default
+complete -c agent-browser -f
+
+# helper: true when no subcommand has been given yet
+function __agent_browser_needs_command
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 1
+end
+
+# helper: true when the given subcommand is active
+function __agent_browser_using_command
+    set -l cmd (commandline -opc)
+    test (count $cmd) -gt 1; and test "$cmd[2]" = "$argv[1]"
+end
+
+# ── top-level commands ──
+
+# core
+complete -c agent-browser -n __agent_browser_needs_command -a open        -d 'Navigate to URL'
+complete -c agent-browser -n __agent_browser_needs_command -a click       -d 'Click element'
+complete -c agent-browser -n __agent_browser_needs_command -a dblclick    -d 'Double-click element'
+complete -c agent-browser -n __agent_browser_needs_command -a type        -d 'Type into element'
+complete -c agent-browser -n __agent_browser_needs_command -a fill        -d 'Clear and fill element'
+complete -c agent-browser -n __agent_browser_needs_command -a press       -d 'Press key'
+complete -c agent-browser -n __agent_browser_needs_command -a keyboard    -d 'Keyboard actions'
+complete -c agent-browser -n __agent_browser_needs_command -a hover       -d 'Hover element'
+complete -c agent-browser -n __agent_browser_needs_command -a focus       -d 'Focus element'
+complete -c agent-browser -n __agent_browser_needs_command -a check       -d 'Check checkbox'
+complete -c agent-browser -n __agent_browser_needs_command -a uncheck     -d 'Uncheck checkbox'
+complete -c agent-browser -n __agent_browser_needs_command -a select      -d 'Select dropdown option'
+complete -c agent-browser -n __agent_browser_needs_command -a drag        -d 'Drag and drop'
+complete -c agent-browser -n __agent_browser_needs_command -a upload      -d 'Upload files'
+complete -c agent-browser -n __agent_browser_needs_command -a download    -d 'Download file'
+complete -c agent-browser -n __agent_browser_needs_command -a scroll      -d 'Scroll page'
+complete -c agent-browser -n __agent_browser_needs_command -a scrollintoview -d 'Scroll element into view'
+complete -c agent-browser -n __agent_browser_needs_command -a wait        -d 'Wait for element or time'
+complete -c agent-browser -n __agent_browser_needs_command -a screenshot  -d 'Take screenshot'
+complete -c agent-browser -n __agent_browser_needs_command -a pdf         -d 'Save as PDF'
+complete -c agent-browser -n __agent_browser_needs_command -a snapshot    -d 'Accessibility tree with refs'
+complete -c agent-browser -n __agent_browser_needs_command -a eval        -d 'Run JavaScript'
+complete -c agent-browser -n __agent_browser_needs_command -a connect     -d 'Connect via CDP'
+complete -c agent-browser -n __agent_browser_needs_command -a close       -d 'Close browser'
+# navigation
+complete -c agent-browser -n __agent_browser_needs_command -a back        -d 'Go back'
+complete -c agent-browser -n __agent_browser_needs_command -a forward     -d 'Go forward'
+complete -c agent-browser -n __agent_browser_needs_command -a reload      -d 'Reload page'
+# compound
+complete -c agent-browser -n __agent_browser_needs_command -a get         -d 'Get element info'
+complete -c agent-browser -n __agent_browser_needs_command -a is          -d 'Check element state'
+complete -c agent-browser -n __agent_browser_needs_command -a find        -d 'Find elements'
+complete -c agent-browser -n __agent_browser_needs_command -a mouse       -d 'Mouse actions'
+complete -c agent-browser -n __agent_browser_needs_command -a set         -d 'Browser settings'
+complete -c agent-browser -n __agent_browser_needs_command -a network     -d 'Network actions'
+complete -c agent-browser -n __agent_browser_needs_command -a storage     -d 'Manage web storage'
+complete -c agent-browser -n __agent_browser_needs_command -a cookies     -d 'Manage cookies'
+complete -c agent-browser -n __agent_browser_needs_command -a tab         -d 'Manage tabs'
+complete -c agent-browser -n __agent_browser_needs_command -a auth        -d 'Auth vault'
+complete -c agent-browser -n __agent_browser_needs_command -a session     -d 'Session management'
+complete -c agent-browser -n __agent_browser_needs_command -a dashboard   -d 'Dashboard server'
+complete -c agent-browser -n __agent_browser_needs_command -a stream      -d 'WebSocket streaming'
+complete -c agent-browser -n __agent_browser_needs_command -a diff        -d 'Compare pages/snapshots'
+complete -c agent-browser -n __agent_browser_needs_command -a state       -d 'Manage browser state'
+# debug
+complete -c agent-browser -n __agent_browser_needs_command -a trace       -d 'Record trace'
+complete -c agent-browser -n __agent_browser_needs_command -a profiler    -d 'Record profile'
+complete -c agent-browser -n __agent_browser_needs_command -a record      -d 'Video recording'
+complete -c agent-browser -n __agent_browser_needs_command -a console     -d 'View console logs'
+complete -c agent-browser -n __agent_browser_needs_command -a errors      -d 'View page errors'
+complete -c agent-browser -n __agent_browser_needs_command -a highlight   -d 'Highlight element'
+complete -c agent-browser -n __agent_browser_needs_command -a inspect     -d 'Open Chrome DevTools'
+complete -c agent-browser -n __agent_browser_needs_command -a clipboard   -d 'Clipboard operations'
+# confirmation
+complete -c agent-browser -n __agent_browser_needs_command -a confirm     -d 'Approve pending action'
+complete -c agent-browser -n __agent_browser_needs_command -a deny        -d 'Deny pending action'
+# iOS
+complete -c agent-browser -n __agent_browser_needs_command -a tap         -d 'Touch element (iOS)'
+complete -c agent-browser -n __agent_browser_needs_command -a swipe       -d 'Swipe gesture (iOS)'
+complete -c agent-browser -n __agent_browser_needs_command -a device      -d 'iOS device management'
+# dialog / frame / window
+complete -c agent-browser -n __agent_browser_needs_command -a dialog      -d 'Dialog management'
+complete -c agent-browser -n __agent_browser_needs_command -a frame       -d 'Switch frame context'
+complete -c agent-browser -n __agent_browser_needs_command -a window      -d 'Window management'
+# batch
+complete -c agent-browser -n __agent_browser_needs_command -a batch       -d 'Execute commands from stdin'
+# setup
+complete -c agent-browser -n __agent_browser_needs_command -a install     -d 'Install browser binaries'
+complete -c agent-browser -n __agent_browser_needs_command -a upgrade     -d 'Upgrade to latest version'
+
+# ── subcommands ──
+
+# get
+complete -c agent-browser -n '__agent_browser_using_command get' -a 'text html value attr title url count box styles cdp-url'
+
+# is
+complete -c agent-browser -n '__agent_browser_using_command is' -a 'visible enabled checked'
+
+# find
+complete -c agent-browser -n '__agent_browser_using_command find' -a 'role text label placeholder alt title testid first last nth'
+
+# mouse
+complete -c agent-browser -n '__agent_browser_using_command mouse' -a 'move down up wheel'
+
+# set
+complete -c agent-browser -n '__agent_browser_using_command set' -a 'viewport device geo offline headers credentials media'
+
+# network
+complete -c agent-browser -n '__agent_browser_using_command network' -a 'route unroute requests har'
+
+# storage
+complete -c agent-browser -n '__agent_browser_using_command storage' -a 'local session'
+
+# tab
+complete -c agent-browser -n '__agent_browser_using_command tab' -a 'new list close'
+
+# cookies
+complete -c agent-browser -n '__agent_browser_using_command cookies' -a 'get set clear'
+
+# auth
+complete -c agent-browser -n '__agent_browser_using_command auth' -a 'save login list show delete'
+
+# session
+complete -c agent-browser -n '__agent_browser_using_command session' -a list
+
+# dashboard
+complete -c agent-browser -n '__agent_browser_using_command dashboard' -a 'start stop install'
+
+# stream
+complete -c agent-browser -n '__agent_browser_using_command stream' -a 'enable disable status'
+
+# diff
+complete -c agent-browser -n '__agent_browser_using_command diff' -a 'snapshot screenshot url'
+
+# state
+complete -c agent-browser -n '__agent_browser_using_command state' -a 'save load list clear show clean rename'
+
+# trace
+complete -c agent-browser -n '__agent_browser_using_command trace' -a 'start stop'
+
+# profiler
+complete -c agent-browser -n '__agent_browser_using_command profiler' -a 'start stop'
+
+# record
+complete -c agent-browser -n '__agent_browser_using_command record' -a 'start stop restart'
+
+# clipboard
+complete -c agent-browser -n '__agent_browser_using_command clipboard' -a 'read write copy paste'
+
+# device
+complete -c agent-browser -n '__agent_browser_using_command device' -a list
+
+# dialog
+complete -c agent-browser -n '__agent_browser_using_command dialog' -a 'accept dismiss status'
+
+# keyboard
+complete -c agent-browser -n '__agent_browser_using_command keyboard' -a 'type inserttext'
+
+# window
+complete -c agent-browser -n '__agent_browser_using_command window' -a new
+
+# scroll
+complete -c agent-browser -n '__agent_browser_using_command scroll' -a 'up down left right'
+
+# ── command-specific options ──
+
+# snapshot
+complete -c agent-browser -n '__agent_browser_using_command snapshot' -s i -l interactive -d 'Only interactive elements'
+complete -c agent-browser -n '__agent_browser_using_command snapshot' -s c -l compact     -d 'Remove empty elements'
+complete -c agent-browser -n '__agent_browser_using_command snapshot' -s d -l depth       -d 'Limit tree depth' -x
+complete -c agent-browser -n '__agent_browser_using_command snapshot' -s s -l selector    -d 'Scope to CSS selector' -x
+
+# wait
+complete -c agent-browser -n '__agent_browser_using_command wait' -l url      -d 'Wait for URL pattern' -x
+complete -c agent-browser -n '__agent_browser_using_command wait' -l load     -d 'Wait for load state' -xa 'load domcontentloaded networkidle'
+complete -c agent-browser -n '__agent_browser_using_command wait' -l fn       -d 'Wait for JS function' -x
+complete -c agent-browser -n '__agent_browser_using_command wait' -l text     -d 'Wait for text content' -x
+complete -c agent-browser -n '__agent_browser_using_command wait' -l download -d 'Wait for download'
+
+# close
+complete -c agent-browser -n '__agent_browser_using_command close' -l all -d 'Close all sessions'
+
+# install
+complete -c agent-browser -n '__agent_browser_using_command install' -l with-deps -d 'Install system dependencies'
+
+# console / errors
+complete -c agent-browser -n '__agent_browser_using_command console' -l clear -d 'Clear console logs'
+complete -c agent-browser -n '__agent_browser_using_command errors'  -l clear -d 'Clear page errors'
+
+# batch
+complete -c agent-browser -n '__agent_browser_using_command batch' -l bail -d 'Stop on first error'
+
+# screenshot
+complete -c agent-browser -n '__agent_browser_using_command screenshot' -l full     -d 'Full page screenshot'
+complete -c agent-browser -n '__agent_browser_using_command screenshot' -l annotate -d 'Annotated screenshot'
+
+# ── global options ──
+
+complete -c agent-browser -l session           -d 'Isolated session name' -x
+complete -c agent-browser -l executable-path   -d 'Custom browser executable' -rF
+complete -c agent-browser -l extension         -d 'Load browser extension' -rF
+complete -c agent-browser -l args              -d 'Browser launch args' -x
+complete -c agent-browser -l user-agent        -d 'Custom User-Agent' -x
+complete -c agent-browser -l proxy             -d 'Proxy server URL' -x
+complete -c agent-browser -l proxy-bypass      -d 'Bypass proxy for hosts' -x
+complete -c agent-browser -l ignore-https-errors -d 'Ignore HTTPS errors'
+complete -c agent-browser -l allow-file-access -d 'Allow file:// URLs'
+complete -c agent-browser -s p -l provider     -d 'Browser provider' -xa 'ios browserbase kernel browseruse browserless agentcore'
+complete -c agent-browser -l device            -d 'iOS device name' -x
+complete -c agent-browser -l json              -d 'JSON output'
+complete -c agent-browser -l annotate          -d 'Annotated screenshot'
+complete -c agent-browser -l screenshot-dir    -d 'Screenshot directory' -rF
+complete -c agent-browser -l screenshot-quality -d 'JPEG quality 0-100' -x
+complete -c agent-browser -l screenshot-format -d 'Screenshot format' -xa 'png jpeg'
+complete -c agent-browser -l headed            -d 'Show browser window'
+complete -c agent-browser -l cdp               -d 'Connect via CDP port' -x
+complete -c agent-browser -l color-scheme      -d 'Color scheme' -xa 'dark light no-preference'
+complete -c agent-browser -l download-path     -d 'Download directory' -rF
+complete -c agent-browser -l content-boundaries -d 'Wrap output in markers'
+complete -c agent-browser -l max-output        -d 'Truncate to N chars' -x
+complete -c agent-browser -l allowed-domains   -d 'Restrict domains' -x
+complete -c agent-browser -l action-policy     -d 'Action policy file' -rF
+complete -c agent-browser -l confirm-actions   -d 'Categories needing confirmation' -x
+complete -c agent-browser -l confirm-interactive -d 'Interactive confirmation'
+complete -c agent-browser -l engine            -d 'Browser engine' -xa 'chrome lightpanda'
+complete -c agent-browser -l no-auto-dialog    -d 'Disable auto dialog dismiss'
+complete -c agent-browser -l config            -d 'Config file path' -rF
+complete -c agent-browser -l profile           -d 'Persistent login profile' -rF
+complete -c agent-browser -l session-name      -d 'Auto-save/restore state name' -x
+complete -c agent-browser -l state             -d 'Load saved auth state' -rF
+complete -c agent-browser -l auto-connect      -d 'Connect to running Chrome'
+complete -c agent-browser -l headers           -d 'HTTP headers (JSON)' -x
+complete -c agent-browser -l debug             -d 'Debug output'
+complete -c agent-browser -s V -l version      -d 'Show version'

--- a/completions/agent-browser.zsh
+++ b/completions/agent-browser.zsh
@@ -1,0 +1,417 @@
+#compdef agent-browser
+
+# Zsh completion for agent-browser
+# https://github.com/vercel-labs/agent-browser
+
+_agent_browser_global_options() {
+  local -a opts=(
+    '--session[Isolated session name]:name:'
+    '--executable-path[Custom browser executable]:path:_files'
+    '--extension[Load browser extension]:path:_files -/'
+    '--args[Browser launch args]:args:'
+    '--user-agent[Custom User-Agent]:ua:'
+    '--proxy[Proxy server URL]:url:'
+    '--proxy-bypass[Bypass proxy for hosts]:hosts:'
+    '--ignore-https-errors[Ignore HTTPS certificate errors]'
+    '--allow-file-access[Allow file:// URLs]'
+    '(-p --provider)'{-p,--provider}'[Browser provider]:provider:(ios browserbase kernel browseruse browserless agentcore)'
+    '--device[iOS device name]:name:'
+    '--json[JSON output]'
+    '--annotate[Annotated screenshot with labels]'
+    '--screenshot-dir[Default screenshot directory]:path:_files -/'
+    '--screenshot-quality[JPEG quality 0-100]:quality:'
+    '--screenshot-format[Screenshot format]:format:(png jpeg)'
+    '--headed[Show browser window]'
+    '--cdp[Connect via CDP port]:port:'
+    '--color-scheme[Color scheme]:scheme:(dark light no-preference)'
+    '--download-path[Default download directory]:path:_files -/'
+    '--content-boundaries[Wrap output in boundary markers]'
+    '--max-output[Truncate output to N chars]:chars:'
+    '--allowed-domains[Restrict navigation domains]:list:'
+    '--action-policy[Action policy JSON file]:path:_files'
+    '--confirm-actions[Categories requiring confirmation]:list:'
+    '--confirm-interactive[Interactive confirmation prompts]'
+    '--engine[Browser engine]:engine:(chrome lightpanda)'
+    '--no-auto-dialog[Disable automatic dialog dismissal]'
+    '--config[Custom config file]:path:_files'
+    '--profile[Persist login sessions]:path:_files -/'
+    '--session-name[Auto-save/restore state name]:name:'
+    '--state[Load saved auth state]:path:_files'
+    '--auto-connect[Connect to running Chrome]'
+    '--headers[HTTP headers (JSON)]:json:'
+    '--debug[Debug output]'
+    '(-V --version)'{-V,--version}'[Show version]'
+  )
+  _values -w 'global options' $opts
+}
+
+_agent_browser_snapshot_options() {
+  local -a opts=(
+    '(-i --interactive)'{-i,--interactive}'[Only interactive elements]'
+    '(-c --compact)'{-c,--compact}'[Remove empty structural elements]'
+    '(-d --depth)'{-d,--depth}'[Limit tree depth]:depth:'
+    '(-s --selector)'{-s,--selector}'[Scope to CSS selector]:selector:'
+  )
+  _arguments $opts
+}
+
+_agent_browser_get_subcommands() {
+  local -a subcmds=(
+    'text:Get text content'
+    'html:Get HTML content'
+    'value:Get input value'
+    'attr:Get attribute value'
+    'title:Get page title'
+    'url:Get page URL'
+    'count:Get element count'
+    'box:Get bounding box'
+    'styles:Get computed styles'
+    'cdp-url:Get CDP WebSocket URL'
+  )
+  _describe 'get subcommand' subcmds
+}
+
+_agent_browser_is_subcommands() {
+  local -a subcmds=(
+    'visible:Check if element is visible'
+    'enabled:Check if element is enabled'
+    'checked:Check if element is checked'
+  )
+  _describe 'is subcommand' subcmds
+}
+
+_agent_browser_find_subcommands() {
+  local -a subcmds=(
+    'role:Find by ARIA role'
+    'text:Find by text content'
+    'label:Find by label'
+    'placeholder:Find by placeholder'
+    'alt:Find by alt text'
+    'title:Find by title'
+    'testid:Find by test ID'
+    'first:Find first match'
+    'last:Find last match'
+    'nth:Find nth match'
+  )
+  _describe 'find subcommand' subcmds
+}
+
+_agent_browser_mouse_subcommands() {
+  local -a subcmds=(
+    'move:Move mouse to coordinates'
+    'down:Press mouse button'
+    'up:Release mouse button'
+    'wheel:Scroll mouse wheel'
+  )
+  _describe 'mouse subcommand' subcmds
+}
+
+_agent_browser_set_subcommands() {
+  local -a subcmds=(
+    'viewport:Set viewport size'
+    'device:Set device emulation'
+    'geo:Set geolocation'
+    'offline:Set offline mode'
+    'headers:Set HTTP headers'
+    'credentials:Set HTTP credentials'
+    'media:Set media features'
+  )
+  _describe 'set subcommand' subcmds
+}
+
+_agent_browser_network_subcommands() {
+  local -a subcmds=(
+    'route:Intercept network requests'
+    'unroute:Remove network interception'
+    'requests:View captured requests'
+    'har:Record HAR file'
+  )
+  _describe 'network subcommand' subcmds
+}
+
+_agent_browser_storage_subcommands() {
+  local -a subcmds=(
+    'local:Manage localStorage'
+    'session:Manage sessionStorage'
+  )
+  _describe 'storage subcommand' subcmds
+}
+
+_agent_browser_tab_subcommands() {
+  local -a subcmds=(
+    'new:Open new tab'
+    'list:List tabs'
+    'close:Close tab'
+  )
+  _describe 'tab subcommand' subcmds
+}
+
+_agent_browser_cookies_subcommands() {
+  local -a subcmds=(
+    'get:Get cookies'
+    'set:Set cookie'
+    'clear:Clear cookies'
+  )
+  _describe 'cookies subcommand' subcmds
+}
+
+_agent_browser_auth_subcommands() {
+  local -a subcmds=(
+    'save:Save auth profile'
+    'login:Login using saved credentials'
+    'list:List saved auth profiles'
+    'show:Show auth profile metadata'
+    'delete:Delete auth profile'
+  )
+  _describe 'auth subcommand' subcmds
+}
+
+_agent_browser_session_subcommands() {
+  local -a subcmds=(
+    'list:List active sessions'
+  )
+  _describe 'session subcommand' subcmds
+}
+
+_agent_browser_dashboard_subcommands() {
+  local -a subcmds=(
+    'start:Start the dashboard server'
+    'stop:Stop the dashboard server'
+    'install:Install the dashboard'
+  )
+  _describe 'dashboard subcommand' subcmds
+}
+
+_agent_browser_stream_subcommands() {
+  local -a subcmds=(
+    'enable:Start WebSocket streaming'
+    'disable:Stop WebSocket streaming'
+    'status:Show streaming status'
+  )
+  _describe 'stream subcommand' subcmds
+}
+
+_agent_browser_diff_subcommands() {
+  local -a subcmds=(
+    'snapshot:Compare current vs last snapshot'
+    'screenshot:Compare current vs baseline image'
+    'url:Compare two pages'
+  )
+  _describe 'diff subcommand' subcmds
+}
+
+_agent_browser_state_subcommands() {
+  local -a subcmds=(
+    'save:Save browser state'
+    'load:Load browser state'
+    'list:List saved states'
+    'clear:Clear saved states'
+    'show:Show state details'
+    'clean:Clean expired states'
+    'rename:Rename saved state'
+  )
+  _describe 'state subcommand' subcmds
+}
+
+_agent_browser_trace_subcommands() {
+  local -a subcmds=(
+    'start:Start recording trace'
+    'stop:Stop and save trace'
+  )
+  _describe 'trace subcommand' subcmds
+}
+
+_agent_browser_profiler_subcommands() {
+  local -a subcmds=(
+    'start:Start profiling'
+    'stop:Stop and save profile'
+  )
+  _describe 'profiler subcommand' subcmds
+}
+
+_agent_browser_record_subcommands() {
+  local -a subcmds=(
+    'start:Start video recording'
+    'stop:Stop and save video'
+    'restart:Restart recording'
+  )
+  _describe 'record subcommand' subcmds
+}
+
+_agent_browser_clipboard_subcommands() {
+  local -a subcmds=(
+    'read:Read clipboard'
+    'write:Write to clipboard'
+    'copy:Copy to clipboard'
+    'paste:Paste from clipboard'
+  )
+  _describe 'clipboard subcommand' subcmds
+}
+
+_agent_browser_device_subcommands() {
+  local -a subcmds=(
+    'list:List iOS simulators'
+  )
+  _describe 'device subcommand' subcmds
+}
+
+_agent_browser_dialog_subcommands() {
+  local -a subcmds=(
+    'accept:Accept dialog'
+    'dismiss:Dismiss dialog'
+    'status:Show dialog status'
+  )
+  _describe 'dialog subcommand' subcmds
+}
+
+_agent_browser_scroll_directions() {
+  local -a dirs=(
+    'up:Scroll up'
+    'down:Scroll down'
+    'left:Scroll left'
+    'right:Scroll right'
+  )
+  _describe 'direction' dirs
+}
+
+_agent_browser_wait_options() {
+  local -a opts=(
+    '--url[Wait for URL pattern]:pattern:'
+    '--load[Wait for load state]:state:(load domcontentloaded networkidle)'
+    '--fn[Wait for JS function]:function:'
+    '--text[Wait for text content]:text:'
+    '--download[Wait for download]'
+  )
+  _arguments $opts
+}
+
+_agent_browser() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  local -a commands=(
+    # core
+    'open:Navigate to URL'
+    'click:Click element'
+    'dblclick:Double-click element'
+    'type:Type into element'
+    'fill:Clear and fill element'
+    'press:Press key'
+    'keyboard:Keyboard actions'
+    'hover:Hover element'
+    'focus:Focus element'
+    'check:Check checkbox'
+    'uncheck:Uncheck checkbox'
+    'select:Select dropdown option'
+    'drag:Drag and drop'
+    'upload:Upload files'
+    'download:Download file by clicking element'
+    'scroll:Scroll page'
+    'scrollintoview:Scroll element into view'
+    'wait:Wait for element or time'
+    'screenshot:Take screenshot'
+    'pdf:Save as PDF'
+    'snapshot:Accessibility tree with refs'
+    'eval:Run JavaScript'
+    'connect:Connect via CDP'
+    'close:Close browser'
+    # navigation
+    'back:Go back'
+    'forward:Go forward'
+    'reload:Reload page'
+    # compound
+    'get:Get element info'
+    'is:Check element state'
+    'find:Find elements by locator'
+    'mouse:Mouse actions'
+    'set:Browser settings'
+    'network:Network actions'
+    'storage:Manage web storage'
+    'cookies:Manage cookies'
+    'tab:Manage tabs'
+    'auth:Auth vault'
+    'session:Session management'
+    'dashboard:Dashboard server'
+    'stream:WebSocket streaming'
+    'diff:Compare pages/snapshots'
+    'state:Manage browser state'
+    # debug
+    'trace:Record Chrome DevTools trace'
+    'profiler:Record Chrome DevTools profile'
+    'record:Video recording'
+    'console:View console logs'
+    'errors:View page errors'
+    'highlight:Highlight element'
+    'inspect:Open Chrome DevTools'
+    'clipboard:Clipboard operations'
+    # confirmation
+    'confirm:Approve pending action'
+    'deny:Deny pending action'
+    # iOS
+    'tap:Touch element (iOS)'
+    'swipe:Swipe gesture (iOS)'
+    'device:iOS device management'
+    # dialog
+    'dialog:Dialog management'
+    # frame
+    'frame:Switch frame context'
+    # window
+    'window:Window management'
+    # batch
+    'batch:Execute commands from stdin'
+    # setup
+    'install:Install browser binaries'
+    'upgrade:Upgrade to latest version'
+  )
+
+  _arguments -C \
+    '1:command:->command' \
+    '*::arg:->args' \
+    && return
+
+  case $state in
+    command)
+      _describe 'command' commands
+      ;;
+    args)
+      case ${line[1]} in
+        get)        _agent_browser_get_subcommands ;;
+        is)         _agent_browser_is_subcommands ;;
+        find)       _agent_browser_find_subcommands ;;
+        mouse)      _agent_browser_mouse_subcommands ;;
+        set)        _agent_browser_set_subcommands ;;
+        network)    _agent_browser_network_subcommands ;;
+        storage)    _agent_browser_storage_subcommands ;;
+        tab)        _agent_browser_tab_subcommands ;;
+        cookies)    _agent_browser_cookies_subcommands ;;
+        auth)       _agent_browser_auth_subcommands ;;
+        session)    _agent_browser_session_subcommands ;;
+        dashboard)  _agent_browser_dashboard_subcommands ;;
+        stream)     _agent_browser_stream_subcommands ;;
+        diff)       _agent_browser_diff_subcommands ;;
+        state)      _agent_browser_state_subcommands ;;
+        trace)      _agent_browser_trace_subcommands ;;
+        profiler)   _agent_browser_profiler_subcommands ;;
+        record)     _agent_browser_record_subcommands ;;
+        clipboard)  _agent_browser_clipboard_subcommands ;;
+        device)     _agent_browser_device_subcommands ;;
+        dialog)     _agent_browser_dialog_subcommands ;;
+        scroll)     _agent_browser_scroll_directions ;;
+        wait)       _agent_browser_wait_options ;;
+        snapshot)   _agent_browser_snapshot_options ;;
+        screenshot) _arguments '--full[Full page screenshot]' '1:path:_files' ;;
+        pdf)        _arguments '1:path:_files' ;;
+        open)       _arguments '1:url:' ;;
+        connect)    _arguments '1:port or url:' ;;
+        close)      _arguments '--all[Close all sessions]' ;;
+        install)    _arguments '--with-deps[Install system dependencies]' ;;
+        console)    _arguments '--clear[Clear console logs]' ;;
+        errors)     _arguments '--clear[Clear page errors]' ;;
+        batch)      _arguments '--bail[Stop on first error]' ;;
+        *)          _default ;;
+      esac
+      ;;
+  esac
+}
+
+_agent_browser "$@"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "files": [
     "bin",
+    "completions",
     "scripts",
     "skills"
   ],


### PR DESCRIPTION
## Summary

- Add shell completion scripts for **bash**, **zsh**, and **fish** in `completions/`
- Covers all commands, subcommands (nested two levels), and global options
- Built from the current `--help` output (v0.24.0)

Once merged, the Homebrew formula can be updated to install these automatically via `bash_completion.install`, `zsh_completion.install`, and `fish_completion.install`.