### PR TITLE
Add --ignore-default-args flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--init-script <path>` | Register a page init script before the first navigation (repeatable; or `AGENT_BROWSER_INIT_SCRIPTS` env) |
 | `--enable <feature>` | Built-in init scripts: `react-devtools` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
 | `--args <args>` | Browser launch args, comma or newline separated (or `AGENT_BROWSER_ARGS` env) |
+| `--ignore-default-args <list>` | Remove specific default Chrome flags, comma-separated (or `AGENT_BROWSER_IGNORE_DEFAULT_ARGS` env) |
 | `--user-agent <ua>` | Custom User-Agent string (or `AGENT_BROWSER_USER_AGENT` env) |
 | `--proxy <url>` | Proxy server URL with optional auth (or `AGENT_BROWSER_PROXY` env) |
 | `--proxy-bypass <hosts>` | Hosts to bypass proxy (or `AGENT_BROWSER_PROXY_BYPASS` env) |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2715,6 +2715,8 @@ mod tests {
             cli_annotate: false,
             cli_download_path: false,
             cli_headed: false,
+            cli_ignore_default_args: false,
+            ignore_default_args: None,
             annotate: false,
             color_scheme: None,
             download_path: None,

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -414,6 +414,7 @@ pub struct DaemonOptions<'a> {
     pub default_timeout: Option<u64>,
     pub cdp: Option<&'a str>,
     pub no_auto_dialog: bool,
+    pub ignore_default_args: Option<&'a [String]>,
 }
 
 fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
@@ -506,6 +507,11 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if opts.no_auto_dialog {
         cmd.env("AGENT_BROWSER_NO_AUTO_DIALOG", "1");
+    }
+    if let Some(ida) = opts.ignore_default_args {
+        if !ida.is_empty() {
+            cmd.env("AGENT_BROWSER_IGNORE_DEFAULT_ARGS", ida.join(","));
+        }
     }
 }
 

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -80,6 +80,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         default_timeout: None,
         cdp: None,
         no_auto_dialog: false,
+        ignore_default_args: None,
     };
 
     let started = Instant::now();

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -91,6 +91,7 @@ pub struct Config {
     pub idle_timeout: Option<String>,
     pub no_auto_dialog: Option<bool>,
     pub model: Option<String>,
+    pub ignore_default_args: Option<Vec<String>>,
 }
 
 impl Config {
@@ -152,6 +153,7 @@ impl Config {
             idle_timeout: other.idle_timeout.or(self.idle_timeout),
             no_auto_dialog: other.no_auto_dialog.or(self.no_auto_dialog),
             model: other.model.or(self.model),
+            ignore_default_args: other.ignore_default_args.or(self.ignore_default_args),
         }
     }
 }
@@ -240,6 +242,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--screenshot-format",
         "--idle-timeout",
         "--model",
+        "--ignore-default-args",
     ];
     let mut i = 0;
     while i < args.len() {
@@ -328,6 +331,7 @@ pub struct Flags {
     pub model: Option<String>,
     pub verbose: bool,
     pub quiet: bool,
+    pub ignore_default_args: Option<Vec<String>>,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -345,6 +349,7 @@ pub struct Flags {
     pub cli_annotate: bool,
     pub cli_download_path: bool,
     pub cli_headed: bool,
+    pub cli_ignore_default_args: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -503,6 +508,15 @@ pub fn parse_flags(args: &[String]) -> Flags {
         model: env::var("AI_GATEWAY_MODEL").ok().or(config.model),
         verbose: false,
         quiet: false,
+        ignore_default_args: env::var("AGENT_BROWSER_IGNORE_DEFAULT_ARGS")
+            .ok()
+            .map(|s| {
+                s.split([',', '\n'])
+                    .map(|f| f.trim().to_string())
+                    .filter(|f| !f.is_empty())
+                    .collect()
+            })
+            .or(config.ignore_default_args),
         cli_executable_path: false,
         cli_extensions: false,
         cli_init_scripts: false,
@@ -517,6 +531,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_annotate: false,
         cli_download_path: false,
         cli_headed: false,
+        cli_ignore_default_args: false,
     };
 
     let mut i = 0;
@@ -819,6 +834,18 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "-q" | "--quiet" => {
                 flags.quiet = true;
             }
+            "--ignore-default-args" => {
+                if let Some(s) = args.get(i + 1) {
+                    flags.ignore_default_args = Some(
+                        s.split(',')
+                            .map(|f| f.trim().to_string())
+                            .filter(|f| !f.is_empty())
+                            .collect(),
+                    );
+                    flags.cli_ignore_default_args = true;
+                    i += 1;
+                }
+            }
             "--config" => {
                 // Already handled by load_config(); skip the value
                 i += 1;
@@ -887,6 +914,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--screenshot-format",
         "--idle-timeout",
         "--model",
+        "--ignore-default-args",
     ];
 
     let mut i = 0;
@@ -1522,6 +1550,40 @@ mod tests {
             "open".to_string(),
             "example.com".to_string(),
             "--no-auto-dialog".to_string(),
+        ];
+        let clean = clean_args(&input);
+        assert_eq!(clean, vec!["open", "example.com"]);
+    }
+
+    #[test]
+    fn test_parse_ignore_default_args_flag() {
+        let flags = parse_flags(&args(
+            "--ignore-default-args --disable-component-update,--disable-sync open example.com",
+        ));
+        assert_eq!(
+            flags.ignore_default_args,
+            Some(vec![
+                "--disable-component-update".to_string(),
+                "--disable-sync".to_string(),
+            ])
+        );
+        assert!(flags.cli_ignore_default_args);
+    }
+
+    #[test]
+    fn test_parse_ignore_default_args_not_set_without_flag() {
+        let flags = parse_flags(&args("open example.com"));
+        assert!(flags.ignore_default_args.is_none());
+        assert!(!flags.cli_ignore_default_args);
+    }
+
+    #[test]
+    fn test_clean_args_removes_ignore_default_args() {
+        let input: Vec<String> = vec![
+            "--ignore-default-args".to_string(),
+            "--disable-component-update,--disable-sync".to_string(),
+            "open".to_string(),
+            "example.com".to_string(),
         ];
         let clean = clean_args(&input);
         assert_eq!(clean, vec!["open", "example.com"]);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -756,6 +756,7 @@ fn main() {
         default_timeout: flags.default_timeout,
         cdp: flags.cdp.as_deref(),
         no_auto_dialog: flags.no_auto_dialog,
+        ignore_default_args: flags.ignore_default_args.as_deref(),
     };
 
     let daemon_result = match ensure_daemon(&flags.session, &daemon_opts) {
@@ -815,6 +816,7 @@ fn main() {
             flags.cli_allow_file_access.then_some("--allow-file-access"),
             flags.cli_download_path.then_some("--download-path"),
             flags.cli_headed.then_some("--headed"),
+            flags.cli_ignore_default_args.then_some("--ignore-default-args"),
         ]
         .into_iter()
         .flatten()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -816,7 +816,9 @@ fn main() {
             flags.cli_allow_file_access.then_some("--allow-file-access"),
             flags.cli_download_path.then_some("--download-path"),
             flags.cli_headed.then_some("--headed"),
-            flags.cli_ignore_default_args.then_some("--ignore-default-args"),
+            flags
+                .cli_ignore_default_args
+                .then_some("--ignore-default-args"),
         ]
         .into_iter()
         .flatten()

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1909,7 +1909,16 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
                     .collect()
             })
-            .unwrap_or_default(),
+            .unwrap_or_else(|| {
+                env::var("AGENT_BROWSER_IGNORE_DEFAULT_ARGS")
+                    .map(|v| {
+                        v.split([',', '\n'])
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            }),
     };
 
     let new_hash = launch_hash(&launch_options);

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -196,6 +196,7 @@ fn launch_hash(opts: &LaunchOptions) -> u64 {
     opts.proxy_password.hash(&mut h);
     opts.user_agent.hash(&mut h);
     opts.allow_file_access.hash(&mut h);
+    opts.ignore_default_args.hash(&mut h);
     h.finish()
 }
 
@@ -1724,6 +1725,14 @@ fn launch_options_from_env() -> LaunchOptions {
         download_path: env::var("AGENT_BROWSER_DOWNLOAD_PATH").ok(),
         viewport_size: None,
         use_real_keychain: false,
+        ignore_default_args: env::var("AGENT_BROWSER_IGNORE_DEFAULT_ARGS")
+            .map(|v| {
+                v.split([',', '\n'])
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default(),
     }
 }
 
@@ -1892,6 +1901,15 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             .map(String::from),
         viewport_size: None,
         use_real_keychain: false,
+        ignore_default_args: cmd
+            .get("ignoreDefaultArgs")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default(),
     };
 
     let new_hash = launch_hash(&launch_options);

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -96,6 +96,7 @@ pub struct LaunchOptions {
     pub proxy_password: Option<String>,
     pub profile: Option<String>,
     pub args: Vec<String>,
+    pub ignore_default_args: Vec<String>,
     pub allow_file_access: bool,
     pub extensions: Option<Vec<String>>,
     pub storage_state: Option<String>,
@@ -123,6 +124,7 @@ impl Default for LaunchOptions {
             proxy_password: None,
             profile: None,
             args: Vec::new(),
+            ignore_default_args: Vec::new(),
             allow_file_access: false,
             extensions: None,
             storage_state: None,
@@ -159,6 +161,10 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         "--enable-features=NetworkService,NetworkServiceInProcess".to_string(),
         "--metrics-recording-only".to_string(),
     ];
+
+    if !options.ignore_default_args.is_empty() {
+        args.retain(|arg| !options.ignore_default_args.contains(arg));
+    }
 
     if !options.use_real_keychain {
         args.push("--password-store=basic".to_string());
@@ -1956,5 +1962,64 @@ mod tests {
 
         let result = resolve_cdp_from_active_port(port, "/devtools/browser/dead").await;
         assert!(result.is_err(), "should fail when nothing is listening");
+    }
+
+    #[test]
+    fn test_build_args_ignore_default_args_exact_match() {
+        let opts = LaunchOptions {
+            ignore_default_args: vec![
+                "--disable-component-update".to_string(),
+                "--disable-sync".to_string(),
+            ],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            !result.args.iter().any(|a| a == "--disable-component-update"),
+            "exact-matched flag should be removed"
+        );
+        assert!(
+            !result.args.iter().any(|a| a == "--disable-sync"),
+            "exact-matched flag should be removed"
+        );
+        assert!(
+            result.args.iter().any(|a| a == "--no-first-run"),
+            "non-ignored flags should remain"
+        );
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_ignore_default_args_no_prefix_match() {
+        let opts = LaunchOptions {
+            ignore_default_args: vec!["--disable-features".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            result
+                .args
+                .iter()
+                .any(|a| a.starts_with("--disable-features=")),
+            "--disable-features should not remove --disable-features=Translate (exact match only)"
+        );
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_ignore_default_args_empty_no_effect() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            result.args.iter().any(|a| a == "--disable-component-update"),
+            "default flags should remain when ignore list is empty"
+        );
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
     }
 }

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -1975,7 +1975,10 @@ mod tests {
         };
         let result = build_chrome_args(&opts).unwrap();
         assert!(
-            !result.args.iter().any(|a| a == "--disable-component-update"),
+            !result
+                .args
+                .iter()
+                .any(|a| a == "--disable-component-update"),
             "exact-matched flag should be removed"
         );
         assert!(
@@ -2015,7 +2018,10 @@ mod tests {
         let opts = LaunchOptions::default();
         let result = build_chrome_args(&opts).unwrap();
         assert!(
-            result.args.iter().any(|a| a == "--disable-component-update"),
+            result
+                .args
+                .iter()
+                .any(|a| a == "--disable-component-update"),
             "default flags should remain when ignore list is empty"
         );
         if let Some(ref dir) = result.temp_user_data_dir {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3085,6 +3085,8 @@ Options:
                              (or AGENT_BROWSER_ENABLE env)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
                              e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
+  --ignore-default-args <list>  Remove specific default Chrome flags, comma-separated
+                             (or AGENT_BROWSER_IGNORE_DEFAULT_ARGS)
   --user-agent <ua>          Custom User-Agent (or AGENT_BROWSER_USER_AGENT)
   --proxy <server>           Proxy server URL (or AGENT_BROWSER_PROXY, HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
                              Supports authenticated proxies: --proxy "http://user:pass@127.0.0.1:7890"

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -95,6 +95,7 @@ This enables control of:
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>
     <tr><td><code>--executable-path</code></td><td>Custom browser executable</td></tr>
     <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (comma-separated)</td></tr>
+    <tr><td><code>--ignore-default-args &lt;list&gt;</code></td><td>Remove specific default Chrome flags (comma-separated)</td></tr>
     <tr><td><code>--user-agent &lt;ua&gt;</code></td><td>Custom User-Agent string</td></tr>
     <tr><td><code>--proxy &lt;url&gt;</code></td><td>Proxy server URL</td></tr>
     <tr><td><code>--proxy-bypass &lt;hosts&gt;</code></td><td>Hosts to bypass proxy</td></tr>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -482,6 +482,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 --init-script <path>     # Register a page init script before first navigation (repeatable)
 --enable <feature>       # Built-in init scripts: react-devtools (repeatable or comma-list)
 --args <args>            # Browser launch args (comma separated)
+--ignore-default-args <list>  # Remove specific default Chrome flags (comma separated)
 --user-agent <ua>        # Custom User-Agent string
 --proxy <url>            # Proxy server URL
 --proxy-bypass <hosts>   # Hosts to bypass proxy

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -70,6 +70,7 @@ Every CLI flag can be set in the config file using its camelCase equivalent:
     <tr><td><code>proxy</code></td><td><code>--proxy</code></td><td>string</td></tr>
     <tr><td><code>proxyBypass</code></td><td><code>--proxy-bypass</code></td><td>string</td></tr>
     <tr><td><code>args</code></td><td><code>--args</code></td><td>string</td></tr>
+    <tr><td><code>ignoreDefaultArgs</code></td><td><code>--ignore-default-args</code></td><td>string[]</td></tr>
     <tr><td><code>userAgent</code></td><td><code>--user-agent</code></td><td>string</td></tr>
     <tr><td><code>provider</code></td><td><code>-p, --provider</code></td><td>string</td></tr>
     <tr><td><code>device</code></td><td><code>--device</code></td><td>string</td></tr>

--- a/docs/src/app/engines/chrome/page.mdx
+++ b/docs/src/app/engines/chrome/page.mdx
@@ -90,6 +90,7 @@ These features are available only with Chrome:
     <tr><td>File URL access</td><td><code>--allow-file-access</code></td></tr>
     <tr><td>Headed mode</td><td><code>--headed</code></td></tr>
     <tr><td>Custom launch args</td><td><code>--args &lt;args&gt;</code></td></tr>
+    <tr><td>Remove default flags</td><td><code>--ignore-default-args &lt;list&gt;</code></td></tr>
   </tbody>
 </table>
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -297,21 +297,22 @@ agent-browser state load auth.json    # Restore saved state
 ## Global Options
 
 ```bash
-agent-browser --session <name> ...    # Isolated browser session
-agent-browser --json ...              # JSON output for parsing
-agent-browser --headed ...            # Show browser window (not headless)
-agent-browser --full ...              # Full page screenshot (-f)
-agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
-agent-browser -p <provider> ...       # Cloud browser provider (--provider)
-agent-browser --proxy <url> ...       # Use proxy server
-agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy
-agent-browser --headers <json> ...    # HTTP headers scoped to URL's origin
-agent-browser --executable-path <p>   # Custom browser executable
-agent-browser --extension <path> ...  # Load browser extension (repeatable)
-agent-browser --ignore-https-errors   # Ignore SSL certificate errors
-agent-browser --help                  # Show help (-h)
-agent-browser --version               # Show version (-V)
-agent-browser <command> --help        # Show detailed help for a command
+agent-browser --session <name> ...       # Isolated browser session
+agent-browser --json ...                 # JSON output for parsing
+agent-browser --headed ...               # Show browser window (not headless)
+agent-browser --full ...                 # Full page screenshot (-f)
+agent-browser --cdp <port> ...           # Connect via Chrome DevTools Protocol
+agent-browser -p <provider> ...          # Cloud browser provider (--provider)
+agent-browser --proxy <url> ...          # Use proxy server
+agent-browser --proxy-bypass <hosts>     # Hosts to bypass proxy
+agent-browser --headers <json> ...       # HTTP headers scoped to URL's origin
+agent-browser --executable-path <p>      # Custom browser executable
+agent-browser --extension <path> ...     # Load browser extension (repeatable)
+agent-browser --ignore-https-errors      # Ignore SSL certificate errors
+agent-browser --ignore-default-args <f>  # Remove default Chrome flags (comma-separated)
+agent-browser --help                     # Show help (-h)
+agent-browser --version                  # Show version (-V)
+agent-browser <command> --help           # Show detailed help for a command
 ```
 
 ## Debugging
@@ -386,4 +387,5 @@ AGENT_BROWSER_ENABLE="react-devtools"        # Comma-separated built-in init scr
 AGENT_BROWSER_PROVIDER="browserbase"         # Cloud browser provider
 AGENT_BROWSER_STREAM_PORT="9223"             # Override WebSocket streaming port (default: OS-assigned)
 AGENT_BROWSER_HOME="/path/to/agent-browser"  # Custom install location
+AGENT_BROWSER_IGNORE_DEFAULT_ARGS="--f1,--f2" # Remove specific default Chrome flags
 ```

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -49,3 +49,17 @@ installed version.
 - Accessibility-tree snapshots with element refs for reliable interaction
 - Sessions, authentication vault, state persistence, video recording
 - Specialized skills for Electron apps, Slack, exploratory testing, cloud providers
+
+## Removing Default Chrome Flags
+
+Use `--ignore-default-args` to selectively remove specific flags from the default set of Chrome launch arguments. This is useful when a default flag conflicts with your use case.
+
+```bash
+# Remove specific default flags (comma-separated)
+agent-browser --ignore-default-args "--disable-component-update,--disable-sync" open https://example.com
+
+# Via environment variable
+AGENT_BROWSER_IGNORE_DEFAULT_ARGS="--disable-component-update,--disable-sync" agent-browser open https://example.com
+```
+
+Only exact matches are removed. For example, `--disable-features` will not remove `--disable-features=TranslateUI` or other flags that share the same prefix.


### PR DESCRIPTION
Fix https://github.com/vercel-labs/agent-browser/issues/682

My use-case is to control a Chromium browser with working component updates. Component updater is currently hard-disabled in agent-browser [code](https://github.com/vercel-labs/agent-browser/blob/fcb6615f5a1f89b7bb012921a8e489d7d1c8f7e8/cli/src/native/cdp/chrome.rs#L148). 

Playwright allows you to ignoreDefaultArgs, allowing users to remove specific hardcoded Chrome flags from build_chrome_args(). There should be a similar option for `agent-browser`.

This new flag is available via CLI flag, AGENT_BROWSER_IGNORE_DEFAULT_ARGS env var, and config file (`ignoreDefaultArgs`). Plumbed through daemon env forwarding and launch hash for relaunch detection.

Note: I used Claude Code to assist with the PR. Happy to work through any feedback. This shouldn't be a large change. 