### PR TITLE
fix: default cookie sameSite to Lax when Chrome returns empty value

### DIFF
--- a/cli/src/native/cookies.rs
+++ b/cli/src/native/cookies.rs
@@ -29,10 +29,13 @@ pub async fn get_all_cookies(client: &CdpClient, session_id: &str) -> Result<Vec
         .send_command_no_params("Network.getAllCookies", Some(session_id))
         .await?;
 
-    let cookies: Vec<Cookie> = result
+    let mut cookies: Vec<Cookie> = result
         .get("cookies")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default();
+
+    // Chrome may return empty sameSite; default to "Lax" to match Playwright behavior
+    fill_default_same_site(&mut cookies);
 
     Ok(cookies)
 }
@@ -51,12 +54,27 @@ pub async fn get_cookies(
         .send_command("Network.getCookies", Some(params), Some(session_id))
         .await?;
 
-    let cookies: Vec<Cookie> = result
+    let mut cookies: Vec<Cookie> = result
         .get("cookies")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default();
 
+    // Chrome may return empty sameSite; default to "Lax" to match Playwright behavior
+    fill_default_same_site(&mut cookies);
+
     Ok(cookies)
+}
+
+/// When Chrome CDP returns cookies with an empty `sameSite` field, default it
+/// to `"Lax"` so that saved state files always include the attribute. This
+/// matches Playwright's serialization behavior and prevents session cookies
+/// from being dropped during cross-origin redirects when the state is restored.
+fn fill_default_same_site(cookies: &mut [Cookie]) {
+    for cookie in cookies.iter_mut() {
+        if cookie.same_site.is_none() {
+            cookie.same_site = Some("Lax".to_string());
+        }
+    }
 }
 
 pub async fn set_cookies(


### PR DESCRIPTION
## Summary

- When Chrome CDP's `Network.getAllCookies` returns cookies with an empty `sameSite` field, the Rust `Option<String>` deserializes to `None` and `#[serde(skip_serializing_if = "Option::is_none")]` omits it from the saved state file.
- On restore via `load_state`, `Network.setCookies` receives cookies without `sameSite`, causing them to be dropped during cross-origin redirects (e.g. CAS authentication chains), which breaks session reuse.
- This defaults `sameSite` to `"Lax"` when it is `None` in both `get_all_cookies` and `get_cookies`, matching Playwright's serialization behavior.

## Reproduction

Save state with `state save`, inspect the JSON — cookies like `JSESSIONID` are missing the `sameSite` field. When restored, cross-origin redirect chains fail to carry the session cookie, forcing re-authentication.

**0.19.0 (working):** `{ "sameSite": "Lax", ... }`
**0.25.4 (broken):** `{ ... }` ← `sameSite` field missing

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Save state, inspect that all cookies now include `sameSite`
- [ ] Load a previously saved state and verify session cookies are carried across cross-origin redirects