### PR TITLE
fix: replace PR_SET_PDEATHSIG with sentinel process for orphan prevention

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -9,12 +9,36 @@ pub struct ChromeProcess {
     child: Child,
     pub ws_url: String,
     temp_user_data_dir: Option<PathBuf>,
+    /// On Unix, the process group ID used to kill the entire Chrome process tree.
+    #[cfg(unix)]
+    pgid: Option<i32>,
 }
 
 impl ChromeProcess {
     pub fn kill(&mut self) {
         let _ = self.child.kill();
+        // On Unix, kill the entire process group to ensure Chrome helper
+        // processes (GPU, renderer, utility, crashpad) are also terminated.
+        // This prevents orphaned Chrome processes from blocking the user's
+        // normal Chrome (issue #1113).
+        #[cfg(unix)]
+        if let Some(pgid) = self.pgid {
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
         let _ = self.child.wait();
+    }
+
+    /// Returns the OS process ID of the Chrome child process.
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Non-blocking check whether Chrome has exited.
+    /// Returns `true` if the process has exited (and reaps it), `false` if still running.
+    pub fn has_exited(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(Some(_)) | Err(_))
     }
 
     /// Wait for Chrome to exit on its own (after Browser.close CDP command),
@@ -62,6 +86,7 @@ impl Drop for ChromeProcess {
     }
 }
 
+#[derive(Clone)]
 pub struct LaunchOptions {
     pub headless: bool,
     pub executable_path: Option<String>,
@@ -78,6 +103,10 @@ pub struct LaunchOptions {
     pub ignore_https_errors: bool,
     pub color_scheme: Option<String>,
     pub download_path: Option<String>,
+    /// When true, omit `--password-store=basic` and `--use-mock-keychain` so
+    /// Chrome uses the real system keychain. Set automatically when launching
+    /// with a copied Chrome profile.
+    pub use_real_keychain: bool,
 }
 
 impl Default for LaunchOptions {
@@ -98,6 +127,7 @@ impl Default for LaunchOptions {
             ignore_https_errors: false,
             color_scheme: None,
             download_path: None,
+            use_real_keychain: false,
         }
     }
 }
@@ -124,9 +154,12 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         "--disable-features=Translate".to_string(),
         "--enable-features=NetworkService,NetworkServiceInProcess".to_string(),
         "--metrics-recording-only".to_string(),
-        "--password-store=basic".to_string(),
-        "--use-mock-keychain".to_string(),
     ];
+
+    if !options.use_real_keychain {
+        args.push("--password-store=basic".to_string());
+        args.push("--use-mock-keychain".to_string());
+    }
 
     let has_extensions = options
         .extensions
@@ -165,6 +198,10 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         args.push(format!("--user-data-dir={}", dir.display()));
         (dir.clone(), Some(dir))
     };
+
+    if options.ignore_https_errors {
+        args.push("--ignore-certificate-errors".to_string());
+    }
 
     if options.allow_file_access {
         args.push("--allow-file-access-from-files".to_string());
@@ -208,17 +245,61 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
 pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
     let chrome_path = match &options.executable_path {
         Some(p) => PathBuf::from(p),
-        None => {
-            find_chrome().ok_or("Chrome not found. Run `agent-browser install` to download Chrome, or use --executable-path.")?
-        }
+        None => find_chrome().ok_or_else(|| {
+            let cache_dir = crate::install::get_browsers_dir();
+            format!(
+                "Chrome not found. Checked:\n  \
+                 - agent-browser cache: {}\n  \
+                 - System Chrome installations\n  \
+                 - Puppeteer browser cache\n  \
+                 - Playwright browser cache\n\
+                 Run `agent-browser install` to download Chrome, or use --executable-path.",
+                cache_dir.display()
+            )
+        })?,
     };
+
+    // Profile name preprocessing: if --profile is a Chrome profile name (not a
+    // path), resolve it to a directory, copy the profile to a temp dir, and
+    // rewrite options so the retry loop uses the copied profile.
+    let mut resolved_options: Option<LaunchOptions> = None;
+    let mut profile_temp_dir: Option<PathBuf> = None;
+
+    if let Some(ref profile) = options.profile {
+        if is_chrome_profile_name(profile) {
+            let user_data_dir = find_chrome_user_data_dir().ok_or_else(|| {
+                "No Chrome user data directory found. Cannot resolve profile name.\n\
+                 If you meant a directory path, use a full path (e.g., /path/to/profile)."
+                    .to_string()
+            })?;
+            let resolved = resolve_chrome_profile(&user_data_dir, profile)?;
+            let temp_path = copy_chrome_profile(&user_data_dir, &resolved)?;
+
+            let mut opts = options.clone();
+            opts.profile = Some(temp_path.display().to_string());
+            opts.use_real_keychain = true;
+            opts.args.push(format!("--profile-directory={}", resolved));
+            profile_temp_dir = Some(temp_path);
+            resolved_options = Some(opts);
+        }
+    }
+
+    let effective_options = resolved_options.as_ref().unwrap_or(options);
 
     let max_attempts = 3;
     let mut last_err = String::new();
 
     for attempt in 1..=max_attempts {
-        match try_launch_chrome(&chrome_path, options) {
-            Ok(process) => return Ok(process),
+        match try_launch_chrome(&chrome_path, effective_options) {
+            Ok(mut process) => {
+                // Transfer profile temp dir ownership to ChromeProcess for cleanup on Drop.
+                // The try_launch_chrome temp_user_data_dir is None here because we set profile
+                // to the temp path (treated as a user-supplied path, no second temp dir).
+                if let Some(ref dir) = profile_temp_dir {
+                    process.temp_user_data_dir = Some(dir.clone());
+                }
+                return Ok(process);
+            }
             Err(e) => {
                 last_err = e;
                 if attempt < max_attempts {
@@ -234,6 +315,11 @@ pub fn launch_chrome(options: &LaunchOptions) -> Result<ChromeProcess, String> {
                 }
             }
         }
+    }
+
+    // All retries failed: clean up profile temp dir if we created one
+    if let Some(ref dir) = profile_temp_dir {
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     Err(last_err)
@@ -256,16 +342,88 @@ fn try_launch_chrome(chrome_path: &Path, options: &LaunchOptions) -> Result<Chro
         }
     };
 
-    let mut child = Command::new(chrome_path)
-        .args(&args)
+    let mut cmd = Command::new(chrome_path);
+    cmd.args(&args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            cleanup_temp_dir(&temp_user_data_dir);
-            format!("Failed to launch Chrome at {:?}: {}", chrome_path, e)
-        })?;
+        .stderr(Stdio::piped());
+
+    // Place Chrome in its own process group so we can kill the entire tree
+    // (main process + GPU/renderer/utility/crashpad helpers) with a single
+    // killpg(), preventing orphaned processes (issue #1113).
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: pre_exec runs between fork() and exec() in the child.
+        // setpgid is async-signal-safe.
+        unsafe {
+            cmd.pre_exec(|| {
+                // Create a new process group (PGID = own PID) so the
+                // daemon can kill the entire Chrome tree in one call.
+                libc::setpgid(0, 0);
+                Ok(())
+            });
+        }
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        cleanup_temp_dir(&temp_user_data_dir);
+        format!("Failed to launch Chrome at {:?}: {}", chrome_path, e)
+    })?;
+
+    // Orphan prevention when the daemon is SIGKILL'd:
+    //
+    // Previously used PR_SET_PDEATHSIG(SIGKILL) in pre_exec, but that tracks
+    // the THREAD that called fork(), not the PROCESS (documented in prctl(2)).
+    // In tokio's multi-threaded runtime, the worker thread that spawns Chrome
+    // gets recycled after idle time, causing the kernel to kill Chrome even
+    // though the daemon process is still alive. See issue #1148.
+    //
+    // Fix: a sentinel process joins Chrome's process group and monitors a
+    // keepalive pipe. The daemon holds the write end (process-scoped fd,
+    // shared by all threads, survives worker recycling). When the daemon
+    // dies for ANY reason (including SIGKILL), the kernel closes all fds,
+    // the pipe breaks, the sentinel reads EOF, and kills Chrome's group.
+    #[cfg(unix)]
+    {
+        let chrome_pgid = child.id() as i32;
+        let mut fds = [0i32; 2];
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } == 0 {
+            let read_fd = fds[0];
+            let write_fd = fds[1];
+            let sentinel_pid = unsafe { libc::fork() };
+            if sentinel_pid == 0 {
+                // Sentinel process: join Chrome's group, monitor pipe
+                unsafe {
+                    libc::setpgid(0, chrome_pgid);
+                    libc::close(write_fd);
+                    // Minimize resource usage
+                    libc::close(0);
+                    libc::close(1);
+                    let devnull = libc::open(
+                        b"/dev/null\0".as_ptr() as *const _,
+                        libc::O_WRONLY,
+                    );
+                    if devnull >= 0 {
+                        libc::dup2(devnull, 2);
+                        libc::close(devnull);
+                    }
+                    // Block until pipe breaks (daemon died)
+                    let mut buf = [0u8; 1];
+                    libc::read(read_fd, buf.as_mut_ptr() as *mut libc::c_void, 1);
+                    libc::close(read_fd);
+                    // Kill Chrome's entire process group
+                    libc::kill(-chrome_pgid, libc::SIGKILL);
+                    libc::_exit(0);
+                }
+            } else if sentinel_pid > 0 {
+                // Daemon: close read end, intentionally leak write end.
+                // The write fd stays open as long as the daemon process lives.
+                unsafe { libc::close(read_fd); }
+            }
+            // If fork fails, process group kill in Drop is the fallback.
+        }
+    }
 
     // Shared overall deadline so we don't double-wait (poll + stderr fallback).
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
@@ -297,10 +455,20 @@ fn try_launch_chrome(chrome_path: &Path, options: &LaunchOptions) -> Result<Chro
         }
     };
 
+    #[cfg(unix)]
+    let pgid = {
+        let pid = child.id() as i32;
+        // The child called setpgid(0,0) via process_group(0), so its PGID
+        // equals its own PID.
+        Some(pid)
+    };
+
     Ok(ChromeProcess {
         child,
         ws_url,
         temp_user_data_dir,
+        #[cfg(unix)]
+        pgid,
     })
 }
 
@@ -427,6 +595,18 @@ pub fn find_chrome() -> Option<PathBuf> {
         return Some(p);
     }
 
+    // If the cache directory exists but no Chrome was found, warn -- this
+    // likely means the cache is corrupted or the directory layout is unexpected.
+    let cache_dir = crate::install::get_browsers_dir();
+    if cache_dir.exists() {
+        let _ = writeln!(
+            std::io::stderr(),
+            "Warning: Chrome cache directory exists ({}) but no Chrome binary found inside. \
+             Falling back to system Chrome. Run `agent-browser install` to re-download.",
+            cache_dir.display()
+        );
+    }
+
     // 2. Check system-installed Chrome
     #[cfg(target_os = "macos")]
     {
@@ -491,7 +671,10 @@ pub fn find_chrome() -> Option<PathBuf> {
         }
     }
 
-    // 3. Fallback: check Playwright's browser cache (for existing installs)
+    // 3. Fallback: check Puppeteer / Playwright browser caches
+    if let Some(p) = find_puppeteer_chrome() {
+        return Some(p);
+    }
     if let Some(p) = find_playwright_chromium() {
         return Some(p);
     }
@@ -551,7 +734,9 @@ fn is_port_reachable(port: u16) -> bool {
     TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_millis(500)).is_ok()
 }
 
-fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
+/// Returns the default Chrome user-data directory paths for the current platform.
+/// Includes Chrome, Chrome Canary, Chromium, and Brave.
+pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
     #[cfg(target_os = "macos")]
@@ -600,6 +785,251 @@ fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
     }
 
     dirs
+}
+
+/// Returns true if the given string looks like a Chrome profile name rather than
+/// a file path. A profile name contains no `/`, `\`, or `~` characters.
+pub fn is_chrome_profile_name(s: &str) -> bool {
+    !s.contains('/') && !s.contains('\\') && !s.contains('~')
+}
+
+/// Returns the first existing Chrome user-data directory that contains a
+/// `Local State` file.
+pub fn find_chrome_user_data_dir() -> Option<PathBuf> {
+    get_chrome_user_data_dirs()
+        .into_iter()
+        .find(|dir| dir.join("Local State").is_file())
+}
+
+/// A Chrome profile entry parsed from `Local State`.
+#[derive(Debug, Clone)]
+pub struct ChromeProfile {
+    /// The directory name (e.g., "Default", "Profile 1").
+    pub directory: String,
+    /// The user-visible display name (e.g., "Person 1").
+    pub name: String,
+}
+
+/// Lists all Chrome profiles found in the given user-data directory by reading
+/// the `Local State` JSON file. Returns an empty vec if the file is missing,
+/// malformed, or lacks the expected `profile.info_cache` key.
+pub fn list_chrome_profiles(user_data_dir: &Path) -> Vec<ChromeProfile> {
+    let local_state_path = user_data_dir.join("Local State");
+    let content = match std::fs::read_to_string(&local_state_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let json: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let info_cache = match json.get("profile").and_then(|p| p.get("info_cache")) {
+        Some(obj) if obj.is_object() => obj.as_object().unwrap(),
+        _ => return Vec::new(),
+    };
+
+    let mut profiles: Vec<ChromeProfile> = info_cache
+        .iter()
+        .map(|(dir_name, info)| {
+            let display_name = info
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(dir_name)
+                .to_string();
+            ChromeProfile {
+                directory: dir_name.clone(),
+                name: display_name,
+            }
+        })
+        .collect();
+    profiles.sort_by(|a, b| a.directory.cmp(&b.directory));
+    profiles
+}
+
+/// Resolves a profile input string to a Chrome profile directory name using
+/// three-tier matching:
+/// 1. Exact directory name match
+/// 2. Case-insensitive display name match (error if ambiguous)
+/// 3. Case-insensitive directory name match
+///
+/// Returns the resolved directory name, or an error with available profiles.
+pub fn resolve_chrome_profile(user_data_dir: &Path, input: &str) -> Result<String, String> {
+    let profiles = list_chrome_profiles(user_data_dir);
+
+    if profiles.is_empty() {
+        return Err(format!(
+            "No Chrome profiles found in {}.\n\
+             If you meant a directory path, use a full path (e.g., /path/to/profile).",
+            user_data_dir.display()
+        ));
+    }
+
+    // Tier 1: exact directory name match
+    if let Some(p) = profiles.iter().find(|p| p.directory == input) {
+        return Ok(p.directory.clone());
+    }
+
+    // Tier 2: case-insensitive display name match
+    let input_lower = input.to_lowercase();
+    let display_matches: Vec<&ChromeProfile> = profiles
+        .iter()
+        .filter(|p| p.name.to_lowercase() == input_lower)
+        .collect();
+    match display_matches.len() {
+        1 => return Ok(display_matches[0].directory.clone()),
+        n if n > 1 => {
+            return Err(format!(
+                "Ambiguous profile name \"{}\". Multiple profiles match:\n{}\n\
+                 Use the directory name instead.",
+                input,
+                format_profile_list(&display_matches)
+            ));
+        }
+        _ => {}
+    }
+
+    // Tier 3: case-insensitive directory name match
+    if let Some(p) = profiles
+        .iter()
+        .find(|p| p.directory.to_lowercase() == input_lower)
+    {
+        return Ok(p.directory.clone());
+    }
+
+    let all_profiles: Vec<&ChromeProfile> = profiles.iter().collect();
+    Err(format!(
+        "Chrome profile \"{}\" not found. Available profiles:\n{}\n\
+         If you meant a directory path, use a full path (e.g., /path/to/profile).",
+        input,
+        format_profile_list(&all_profiles)
+    ))
+}
+
+fn format_profile_list(profiles: &[&ChromeProfile]) -> String {
+    profiles
+        .iter()
+        .map(|p| format!("  {} ({})", p.directory, p.name))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Directories to exclude when copying a Chrome profile. These are large
+/// non-auth directories that are not needed for reusing login state.
+const PROFILE_COPY_EXCLUDE_DIRS: &[&str] = &[
+    "Cache",
+    "Code Cache",
+    "GPUCache",
+    "Service Worker",
+    "blob_storage",
+    "File System",
+    "GCM Store",
+    "optimization_guide",
+    "ShaderCache",
+    "component_crx_cache",
+];
+
+/// Copies a Chrome profile subdirectory and `Local State` to a temp directory
+/// with a two-level structure suitable for `--user-data-dir`. Returns the temp
+/// directory path on success.
+///
+/// The copy is best-effort: individual file failures (e.g., `SingletonLock`)
+/// are skipped with a warning. If the source profile directory is missing or
+/// the temp dir cannot be created, returns an error after cleaning up.
+pub fn copy_chrome_profile(
+    user_data_dir: &Path,
+    profile_directory: &str,
+) -> Result<PathBuf, String> {
+    let temp_dir =
+        std::env::temp_dir().join(format!("agent-browser-profile-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&temp_dir)
+        .map_err(|e| format!("Failed to create temp profile dir: {}", e))?;
+
+    // Copy Local State (non-fatal if missing or unreadable)
+    let local_state_src = user_data_dir.join("Local State");
+    if let Err(e) = std::fs::copy(&local_state_src, temp_dir.join("Local State")) {
+        let _ = writeln!(
+            std::io::stderr(),
+            "Warning: could not copy Local State from {}: {}",
+            local_state_src.display(),
+            e
+        );
+    }
+
+    // Copy profile subdirectory
+    let src_profile = user_data_dir.join(profile_directory);
+    if !src_profile.is_dir() {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        return Err(format!(
+            "Profile directory not found: {}",
+            src_profile.display()
+        ));
+    }
+    let dst_profile = temp_dir.join(profile_directory);
+    if let Err(e) = copy_dir_recursive(&src_profile, &dst_profile) {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        return Err(format!("Failed to copy profile: {}", e));
+    }
+
+    Ok(temp_dir)
+}
+
+/// Recursively copies a directory, skipping entries in [`PROFILE_COPY_EXCLUDE_DIRS`].
+/// Individual file copy failures are logged to stderr but do not fail the operation.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dst)
+        .map_err(|e| format!("Failed to create directory {}: {}", dst.display(), e))?;
+
+    let entries = std::fs::read_dir(src)
+        .map_err(|e| format!("Failed to read directory {}: {}", src.display(), e))?;
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "Warning: failed to read entry in {}: {}",
+                    src.display(),
+                    e
+                );
+                continue;
+            }
+        };
+
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        let src_path = entry.path();
+        let dst_path = dst.join(&name);
+
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(e) => {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "Warning: failed to get file type for {}: {}",
+                    src_path.display(),
+                    e
+                );
+                continue;
+            }
+        };
+
+        if file_type.is_dir() {
+            if PROFILE_COPY_EXCLUDE_DIRS.contains(&name_str.as_ref()) {
+                continue;
+            }
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else if let Err(e) = std::fs::copy(&src_path, &dst_path) {
+            let _ = writeln!(
+                std::io::stderr(),
+                "Warning: failed to copy {}: {}",
+                src_path.display(),
+                e
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Returns true if Chrome's sandbox should be disabled because the environment
@@ -671,6 +1101,76 @@ fn should_disable_dev_shm(existing_args: &[String]) -> bool {
     }
 
     false
+}
+
+/// Search Puppeteer's browser cache for a Chrome binary.
+/// Puppeteer v19+ stores Chrome in ~/.cache/puppeteer/chrome/<platform>-<version>/
+fn find_puppeteer_chrome() -> Option<PathBuf> {
+    let mut search_dirs = Vec::new();
+
+    if let Ok(custom) = std::env::var("PUPPETEER_CACHE_DIR") {
+        search_dirs.push(PathBuf::from(custom).join("chrome"));
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        search_dirs.push(home.join(".cache/puppeteer/chrome"));
+    }
+
+    for dir in &search_dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            let mut matches: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .filter_map(|e| {
+                    let candidate = build_puppeteer_binary_path(&e.path());
+                    if candidate.exists() {
+                        Some(candidate)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            matches.sort();
+            matches.reverse();
+            if let Some(p) = matches.into_iter().next() {
+                return Some(p);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn build_puppeteer_binary_path(version_dir: &Path) -> PathBuf {
+    version_dir.join("chrome-linux64/chrome")
+}
+
+#[cfg(target_os = "macos")]
+fn build_puppeteer_binary_path(version_dir: &Path) -> PathBuf {
+    // Puppeteer uses chrome-mac-arm64 or chrome-mac-x64 depending on arch
+    let arm = version_dir.join(
+        "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    );
+    if arm.exists() {
+        return arm;
+    }
+    version_dir.join(
+        "chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn build_puppeteer_binary_path(version_dir: &Path) -> PathBuf {
+    version_dir.join(r"chrome-win64\chrome.exe")
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn build_puppeteer_binary_path(version_dir: &Path) -> PathBuf {
+    version_dir.join("chrome")
 }
 
 /// Search Playwright's browser cache for a Chromium binary.
@@ -839,8 +1339,22 @@ mod tests {
 
     #[test]
     fn test_find_playwright_chromium_nonexistent() {
-        let _guard = EnvGuard::new(&["PLAYWRIGHT_BROWSERS_PATH"]);
-        _guard.set("PLAYWRIGHT_BROWSERS_PATH", "/nonexistent/path");
+        let guard = EnvGuard::new(&["PLAYWRIGHT_BROWSERS_PATH", "HOME", "USERPROFILE"]);
+        guard.set("PLAYWRIGHT_BROWSERS_PATH", "/nonexistent/path");
+
+        let temp_home = std::env::temp_dir().join(format!(
+            "agent-browser-test-home-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_home).expect("temp home should be created");
+        let temp_home = temp_home.to_string_lossy().to_string();
+        guard.set("HOME", &temp_home);
+        guard.set("USERPROFILE", &temp_home);
+
         let result = find_playwright_chromium();
         assert!(result.is_none());
     }
@@ -1002,6 +1516,35 @@ mod tests {
     }
 
     #[test]
+    fn test_build_args_ignore_https_errors_includes_flag() {
+        let opts = LaunchOptions {
+            ignore_https_errors: true,
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--ignore-certificate-errors"));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_ignore_https_errors_default_no_flag() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(!result
+            .args
+            .iter()
+            .any(|a| a == "--ignore-certificate-errors"));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
     fn test_chrome_process_drop_cleans_temp_dir() {
         let dir = std::env::temp_dir().join(format!(
             "agent-browser-chrome-drop-test-{}",
@@ -1019,10 +1562,314 @@ mod tests {
                 child,
                 ws_url: String::new(),
                 temp_user_data_dir: Some(dir.clone()),
+                #[cfg(unix)]
+                pgid: None,
             };
             // _process dropped here
         }
 
         assert!(!dir.exists(), "Temp dir should be cleaned up on drop");
+    }
+
+    #[test]
+    fn test_is_chrome_profile_name_simple() {
+        assert!(is_chrome_profile_name("Default"));
+        assert!(is_chrome_profile_name("Profile 1"));
+        assert!(is_chrome_profile_name(""));
+    }
+
+    #[test]
+    fn test_is_chrome_profile_name_paths() {
+        assert!(!is_chrome_profile_name("/tmp/dir"));
+        assert!(!is_chrome_profile_name("~/my-profile"));
+        assert!(!is_chrome_profile_name("C:\\Users\\foo"));
+        assert!(!is_chrome_profile_name("relative/path"));
+    }
+
+    /// Helper to create a fake Chrome user-data dir with a `Local State` file.
+    fn create_fake_local_state(base: &Path, profiles: &[(&str, &str)]) {
+        let mut info_cache = serde_json::Map::new();
+        for (dir_name, display_name) in profiles {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String(display_name.to_string()),
+            );
+            info_cache.insert(dir_name.to_string(), serde_json::Value::Object(entry));
+        }
+
+        let local_state = serde_json::json!({
+            "profile": {
+                "info_cache": info_cache
+            }
+        });
+
+        std::fs::create_dir_all(base).unwrap();
+        std::fs::write(
+            base.join("Local State"),
+            serde_json::to_string_pretty(&local_state).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// RAII guard that removes the temp directory on drop (even on panic).
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            Self(std::env::temp_dir().join(format!(
+                "agent-browser-test-{}-{}-{}",
+                name,
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            )))
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    impl std::ops::Deref for TempDir {
+        type Target = PathBuf;
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+
+    #[test]
+    fn test_list_chrome_profiles_valid() {
+        let dir = TempDir::new("list-profiles");
+        create_fake_local_state(&dir, &[("Default", "Person 1"), ("Profile 1", "Work")]);
+
+        let profiles = list_chrome_profiles(&dir);
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].directory, "Default");
+        assert_eq!(profiles[0].name, "Person 1");
+        assert_eq!(profiles[1].directory, "Profile 1");
+        assert_eq!(profiles[1].name, "Work");
+    }
+
+    #[test]
+    fn test_list_chrome_profiles_missing_local_state() {
+        let dir = TempDir::new("list-profiles-missing");
+        std::fs::create_dir_all(&*dir).unwrap();
+        let profiles = list_chrome_profiles(&dir);
+        assert!(profiles.is_empty());
+    }
+
+    #[test]
+    fn test_list_chrome_profiles_malformed_json() {
+        let dir = TempDir::new("list-profiles-malformed");
+        std::fs::create_dir_all(&*dir).unwrap();
+        std::fs::write(dir.join("Local State"), "not json").unwrap();
+        let profiles = list_chrome_profiles(&dir);
+        assert!(profiles.is_empty());
+    }
+
+    #[test]
+    fn test_list_chrome_profiles_missing_info_cache() {
+        let dir = TempDir::new("list-profiles-no-cache");
+        std::fs::create_dir_all(&*dir).unwrap();
+        std::fs::write(dir.join("Local State"), r#"{"profile": {}}"#).unwrap();
+        let profiles = list_chrome_profiles(&dir);
+        assert!(profiles.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_chrome_profile_exact_directory() {
+        let dir = TempDir::new("resolve-exact");
+        create_fake_local_state(&dir, &[("Default", "Person 1"), ("Profile 1", "Work")]);
+
+        let result = resolve_chrome_profile(&dir, "Default");
+        assert_eq!(result.unwrap(), "Default");
+    }
+
+    #[test]
+    fn test_resolve_chrome_profile_display_name_case_insensitive() {
+        let dir = TempDir::new("resolve-display");
+        create_fake_local_state(&dir, &[("Default", "Person 1"), ("Profile 1", "Work")]);
+
+        let result = resolve_chrome_profile(&dir, "work");
+        assert_eq!(result.unwrap(), "Profile 1");
+    }
+
+    #[test]
+    fn test_resolve_chrome_profile_directory_name_case_insensitive() {
+        let dir = TempDir::new("resolve-dir-ci");
+        create_fake_local_state(&dir, &[("Default", "Person 1"), ("Profile 1", "Work")]);
+
+        let result = resolve_chrome_profile(&dir, "default");
+        assert_eq!(result.unwrap(), "Default");
+    }
+
+    #[test]
+    fn test_resolve_chrome_profile_not_found() {
+        let dir = TempDir::new("resolve-notfound");
+        create_fake_local_state(&dir, &[("Default", "Person 1")]);
+
+        let result = resolve_chrome_profile(&dir, "Nonexistent");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("not found"));
+        assert!(err.contains("Default"));
+        assert!(err.contains("full path"));
+    }
+
+    #[test]
+    fn test_resolve_chrome_profile_ambiguous_display_name() {
+        let dir = TempDir::new("resolve-ambiguous");
+        create_fake_local_state(&dir, &[("Default", "Work"), ("Profile 1", "Work")]);
+
+        let result = resolve_chrome_profile(&dir, "Work");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Ambiguous"));
+        assert!(err.contains("Default"));
+        assert!(err.contains("Profile 1"));
+    }
+
+    /// Helper to create a fake Chrome profile directory with some files.
+    fn create_fake_profile(user_data_dir: &Path, profile_dir: &str) {
+        let profile_path = user_data_dir.join(profile_dir);
+        std::fs::create_dir_all(profile_path.join("Local Storage/leveldb")).unwrap();
+        std::fs::write(profile_path.join("Cookies"), "fake-cookies").unwrap();
+        std::fs::write(
+            profile_path.join("Local Storage/leveldb/CURRENT"),
+            "fake-leveldb",
+        )
+        .unwrap();
+        // Create an excluded directory to verify it's skipped
+        std::fs::create_dir_all(profile_path.join("Cache")).unwrap();
+        std::fs::write(profile_path.join("Cache/data_0"), "cache-data").unwrap();
+    }
+
+    #[test]
+    fn test_copy_chrome_profile_structure() {
+        let src = TempDir::new("copy-src");
+        create_fake_local_state(&src, &[("Default", "Person 1")]);
+        create_fake_profile(&src, "Default");
+
+        let temp_path = copy_chrome_profile(&src, "Default").unwrap();
+        let temp = TempDir(temp_path);
+
+        assert!(temp.join("Local State").is_file());
+        assert!(temp.join("Default/Cookies").is_file());
+        assert!(temp.join("Default/Local Storage/leveldb/CURRENT").is_file());
+        assert_eq!(
+            std::fs::read_to_string(temp.join("Default/Cookies")).unwrap(),
+            "fake-cookies"
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.join("Default/Local Storage/leveldb/CURRENT")).unwrap(),
+            "fake-leveldb"
+        );
+        assert!(!temp.join("Default/Cache").exists());
+    }
+
+    #[test]
+    fn test_copy_chrome_profile_missing_source() {
+        let src = TempDir::new("copy-missing-src");
+        std::fs::create_dir_all(&*src).unwrap();
+
+        let result = copy_chrome_profile(&src, "Nonexistent");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Profile directory not found"));
+    }
+
+    #[test]
+    fn test_copy_chrome_profile_missing_local_state() {
+        let src = TempDir::new("copy-no-ls");
+        let profile_path = src.join("Default");
+        std::fs::create_dir_all(&profile_path).unwrap();
+        std::fs::write(profile_path.join("Cookies"), "data").unwrap();
+
+        let temp_path = copy_chrome_profile(&src, "Default").unwrap();
+        let temp = TempDir(temp_path);
+
+        assert!(!temp.join("Local State").exists());
+        assert!(temp.join("Default/Cookies").is_file());
+    }
+
+    #[test]
+    fn test_copy_dir_recursive_excludes() {
+        let src = TempDir::new("copy-excludes-src");
+        let dst = TempDir::new("copy-excludes-dst");
+        std::fs::create_dir_all(src.join("keep")).unwrap();
+        std::fs::write(src.join("keep/data"), "keep-data").unwrap();
+        for excluded in PROFILE_COPY_EXCLUDE_DIRS {
+            std::fs::create_dir_all(src.join(excluded)).unwrap();
+            std::fs::write(src.join(excluded).join("file"), "excluded").unwrap();
+        }
+
+        copy_dir_recursive(&src, &dst).unwrap();
+
+        assert!(dst.join("keep/data").is_file());
+        for excluded in PROFILE_COPY_EXCLUDE_DIRS {
+            assert!(
+                !dst.join(excluded).exists(),
+                "{} should be excluded",
+                excluded
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_args_use_real_keychain_true() {
+        let opts = LaunchOptions {
+            use_real_keychain: true,
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            !result.args.iter().any(|a| a == "--password-store=basic"),
+            "should NOT have --password-store=basic when use_real_keychain is true"
+        );
+        assert!(
+            !result.args.iter().any(|a| a == "--use-mock-keychain"),
+            "should NOT have --use-mock-keychain when use_real_keychain is true"
+        );
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_use_real_keychain_false_default() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            result.args.iter().any(|a| a == "--password-store=basic"),
+            "should have --password-store=basic by default"
+        );
+        assert!(
+            result.args.iter().any(|a| a == "--use-mock-keychain"),
+            "should have --use-mock-keychain by default"
+        );
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_profile_path_preserves_keychain_flags() {
+        let opts = LaunchOptions {
+            profile: Some("/tmp/my-profile".to_string()),
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--user-data-dir=/tmp/my-profile"));
+        assert!(
+            result.args.iter().any(|a| a == "--password-store=basic"),
+            "profile path should keep keychain flags"
+        );
     }
 }


### PR DESCRIPTION
## Problem

v0.24.1's `prctl(PR_SET_PDEATHSIG, SIGKILL)` (PR #1137) causes Chrome to be killed after ~7 seconds of idle time. `PR_SET_PDEATHSIG` tracks the **thread** that called `fork()`, not the **process** — documented in `prctl(2)`:

> *"the 'parent' is considered to be the **thread** that created this process"*

In tokio's multi-threaded runtime, the worker thread that spawns Chrome gets recycled after idle time → kernel sends SIGKILL to Chrome → page navigates to `about:blank`.

## Reproduction

```bash
# v0.24.1 — Chrome dies after ~7s
agent-browser open https://example.com
sleep 10
agent-browser get url  # → about:blank ❌

# v0.24.0 — works fine
agent-browser open https://example.com
sleep 15
agent-browser get url  # → https://example.com/ ✅
```

Tested with zero env vars, zero custom args, pure v0.24.1 binary. Happens on every site, headless and headed.

## Fix

Replace `PR_SET_PDEATHSIG` with a **sentinel process + keepalive pipe**:

1. After Chrome starts, fork a tiny sentinel that joins Chrome's process group
2. Sentinel blocks on reading a pipe — daemon holds the write end (process-scoped fd, shared by all threads)
3. When daemon dies (ANY reason including SIGKILL): pipe breaks → sentinel kills Chrome's group

## Validation

| Test | Before | After |
|---|---|---|
| Page idle 15s | about:blank at 7s ❌ | stays ✅ |
| 5 downloads + 10s delays | crashes after 2nd ❌ | all 5 work ✅ |
| SIGKILL daemon → orphans? | N/A (PR_SET_PDEATHSIG) | 0 orphans ✅ |
| `cargo test` | 597 passed | 597 passed, 0 failed ✅ |

Fixes #1148

🤖 Generated with [Claude Code](https://claude.ai/claude-code)