### PR TITLE
fix: prevent recording deadlocks when ffmpeg stalls

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -542,7 +542,7 @@ impl DaemonState {
         }
     }
 
-    /// Spawn a background task that polls screenshots and pipes them to ffmpeg.
+    /// Spawn a background task that polls screenshots and streams them into ffmpeg.
     async fn start_recording_task(
         &mut self,
         client: Arc<CdpClient>,

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -384,6 +384,69 @@ async fn e2e_snapshot_and_click_ref() {
 
 #[tokio::test]
 #[ignore]
+async fn e2e_video_recording_stop_flushes_webm() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let output_path = std::env::temp_dir()
+        .join(format!("agent-browser-e2e-video-{}.webm", uuid::Uuid::new_v4()))
+        .to_string_lossy()
+        .to_string();
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "video_start", "path": output_path }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+
+    let resp = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        execute_command(&json!({ "id": "4", "action": "video_stop" }), &mut state),
+    )
+    .await
+    .expect("video_stop should not hang");
+    assert_success(&resp);
+
+    let metadata = std::fs::metadata(&output_path).expect("Recorded video should exist");
+    assert!(
+        metadata.len() > 10 * 1024,
+        "Recorded video should be non-trivial size, got {} bytes",
+        metadata.len()
+    );
+
+    let ffprobe = std::process::Command::new("ffprobe")
+        .args(["-hide_banner", &output_path])
+        .output()
+        .expect("ffprobe should be installed for e2e recording validation");
+    assert!(
+        ffprobe.status.success(),
+        "ffprobe should accept the recorded webm: {}",
+        String::from_utf8_lossy(&ffprobe.stderr)
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    let _ = std::fs::remove_file(&output_path);
+}
+
+#[tokio::test]
+#[ignore]
 async fn e2e_screenshot() {
     let mut state = DaemonState::new();
 

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -3,6 +3,7 @@ use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 
@@ -11,6 +12,13 @@ use super::cdp::types::{CaptureScreenshotParams, CaptureScreenshotResult};
 
 const CAPTURE_INTERVAL_MS: u64 = 100;
 const CAPTURE_FPS: u32 = 10;
+// Bound each screenshot capture so record stop can always observe cancellation.
+const SCREENSHOT_COMMAND_TIMEOUT_MS: u64 = 1_500;
+// Bound stop latency so a wedged capture task does not hang the CLI forever.
+const RECORDING_STOP_TIMEOUT_MS: u64 = 5_000;
+// Keep only the tail of ffmpeg stderr so diagnostics remain available without
+// allowing the pipe to block the encoder.
+const FFMPEG_STDERR_TAIL_BYTES: usize = 8 * 1024;
 
 pub struct RecordingState {
     pub active: bool,
@@ -143,6 +151,31 @@ pub fn spawn_recording_task(
             .stdin
             .take()
             .ok_or_else(|| "Failed to open ffmpeg stdin".to_string())?;
+        let stderr = ffmpeg
+            .stderr
+            .take()
+            .ok_or_else(|| "Failed to open ffmpeg stderr".to_string())?;
+        let stderr_task = tokio::spawn(async move {
+            let mut stderr = stderr;
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 2048];
+
+            loop {
+                match stderr.read(&mut chunk).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        if buf.len() > FFMPEG_STDERR_TAIL_BYTES {
+                            let overflow = buf.len() - FFMPEG_STDERR_TAIL_BYTES;
+                            buf.drain(..overflow);
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            buf
+        });
 
         let mut interval = tokio::time::interval(Duration::from_millis(CAPTURE_INTERVAL_MS));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -161,9 +194,15 @@ pub fn spawn_recording_task(
                 _ = interval.tick() => {}
             }
 
-            let result: Result<CaptureScreenshotResult, _> = client
-                .send_command_typed("Page.captureScreenshot", &params, Some(&session_id))
-                .await;
+            let result: Result<CaptureScreenshotResult, _> = match tokio::time::timeout(
+                Duration::from_millis(SCREENSHOT_COMMAND_TIMEOUT_MS),
+                client.send_command_typed("Page.captureScreenshot", &params, Some(&session_id)),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => continue,
+            };
 
             let screenshot = match result {
                 Ok(s) => s,
@@ -191,17 +230,21 @@ pub fn spawn_recording_task(
 
         drop(stdin);
 
-        let output = ffmpeg
-            .wait_with_output()
+        let status = ffmpeg
+            .wait()
             .await
             .map_err(|e| format!("ffmpeg wait failed: {}", e))?;
+        let stderr = stderr_task
+            .await
+            .map_err(|e| format!("ffmpeg stderr task failed: {}", e))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!(
-                "ffmpeg failed: {}",
-                stderr.chars().take(300).collect::<String>()
-            ));
+        if !status.success() {
+            let stderr = String::from_utf8_lossy(&stderr);
+            let stderr = stderr.trim();
+            if stderr.is_empty() {
+                return Err(format!("ffmpeg exited with status {}", status));
+            }
+            return Err(format!("ffmpeg exited with status {}: {}", status, stderr));
         }
 
         Ok(())
@@ -216,11 +259,16 @@ pub async fn stop_recording_task(state: &mut RecordingState) -> Result<(), Strin
     let counter = state.shared_frame_count.take();
     let handle = state.capture_task.take();
 
-    let result = if let Some(h) = handle {
-        match h.await {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(e)) => Err(e),
-            Err(e) => Err(format!("Recording task panicked: {}", e)),
+    let result = if let Some(mut h) = handle {
+        match tokio::time::timeout(Duration::from_millis(RECORDING_STOP_TIMEOUT_MS), &mut h).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(e))) => Err(e),
+            Ok(Err(e)) => Err(format!("Recording task panicked: {}", e)),
+            Err(_) => {
+                h.abort();
+                let _ = h.await;
+                Err("Timed out stopping recording task".to_string())
+            }
         }
     } else {
         Ok(())
@@ -236,6 +284,7 @@ pub async fn stop_recording_task(state: &mut RecordingState) -> Result<(), Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::pending;
 
     #[test]
     fn test_recording_state_new() {
@@ -319,5 +368,25 @@ mod tests {
         let args_str: Vec<&str> = args.iter().filter_map(|a| a.to_str()).collect();
         assert!(args_str.contains(&"libx264"));
         assert!(args_str.contains(&"/tmp/out.mp4"));
+    }
+
+    #[tokio::test]
+    async fn test_stop_recording_task_times_out_and_aborts_hung_task() {
+        let mut state = RecordingState::new();
+        let (cancel_tx, _cancel_rx) = oneshot::channel();
+        let shared_count = Arc::new(AtomicU64::new(7));
+
+        state.cancel_tx = Some(cancel_tx);
+        state.shared_frame_count = Some(shared_count);
+        state.capture_task = Some(tokio::spawn(async move {
+            pending::<Result<(), String>>().await
+        }));
+
+        let result = stop_recording_task(&mut state).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Timed out"));
+        assert_eq!(state.frame_count, 7);
+        assert!(state.capture_task.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- prevent `record stop` from hanging forever when the screenshot capture loop wedges
- keep the streaming recording architecture and continuously drain `ffmpeg` stderr so encoder logging cannot deadlock the process
- add targeted timeout coverage for screenshot capture and recording shutdown
- add an ignored native e2e regression test that proves `video_stop` flushes a usable WebM instead of hanging

## Problem
`agent-browser record start` could succeed while `record stop` hung indefinitely and never flushed a WebM.

The root cause is in the streaming recording pipeline:
- the background task captures JPEG frames with `Page.captureScreenshot`
- those frames are streamed into a long-lived `ffmpeg` process over stdin
- `ffmpeg` writes progress and diagnostics to stderr continuously
- if stderr is piped but never drained, that pipe can fill up
- once stderr backpressure blocks `ffmpeg`, it stops consuming stdin frames and wedges the recording task

That leaves `record stop` waiting forever for the task to finish.

## Solution
This change keeps the existing real-time streaming design and hardens it in two ways:

1. It continues to pipe `ffmpeg` stderr, but drains it in a background task and keeps only a small tail for diagnostics.
2. It adds explicit timeouts around:
   - each `Page.captureScreenshot` call
   - the recording task shutdown path in `record stop`

If capture stalls, `record stop` now fails fast instead of hanging forever.

## Testing
I verified this change at three levels.

### Unit / focused validation
- `cargo fmt --manifest-path cli/Cargo.toml`
- `cargo test --manifest-path cli/Cargo.toml recording -- --nocapture`
- `cargo build --manifest-path cli/Cargo.toml`

### New regression coverage
Added ignored native e2e coverage in `cli/src/native/e2e_tests.rs` for:
- launch browser
- navigate
- `video_start`
- wait briefly
- `video_stop`
- assert the `.webm` exists, is non-trivial in size, and is accepted by `ffprobe`

Run with:
- `cargo test --manifest-path cli/Cargo.toml e2e_video_recording_stop_flushes_webm -- --ignored --test-threads=1`

### Before / after verification
Using that same e2e test:
- on this patched branch, it passes
- on clean `upstream/main`, the same test fails because `video_stop` hangs and hits the 5 second timeout

### End-to-end verification
I also verified this outside the test harness with:
- raw `agent-browser open -> record start -> sleep -> record stop`
- full ProofShot `start -> stop` flow using the patched binary

Both now produce valid WebM output instead of hanging during `record stop`.