### PR TITLE
fix(ci): install ffmpeg for e2e recording test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
         run: |
           cargo run --manifest-path cli/Cargo.toml -- install --with-deps
 
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Run e2e tests
         run: cargo test --profile ci --manifest-path cli/Cargo.toml e2e -- --ignored --test-threads=1
 


### PR DESCRIPTION
## Summary

- Install ffmpeg in the Native E2E Tests CI job so `e2e_recording_inherits_viewport` (added in #1208) can run successfully. Without it, `recording_start` fails with "ffmpeg not found".