### PR TITLE
fix: recover GitHub release when npm published but release creation failed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
+      needs_github_release: ${{ steps.check.outputs.needs_github_release }}
       version: ${{ steps.check.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Compare package.json version to npm
+      - name: Compare package.json version to npm and check GitHub release
         id: check
         run: |
           LOCAL_VERSION=$(node -p "require('./package.json').version")
@@ -34,16 +35,30 @@ jobs:
           if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
             echo "Version changed: $NPM_VERSION -> $LOCAL_VERSION"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "needs_github_release=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Version unchanged, skipping release"
+            echo "Version unchanged on npm, skipping build and publish"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
+
+            # Check if GitHub release exists; it may be missing if a prior run
+            # published to npm but failed before creating the release.
+            TAG="v$LOCAL_VERSION"
+            if gh release view "$TAG" &>/dev/null; then
+              echo "GitHub release $TAG exists"
+              echo "needs_github_release=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "GitHub release $TAG is missing, will rebuild and create it"
+              echo "needs_github_release=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
           echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-binaries:
     name: Build ${{ matrix.name }}
     needs: check-release
-    if: needs.check-release.outputs.should_release == 'true'
+    if: needs.check-release.outputs.should_release == 'true' || needs.check-release.outputs.needs_github_release == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -168,6 +183,7 @@ jobs:
   publish:
     name: Publish to npm
     needs: [check-release, build-binaries]
+    if: needs.check-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -242,7 +258,8 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [check-release, publish]
+    needs: [check-release, build-binaries, publish]
+    if: always() && needs.build-binaries.result == 'success' && needs.check-release.outputs.needs_github_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- `check-release` now detects when the npm version matches but the GitHub release is missing
- `build-binaries` and `github-release` run in that case so binaries, dashboard, and release notes are created without requiring a version bump
- `publish` is skipped when npm already has the version
- `github-release` uses `if: always()` with `build-binaries.result == 'success'` so it runs even when `publish` is skipped