### PR TITLE
fix(chrome): always set --disable-dev-shm-usage by default

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -1028,33 +1028,15 @@ fn should_disable_sandbox(existing_args: &[String]) -> bool {
 }
 
 /// Returns true if Chrome should use disk instead of /dev/shm for shared memory.
-/// On CI runners and containers, /dev/shm is often too small (64MB default),
-/// which causes Chrome to crash mid-session.
+///
+/// We enable this by default because many container runtimes mount `/dev/shm`
+/// with small limits (often 64MB), which can cause Chromium to crash.
 fn should_disable_dev_shm(existing_args: &[String]) -> bool {
     if existing_args.iter().any(|a| a == "--disable-dev-shm-usage") {
-        return false;
+        return false; // already set by user
     }
 
-    if std::env::var("CI").is_ok() {
-        return true;
-    }
-
-    #[cfg(unix)]
-    {
-        if unsafe { libc::geteuid() } == 0 {
-            return true;
-        }
-        if Path::new("/.dockerenv").exists() || Path::new("/run/.containerenv").exists() {
-            return true;
-        }
-        if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
-            if cgroup.contains("docker") || cgroup.contains("kubepods") || cgroup.contains("lxc") {
-                return true;
-            }
-        }
-    }
-
-    false
+    true
 }
 
 /// Search Puppeteer's browser cache for a Chrome binary.


### PR DESCRIPTION
### Motivation

- Chromium can crash in container environments when `/dev/shm` is small, so the default launch should use disk for shared memory by adding `--disable-dev-shm-usage`.
- Simplify the detection logic to make the safer behavior the default while still avoiding duplicate flags when the user provides the argument.
- Reference of puppeteer https://github.com/puppeteer/puppeteer/issues/1834

### Description

- Updated `cli/src/native/cdp/chrome.rs` to always enable `--disable-dev-shm-usage` by default via a simplified `should_disable_dev_shm` implementation that returns `true` unless the user already passed `--disable-dev-shm-usage`.
- Added/clarified the doc comment above `should_disable_dev_shm` to explain why the flag is enabled by default in container-like environments.
- The existing `build_chrome_args` flow already calls `should_disable_dev_shm`, so Chromium launch args will now include `--disable-dev-shm-usage` when appropriate.

### Testing

- Ran formatting check: `cd cli && cargo fmt -- --check`, which succeeded.
- Ran the focused test command: `cd cli && cargo test -q should_disable_dev_shm`, which completed successfully (0 tests executed and test run finished with status `ok`).