### PR TITLE
fix: preserve the active page when removing earlier tabs

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -111,6 +111,26 @@ fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo)
     false
 }
 
+fn active_page_index_after_removal(
+    active_page_index: usize,
+    removed_index: usize,
+    remaining_pages: usize,
+) -> usize {
+    if remaining_pages == 0 {
+        return 0;
+    }
+
+    if removed_index < active_page_index {
+        return active_page_index - 1;
+    }
+
+    if active_page_index >= remaining_pages {
+        return remaining_pages - 1;
+    }
+
+    active_page_index
+}
+
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
@@ -830,6 +850,14 @@ impl BrowserManager {
         }
     }
 
+    fn update_active_page_after_removal(&mut self, removed_index: usize) {
+        self.active_page_index = active_page_index_after_removal(
+            self.active_page_index,
+            removed_index,
+            self.pages.len(),
+        );
+    }
+
     pub fn tab_list(&self) -> Vec<Value> {
         self.pages
             .iter()
@@ -929,6 +957,7 @@ impl BrowserManager {
         }
 
         let page = self.pages.remove(target_index);
+        self.update_active_page_after_removal(target_index);
         let _ = self
             .client
             .send_command_typed::<_, Value>(
@@ -939,10 +968,6 @@ impl BrowserManager {
                 None,
             )
             .await;
-
-        if self.active_page_index >= self.pages.len() {
-            self.active_page_index = self.pages.len() - 1;
-        }
 
         let session_id = self.pages[self.active_page_index].session_id.clone();
         self.enable_domains(&session_id).await?;
@@ -1201,7 +1226,7 @@ impl BrowserManager {
     pub fn remove_page_by_target_id(&mut self, target_id: &str) {
         if let Some(pos) = self.pages.iter().position(|p| p.target_id == target_id) {
             self.pages.remove(pos);
-            self.update_active_page_if_needed();
+            self.update_active_page_after_removal(pos);
         }
     }
 
@@ -1524,6 +1549,26 @@ mod tests {
         assert!(update_page_target_info_in_pages(&mut pages, &target));
         assert_eq!(pages[0].url, "https://example.com/popup");
         assert_eq!(pages[0].title, "Popup");
+    }
+
+    #[test]
+    fn test_active_page_index_after_removal_shifts_when_earlier_tab_is_removed() {
+        assert_eq!(active_page_index_after_removal(2, 0, 3), 1);
+    }
+
+    #[test]
+    fn test_active_page_index_after_removal_keeps_same_slot_when_later_tab_is_removed() {
+        assert_eq!(active_page_index_after_removal(1, 2, 3), 1);
+    }
+
+    #[test]
+    fn test_active_page_index_after_removal_clamps_when_active_last_tab_is_removed() {
+        assert_eq!(active_page_index_after_removal(3, 3, 3), 2);
+    }
+
+    #[test]
+    fn test_active_page_index_after_removal_resets_when_last_page_disappears() {
+        assert_eq!(active_page_index_after_removal(0, 0, 0), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the same logical active page when a tab before it is removed
- apply the same adjustment to both `tab close` and destroyed-target cleanup
- add regression tests for earlier-tab removal, later-tab removal, last-tab clamping, and the empty-page case

Closes #1219.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml`
- `cargo test --manifest-path cli/Cargo.toml active_page_index_after_removal`
- `cargo test --manifest-path cli/Cargo.toml tab_`
- manual CLI validation with `AGENT_BROWSER_ARGS=--no-sandbox`: open A/B/C/D, switch to C, run `tab close 0`, verify `get title` still returns `C` and the active tab is now index `1`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`

