### PR TITLE
feat: support viewport config option

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2325,6 +2325,7 @@ mod tests {
             screenshot_format: None,
             idle_timeout: None,
             no_auto_dialog: false,
+            viewport: None,
         }
     }
 

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -220,6 +220,7 @@ pub struct DaemonOptions<'a> {
     pub idle_timeout: Option<&'a str>,
     pub cdp: Option<&'a str>,
     pub no_auto_dialog: bool,
+    pub viewport: Option<&'a str>,
 }
 
 fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
@@ -291,6 +292,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if let Some(engine) = opts.engine {
         cmd.env("AGENT_BROWSER_ENGINE", engine);
+    }
+    if let Some(viewport) = opts.viewport {
+        cmd.env("AGENT_BROWSER_VIEWPORT", viewport);
     }
     if opts.auto_connect {
         cmd.env("AGENT_BROWSER_AUTO_CONNECT", "1");

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -88,6 +88,7 @@ pub struct Config {
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>,
     pub no_auto_dialog: Option<bool>,
+    pub viewport: Option<String>,
 }
 
 impl Config {
@@ -134,6 +135,7 @@ impl Config {
             screenshot_format: other.screenshot_format.or(self.screenshot_format),
             idle_timeout: other.idle_timeout.or(self.idle_timeout),
             no_auto_dialog: other.no_auto_dialog.or(self.no_auto_dialog),
+            viewport: other.viewport.or(self.viewport),
         }
     }
 }
@@ -301,6 +303,7 @@ pub struct Flags {
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>, // Canonical milliseconds string for AGENT_BROWSER_IDLE_TIMEOUT_MS
     pub no_auto_dialog: bool,
+    pub viewport: Option<String>,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -434,6 +437,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         .or(config.idle_timeout),
         no_auto_dialog: env_var_is_truthy("AGENT_BROWSER_NO_AUTO_DIALOG")
             || config.no_auto_dialog.unwrap_or(false),
+        viewport: env::var("AGENT_BROWSER_VIEWPORT").ok().or(config.viewport),
         cli_executable_path: false,
         cli_extensions: false,
         cli_profile: false,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -722,6 +722,7 @@ fn main() {
         idle_timeout: flags.idle_timeout.as_deref(),
         cdp: flags.cdp.as_deref(),
         no_auto_dialog: flags.no_auto_dialog,
+        viewport: flags.viewport.as_deref(),
     };
 
     let daemon_result = match ensure_daemon(&flags.session, &daemon_opts) {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1495,6 +1495,7 @@ fn launch_options_from_env() -> LaunchOptions {
             .unwrap_or(false),
         color_scheme: env::var("AGENT_BROWSER_COLOR_SCHEME").ok(),
         download_path: env::var("AGENT_BROWSER_DOWNLOAD_PATH").ok(),
+        viewport: env::var("AGENT_BROWSER_VIEWPORT").ok(),
     }
 }
 
@@ -1718,6 +1719,19 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             .get("downloadPath")
             .and_then(|v| v.as_str())
             .map(String::from),
+        viewport: cmd
+            .get("viewport")
+            .and_then(|v| {
+                // Support both string "1920x1080" and object {"width": 1920, "height": 1080}
+                if let Some(s) = v.as_str() {
+                    Some(s.to_string())
+                } else {
+                    let width = v.get("width")?.as_u64()?;
+                    let height = v.get("height")?.as_u64()?;
+                    Some(format!("{}x{}", width, height))
+                }
+            })
+            .or_else(|| env::var("AGENT_BROWSER_VIEWPORT").ok()),
     };
 
     // Store proxy credentials for Fetch.authRequired handling

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -11,6 +11,23 @@ use super::cdp::discovery::discover_cdp_url;
 use super::cdp::lightpanda::{launch_lightpanda, LightpandaLaunchOptions, LightpandaProcess};
 use super::cdp::types::*;
 
+
+/// Parse viewport string like "1920x1080" or "1920,1080" into (width, height)
+fn parse_viewport(s: &str) -> Option<(u32, u32)> {
+    let parts: Vec<&str> = if s.contains(',') {
+        s.split(',').collect()
+    } else {
+        s.split('x').collect()
+    };
+    if parts.len() == 2 {
+        let width = parts[0].trim().parse::<u32>().ok()?;
+        let height = parts[1].trim().parse::<u32>().ok()?;
+        Some((width, height))
+    } else {
+        None
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Launch validation
 // ---------------------------------------------------------------------------
@@ -239,6 +256,7 @@ impl BrowserManager {
         let user_agent = options.user_agent.clone();
         let color_scheme = options.color_scheme.clone();
         let download_path = options.download_path.clone();
+        let viewport = options.viewport.clone();
 
         let (ws_url, process) = match engine {
             "lightpanda" => {
@@ -322,6 +340,24 @@ impl BrowserManager {
                     None,
                 )
                 .await;
+        }
+
+        if let Some(ref viewport_str) = viewport {
+            if let Some((width, height)) = parse_viewport(viewport_str) {
+                let _ = manager
+                    .client
+                    .send_command(
+                        "Emulation.setDeviceMetricsOverride",
+                        Some(json!({
+                            "width": width,
+                            "height": height,
+                            "deviceScaleFactor": 1,
+                            "mobile": false
+                        })),
+                        Some(&session_id),
+                    )
+                    .await;
+            }
         }
 
         Ok(manager)

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -89,6 +89,7 @@ pub struct LaunchOptions {
     pub ignore_https_errors: bool,
     pub color_scheme: Option<String>,
     pub download_path: Option<String>,
+    pub viewport: Option<String>,
 }
 
 impl Default for LaunchOptions {
@@ -109,6 +110,7 @@ impl Default for LaunchOptions {
             ignore_https_errors: false,
             color_scheme: None,
             download_path: None,
+            viewport: None,
         }
     }
 }


### PR DESCRIPTION
  ## Problem                                                                                    
                                                                                                
  Users need to run `set viewport` after every `open` command to configure viewport size.       
Currently, viewport configuration in config file is not supported. (#1179)                     
                                                                                                
  ## Changes                                                                                    
                                                                  
  - Add `viewport` field to `~/.agent-browser/config.json`
  - Parse viewport string in format `WIDTHxHEIGHT` or `WIDTH,HEIGHT`                            
  - Apply viewport via CDP `Emulation.setDeviceMetricsOverride` on browser launch
                                                                                                
  **Modified files:**                                                                           
  - `cli/src/flags.rs` - config parsing                                                         
  - `cli/src/connection.rs` - daemon options                                                    
  - `cli/src/main.rs` - pass viewport to daemon                                                 
  - `cli/src/native/cdp/chrome.rs` - LaunchOptions                                              
  - `cli/src/native/actions.rs` - env var handling                                              
  - `cli/src/native/browser.rs` - CDP viewport application        
  -  `cli/src/commands.rs` - add viewport field to test helper                              
                                                                                                
  ## Usage  
   
  Config file: `~/.agent-browser/config.json`                                                   
                                                                                                
  Supports both `x` and `,` as separators (e.g., `1920x1080` or `1920,1080`)                                                                                   
                                                                                                
  ```                                                                                   
{"headed": true, "viewport": "1720x1000", "args": "--start-fullscreen"}                                                                                                                                                                           
                                                                                                
  $ agb --headed open https://whatismyviewport.com                                              
  ✓ What is my viewport                                                                         
                                                                                                
  $ agb eval 'window.innerWidth + "x" + window.innerHeight'                                     
  "1720x1000"                                                                                   
                                                                                                
  $ agb screenshot ./test.png                                                                   
  ✓ Screenshot saved to ./test.png                # → screenshot works (not black)                                              
                                                                                                                                                                               
  ```    
  ```                                                                                    
  {"headed": true, "viewport": "1720,1000", "args": "--start-fullscreen"}                       
                                                                                                
  $ agb --headed open https://whatismyviewport.com
  ✓ What is my viewport                                                                         
    https://whatismyviewport.com/                                                               
                                                                                                
  $ agb eval 'window.innerWidth + "x" + window.innerHeight'                                     
  "1720x1000"                                                                                   
                                                                                                
  $ agb screenshot ./test.png                                                                   
  ✓ Screenshot saved to ./test.png               # → screenshot works (not black)   
  ```  

  ## Test Plan                                                       
                                                                                                
  - cargo check — no errors                                                                     
  - cargo test — 565 passed, 0 failed
  - Manual verification: viewport config applies correctly on browser launch  