### PR TITLE
feat(cli): add direct CDP connect flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
 agent-browser pdf <path>              # Save as PDF
 agent-browser snapshot                # Accessibility tree with refs (best for AI)
 agent-browser eval <js>               # Run JavaScript (-b for base64, --stdin for piped input)
-agent-browser connect <port>          # Connect to browser via CDP
+agent-browser connect [--direct] <port|url>  # Connect to browser via CDP
 agent-browser stream enable [--port <port>]  # Start runtime WebSocket streaming
 agent-browser stream status           # Show runtime streaming state and bound port
 agent-browser stream disable          # Stop runtime WebSocket streaming
@@ -972,12 +972,17 @@ agent-browser --cdp 9222 snapshot
 
 # Connect to remote browser via WebSocket URL
 agent-browser --cdp "wss://your-browser-service.com/cdp?token=..." snapshot
+
+# Connect directly to a page-level WebSocket URL
+agent-browser connect --direct "ws://localhost:19222/devtools/page/ABC123"
 ```
 
 The `--cdp` flag accepts either:
 
 - A port number (e.g., `9222`) for local connections via `http://localhost:{port}`
 - A full WebSocket URL (e.g., `wss://...` or `ws://...`) for remote browser services
+
+Use `agent-browser connect --direct <ws-url>` when you already have a page-level CDP WebSocket URL such as `ws://localhost:19222/devtools/page/ABC123`. This skips browser-level `Target.*` discovery and talks to the page session directly.
 
 This enables control of:
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -773,9 +773,39 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Connect (CDP) ===
         "connect" => {
-            let endpoint = rest.first().ok_or_else(|| ParseError::MissingArguments {
+            let mut direct = false;
+            let mut endpoint: Option<&str> = None;
+
+            for arg in rest {
+                match arg.as_ref() {
+                    // Page-level CDP sockets do not support browser-level Target.*
+                    // discovery, so `connect --direct <ws-url>` opts into the
+                    // existing direct page-session path.
+                    "--direct" => direct = true,
+                    value if value.starts_with('-') => {
+                        return Err(ParseError::InvalidValue {
+                            message: format!("Unknown option for connect: {}", value),
+                            usage: "connect [--direct] <port|url>",
+                        });
+                    }
+                    value => {
+                        if endpoint.is_some() {
+                            return Err(ParseError::InvalidValue {
+                                message: format!(
+                                    "Unexpected argument: '{}'. connect accepts a single <port|url>",
+                                    value
+                                ),
+                                usage: "connect [--direct] <port|url>",
+                            });
+                        }
+                        endpoint = Some(value);
+                    }
+                }
+            }
+
+            let endpoint = endpoint.ok_or_else(|| ParseError::MissingArguments {
                 context: "connect".to_string(),
-                usage: "connect <port|url>",
+                usage: "connect [--direct] <port|url>",
             })?;
             // Check if it's a URL (ws://, wss://, http://, https://)
             if endpoint.starts_with("ws://")
@@ -783,14 +813,19 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 || endpoint.starts_with("http://")
                 || endpoint.starts_with("https://")
             {
-                Ok(json!({ "id": id, "action": "launch", "cdpUrl": endpoint }))
+                Ok(json!({
+                    "id": id,
+                    "action": "launch",
+                    "cdpUrl": endpoint,
+                    "direct": direct
+                }))
             } else {
                 // It's a port number - validate and use cdpPort field
                 let port: u16 = match endpoint.parse::<u32>() {
                     Ok(0) => {
                         return Err(ParseError::InvalidValue {
                             message: "Invalid port: port must be greater than 0".to_string(),
-                            usage: "connect <port|url>",
+                            usage: "connect [--direct] <port|url>",
                         });
                     }
                     Ok(p) if p > 65535 => {
@@ -799,7 +834,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 "Invalid port: {} is out of range (valid range: 1-65535)",
                                 p
                             ),
-                            usage: "connect <port|url>",
+                            usage: "connect [--direct] <port|url>",
                         });
                     }
                     Ok(p) => p as u16,
@@ -809,11 +844,16 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 "Invalid value: '{}' is not a valid port number or URL",
                                 endpoint
                             ),
-                            usage: "connect <port|url>",
+                            usage: "connect [--direct] <port|url>",
                         });
                     }
                 };
-                Ok(json!({ "id": id, "action": "launch", "cdpPort": port }))
+                Ok(json!({
+                    "id": id,
+                    "action": "launch",
+                    "cdpPort": port,
+                    "direct": direct
+                }))
             }
         }
 
@@ -3732,6 +3772,7 @@ mod tests {
         assert_eq!(cmd["action"], "launch");
         assert_eq!(cmd["cdpPort"], 9222);
         assert!(cmd.get("cdpUrl").is_none());
+        assert_eq!(cmd["direct"], false);
     }
 
     #[test]
@@ -3744,6 +3785,7 @@ mod tests {
         assert_eq!(cmd["action"], "launch");
         assert_eq!(cmd["cdpUrl"], "ws://localhost:9222/devtools/browser/abc123");
         assert!(cmd.get("cdpPort").is_none());
+        assert_eq!(cmd["direct"], false);
     }
 
     #[test]
@@ -3759,6 +3801,7 @@ mod tests {
             "wss://remote-browser.example.com/cdp?token=xyz"
         );
         assert!(cmd.get("cdpPort").is_none());
+        assert_eq!(cmd["direct"], false);
     }
 
     #[test]
@@ -3768,6 +3811,41 @@ mod tests {
         assert_eq!(cmd["action"], "launch");
         assert_eq!(cmd["cdpUrl"], "http://localhost:9222");
         assert!(cmd.get("cdpPort").is_none());
+        assert_eq!(cmd["direct"], false);
+    }
+
+    #[test]
+    fn test_connect_with_direct_ws_url() {
+        let input: Vec<String> = vec![
+            "connect".to_string(),
+            "--direct".to_string(),
+            "ws://localhost:19222/devtools/page/ABC123".to_string(),
+        ];
+        let cmd = parse_command(&input, &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "launch");
+        assert_eq!(cmd["cdpUrl"], "ws://localhost:19222/devtools/page/ABC123");
+        assert_eq!(cmd["direct"], true);
+        assert!(cmd.get("cdpPort").is_none());
+    }
+
+    #[test]
+    fn test_connect_with_direct_before_port() {
+        let cmd = parse_command(&args("connect --direct 9222"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "launch");
+        assert_eq!(cmd["cdpPort"], 9222);
+        assert_eq!(cmd["direct"], true);
+    }
+
+    #[test]
+    fn test_connect_with_direct_after_url() {
+        let input: Vec<String> = vec![
+            "connect".to_string(),
+            "ws://localhost:19222/devtools/page/ABC123".to_string(),
+            "--direct".to_string(),
+        ];
+        let cmd = parse_command(&input, &default_flags()).unwrap();
+        assert_eq!(cmd["cdpUrl"], "ws://localhost:19222/devtools/page/ABC123");
+        assert_eq!(cmd["direct"], true);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1672,6 +1672,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         .unwrap_or(true);
     let cdp_url = cmd.get("cdpUrl").and_then(|v| v.as_str());
     let cdp_port = cmd.get("cdpPort").and_then(|v| v.as_u64());
+    let direct = cmd.get("direct").and_then(|v| v.as_bool()).unwrap_or(false);
     let auto_connect = cmd
         .get("autoConnect")
         .and_then(|v| v.as_bool())
@@ -1798,7 +1799,15 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(url) = cdp_url {
         state.reset_input_state();
-        state.browser = Some(BrowserManager::connect_cdp(url).await?);
+        state.browser = Some(
+            // `connect --direct` is only meaningful for WebSocket URLs that
+            // already point at a specific page session.
+            if direct && (url.starts_with("ws://") || url.starts_with("wss://")) {
+                BrowserManager::connect_cdp_direct(url).await?
+            } else {
+                BrowserManager::connect_cdp(url).await?
+            },
+        );
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -604,7 +604,7 @@ impl BrowserManager {
                 match rx.recv().await {
                     Ok(event) => {
                         if event.method == event_name
-                            && event.session_id.as_deref() == Some(session_id)
+                            && event_matches_session(event.session_id.as_deref(), session_id)
                         {
                             return Ok(());
                         }
@@ -1258,7 +1258,7 @@ async fn poll_network_idle(
                 tokio::time::timeout(tokio::time::Duration::from_millis(600), rx.recv()).await;
 
             match recv_result {
-                Ok(Ok(event)) if event.session_id.as_deref() == Some(session_id) => {
+                Ok(Ok(event)) if event_matches_session(event.session_id.as_deref(), session_id) => {
                     let mut p = pending.lock().await;
                     match event.method.as_str() {
                         "Network.requestWillBeSent" => {
@@ -1312,6 +1312,14 @@ async fn poll_network_idle(
     })
     .await
     .map_err(|_| "Timeout waiting for networkidle".to_string())?
+}
+
+fn event_matches_session(event_session_id: Option<&str>, expected_session_id: &str) -> bool {
+    if expected_session_id.is_empty() {
+        event_session_id.is_none() || event_session_id == Some("")
+    } else {
+        event_session_id == Some(expected_session_id)
+    }
 }
 
 async fn connect_cdp_with_retry(
@@ -1716,6 +1724,28 @@ mod tests {
         }
     }
 
+    fn cdp_event_direct(method: &str, params: Value) -> CdpEvent {
+        CdpEvent {
+            method: method.to_string(),
+            params,
+            session_id: None,
+        }
+    }
+
+    #[test]
+    fn test_event_matches_session_standard_session() {
+        assert!(event_matches_session(Some("s1"), "s1"));
+        assert!(!event_matches_session(None, "s1"));
+        assert!(!event_matches_session(Some("s2"), "s1"));
+    }
+
+    #[test]
+    fn test_event_matches_session_direct_page() {
+        assert!(event_matches_session(None, ""));
+        assert!(event_matches_session(Some(""), ""));
+        assert!(!event_matches_session(Some("s1"), ""));
+    }
+
     /// Regression test for #846: when no network events arrive at all (e.g.
     /// page fully served from cache), poll_network_idle must NOT return
     /// instantly.  It should observe at least 500 ms of idle before resolving.
@@ -1860,5 +1890,33 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("Timeout waiting for networkidle"));
+    }
+
+    #[tokio::test]
+    async fn test_network_idle_direct_page_without_session_id() {
+        let (tx, mut rx) = broadcast::channel::<CdpEvent>(16);
+
+        let _keep_alive = tx.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            let _ = tx.send(cdp_event_direct(
+                "Network.requestWillBeSent",
+                json!({ "requestId": "r1" }),
+            ));
+            sleep(Duration::from_millis(100)).await;
+            let _ = tx.send(cdp_event_direct(
+                "Network.loadingFinished",
+                json!({ "requestId": "r1" }),
+            ));
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            poll_network_idle("", &mut rx, Duration::from_secs(5)),
+        )
+        .await
+        .expect("outer timeout should not fire");
+
+        assert!(result.is_ok());
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2432,7 +2432,7 @@ Examples:
             r##"
 agent-browser connect - Connect to browser via CDP
 
-Usage: agent-browser connect <port|url>
+Usage: agent-browser connect [--direct] <port|url>
 
 Connects to a running browser instance via Chrome DevTools Protocol (CDP).
 This allows controlling browsers, Electron apps, or remote browser services.
@@ -2441,9 +2441,14 @@ Arguments:
   <port>               Local port number (e.g., 9222)
   <url>                Full WebSocket URL (ws://, wss://, http://, https://)
 
+Options:
+  --direct             Connect directly to a page-level WebSocket URL without
+                       Target.* discovery
+
 Supported URL formats:
   - Port number: 9222 (connects to http://localhost:9222)
   - WebSocket URL: ws://localhost:9222/devtools/browser/...
+  - Page WebSocket URL: ws://localhost:19222/devtools/page/ABC123 (use --direct)
   - Remote service: wss://remote-browser.example.com/cdp?token=...
 
 Global Options:
@@ -2457,6 +2462,9 @@ Examples:
 
   # Connect using WebSocket URL from /json/version endpoint
   agent-browser connect "ws://localhost:9222/devtools/browser/abc123"
+
+  # Connect directly to a page-level WebSocket URL
+  agent-browser connect --direct "ws://localhost:19222/devtools/page/ABC123"
 
   # Connect to remote browser service
   agent-browser connect "wss://browser-service.example.com/cdp?token=xyz"
@@ -2749,7 +2757,7 @@ Core Commands:
   pdf <path>                 Save as PDF
   snapshot                   Accessibility tree with refs (for AI)
   eval <js>                  Run JavaScript
-  connect <port|url>         Connect to browser via CDP
+  connect [--direct] <port|url>  Connect to browser via CDP
   close [--all]              Close browser (--all closes every session)
 
 Navigation:

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -25,12 +25,17 @@ agent-browser --cdp "wss://browser-service.com/cdp?token=..." snapshot
 
 # Works with any CDP-compatible service
 agent-browser --cdp "ws://localhost:9222/devtools/browser/abc123" open example.com
+
+# Connect directly to a page-level WebSocket session
+agent-browser connect --direct "ws://localhost:19222/devtools/page/ABC123"
 ```
 
 The `--cdp` flag accepts either:
 
 - A port number (e.g., `9222`) for local connections via `http://localhost:{port}`
 - A full WebSocket URL (e.g., `wss://...` or `ws://...`) for remote browser services
+
+Use `agent-browser connect --direct <ws-url>` when you already have a page-level CDP WebSocket URL such as `ws://localhost:19222/devtools/page/ABC123`. This skips browser-level `Target.*` discovery and connects straight to the page session.
 
 ## Auto-Connect
 

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -46,6 +46,8 @@ agent-browser open https://example.com && agent-browser screenshot
 
 **When to chain:** Use `&&` when you don't need to read the output of an intermediate command before proceeding (e.g., open + wait + screenshot). Run commands separately when you need to parse the output first (e.g., snapshot to discover refs, then interact using those refs).
 
+Use `agent-browser connect --direct <ws-url>` when you already have a page-level CDP WebSocket URL such as `ws://localhost:19222/devtools/page/ABC123`. This skips `Target.*` discovery, which is required for page sessions exposed by some embedded browsers and framework integrations.
+
 ## Handling Authentication
 
 When automating a site that requires login, choose the approach that fits:


### PR DESCRIPTION
# ⚠️ This was vibecoded with codex (gpt-5.4 medium), I am not a rust developper

Closes  #1185

## Summary

  This exposes the existing direct page-session CDP path through the CLI by adding a --direct flag to
  agent-browser connect.

  With this change, users can connect directly to page-level WebSocket URLs like:

  agent-browser connect --direct "ws://localhost:19222/devtools/page/ABC123"

  ## Problem

  agent-browser connect currently assumes browser-level CDP endpoints and always goes through the
  Target.* discovery flow.

  That breaks for page-level WebSocket URLs such as:

  ws://localhost:19222/devtools/page/ABC123

  because page sessions do not support browser-level commands like Target.getTargets.

  This is already handled internally in the codebase through the existing direct-page path in
  BrowserManager::connect_cdp_direct(), but it was only used by provider integrations and not exposed
  to CLI users.

  ## Why this matters

  Some embedding frameworks, including CEF-style setups, expose:

  - one shared CDP port for multiple tabs
  - per-tab isolation through page-level WebSocket URLs

  In those cases, users need to connect directly to a page session instead of a browser session.

  ## Changes

  - Added --direct to the connect subcommand parser
  - Passed the direct flag through the launch/connect flow
  - In handle_launch(), when direct is true and the input is a WebSocket URL, use
    BrowserManager::connect_cdp_direct(url) instead of connect_cdp(url)
  - Added parser tests covering:
      - normal port/url behavior
      - --direct with page-level ws URLs
      - --direct before and after the endpoint
  - Updated user-facing docs:
      - cli/src/output.rs
      - README.md
      - skills/agent-browser/SKILL.md
      - docs/src/app/cdp-mode/page.mdx
  - Added inline source comments documenting the direct-page behavior

  ## Example

  agent-browser connect --direct "ws://localhost:19222/devtools/page/ABC123"

  ## Testing

  cd cli
  cargo fmt --all --check
  cargo test test_connect_ -- --nocapture

  Both passed locally.

  ## Notes

  This is opt-in only. Existing connect <port|url> behavior remains unchanged unless --direct is
  explicitly provided.