### PR TITLE
fix: re-apply ignore_https_errors to recording context

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3939,6 +3939,19 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
                 .await;
         }
 
+        // Re-apply HTTPS error ignore to the recording context.
+        // Security.setIgnoreCertificateErrors at launch only applies to the session it was sent on.
+        if mgr.ignore_https_errors {
+            let _ = mgr
+                .client
+                .send_command(
+                    "Security.setIgnoreCertificateErrors",
+                    Some(json!({ "ignore": true })),
+                    Some(&new_session_id),
+                )
+                .await;
+        }
+
         // Transfer cookies to new context
         if let Some(ref cr) = cookies_result {
             if let Some(cookie_arr) = cr.get("cookies").and_then(|v| v.as_array()) {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -202,6 +202,8 @@ pub struct BrowserManager {
     default_timeout_ms: u64,
     /// Stored download path from launch options, re-applied to new contexts (e.g., recording)
     pub download_path: Option<String>,
+    /// Whether to ignore HTTPS certificate errors, re-applied to new contexts (e.g., recording)
+    pub ignore_https_errors: bool,
     /// Origins visited during this session, used by save_state to collect cross-origin localStorage.
     visited_origins: HashSet<String>,
 }
@@ -273,6 +275,7 @@ impl BrowserManager {
                 active_page_index: 0,
                 default_timeout_ms: 25_000,
                 download_path: download_path.clone(),
+                ignore_https_errors,
                 visited_origins: HashSet::new(),
             };
             manager.discover_and_attach_targets().await?;
@@ -360,6 +363,7 @@ impl BrowserManager {
             active_page_index: 0,
             default_timeout_ms: 25_000,
             download_path: None,
+            ignore_https_errors: false,
             visited_origins: HashSet::new(),
         };
 
@@ -1331,6 +1335,7 @@ async fn initialize_lightpanda_manager(
             active_page_index: 0,
             default_timeout_ms: 25_000,
             download_path: None,
+            ignore_https_errors: false,
             visited_origins: HashSet::new(),
         };
 


### PR DESCRIPTION
  `record start` calls `Target.createBrowserContext` to create an isolated BrowserContext for the recording session.
  `Security.setIgnoreCertificateErrors` is session-scoped — it only applies to the session it was sent on and does
  not propagate to new contexts. As a result, the recording context always starts with default certificate validation enabled, regardless of `--ignore-https-errors` or `AGENT_BROWSER_IGNORE_HTTPS_ERRORS`.

  Symptoms reported in #1172:
  - Navigation to self-signed HTTPS URLs succeeds in the normal context
  - The same URL times out immediately after `record start`
  - Affects all local HTTPS development environments (e.g. mkcert)

  The fix stores `ignore_https_errors` in `BrowserManager` alongside `download_path`, and re-applies `Security.setIgnoreCertificateErrors` to the new session after context creation — matching the existing pattern for `Browser.setDownloadBehavior` re-application.

  Fixes #1172