### PR TITLE
feat: Improve dev-shm detection for Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,16 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--config <path>` | Use a custom config file (or `AGENT_BROWSER_CONFIG` env) |
 | `--debug` | Debug output |
 
+### Containers and CI
+
+In Docker, devcontainers, CI runners, or other sandboxed Linux environments, Chrome may need extra launch flags:
+
+```bash
+agent-browser --args "--no-sandbox,--disable-dev-shm-usage" open example.com
+```
+
+agent-browser automatically adds `--no-sandbox` when the runtime looks sandbox-constrained, and automatically adds `--disable-dev-shm-usage` when `/dev/shm` is smaller than 128 MiB. Manual `--args` still work if you want to pin the behavior explicitly.
+
 ## Observability Dashboard
 
 Monitor agent-browser sessions in real time with a local web dashboard showing a live viewport and command activity feed.

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -989,37 +990,128 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
 /// Returns true if Chrome's sandbox should be disabled because the environment
 /// doesn't support it (containers, VMs, CI runners, running as root).
 fn should_disable_sandbox(existing_args: &[String]) -> bool {
+    let is_ci = env::var_os("CI").is_some();
+
+    #[cfg(unix)]
+    let is_root = unsafe { libc::geteuid() } == 0;
+    #[cfg(not(unix))]
+    let is_root = false;
+
+    should_disable_sandbox_for_environment(existing_args, is_ci, is_root, is_containerized())
+}
+
+fn should_disable_sandbox_for_environment(
+    existing_args: &[String],
+    is_ci: bool,
+    is_root: bool,
+    is_containerized: bool,
+) -> bool {
     if existing_args.iter().any(|a| a == "--no-sandbox") {
         return false; // already set by user
     }
 
     // CI environments (GitHub Actions, GitLab CI, etc.) often lack user namespace
     // support due to AppArmor or kernel restrictions.
-    if std::env::var("CI").is_ok() {
+    if is_ci {
+        return true;
+    }
+
+    // Root user often lacks the Chrome sandbox prerequisites even on bare metal.
+    if is_root {
+        return true;
+    }
+
+    is_containerized
+}
+
+/// Returns true if Chrome should use disk instead of /dev/shm for shared memory.
+/// On Linux containers and CI runners, `/dev/shm` is often too small
+/// (64 MiB is a common default), which causes Chrome to crash mid-session.
+fn should_disable_dev_shm(existing_args: &[String]) -> bool {
+    let is_ci = env::var_os("CI").is_some();
+    let is_containerized = is_containerized();
+
+    #[cfg(unix)]
+    let dev_shm_status = detect_dev_shm_status();
+    #[cfg(not(unix))]
+    let dev_shm_status = None;
+
+    should_disable_dev_shm_for_environment(existing_args, is_ci, is_containerized, dev_shm_status)
+}
+
+fn should_disable_dev_shm_for_environment(
+    existing_args: &[String],
+    is_ci: bool,
+    is_containerized: bool,
+    #[cfg(unix)] dev_shm_status: Option<DevShmStatus>,
+    #[cfg(not(unix))] _dev_shm_status: Option<()>,
+) -> bool {
+    if existing_args.iter().any(|a| a == "--disable-dev-shm-usage") {
+        return false;
+    }
+
+    if is_ci {
         return true;
     }
 
     #[cfg(unix)]
     {
-        // Root user -- standard container default, Chrome sandbox requires non-root
-        if unsafe { libc::geteuid() } == 0 {
+        match dev_shm_status {
+            Some(DevShmStatus::TooSmall) => return true,
+            Some(DevShmStatus::Healthy) => return false,
+            Some(DevShmStatus::Missing) | None => {}
+        }
+
+        if is_containerized {
+            return true;
+        }
+    }
+
+    false
+}
+
+const CONTAINER_CGROUP_MARKERS: &[&str] = &[
+    "docker",
+    "kubepods",
+    "containerd",
+    "cri-containerd",
+    "libpod",
+    "podman",
+    "lxc",
+];
+
+#[cfg(unix)]
+const MIN_DEV_SHM_BYTES: u64 = 128 * 1024 * 1024;
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DevShmStatus {
+    Missing,
+    TooSmall,
+    Healthy,
+}
+
+/// Best-effort detection for containerized runtimes across Docker, Podman,
+/// Kubernetes/containerd, and systemd-managed containers.
+fn is_containerized() -> bool {
+    #[cfg(unix)]
+    {
+        if env::var_os("container").is_some_and(|value| !value.is_empty()) {
             return true;
         }
 
-        // Docker container
-        if Path::new("/.dockerenv").exists() {
+        if Path::new("/.dockerenv").exists()
+            || Path::new("/run/.containerenv").exists()
+            || Path::new("/run/systemd/container").exists()
+        {
             return true;
         }
 
-        // Podman container
-        if Path::new("/run/.containerenv").exists() {
-            return true;
-        }
-
-        // Generic container detection: cgroup contains docker/kubepods/lxc
-        if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
-            if cgroup.contains("docker") || cgroup.contains("kubepods") || cgroup.contains("lxc") {
-                return true;
+        for path in ["/proc/1/cgroup", "/proc/self/cgroup"] {
+            if let Ok(cgroup) = std::fs::read_to_string(path) {
+                if cgroup_indicates_container(&cgroup) {
+                    return true;
+                }
             }
         }
     }
@@ -1027,34 +1119,42 @@ fn should_disable_sandbox(existing_args: &[String]) -> bool {
     false
 }
 
-/// Returns true if Chrome should use disk instead of /dev/shm for shared memory.
-/// On CI runners and containers, /dev/shm is often too small (64MB default),
-/// which causes Chrome to crash mid-session.
-fn should_disable_dev_shm(existing_args: &[String]) -> bool {
-    if existing_args.iter().any(|a| a == "--disable-dev-shm-usage") {
-        return false;
+fn cgroup_indicates_container(cgroup: &str) -> bool {
+    CONTAINER_CGROUP_MARKERS
+        .iter()
+        .any(|marker| cgroup.contains(marker))
+}
+
+#[cfg(unix)]
+fn detect_dev_shm_status() -> Option<DevShmStatus> {
+    let dev_shm = Path::new("/dev/shm");
+    if !dev_shm.exists() {
+        return Some(DevShmStatus::Missing);
     }
 
-    if std::env::var("CI").is_ok() {
-        return true;
+    // `/dev/shm` capacity is the real signal we care about. If statvfs fails,
+    // fall back to container heuristics instead of guessing here.
+    let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    let rc = unsafe { libc::statvfs(b"/dev/shm\0".as_ptr().cast(), stats.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
     }
 
-    #[cfg(unix)]
-    {
-        if unsafe { libc::geteuid() } == 0 {
-            return true;
-        }
-        if Path::new("/.dockerenv").exists() || Path::new("/run/.containerenv").exists() {
-            return true;
-        }
-        if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
-            if cgroup.contains("docker") || cgroup.contains("kubepods") || cgroup.contains("lxc") {
-                return true;
-            }
-        }
-    }
+    let stats = unsafe { stats.assume_init() };
+    let block_size = u64::from(stats.f_frsize);
+    let total_bytes = u64::from(stats.f_blocks).saturating_mul(block_size);
+    let available_bytes = u64::from(stats.f_bavail).saturating_mul(block_size);
 
-    false
+    Some(dev_shm_status_from_capacity(total_bytes, available_bytes))
+}
+
+#[cfg(unix)]
+fn dev_shm_status_from_capacity(total_bytes: u64, available_bytes: u64) -> DevShmStatus {
+    if total_bytes < MIN_DEV_SHM_BYTES || available_bytes < MIN_DEV_SHM_BYTES {
+        DevShmStatus::TooSmall
+    } else {
+        DevShmStatus::Healthy
+    }
 }
 
 /// Search Puppeteer's browser cache for a Chrome binary.
@@ -1262,6 +1362,86 @@ mod tests {
     fn test_should_disable_sandbox_skips_if_already_set() {
         let args = vec!["--headless=new".to_string(), "--no-sandbox".to_string()];
         assert!(!should_disable_sandbox(&args));
+    }
+
+    #[test]
+    fn test_should_disable_sandbox_for_containerized_env() {
+        let args = vec!["--headless=new".to_string()];
+        assert!(should_disable_sandbox_for_environment(
+            &args, false, false, true
+        ));
+    }
+
+    #[test]
+    fn test_cgroup_indicates_container_matches_containerd() {
+        let cgroup = "0::/kubepods.slice/pod123/cri-containerd-abcdef.scope";
+        assert!(cgroup_indicates_container(cgroup));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_should_disable_dev_shm_skips_if_already_set() {
+        let args = vec![
+            "--headless=new".to_string(),
+            "--disable-dev-shm-usage".to_string(),
+        ];
+        assert!(!should_disable_dev_shm_for_environment(
+            &args,
+            false,
+            true,
+            Some(DevShmStatus::TooSmall),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dev_shm_status_marks_small_tmpfs_as_too_small() {
+        assert_eq!(
+            dev_shm_status_from_capacity(64 * 1024 * 1024, 64 * 1024 * 1024),
+            DevShmStatus::TooSmall
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dev_shm_status_accepts_large_tmpfs() {
+        assert_eq!(
+            dev_shm_status_from_capacity(512 * 1024 * 1024, 256 * 1024 * 1024),
+            DevShmStatus::Healthy
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_should_disable_dev_shm_when_tmpfs_missing_falls_back_to_container_signal() {
+        let args = vec!["--headless=new".to_string()];
+        assert!(should_disable_dev_shm_for_environment(
+            &args,
+            false,
+            true,
+            Some(DevShmStatus::Missing),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_should_disable_dev_shm_when_tmpfs_is_healthy() {
+        let args = vec!["--headless=new".to_string()];
+        assert!(!should_disable_dev_shm_for_environment(
+            &args,
+            false,
+            false,
+            Some(DevShmStatus::Healthy),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_should_disable_dev_shm_falls_back_to_container_signal() {
+        let args = vec!["--headless=new".to_string()];
+        assert!(should_disable_dev_shm_for_environment(
+            &args, false, true, None
+        ));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2933,6 +2933,8 @@ Options:
   --extension <path>         Load browser extensions (repeatable)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
                              e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
+                             Chrome auto-adds --no-sandbox and --disable-dev-shm-usage
+                             in constrained Linux environments when needed
   --user-agent <ua>          Custom User-Agent (or AGENT_BROWSER_USER_AGENT)
   --proxy <server>           Proxy server URL (or AGENT_BROWSER_PROXY, HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
                              Supports authenticated proxies: --proxy "http://user:pass@127.0.0.1:7890"

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -112,6 +112,8 @@ Every CLI flag can be set in the config file using its camelCase equivalent:
 }
 ```
 
+agent-browser already auto-adds `--no-sandbox` when the sandbox looks unavailable, and auto-adds `--disable-dev-shm-usage` when `/dev/shm` is too small. Keeping these args in config can still be useful when you want an explicit, pinned setup for CI images.
+
 ### iOS Testing
 
 ```json

--- a/docs/src/app/engines/chrome/page.mdx
+++ b/docs/src/app/engines/chrome/page.mdx
@@ -95,10 +95,10 @@ These features are available only with Chrome:
 
 ## Containers and CI
 
-In Docker, CI runners, or other sandboxed environments, Chrome's user namespace sandbox may need to be disabled:
+In Docker, CI runners, devcontainers, or other sandboxed Linux environments, Chrome may need extra launch flags:
 
 ```bash
-agent-browser --args "--no-sandbox" open example.com
+agent-browser --args "--no-sandbox,--disable-dev-shm-usage" open example.com
 ```
 
-agent-browser automatically adds `--no-sandbox` when it detects a container environment (Docker, Podman, running as root).
+agent-browser automatically adds `--no-sandbox` when the runtime looks sandbox-constrained. It also automatically adds `--disable-dev-shm-usage` when `/dev/shm` is smaller than 128 MiB, which is common in containers with the default 64 MiB shared-memory mount.

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -36,6 +36,7 @@ agent-browser skills get <name> --full    # Include references and templates
 - Fast native Rust CLI, not a Node.js wrapper
 - Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
 - Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
+- Automatically hardens Chrome launch in constrained Linux environments by adding `--no-sandbox` and `--disable-dev-shm-usage` when needed
 - Accessibility-tree snapshots with element refs for reliable interaction
 - Sessions, authentication vault, state persistence, video recording
 - Specialized skills for Electron apps, Slack, exploratory testing, cloud providers


### PR DESCRIPTION
 ## Summary

  Improves Chrome launch handling for constrained Linux environments, with a more accurate `--disable-dev-shm-usage` decision path.

  ## What changed

  - Refactored Chrome environment detection in `cli/src/native/cdp/chrome.rs`
  - Expanded container heuristics used for `--no-sandbox`
    - added support for more container markers such as `containerd`, `cri-containerd`, `libpod`, and `podman`
    - check both `/proc/1/cgroup` and `/proc/self/cgroup`
    - check additional runtime signals like the `container` env var and `/run/systemd/container`
  - Changed `--disable-dev-shm-usage` auto-detection to prefer real `/dev/shm` capacity checks
    - automatically enable it when `/dev/shm` is smaller than `128 MiB`
    - do not enable it solely because `/dev/shm` is missing
  - Added focused unit tests for container detection and `/dev/shm` decision logic
  - Updated help text and docs to reflect the new behavior

  ## Why

  The previous `--disable-dev-shm-usage` logic relied too heavily on container heuristics. That could miss some environments, and it also used container detection as a proxy for the real issue.

  The root problem here is not "being in a container" by itself. The real problem is a too-small shared memory mount, which is common in containers but should be detected directly when possible.

  This change makes the behavior more precise:
  - `--no-sandbox` still uses runtime heuristics
  - `--disable-dev-shm-usage` now primarily follows actual `/dev/shm` capacity