### PR TITLE
fix: rewrite getByRole to use CDP accessibility tree with ref-based element resolution

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5229,31 +5229,35 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         )
         .await?;
 
-    let backend_node_id = find_ax_node_by_role(&ax_tree.nodes, role, name, exact)?;
+    let (backend_node_id, actual_name) = find_ax_node_by_role(&ax_tree.nodes, role, name, exact)?;
 
     // Register a temporary ref so execute_subaction can resolve the element
     // via backendNodeId directly — no marker attribute needed.
-    let temp_ref = format!("e{}", state.ref_map.next_ref_num());
+    let ref_num = state.ref_map.next_ref_num();
+    let temp_ref = format!("e{}", ref_num);
     state.ref_map.add_with_frame(
         temp_ref.clone(),
         Some(backend_node_id),
         role,
-        name.unwrap_or(""),
+        &actual_name,
         None,
         state.active_frame_id.as_deref(),
     );
+    state.ref_map.set_next_ref_num(ref_num + 1);
 
-    execute_subaction(cmd, state, &format!("@{}", temp_ref)).await
+    let result = execute_subaction(cmd, state, &format!("@{}", temp_ref)).await;
+    state.ref_map.remove(&temp_ref);
+    result
 }
 
 /// Search the accessibility tree for a node matching the given role and
-/// optional name. Returns the `backendDOMNodeId` of the first match.
+/// optional name. Returns `(backendDOMNodeId, actual_name)` of the first match.
 fn find_ax_node_by_role(
     nodes: &[super::cdp::types::AXNode],
     role: &str,
     name: Option<&str>,
     exact: bool,
-) -> Result<i64, String> {
+) -> Result<(i64, String), String> {
     for node in nodes {
         if node.ignored.unwrap_or(false) {
             continue;
@@ -5264,13 +5268,15 @@ fn find_ax_node_by_role(
             continue;
         }
 
+        let node_name = super::element::extract_ax_string(&node.name);
+
         let Some(target_name) = name else {
-            return node
+            let id = node
                 .backend_d_o_m_node_id
-                .ok_or_else(|| format!("AX node has no backendDOMNodeId for role={}", role));
+                .ok_or_else(|| format!("AX node has no backendDOMNodeId for role={}", role))?;
+            return Ok((id, node_name));
         };
 
-        let node_name = super::element::extract_ax_string(&node.name);
         let matches = if exact {
             node_name == target_name
         } else {
@@ -5278,12 +5284,13 @@ fn find_ax_node_by_role(
         };
 
         if matches {
-            return node.backend_d_o_m_node_id.ok_or_else(|| {
+            let id = node.backend_d_o_m_node_id.ok_or_else(|| {
                 format!(
                     "AX node has no backendDOMNodeId for role={} name={}",
                     role, target_name
                 )
-            });
+            })?;
+            return Ok((id, node_name));
         }
     }
 
@@ -8533,8 +8540,9 @@ mod tests {
             make_ax_node("3", "link", "Another Link", Some(43), false),
         ];
 
-        let result = find_ax_node_by_role(&nodes, "link", Some("Example Link"), true);
-        assert_eq!(result.unwrap(), 42);
+        let (id, name) = find_ax_node_by_role(&nodes, "link", Some("Example Link"), true).unwrap();
+        assert_eq!(id, 42);
+        assert_eq!(name, "Example Link");
     }
 
     #[test]
@@ -8546,8 +8554,8 @@ mod tests {
 
         assert!(find_ax_node_by_role(&nodes, "link", Some("More"), true).is_err());
 
-        let result = find_ax_node_by_role(&nodes, "link", Some("More"), false);
-        assert_eq!(result.unwrap(), 10);
+        let (id, _) = find_ax_node_by_role(&nodes, "link", Some("More"), false).unwrap();
+        assert_eq!(id, 10);
     }
 
     #[test]
@@ -8557,8 +8565,8 @@ mod tests {
             make_ax_node("2", "button", "Submit", Some(6), false),
         ];
 
-        let result = find_ax_node_by_role(&nodes, "button", None, false);
-        assert_eq!(result.unwrap(), 6);
+        let (id, _) = find_ax_node_by_role(&nodes, "button", None, false).unwrap();
+        assert_eq!(id, 6);
     }
 
     #[test]
@@ -8571,7 +8579,7 @@ mod tests {
         let result = find_ax_node_by_role(&nodes, "link", Some("Hidden Link"), true);
         assert!(result.is_err());
 
-        let result = find_ax_node_by_role(&nodes, "link", Some("Visible Link"), true);
-        assert_eq!(result.unwrap(), 100);
+        let (id, _) = find_ax_node_by_role(&nodes, "link", Some("Visible Link"), true).unwrap();
+        assert_eq!(id, 100);
     }
 }

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -103,6 +103,10 @@ impl RefMap {
         entries
     }
 
+    pub fn remove(&mut self, ref_id: &str) {
+        self.map.remove(ref_id);
+    }
+
     pub fn clear(&mut self) {
         self.map.clear();
         self.next_ref = 1;


### PR DESCRIPTION
## Summary

Fixes #1123

`find role link` generated `querySelectorAll('[role="link"], link')` which matched `<link>` stylesheet elements instead of `<a>` anchor tags. This happened because ARIA role names were used directly as CSS tag selectors — `link` is the ARIA role, but the HTML element is `<a>`.

This PR replaces the JS-based DOM query with the CDP `Accessibility.getFullAXTree` API, where the browser engine correctly computes implicit ARIA roles per the [WAI-ARIA / HTML-AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings). Matched elements are resolved via a temporary ref entry in the existing ref system, avoiding marker attribute DOM pollution entirely.

### Approach

1. Query the browser's accessibility tree via `Accessibility.getFullAXTree`
2. Find the matching AX node by role/name in Rust (`find_ax_node_by_role`)
3. Register a temporary ref with the `backendDOMNodeId` in the ref_map
4. `execute_subaction` resolves the element via the ref system directly


### Why CDP Accessibility Tree?

| Approach | Role judgment | Maintenance | Accuracy |
|----------|--------------|-------------|----------|
| CSS selector mapping (e.g. `link` → `a[href]`) | Our table | Manual updates | Incomplete — conditional roles hard to express |
| **CDP Accessibility Tree** ✅ | Browser engine | Automatic with Chrome updates | 100% — browser is the authority |

### Reproduction (before → after)

```bash
agent-browser navigate https://example.com

# BEFORE: ✗ "No element found: getByRole('link', { name: 'Learn more', exact: true })"
# AFTER:  ✓ Done (clicks the <a> element correctly)
agent-browser find role link click --name "Learn more" --exact
```

## Test plan

- [x] `cargo check` / `cargo fmt` / `cargo clippy` — all clean
- [x] `cargo test` — 597 passed, 0 failed (+ 4 new regression tests)
- [x] Manual verification on https://example.com — `find role link click --name "Learn more" --exact` succeeds
- [x] `find role link click` (no name) — finds first link
- [x] `find role link click --name "Learn"` (substring) — matches
- [x] `find role link click --name "Learn" --exact` — correctly rejects partial match
- [x] `find role button click --name "Google 검색"` — button role regression check