### PR TITLE
fix: CI test failures on Windows and E2E

### DIFF
--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -1029,7 +1029,9 @@ mod tests {
         // The new code should include the root cause (connection refused)
         // not just the vague "error sending request for url"
         assert!(
-            err.contains("Connection refused") || err.contains("connection refused"),
+            err.contains("Connection refused")
+                || err.contains("connection refused")
+                || err.contains("actively refused it"),
             "expected 'connection refused' in error, got: {}",
             err
         );

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3063,12 +3063,17 @@ async fn start_delayed_login_server(
       setTimeout(() => {{
         const root = document.getElementById('root');
         root.innerHTML = `
-          <form id="login-form" onsubmit="event.preventDefault(); window.__submitted = true;">
+          <form id="login-form">
             <input type="email" name="email" />
             <input type="password" name="password" />
             <button type="submit">Sign in</button>
           </form>
         `;
+        document.getElementById('login-form').addEventListener('submit', function(e) {{
+          e.preventDefault();
+          e.stopPropagation();
+          window.__submitted = true;
+        }});
       }}, {render_delay_ms});
     </script>
   </body>
@@ -3865,13 +3870,15 @@ async fn e2e_relaunch_on_options_change() {
         "identical options must reuse the browser"
     );
 
-    // Third launch — different options (extensions added) → must relaunch, not reuse.
+    // Third launch — different options (userAgent changed) → must relaunch, not reuse.
+    // We use userAgent instead of extensions because extensions force headed mode,
+    // which requires a display server and fails in headless CI environments.
     let resp = execute_command(
         &json!({
             "id": "3",
             "action": "launch",
             "headless": true,
-            "extensions": ["/tmp/fake-extension"]
+            "userAgent": "agent-browser-test/1.0"
         }),
         &mut state,
     )


### PR DESCRIPTION
## Summary

- **Windows unit test**: `download_bytes_connection_refused_includes_details` fails because Windows returns `"No connection could be made because the target machine actively refused it"` instead of `"connection refused"`. Added the Windows error pattern to the assertion.
- **E2E relaunch test**: `e2e_relaunch_on_options_change` fails because extensions force headed mode (skips `--headless`), which requires a display server unavailable in CI. Changed the test to use `userAgent` instead, which still changes the launch hash and triggers a relaunch while keeping Chrome headless.
- **E2E auth login SPA test**: `e2e_auth_login_waits_for_delayed_spa_form_render` fails intermittently because the inline `onsubmit` handler on a form created via `innerHTML` can be unreliable. Switched to `addEventListener` with `stopPropagation` for more robust form submission prevention.