### PR TITLE
Prepare v0.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,32 @@
 # agent-browser
 
-## 0.25.3
+## 0.25.4
 
 <!-- release:start -->
+### New Features
+
+- **`skills` command** - Added `agent-browser skills` command for discovering and installing agent skills, with built-in evaluation support for testing skills against live browser sessions (#1225, #1227)
+
+### Bug Fixes
+
+- Fixed **custom viewport dimensions** not being used in streaming frame metadata and image resolution (#1033)
+- Fixed **`--ignore-https-errors`** not being re-applied to recording contexts, causing TLS errors during screen recordings (#1178)
+- Fixed **duplicate option numbering** in the auth skill documentation (#1161)
+
+### Documentation
+
+- The docs site header now **dynamically fetches** the GitHub star count (#1202)
+
+### Contributors
+
+- @ctate
+- @jin-2-kakaoent
+- @juniper929
+- @Marshall-Sun
+<!-- release:end -->
+
+## 0.25.3
+
 ### Bug Fixes
 
 - Fixed **hidden radio/checkbox inputs missing from snapshot refs** when a `<label>` wraps a `display:none` `<input type="radio">` or `<input type="checkbox">`. Chrome excludes these inputs from the accessibility tree entirely, making it impossible for AI agents to identify radio buttons and checkboxes via refs. Hidden inputs inside elements are now detected during cursor-interactive scanning and their parent nodes are promoted to the correct role with proper name and checked state (#1085)
@@ -16,7 +40,6 @@
 - @ctate
 - @jin-2-kakaoent
 - @hyunjinee
-<!-- release:end -->
 
 ## 0.25.2
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.25.3"
+version = "0.25.4"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.25.4
+
+<p className="text-[#888] text-sm">April 12, 2026</p>
+
+### New Features
+
+- **`skills` command** - Added `agent-browser skills` command for discovering and installing agent skills, with built-in evaluation support for testing skills against live browser sessions (#1225, #1227)
+
+### Bug Fixes
+
+- Fixed **custom viewport dimensions** not being used in streaming frame metadata and image resolution (#1033)
+- Fixed **`--ignore-https-errors`** not being re-applied to recording contexts, causing TLS errors during screen recordings (#1178)
+- Fixed **duplicate option numbering** in the auth skill documentation (#1161)
+
+### Documentation
+
+- The docs site header now **dynamically fetches** the GitHub star count (#1202)
+
+---
+
 ## v0.25.3
 
 <p className="text-[#888] text-sm">April 7, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "files": [

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bump version to 0.25.4 across `package.json`, `cli/Cargo.toml`, `cli/Cargo.lock`, and `packages/dashboard/package.json`
- Add changelog entry for `skills` command, bug fixes (viewport streaming, recording context HTTPS errors, skill docs), and docs improvements
- Update docs changelog at `docs/src/app/changelog/page.mdx`

## Changes in this release

### New Features

- **`skills` command** - Added `agent-browser skills` command for discovering and installing agent skills, with built-in evaluation support (#1225, #1227)

### Bug Fixes

- Fixed **custom viewport dimensions** not being used in streaming frame metadata and image resolution (#1033)
- Fixed **`--ignore-https-errors`** not being re-applied to recording contexts (#1178)
- Fixed **duplicate option numbering** in the auth skill documentation (#1161)

### Documentation

- The docs site header now **dynamically fetches** the GitHub star count (#1202)