### PR TITLE
fix: inherit viewport dimensions in recording context

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -248,6 +248,9 @@ pub struct DaemonState {
     pub engine: String,
     /// Default timeout for wait operations, from AGENT_BROWSER_DEFAULT_TIMEOUT env var.
     pub default_timeout_ms: u64,
+    /// Last viewport settings (width, height, deviceScaleFactor, mobile),
+    /// re-applied to new contexts (e.g., recording).
+    pub viewport: Option<(i32, i32, f64, bool)>,
 }
 
 impl DaemonState {
@@ -301,6 +304,7 @@ impl DaemonState {
                 .ok()
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(30_000),
+            viewport: None,
         }
     }
 
@@ -3605,7 +3609,7 @@ async fn handle_tab_close(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     mgr.tab_close(index).await
 }
 
-async fn handle_viewport(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_viewport(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let width = cmd.get("width").and_then(|v| v.as_i64()).unwrap_or(1280) as i32;
     let height = cmd.get("height").and_then(|v| v.as_i64()).unwrap_or(720) as i32;
@@ -3616,6 +3620,9 @@ async fn handle_viewport(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
     let mobile = cmd.get("mobile").and_then(|v| v.as_bool()).unwrap_or(false);
 
     mgr.set_viewport(width, height, scale, mobile).await?;
+
+    // Remember viewport for re-application to new contexts (e.g., recording)
+    state.viewport = Some((width, height, scale, mobile));
 
     // Update stream server viewport so status messages and screencast use the new dimensions
     if let Some(ref server) = state.stream_server {
@@ -3872,6 +3879,8 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
 
+    let viewport = state.viewport;
+
     let (client, new_session_id) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
         let old_session_id = mgr.active_session_id()?.to_string();
@@ -3984,6 +3993,12 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
             title: String::new(),
             target_type: "page".to_string(),
         });
+
+        // Re-apply viewport to the recording context so it inherits the
+        // user's custom resolution instead of falling back to the default.
+        if let Some((w, h, scale, mobile)) = viewport {
+            let _ = mgr.set_viewport(w, h, scale, mobile).await;
+        }
 
         // Navigate to URL
         if nav_url != "about:blank" {
@@ -4661,7 +4676,7 @@ async fn handle_wheel(cmd: &Value, state: &DaemonState) -> Result<Value, String>
     Ok(json!({ "scrolled": true, "deltaX": delta_x, "deltaY": delta_y }))
 }
 
-async fn handle_device(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_device(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let name = cmd
         .get("name")
@@ -4689,6 +4704,8 @@ async fn handle_device(cmd: &Value, state: &DaemonState) -> Result<Value, String
 
     mgr.set_viewport(width, height, scale, mobile).await?;
     mgr.set_user_agent(ua).await?;
+
+    state.viewport = Some((width, height, scale, mobile));
 
     // Update stream server viewport so status messages and screencast use the new dimensions
     if let Some(ref server) = state.stream_server {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3621,7 +3621,6 @@ async fn handle_viewport(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
 
     mgr.set_viewport(width, height, scale, mobile).await?;
 
-    // Remember viewport for re-application to new contexts (e.g., recording)
     state.viewport = Some((width, height, scale, mobile));
 
     // Update stream server viewport so status messages and screencast use the new dimensions
@@ -3994,8 +3993,6 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
             target_type: "page".to_string(),
         });
 
-        // Re-apply viewport to the recording context so it inherits the
-        // user's custom resolution instead of falling back to the default.
         if let Some((w, h, scale, mobile)) = viewport {
             let _ = mgr.set_viewport(w, h, scale, mobile).await;
         }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -4127,3 +4127,95 @@ async fn e2e_upload_with_css_selector() {
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
 }
+
+// ---------------------------------------------------------------------------
+// Recording: viewport inheritance
+// ---------------------------------------------------------------------------
+
+/// Verify that `recording_start` inherits the current viewport dimensions
+/// into the newly created recording context. Without this, the recording
+/// context falls back to the default 1280×720 regardless of what the user set.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_inherits_viewport() {
+    let mut state = DaemonState::new();
+
+    // Launch browser
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Navigate to a simple page
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Viewport</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Set a custom viewport (non-default)
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "viewport", "width": 800, "height": 600 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Start recording — this creates a new browser context and switches to it
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!(
+        "ab-e2e-rec-viewport-{}.webm",
+        std::process::id()
+    ));
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Give the recording context a moment to finish navigation
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // The active page is now in the recording context.
+    // Verify it inherited the custom viewport dimensions.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "window.innerWidth" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let rec_width = get_data(&resp)["result"].as_i64().unwrap();
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "window.innerHeight" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let rec_height = get_data(&resp)["result"].as_i64().unwrap();
+
+    assert_eq!(
+        rec_width, 800,
+        "Recording context width should be 800 (inherited from viewport), got {rec_width}"
+    );
+    assert_eq!(
+        rec_height, 600,
+        "Recording context height should be 600 (inherited from viewport), got {rec_height}"
+    );
+
+    // Stop recording and cleanup
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let _ = std::fs::remove_file(&rec_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -4140,7 +4140,6 @@ async fn e2e_upload_with_css_selector() {
 async fn e2e_recording_inherits_viewport() {
     let mut state = DaemonState::new();
 
-    // Launch browser
     let resp = execute_command(
         &json!({ "id": "1", "action": "launch", "headless": true }),
         &mut state,
@@ -4148,7 +4147,6 @@ async fn e2e_recording_inherits_viewport() {
     .await;
     assert_success(&resp);
 
-    // Navigate to a simple page
     let resp = execute_command(
         &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Viewport</h1>" }),
         &mut state,
@@ -4156,7 +4154,6 @@ async fn e2e_recording_inherits_viewport() {
     .await;
     assert_success(&resp);
 
-    // Set a custom viewport (non-default)
     let resp = execute_command(
         &json!({ "id": "3", "action": "viewport", "width": 800, "height": 600 }),
         &mut state,
@@ -4164,7 +4161,6 @@ async fn e2e_recording_inherits_viewport() {
     .await;
     assert_success(&resp);
 
-    // Start recording — this creates a new browser context and switches to it
     let tmp_dir = std::env::temp_dir();
     let rec_path = tmp_dir.join(format!("ab-e2e-rec-viewport-{}.webm", std::process::id()));
     let resp = execute_command(
@@ -4174,11 +4170,8 @@ async fn e2e_recording_inherits_viewport() {
     .await;
     assert_success(&resp);
 
-    // Give the recording context a moment to finish navigation
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-    // The active page is now in the recording context.
-    // Verify it inherited the custom viewport dimensions.
     let resp = execute_command(
         &json!({ "id": "5", "action": "evaluate", "script": "window.innerWidth" }),
         &mut state,
@@ -4204,7 +4197,6 @@ async fn e2e_recording_inherits_viewport() {
         "Recording context height should be 600 (inherited from viewport), got {rec_height}"
     );
 
-    // Stop recording and cleanup
     let resp = execute_command(
         &json!({ "id": "7", "action": "recording_stop" }),
         &mut state,

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -4166,10 +4166,7 @@ async fn e2e_recording_inherits_viewport() {
 
     // Start recording — this creates a new browser context and switches to it
     let tmp_dir = std::env::temp_dir();
-    let rec_path = tmp_dir.join(format!(
-        "ab-e2e-rec-viewport-{}.webm",
-        std::process::id()
-    ));
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-viewport-{}.webm", std::process::id()));
     let resp = execute_command(
         &json!({ "id": "4", "action": "recording_start", "path": rec_path.to_string_lossy() }),
         &mut state,


### PR DESCRIPTION
## Summary
- When `record start` creates a new browser context, it now re-applies the current viewport settings so the recording resolution matches what the user configured instead of falling back to the default 1280×720
- Both `set viewport` and `set device` paths now store viewport state on `DaemonState` for re-application
- Follows the same "store & re-apply to new context" pattern used by `download_path` and `ignore_https_errors`

## Before / After

| Configured viewport | Before (recording resolution) | After (recording resolution) |
|---|---|---|
| `set viewport 1920 1080` | 1280×578 | 1920×1080 |
| `set viewport 800 600` | 1280×578 | 800×600 |
| `set device "iphone 16 pro"` | 1280×578 | 1206×2622 |

## Test plan
- [x] Added e2e test `e2e_recording_inherits_viewport` — sets 800×600 viewport, starts recording, verifies `window.innerWidth`/`innerHeight` in the recording context
- [x] Manual testing with `ffprobe` across three resolutions (1920×1080, 800×600, iPhone 16 Pro)

Closes #1207