### PR TITLE
CDP feat: tab-level session isolation while sharing the same browser and user profile

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -251,6 +251,10 @@ pub struct DaemonState {
 }
 
 impl DaemonState {
+    pub fn is_isolated(&self) -> bool {
+        self.session_id != "default"
+    }
+
     pub fn new() -> Self {
         Self {
             browser: None,
@@ -674,6 +678,7 @@ impl DaemonState {
     }
 
     fn drain_cdp_events(&mut self) -> DrainedEvents {
+        let is_isolated = self.is_isolated();
         let rx = match self.event_rx.as_mut() {
             Some(rx) => rx,
             None => return DrainedEvents::default(),
@@ -701,7 +706,8 @@ impl DaemonState {
                                         .browser
                                         .as_ref()
                                         .is_none_or(|b| b.has_target(&te.target_info.target_id));
-                                    if !already_tracked {
+                                    let allowed = !is_isolated || self.browser.as_ref().is_some_and(|b| te.target_info.opener_id.as_ref().is_some_and(|op| b.has_target(op)));
+                                    if !already_tracked && allowed {
                                         new_target_ids.insert(te.target_info.target_id.clone());
                                         new_targets.push(te);
                                     }
@@ -722,11 +728,12 @@ impl DaemonState {
                                         .browser
                                         .as_ref()
                                         .is_some_and(|b| b.has_target(&te.target_info.target_id));
+                                    let allowed = !is_isolated || self.browser.as_ref().is_some_and(|b| te.target_info.opener_id.as_ref().is_some_and(|op| b.has_target(op)));
                                     if already_tracked
                                         || new_target_ids.contains(&te.target_info.target_id)
                                     {
                                         changed_targets.push(te);
-                                    } else {
+                                    } else if allowed {
                                         new_target_ids.insert(te.target_info.target_id.clone());
                                         new_targets.push(TargetCreatedEvent {
                                             target_info: te.target_info,
@@ -1479,8 +1486,8 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 
 /// Connect to a running Chrome via auto-discovery and open a fresh tab so
 /// subsequent navigations don't hijack the user's existing tabs.
-async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
-    let mut mgr = BrowserManager::connect_auto().await?;
+async fn connect_auto_with_fresh_tab(isolate: bool) -> Result<BrowserManager, String> {
+    let mut mgr = BrowserManager::connect_auto(isolate).await?;
     mgr.tab_new(None).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let _ = mgr
@@ -1515,7 +1522,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
     write_extensions_file(&state.session_id);
 
     if let Ok(cdp) = env::var("AGENT_BROWSER_CDP") {
-        let mgr = BrowserManager::connect_cdp(&cdp).await?;
+        let mgr = BrowserManager::connect_cdp(&cdp, state.is_isolated()).await?;
         state.reset_input_state();
         state.browser = Some(mgr);
         state.subscribe_to_browser_events();
@@ -1528,7 +1535,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
 
     if env::var("AGENT_BROWSER_AUTO_CONNECT").is_ok() {
         state.reset_input_state();
-        state.browser = Some(connect_auto_with_fresh_tab().await?);
+        state.browser = Some(connect_auto_with_fresh_tab(state.is_isolated()).await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1552,11 +1559,11 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
                 None
             };
             let connect_result = if conn.direct_page {
-                BrowserManager::connect_cdp_direct(&conn.ws_url).await
+                BrowserManager::connect_cdp_direct(&conn.ws_url, state.is_isolated()).await
             } else if ws_headers.is_some() {
-                BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers).await
+                BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers, state.is_isolated()).await
             } else {
-                BrowserManager::connect_cdp(&conn.ws_url).await
+                BrowserManager::connect_cdp(&conn.ws_url, state.is_isolated()).await
             };
             match connect_result {
                 Ok(mgr) => {
@@ -1798,7 +1805,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(url) = cdp_url {
         state.reset_input_state();
-        state.browser = Some(BrowserManager::connect_cdp(url).await?);
+        state.browser = Some(BrowserManager::connect_cdp(url, state.is_isolated()).await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1808,7 +1815,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(port) = cdp_port {
         state.reset_input_state();
-        state.browser = Some(BrowserManager::connect_cdp(&port.to_string()).await?);
+        state.browser = Some(BrowserManager::connect_cdp(&port.to_string(), state.is_isolated()).await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1818,7 +1825,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if auto_connect {
         state.reset_input_state();
-        state.browser = Some(connect_auto_with_fresh_tab().await?);
+        state.browser = Some(connect_auto_with_fresh_tab(state.is_isolated()).await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -1844,11 +1851,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                 };
 
                 let connect_result = if conn.direct_page {
-                    BrowserManager::connect_cdp_direct(&conn.ws_url).await
+                    BrowserManager::connect_cdp_direct(&conn.ws_url, state.is_isolated()).await
                 } else if ws_headers.is_some() {
-                    BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers).await
+                    BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers, state.is_isolated()).await
                 } else {
-                    BrowserManager::connect_cdp(&conn.ws_url).await
+                    BrowserManager::connect_cdp(&conn.ws_url, state.is_isolated()).await
                 };
                 match connect_result {
                     Ok(mgr) => {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -278,7 +278,7 @@ impl BrowserManager {
                 ignore_https_errors,
                 visited_origins: HashSet::new(),
             };
-            manager.discover_and_attach_targets().await?;
+            manager.discover_and_attach_targets(false).await?;
             manager
         };
 
@@ -331,27 +331,29 @@ impl BrowserManager {
         Ok(manager)
     }
 
-    pub async fn connect_cdp(url: &str) -> Result<Self, String> {
-        Self::connect_cdp_inner(url, false, None).await
+    pub async fn connect_cdp(url: &str, isolate_session: bool) -> Result<Self, String> {
+        Self::connect_cdp_inner(url, false, None, isolate_session).await
     }
 
     /// Connect to a provider CDP proxy where the WebSocket IS the page session.
     /// Skips browser-level Target.* commands that most proxies don't support.
-    pub async fn connect_cdp_direct(url: &str) -> Result<Self, String> {
-        Self::connect_cdp_inner(url, true, None).await
+    pub async fn connect_cdp_direct(url: &str, isolate_session: bool) -> Result<Self, String> {
+        Self::connect_cdp_inner(url, true, None, isolate_session).await
     }
 
     pub async fn connect_cdp_with_headers(
         url: &str,
         headers: Option<Vec<(String, String)>>,
+        isolate_session: bool,
     ) -> Result<Self, String> {
-        Self::connect_cdp_inner(url, false, headers).await
+        Self::connect_cdp_inner(url, false, headers, isolate_session).await
     }
 
     async fn connect_cdp_inner(
         url: &str,
         direct_page: bool,
         headers: Option<Vec<(String, String)>>,
+        isolate_session: bool,
     ) -> Result<Self, String> {
         let ws_url = resolve_cdp_url(url).await?;
         let client = Arc::new(CdpClient::connect_with_headers(&ws_url, headers).await?);
@@ -378,17 +380,17 @@ impl BrowserManager {
             manager.active_page_index = 0;
             manager.enable_domains_direct().await?;
         } else {
-            manager.discover_and_attach_targets().await?;
+            manager.discover_and_attach_targets(isolate_session).await?;
         }
         Ok(manager)
     }
 
-    pub async fn connect_auto() -> Result<Self, String> {
+    pub async fn connect_auto(isolate_session: bool) -> Result<Self, String> {
         let ws_url = auto_connect_cdp().await?;
-        Self::connect_cdp(&ws_url).await
+        Self::connect_cdp(&ws_url, isolate_session).await
     }
 
-    async fn discover_and_attach_targets(&mut self) -> Result<(), String> {
+    async fn discover_and_attach_targets(&mut self, isolate_session: bool) -> Result<(), String> {
         self.client
             .send_command_typed::<_, Value>(
                 "Target.setDiscoverTargets",
@@ -402,11 +404,15 @@ impl BrowserManager {
             .send_command_typed("Target.getTargets", &json!({}), None)
             .await?;
 
-        let page_targets: Vec<TargetInfo> = result
-            .target_infos
-            .into_iter()
-            .filter(should_track_target)
-            .collect();
+        let page_targets: Vec<TargetInfo> = if isolate_session {
+            Vec::new()
+        } else {
+            result
+                .target_infos
+                .into_iter()
+                .filter(should_track_target)
+                .collect()
+        };
 
         if page_targets.is_empty() {
             // Create a new tab
@@ -1393,7 +1399,7 @@ async fn discover_and_attach_lightpanda_targets(
 ) -> Result<(), String> {
     run_with_lightpanda_deadline(
         deadline,
-        manager.discover_and_attach_targets(),
+        manager.discover_and_attach_targets(false),
         "Target domain initialization attempt exceeded the remaining startup deadline",
     )
     .await

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -110,6 +110,8 @@ pub struct TargetInfo {
     pub url: String,
     pub attached: Option<bool>,
     pub browser_context_id: Option<String>,
+    #[serde(rename = "openerId")]
+    pub opener_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/package.json
+++ b/package.json
@@ -42,5 +42,7 @@
     "url": "https://github.com/vercel-labs/agent-browser/issues"
   },
   "homepage": "https://agent-browser.dev",
-  "devDependencies": {}
+  "dependencies": {
+    "ws": "^8.20.0"
+  }
 }


### PR DESCRIPTION
This feature ensures that when multiple agents connect to the same browser instance via CDP, they operate in completely isolated scopes.

- Adds `opener_id` to TargetInfo to track popup parent/child relationships.
- Skips attaching to pre-existing targets when a custom session name is specified, creating a fresh 'about:blank' tab instead.
- Filters CDP Target events (created, changed) to ignore tabs that do not belong to the current session or were not spawned from it.

Example Usage:
multiple agents can securely share the same browser profile (and login cookies) while remaining completely blind to each other's activities:
```sh
chromium --remote-debugging-port=9222 --remote-allow-origins=* --user-data-dir=$HOME/chromium_robot_data &
agent-browser --cdp 9222 --session agent1 open x.com
agent-browser --cdp 9222 --session agent2 open youtube.com
```