### PR TITLE
fix(skill): correct duplicate Option numbering in auth section

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -93,7 +93,7 @@ agent-browser close  # State auto-saved
 agent-browser --session-name myapp open https://app.example.com/dashboard
 ```
 
-**Option 4: Auth vault (credentials stored encrypted, login by name)**
+**Option 5: Auth vault (credentials stored encrypted, login by name)**
 
 ```bash
 echo "$PASSWORD" | agent-browser auth save myapp --url https://app.example.com/login --username user --password-stdin
@@ -102,7 +102,7 @@ agent-browser auth login myapp
 
 `auth login` navigates with `load` and then waits for login form selectors to appear before filling/clicking, which is more reliable on delayed SPA login screens.
 
-**Option 5: State file (manual save/load)**
+**Option 6: State file (manual save/load)**
 
 ```bash
 # After logging in:


### PR DESCRIPTION
## What

Fix duplicate Option numbering in the authentication section of `skills/agent-browser/SKILL.md`.

The current file has two headings both labeled **"Option 4"**:
- Line 85: "Option 4: Session name"
- Line 96: "Option 4: Auth vault"

This causes "Option 5: State file" to also be off-by-one.

## Fix

Renumbered sequentially:

| Before | After |
|---|---|
| Option 4: Session name | Option 4: Session name (unchanged) |
| Option 4: Auth vault | **Option 5**: Auth vault |
| Option 5: State file | **Option 6**: State file |

## Scope

Text-only, 3 lines changed. No logic or structural changes.