### PR TITLE
Prepare v0.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # agent-browser
 
-## 0.25.4
+## 0.25.5
 
 <!-- release:start -->
+### Bug Fixes
+
+- Fixed **`--auto-connect` CDP discovery** preferring HTTP endpoint discovery over the DevToolsActivePort websocket path, which could fail on some setups. The CLI now reads the websocket path from DevToolsActivePort first and only falls back to HTTP discovery (#1218)
+- Fixed **recording context viewport** not inheriting the active viewport dimensions, causing recordings to use default resolution instead of the configured viewport (#1208)
+- Fixed **`get box` and `get styles`** printing no data in text mode (#1231, #1233)
+- Fixed **active page changing** when closing or removing earlier tabs. The previously focused page is now preserved correctly (#1220)
+
+### Contributors
+
+- @ctate
+- @jin-2-kakaoent
+- @officialasishkumar
+<!-- release:end -->
+
+## 0.25.4
+
 ### New Features
 
 - **`skills` command** - Added `agent-browser skills` command for discovering and installing agent skills, with built-in evaluation support for testing skills against live browser sessions (#1225, #1227)
@@ -23,7 +39,6 @@
 - @jin-2-kakaoent
 - @juniper929
 - @Marshall-Sun
-<!-- release:end -->
 
 ## 0.25.3
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.25.4"
+version = "0.25.5"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3950,7 +3950,9 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     .await;
     assert_success(&resp);
 
-    // Wait for a frame message and verify both metadata and actual image dimensions
+    // Wait for a frame whose JPEG dimensions match the custom viewport.
+    // Early frames may arrive before Chrome fully applies the viewport resize,
+    // so skip frames with stale dimensions rather than failing immediately.
     let mut found_frame = false;
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
     while tokio::time::Instant::now() < deadline {
@@ -3977,28 +3979,18 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
                 meta
             );
 
-            // Verify the actual JPEG image dimensions match the custom viewport.
             let data_str = parsed
                 .get("data")
                 .and_then(|v| v.as_str())
                 .expect("frame message should include base64-encoded 'data' field");
-            {
-                use base64::Engine;
-                let bytes = base64::engine::general_purpose::STANDARD
-                    .decode(data_str)
-                    .expect("frame data should be valid base64");
-                let (img_w, img_h) = jpeg_dimensions(&bytes)
-                    .expect("frame data should be a valid JPEG with SOF marker");
-                assert_eq!(
-                    img_w, 800,
-                    "JPEG image width should match custom viewport, got: {}",
-                    img_w
-                );
-                assert_eq!(
-                    img_h, 600,
-                    "JPEG image height should match custom viewport, got: {}",
-                    img_h
-                );
+            use base64::Engine;
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(data_str)
+                .expect("frame data should be valid base64");
+            let (img_w, img_h) =
+                jpeg_dimensions(&bytes).expect("frame data should be a valid JPEG with SOF marker");
+            if img_w != 800 || img_h != 600 {
+                continue;
             }
 
             found_frame = true;
@@ -4007,7 +3999,7 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     }
     assert!(
         found_frame,
-        "should have received at least one frame message with correct viewport metadata"
+        "should have received a frame with JPEG dimensions 800x600 within the deadline"
     );
 
     // Cleanup

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.25.5
+
+<p className="text-[#888] text-sm">April 16, 2026</p>
+
+### Bug Fixes
+
+- Fixed **`--auto-connect` CDP discovery** preferring HTTP endpoint discovery over the DevToolsActivePort websocket path, which could fail on some setups. The CLI now reads the websocket path from DevToolsActivePort first and only falls back to HTTP discovery (#1218)
+- Fixed **recording context viewport** not inheriting the active viewport dimensions, causing recordings to use default resolution instead of the configured viewport (#1208)
+- Fixed **`get box` and `get styles`** printing no data in text mode (#1231, #1233)
+- Fixed **active page changing** when closing or removing earlier tabs. The previously focused page is now preserved correctly (#1220)
+
+---
+
 ## v0.25.4
 
 <p className="text-[#888] text-sm">April 12, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "files": [

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps version to 0.25.5 across `package.json`, `cli/Cargo.toml`, `cli/Cargo.lock`, and `packages/dashboard/package.json`
- Adds changelog entry for 4 bug fixes: `--auto-connect` CDP discovery, recording context viewport inheritance, `get box`/`get styles` text output, and active page preservation on tab removal
- Updates docs changelog at `docs/src/app/changelog/page.mdx`