### PR TITLE
feat(tabs): t<N> prefix for tab ids; --label for named tabs; drop --tab peek flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,35 +290,49 @@ agent-browser network har stop [output.har]    # Stop and save HAR (temp path if
 ### Tabs & Windows
 
 ```bash
-agent-browser tab                     # List tabs (shows stable `tabId` for each)
-agent-browser tab new [url]           # New tab (optionally with URL)
-agent-browser tab <id>                # Switch to tab by id
-agent-browser tab close [id]          # Close tab by id (defaults to active tab)
-agent-browser window new              # New window
+agent-browser tab                              # List tabs (shows `tabId` and optional label)
+agent-browser tab new [url]                    # New tab (optionally with URL)
+agent-browser tab new --label docs [url]       # New tab with a user-assigned label
+agent-browser tab <t<N>|label>                 # Switch to a tab by id or label
+agent-browser tab close [t<N>|label]           # Close a tab (defaults to active)
+agent-browser window new                       # New window
 ```
 
-Tab IDs are stable and never reused within a session, so agents can keep
-referring to the same tab across commands even if other tabs are opened or
-closed in between. To run a single command against a specific tab without
-changing the active tab, use the global `--tab <id>` flag. The active tab and
-its element refs (`@e1`, etc.) are preserved across the peek:
+Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused
+within a session, so scripts and agents can keep referring to the same tab
+even after other tabs are opened or closed. Positional integers like `tab 2`
+are **not** accepted; the `t` prefix disambiguates handles from indices and
+mirrors the `@e1` convention used for element refs.
+
+You can also assign a memorable label (`docs`, `app`, `admin`) and use it
+interchangeably with the id. Labels are never auto-generated and never
+rewritten on navigation — they're yours to name and keep:
 
 ```bash
-agent-browser tab new https://docs.example.com   # opens and activates tab 2
-agent-browser snapshot                           # refs @e1..@eN on tab 2
-agent-browser --tab 1 snapshot                   # peek at tab 1 (tab 2 still active)
-agent-browser click @e1                          # tab 2's refs still work
+agent-browser tab new --label docs https://docs.example.com
+agent-browser tab docs                   # switch by label
+agent-browser --tab docs snapshot        # peek by label
 ```
 
-Use `--tab <id>` to peek (one-off read, then return) and `tab <id>` to switch
-(multiple commands on another tab). Element refs are scoped to the tab they
-were snapshotted on, so if you need to interact with another tab by ref,
-snapshot after switching:
+The global `--tab <t<N>|label>` flag runs one command against a specific
+tab and then restores the active tab and its element refs (`@e1`, etc.):
 
 ```bash
-agent-browser tab 1                              # switch permanently to tab 1
-agent-browser snapshot                           # refs for tab 1
-agent-browser click @e3                          # uses tab 1's refs
+agent-browser tab new --label docs https://docs.example.com    # activates t2
+agent-browser snapshot                                         # refs @e1..@eN on t2
+agent-browser --tab t1 snapshot                                # peek t1; t2 still active
+agent-browser click @e1                                        # t2's refs still work
+```
+
+Use `--tab` to peek (one-off read, then return) and `tab <id|label>` to
+switch (multiple commands on another tab). Element refs are scoped to the
+tab that was active when the snapshot ran, so if you need ref-based
+interaction with another tab, switch permanently first:
+
+```bash
+agent-browser tab docs                           # switch permanently
+agent-browser snapshot                           # refs for docs
+agent-browser click @e3                          # uses docs's refs
 ```
 
 ### Frames
@@ -634,7 +648,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 |--------|-------------|
 | `--session <name>` | Use isolated session (or `AGENT_BROWSER_SESSION` env) |
 | `--session-name <name>` | Auto-save/restore session state (or `AGENT_BROWSER_SESSION_NAME` env) |
-| `--tab <id>` | Target a specific tab by stable `tabId` for this command only; the active tab is restored afterward |
+| `--tab <t<N>\|label>` | Target a specific tab by id (`t2`) or label (`docs`) for this command only; the active tab is restored afterward |
 | `--profile <name\|path>` | Chrome profile name or persistent directory path (or `AGENT_BROWSER_PROFILE` env) |
 | `--state <path>` | Load storage state from JSON file (or `AGENT_BROWSER_STATE` env) |
 | `--headers <json>` | Set HTTP headers scoped to the URL's origin |

--- a/README.md
+++ b/README.md
@@ -300,12 +300,25 @@ agent-browser window new              # New window
 Tab IDs are stable and never reused within a session, so agents can keep
 referring to the same tab across commands even if other tabs are opened or
 closed in between. To run a single command against a specific tab without
-changing the active tab, use the global `--tab <id>` flag:
+changing the active tab, use the global `--tab <id>` flag. The active tab and
+its element refs (`@e1`, etc.) are preserved across the peek:
 
 ```bash
 agent-browser tab new https://docs.example.com   # opens and activates tab 2
-agent-browser --tab 1 snapshot                   # peek at tab 1 (tab 2 stays active)
-agent-browser click "#submit"                    # runs on tab 2 as expected
+agent-browser snapshot                           # refs @e1..@eN on tab 2
+agent-browser --tab 1 snapshot                   # peek at tab 1 (tab 2 still active)
+agent-browser click @e1                          # tab 2's refs still work
+```
+
+Use `--tab <id>` to peek (one-off read, then return) and `tab <id>` to switch
+(multiple commands on another tab). Element refs are scoped to the tab they
+were snapshotted on, so if you need to interact with another tab by ref,
+snapshot after switching:
+
+```bash
+agent-browser tab 1                              # switch permanently to tab 1
+agent-browser snapshot                           # refs for tab 1
+agent-browser click @e3                          # uses tab 1's refs
 ```
 
 ### Frames

--- a/README.md
+++ b/README.md
@@ -310,29 +310,10 @@ rewritten on navigation — they're yours to name and keep:
 
 ```bash
 agent-browser tab new --label docs https://docs.example.com
-agent-browser tab docs                   # switch by label
-agent-browser --tab docs snapshot        # peek by label
-```
-
-The global `--tab <t<N>|label>` flag runs one command against a specific
-tab and then restores the active tab and its element refs (`@e1`, etc.):
-
-```bash
-agent-browser tab new --label docs https://docs.example.com    # activates t2
-agent-browser snapshot                                         # refs @e1..@eN on t2
-agent-browser --tab t1 snapshot                                # peek t1; t2 still active
-agent-browser click @e1                                        # t2's refs still work
-```
-
-Use `--tab` to peek (one-off read, then return) and `tab <id|label>` to
-switch (multiple commands on another tab). Element refs are scoped to the
-tab that was active when the snapshot ran, so if you need ref-based
-interaction with another tab, switch permanently first:
-
-```bash
-agent-browser tab docs                           # switch permanently
-agent-browser snapshot                           # refs for docs
-agent-browser click @e3                          # uses docs's refs
+agent-browser tab docs               # switch to the docs tab
+agent-browser snapshot               # populate refs for docs
+agent-browser click @e3              # click uses docs's refs
+agent-browser tab close docs         # close by label
 ```
 
 ### Frames
@@ -648,7 +629,6 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 |--------|-------------|
 | `--session <name>` | Use isolated session (or `AGENT_BROWSER_SESSION` env) |
 | `--session-name <name>` | Auto-save/restore session state (or `AGENT_BROWSER_SESSION_NAME` env) |
-| `--tab <t<N>\|label>` | Target a specific tab by id (`t2`) or label (`docs`) for this command only; the active tab is restored afterward |
 | `--profile <name\|path>` | Chrome profile name or persistent directory path (or `AGENT_BROWSER_PROFILE` env) |
 | `--state <path>` | Load storage state from JSON file (or `AGENT_BROWSER_STATE` env) |
 | `--headers <json>` | Set HTTP headers scoped to the URL's origin |

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -24,11 +24,6 @@
       "type": "string",
       "description": "Auto-save/load state persistence name."
     },
-    "tab": {
-      "type": "string",
-      "pattern": "^(t[0-9]+|[a-zA-Z][a-zA-Z0-9_-]*)$",
-      "description": "Run this command on a specific tab (peek). Accepts either a stable tab id (e.g. `t2`) or a user-assigned label (e.g. `docs`). The active tab and its element refs (@e1, etc.) are restored afterward. Use the `tab <id>` subcommand instead to switch tabs permanently. Positional integers are not accepted to avoid confusion with tab indices."
-    },
     "executablePath": {
       "type": "string",
       "description": "Path to a custom browser executable."

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -27,7 +27,7 @@
     "tab": {
       "type": "integer",
       "minimum": 1,
-      "description": "Target a specific tab by stable tabId for this command only. The active tab is restored afterward."
+      "description": "Run this command on a specific tab by stable tabId (peek). The active tab and its element refs (@e1, etc.) are restored afterward. Use the `tab <id>` subcommand instead to switch tabs permanently."
     },
     "executablePath": {
       "type": "string",

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -25,9 +25,9 @@
       "description": "Auto-save/load state persistence name."
     },
     "tab": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "Run this command on a specific tab by stable tabId (peek). The active tab and its element refs (@e1, etc.) are restored afterward. Use the `tab <id>` subcommand instead to switch tabs permanently."
+      "type": "string",
+      "pattern": "^(t[0-9]+|[a-zA-Z][a-zA-Z0-9_-]*)$",
+      "description": "Run this command on a specific tab (peek). Accepts either a stable tab id (e.g. `t2`) or a user-assigned label (e.g. `docs`). The active tab and its element refs (@e1, etc.) are restored afterward. Use the `tab <id>` subcommand instead to switch tabs permanently. Positional integers are not accepted to avoid confusion with tab indices."
     },
     "executablePath": {
       "type": "string",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1011,31 +1011,51 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Tabs ===
         "tab" => {
-            const VALID: &[&str] = &["list", "new", "close", "<id>"];
             match rest.first().copied() {
                 Some("new") => {
+                    // Accepted forms:
+                    //   tab new [url]
+                    //   tab new --label <name> [url]
+                    //   tab new [url] --label <name>
                     let mut cmd = json!({ "id": id, "action": "tab_new" });
-                    if let Some(url) = rest.get(1) {
-                        cmd["url"] = json!(url);
+                    let mut i = 1;
+                    while i < rest.len() {
+                        match rest[i] {
+                            "--label" => {
+                                let name = rest.get(i + 1).ok_or(ParseError::MissingArguments {
+                                    context: "tab new --label".to_string(),
+                                    usage: "tab new --label <name> [url]",
+                                })?;
+                                cmd["label"] = json!(name);
+                                i += 2;
+                            }
+                            other if !other.starts_with("--") && cmd.get("url").is_none() => {
+                                cmd["url"] = json!(other);
+                                i += 1;
+                            }
+                            other => {
+                                return Err(ParseError::UnknownSubcommand {
+                                    subcommand: other.to_string(),
+                                    valid_options: &["--label", "<url>"],
+                                });
+                            }
+                        }
                     }
                     Ok(cmd)
                 }
                 Some("list") => Ok(json!({ "id": id, "action": "tab_list" })),
                 Some("close") => {
                     let mut cmd = json!({ "id": id, "action": "tab_close" });
-                    if let Some(tab_id) = rest.get(1).and_then(|s| s.parse::<i32>().ok()) {
-                        cmd["tabId"] = json!(tab_id);
+                    if let Some(tab_ref) = rest.get(1) {
+                        cmd["tabId"] = json!(tab_ref);
                     }
                     Ok(cmd)
                 }
-                Some(n) if n.parse::<i32>().is_ok() => {
-                    let tab_id = n.parse::<i32>().expect("already checked parse succeeds");
-                    Ok(json!({ "id": id, "action": "tab_switch", "tabId": tab_id }))
-                }
-                Some(sub) => Err(ParseError::UnknownSubcommand {
-                    subcommand: sub.to_string(),
-                    valid_options: VALID,
-                }),
+                Some(tab_ref) => Ok(json!({
+                    "id": id,
+                    "action": "tab_switch",
+                    "tabId": tab_ref,
+                })),
                 None => Ok(json!({ "id": id, "action": "tab_list" })),
             }
         }
@@ -2852,10 +2872,17 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_switch() {
-        let cmd = parse_command(&args("tab 2"), &default_flags()).unwrap();
+    fn test_tab_switch_by_id() {
+        let cmd = parse_command(&args("tab t2"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "tab_switch");
-        assert_eq!(cmd["tabId"], 2);
+        assert_eq!(cmd["tabId"], "t2");
+    }
+
+    #[test]
+    fn test_tab_switch_by_label() {
+        let cmd = parse_command(&args("tab docs"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_switch");
+        assert_eq!(cmd["tabId"], "docs");
     }
 
     #[test]
@@ -2866,23 +2893,57 @@ mod tests {
 
     #[test]
     fn test_tab_close_with_id() {
-        let cmd = parse_command(&args("tab close 2"), &default_flags()).unwrap();
+        let cmd = parse_command(&args("tab close t2"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "tab_close");
-        assert_eq!(cmd["tabId"], 2);
+        assert_eq!(cmd["tabId"], "t2");
     }
 
     #[test]
-    fn test_tab_switch_sends_tab_id() {
-        let cmd = parse_command(&args("tab 2"), &default_flags()).unwrap();
-        assert_eq!(cmd["tabId"], 2);
+    fn test_tab_close_with_label() {
+        let cmd = parse_command(&args("tab close docs"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_close");
+        assert_eq!(cmd["tabId"], "docs");
+    }
+
+    #[test]
+    fn test_tab_sends_string_tab_id() {
+        let cmd = parse_command(&args("tab t2"), &default_flags()).unwrap();
+        assert!(
+            cmd["tabId"].is_string(),
+            "tabId must be a string, got: {:?}",
+            cmd["tabId"]
+        );
         assert!(cmd.get("index").is_none());
     }
 
     #[test]
-    fn test_tab_close_sends_tab_id() {
-        let cmd = parse_command(&args("tab close 3"), &default_flags()).unwrap();
-        assert_eq!(cmd["tabId"], 3);
-        assert!(cmd.get("index").is_none());
+    fn test_tab_new_with_label() {
+        let cmd = parse_command(&args("tab new --label docs"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_new");
+        assert_eq!(cmd["label"], "docs");
+    }
+
+    #[test]
+    fn test_tab_new_with_label_and_url() {
+        let cmd = parse_command(
+            &args("tab new --label docs https://docs.example.com"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "tab_new");
+        assert_eq!(cmd["label"], "docs");
+        assert_eq!(cmd["url"], "https://docs.example.com");
+    }
+
+    #[test]
+    fn test_tab_new_with_url_then_label() {
+        let cmd = parse_command(
+            &args("tab new https://docs.example.com --label docs"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["url"], "https://docs.example.com");
+        assert_eq!(cmd["label"], "docs");
     }
 
     #[test]
@@ -2892,12 +2953,28 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_unknown_subcommand_errors() {
-        let result = parse_command(&args("tab select 3"), &default_flags());
+    fn test_tab_unknown_flag_errors() {
+        // Unknown flags on `tab new` must error instead of being silently
+        // dropped. This protects against typos like `--labl` or `--new-tab`.
+        let result = parse_command(
+            &args("tab new --unknown-flag https://example.com"),
+            &default_flags(),
+        );
         assert!(
             result.is_err(),
-            "tab select should error, not silently fall through to tab_list"
+            "tab new with an unknown flag must error, got: {:?}",
+            result
         );
+    }
+
+    #[test]
+    fn test_tab_non_keyword_treated_as_ref() {
+        // After the shift to `t<N>`/label ids, non-keyword tokens (`select`,
+        // `docs`, etc.) are valid label refs; `tab <something>` routes to
+        // tab_switch and the runtime decides whether the label exists.
+        let cmd = parse_command(&args("tab select"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_switch");
+        assert_eq!(cmd["tabId"], "select");
     }
 
     // === Network ===

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2362,7 +2362,6 @@ mod tests {
     fn default_flags() -> Flags {
         Flags {
             session: "test".to_string(),
-            tab: None,
             json: false,
             headed: false,
             debug: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -57,7 +57,7 @@ pub struct Config {
     pub json: Option<bool>,
     pub debug: Option<bool>,
     pub session: Option<String>,
-    pub tab: Option<u32>,
+    pub tab: Option<String>,
     pub session_name: Option<String>,
     pub executable_path: Option<String>,
     pub extensions: Option<Vec<String>>,
@@ -276,7 +276,7 @@ pub struct Flags {
     pub headed: bool,
     pub debug: bool,
     pub session: String,
-    pub tab: Option<u32>,
+    pub tab: Option<String>,
     pub headers: Option<String>,
     pub executable_path: Option<String>,
     pub cdp: Option<String>,
@@ -499,7 +499,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             }
             "--tab" => {
                 if let Some(s) = args.get(i + 1) {
-                    flags.tab = s.parse::<u32>().ok();
+                    flags.tab = Some(s.clone());
                     i += 1;
                 }
             }
@@ -1457,21 +1457,34 @@ mod tests {
     // === Tab flag tests ===
 
     #[test]
-    fn test_parse_tab_flag() {
-        let flags = parse_flags(&args("--tab 4 snapshot"));
-        assert_eq!(flags.tab, Some(4));
+    fn test_parse_tab_flag_id() {
+        let flags = parse_flags(&args("--tab t4 snapshot"));
+        assert_eq!(flags.tab.as_deref(), Some("t4"));
+    }
+
+    #[test]
+    fn test_parse_tab_flag_label() {
+        let flags = parse_flags(&args("--tab docs snapshot"));
+        assert_eq!(flags.tab.as_deref(), Some("docs"));
     }
 
     #[test]
     fn test_clean_args_removes_tab_flag() {
-        let cleaned = clean_args(&args("--tab 4 snapshot"));
+        let cleaned = clean_args(&args("--tab t4 snapshot"));
         assert_eq!(cleaned, vec!["snapshot"]);
     }
 
     #[test]
     fn test_parse_tab_config() {
-        let json = r#"{"tab": 4}"#;
+        let json = r#"{"tab": "t4"}"#;
         let config: Config = serde_json::from_str(json).unwrap();
-        assert_eq!(config.tab, Some(4));
+        assert_eq!(config.tab.as_deref(), Some("t4"));
+    }
+
+    #[test]
+    fn test_parse_tab_config_label() {
+        let json = r#"{"tab": "docs"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.tab.as_deref(), Some("docs"));
     }
 }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -57,7 +57,6 @@ pub struct Config {
     pub json: Option<bool>,
     pub debug: Option<bool>,
     pub session: Option<String>,
-    pub tab: Option<String>,
     pub session_name: Option<String>,
     pub executable_path: Option<String>,
     pub extensions: Option<Vec<String>>,
@@ -99,7 +98,6 @@ impl Config {
             json: other.json.or(self.json),
             debug: other.debug.or(self.debug),
             session: other.session.or(self.session),
-            tab: other.tab.or(self.tab),
             session_name: other.session_name.or(self.session_name),
             executable_path: other.executable_path.or(self.executable_path),
             extensions: match (self.extensions, other.extensions) {
@@ -198,7 +196,6 @@ fn parse_bool_arg(args: &[String], i: usize) -> (bool, bool) {
 fn extract_config_path(args: &[String]) -> Option<Option<String>> {
     const FLAGS_WITH_VALUE: &[&str] = &[
         "--session",
-        "--tab",
         "--headers",
         "--executable-path",
         "--cdp",
@@ -276,7 +273,6 @@ pub struct Flags {
     pub headed: bool,
     pub debug: bool,
     pub session: String,
-    pub tab: Option<String>,
     pub headers: Option<String>,
     pub executable_path: Option<String>,
     pub cdp: Option<String>,
@@ -359,7 +355,6 @@ pub fn parse_flags(args: &[String]) -> Flags {
             .ok()
             .or(config.session)
             .unwrap_or_else(|| "default".to_string()),
-        tab: config.tab,
         headers: config.headers,
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH")
             .ok()
@@ -494,12 +489,6 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--session" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.session = s.clone();
-                    i += 1;
-                }
-            }
-            "--tab" => {
-                if let Some(s) = args.get(i + 1) {
-                    flags.tab = Some(s.clone());
                     i += 1;
                 }
             }
@@ -786,7 +775,6 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
     // Global flags that always take a value (need to skip the next arg too)
     const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
         "--session",
-        "--tab",
         "--headers",
         "--executable-path",
         "--cdp",
@@ -1452,39 +1440,5 @@ mod tests {
         ];
         let clean = clean_args(&input);
         assert_eq!(clean, vec!["open", "example.com"]);
-    }
-
-    // === Tab flag tests ===
-
-    #[test]
-    fn test_parse_tab_flag_id() {
-        let flags = parse_flags(&args("--tab t4 snapshot"));
-        assert_eq!(flags.tab.as_deref(), Some("t4"));
-    }
-
-    #[test]
-    fn test_parse_tab_flag_label() {
-        let flags = parse_flags(&args("--tab docs snapshot"));
-        assert_eq!(flags.tab.as_deref(), Some("docs"));
-    }
-
-    #[test]
-    fn test_clean_args_removes_tab_flag() {
-        let cleaned = clean_args(&args("--tab t4 snapshot"));
-        assert_eq!(cleaned, vec!["snapshot"]);
-    }
-
-    #[test]
-    fn test_parse_tab_config() {
-        let json = r#"{"tab": "t4"}"#;
-        let config: Config = serde_json::from_str(json).unwrap();
-        assert_eq!(config.tab.as_deref(), Some("t4"));
-    }
-
-    #[test]
-    fn test_parse_tab_config_label() {
-        let json = r#"{"tab": "docs"}"#;
-        let config: Config = serde_json::from_str(json).unwrap();
-        assert_eq!(config.tab.as_deref(), Some("docs"));
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -738,12 +738,6 @@ fn main() {
         }
     };
 
-    if let Some(ref tab_ref) = flags.tab {
-        if cmd.get("tabId").is_none() {
-            cmd["tabId"] = json!(tab_ref);
-        }
-    }
-
     // Handle --password-stdin for auth save
     if cmd.get("action").and_then(|v| v.as_str()) == Some("auth_save") {
         if cmd.get("password").is_some() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -738,9 +738,9 @@ fn main() {
         }
     };
 
-    if let Some(tab_id) = flags.tab {
+    if let Some(ref tab_ref) = flags.tab {
         if cmd.get("tabId").is_none() {
-            cmd["tabId"] = json!(tab_id);
+            cmd["tabId"] = json!(tab_ref);
         }
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1145,19 +1145,6 @@ impl Drop for DaemonState {
     }
 }
 
-/// Outer-tab state saved across a `--tab N` scoped command so we can restore
-/// the agent's active tab and its refs/iframe context after the peek.
-///
-/// `tab_id` is `None` when the browser didn't have an active tab at the time
-/// of the switch (e.g. all tabs were closed); in that case we still save and
-/// restore the state fields but skip the `tab_switch_by_id` call.
-struct ScopedRestore {
-    tab_id: Option<u32>,
-    ref_map: RefMap,
-    iframe_sessions: HashMap<String, String>,
-    active_frame_id: Option<String>,
-}
-
 pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
     let id = cmd
@@ -1288,70 +1275,6 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             ),
         );
     }
-
-    // Pre-dispatch: if `tabId` is set on a non-tab command, temporarily switch
-    // to that tab for the duration of the command and restore the original
-    // active tab after. This lets `--tab N <cmd>` target a specific tab
-    // without stealing the user's active-tab context.
-    //
-    // We save the outer tab's stable `tab_id` (not its array index) so a tab
-    // close during the scoped command doesn't leave us restoring to a shifted
-    // position. We also save the outer tab's per-tab daemon state
-    // (`ref_map`/`iframe_sessions`/`active_frame_id`) and restore it after so
-    // agents that populated refs on the outer tab can keep using them across a
-    // `--tab N` peek. If the outer tab was closed, we discard both the saved
-    // tab id and the saved state.
-    let scoped_restore: Option<ScopedRestore> = if !matches!(
-        action,
-        "tab_list" | "tab_new" | "tab_switch" | "tab_close" | "launch" | "close"
-    ) {
-        if let Some(tab_ref_str) = cmd.get("tabId").and_then(|v| v.as_str()) {
-            let target_tab_id = match super::browser::TabRef::parse(tab_ref_str) {
-                Ok(tab_ref) => match state
-                    .browser
-                    .as_ref()
-                    .ok_or_else(|| "Browser not launched".to_string())
-                    .and_then(|mgr| mgr.resolve_tab_ref(&tab_ref))
-                {
-                    Ok(id) => id,
-                    Err(e) => return error_response(&id, &e),
-                },
-                Err(e) => return error_response(&id, &e),
-            };
-            let current_tab_id = state.browser.as_ref().and_then(|mgr| mgr.active_tab_id());
-            if current_tab_id == Some(target_tab_id) {
-                // Already on the target tab; no switch, no save/restore.
-                None
-            } else {
-                // Take the outer tab's per-tab state so the scoped command sees
-                // a clean slate and can't resolve outer-tab refs against the
-                // target tab's DOM. `mem::take` replaces with Default, which
-                // is equivalent to clearing.
-                let saved = ScopedRestore {
-                    tab_id: current_tab_id,
-                    ref_map: std::mem::take(&mut state.ref_map),
-                    iframe_sessions: std::mem::take(&mut state.iframe_sessions),
-                    active_frame_id: state.active_frame_id.take(),
-                };
-                if let Some(ref mut mgr) = state.browser {
-                    if let Err(e) = mgr.tab_switch_by_id(target_tab_id).await {
-                        // Restore outer state on switch failure so the caller's
-                        // refs aren't silently dropped on a user error like
-                        // "Tab ID N not found".
-                        state.ref_map = saved.ref_map;
-                        state.iframe_sessions = saved.iframe_sessions;
-                        state.active_frame_id = saved.active_frame_id;
-                        return error_response(&id, &e);
-                    }
-                }
-                Some(saved)
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
 
     let result = match action {
         "launch" => handle_launch(cmd, state).await,
@@ -1510,36 +1433,6 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "mouseup" => handle_mouseup(cmd, state).await,
         _ => Err(format!("Not yet implemented: {}", action)),
     };
-
-    // Post-dispatch: if we temporarily switched tabs for this command, restore
-    // the outer tab and its per-tab state. If the outer tab was closed during
-    // the scoped command, leave the scoped tab active and clear state.
-    if let Some(saved) = scoped_restore {
-        let restore_tab_id = saved.tab_id;
-        let still_exists = restore_tab_id.is_some_and(|tid| {
-            state
-                .browser
-                .as_ref()
-                .is_some_and(|mgr| mgr.has_tab_id(tid))
-        });
-        if still_exists {
-            // Discard whatever the scoped command populated (it belongs to the
-            // scoped tab) and restore the outer tab's state before switching
-            // back.
-            state.ref_map = saved.ref_map;
-            state.iframe_sessions = saved.iframe_sessions;
-            state.active_frame_id = saved.active_frame_id;
-            if let (Some(ref mut mgr), Some(tid)) = (state.browser.as_mut(), restore_tab_id) {
-                let _ = mgr.tab_switch_by_id(tid).await;
-            }
-        } else {
-            // Outer tab is gone — agents on the scoped tab shouldn't see stale
-            // refs from a tab that no longer exists.
-            state.ref_map.clear();
-            state.iframe_sessions.clear();
-            state.active_frame_id = None;
-        }
-    }
 
     let mut resp = match result {
         Ok(data) => success_response(&id, data),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1144,6 +1144,19 @@ impl Drop for DaemonState {
     }
 }
 
+/// Outer-tab state saved across a `--tab N` scoped command so we can restore
+/// the agent's active tab and its refs/iframe context after the peek.
+///
+/// `tab_id` is `None` when the browser didn't have an active tab at the time
+/// of the switch (e.g. all tabs were closed); in that case we still save and
+/// restore the state fields but skip the `tab_switch_by_id` call.
+struct ScopedRestore {
+    tab_id: Option<u32>,
+    ref_map: RefMap,
+    iframe_sessions: HashMap<String, String>,
+    active_frame_id: Option<String>,
+}
+
 pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
     let id = cmd
@@ -1280,10 +1293,14 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // active tab after. This lets `--tab N <cmd>` target a specific tab
     // without stealing the user's active-tab context.
     //
-    // We save the current tab's stable `tab_id` (not its array index) so a
-    // tab close during the scoped command doesn't leave us restoring to a
-    // shifted position. If the saved tab was closed, we skip the restore.
-    let restore_tab_id: Option<u32> = if !matches!(
+    // We save the outer tab's stable `tab_id` (not its array index) so a tab
+    // close during the scoped command doesn't leave us restoring to a shifted
+    // position. We also save the outer tab's per-tab daemon state
+    // (`ref_map`/`iframe_sessions`/`active_frame_id`) and restore it after so
+    // agents that populated refs on the outer tab can keep using them across a
+    // `--tab N` peek. If the outer tab was closed, we discard both the saved
+    // tab id and the saved state.
+    let scoped_restore: Option<ScopedRestore> = if !matches!(
         action,
         "tab_list" | "tab_new" | "tab_switch" | "tab_close" | "launch" | "close"
     ) {
@@ -1291,20 +1308,31 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             let target_tab_id = target_tab_id as u32;
             let current_tab_id = state.browser.as_ref().and_then(|mgr| mgr.active_tab_id());
             if current_tab_id == Some(target_tab_id) {
-                // Already on the target tab; nothing to do.
+                // Already on the target tab; no switch, no save/restore.
                 None
             } else {
-                // Clear per-tab daemon state before switching so refs from the
-                // outer tab can't resolve against the target tab's DOM.
-                state.ref_map.clear();
-                state.iframe_sessions.clear();
-                state.active_frame_id = None;
+                // Take the outer tab's per-tab state so the scoped command sees
+                // a clean slate and can't resolve outer-tab refs against the
+                // target tab's DOM. `mem::take` replaces with Default, which
+                // is equivalent to clearing.
+                let saved = ScopedRestore {
+                    tab_id: current_tab_id,
+                    ref_map: std::mem::take(&mut state.ref_map),
+                    iframe_sessions: std::mem::take(&mut state.iframe_sessions),
+                    active_frame_id: state.active_frame_id.take(),
+                };
                 if let Some(ref mut mgr) = state.browser {
                     if let Err(e) = mgr.tab_switch_by_id(target_tab_id).await {
+                        // Restore outer state on switch failure so the caller's
+                        // refs aren't silently dropped on a user error like
+                        // "Tab ID N not found".
+                        state.ref_map = saved.ref_map;
+                        state.iframe_sessions = saved.iframe_sessions;
+                        state.active_frame_id = saved.active_frame_id;
                         return error_response(&id, &e);
                     }
                 }
-                current_tab_id
+                Some(saved)
             }
         } else {
             None
@@ -1472,20 +1500,32 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     };
 
     // Post-dispatch: if we temporarily switched tabs for this command, restore
-    // the original active tab. Skip silently if the tab no longer exists (e.g.
-    // the scoped command closed it).
-    if let Some(restore_tab_id) = restore_tab_id {
-        let still_exists = state
-            .browser
-            .as_ref()
-            .is_some_and(|mgr| mgr.has_tab_id(restore_tab_id));
+    // the outer tab and its per-tab state. If the outer tab was closed during
+    // the scoped command, leave the scoped tab active and clear state.
+    if let Some(saved) = scoped_restore {
+        let restore_tab_id = saved.tab_id;
+        let still_exists = restore_tab_id.is_some_and(|tid| {
+            state
+                .browser
+                .as_ref()
+                .is_some_and(|mgr| mgr.has_tab_id(tid))
+        });
         if still_exists {
+            // Discard whatever the scoped command populated (it belongs to the
+            // scoped tab) and restore the outer tab's state before switching
+            // back.
+            state.ref_map = saved.ref_map;
+            state.iframe_sessions = saved.iframe_sessions;
+            state.active_frame_id = saved.active_frame_id;
+            if let (Some(ref mut mgr), Some(tid)) = (state.browser.as_mut(), restore_tab_id) {
+                let _ = mgr.tab_switch_by_id(tid).await;
+            }
+        } else {
+            // Outer tab is gone — agents on the scoped tab shouldn't see stale
+            // refs from a tab that no longer exists.
             state.ref_map.clear();
             state.iframe_sessions.clear();
             state.active_frame_id = None;
-            if let Some(ref mut mgr) = state.browser {
-                let _ = mgr.tab_switch_by_id(restore_tab_id).await;
-            }
         }
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -665,6 +665,7 @@ impl DaemonState {
                     let tab_id = mgr.assign_tab_id();
                     mgr.add_page(super::browser::PageInfo {
                         tab_id,
+                        label: None,
                         target_id: te.target_info.target_id.clone(),
                         session_id: attach.session_id,
                         url: te.target_info.url.clone(),
@@ -1304,8 +1305,19 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         action,
         "tab_list" | "tab_new" | "tab_switch" | "tab_close" | "launch" | "close"
     ) {
-        if let Some(target_tab_id) = cmd.get("tabId").and_then(|v| v.as_u64()) {
-            let target_tab_id = target_tab_id as u32;
+        if let Some(tab_ref_str) = cmd.get("tabId").and_then(|v| v.as_str()) {
+            let target_tab_id = match super::browser::TabRef::parse(tab_ref_str) {
+                Ok(tab_ref) => match state
+                    .browser
+                    .as_ref()
+                    .ok_or_else(|| "Browser not launched".to_string())
+                    .and_then(|mgr| mgr.resolve_tab_ref(&tab_ref))
+                {
+                    Ok(id) => id,
+                    Err(e) => return error_response(&id, &e),
+                },
+                Err(e) => return error_response(&id, &e),
+            };
             let current_tab_id = state.browser.as_ref().and_then(|mgr| mgr.active_tab_id());
             if current_tab_id == Some(target_tab_id) {
                 // Already on the target tab; no switch, no save/restore.
@@ -1585,7 +1597,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 /// subsequent navigations don't hijack the user's existing tabs.
 async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
     let mut mgr = BrowserManager::connect_auto().await?;
-    mgr.tab_new(None).await?;
+    mgr.tab_new(None, None).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let _ = mgr
         .client
@@ -2688,7 +2700,7 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
 
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
         state.ref_map.clear();
-        mgr.tab_new(Some(&href)).await?;
+        mgr.tab_new(Some(&href), None).await?;
 
         return Ok(json!({ "clicked": selector, "newTab": true, "url": href }));
     }
@@ -3737,18 +3749,21 @@ async fn handle_tab_list(state: &DaemonState) -> Result<Value, String> {
 async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     let url = cmd.get("url").and_then(|v| v.as_str());
+    let label = cmd.get("label").and_then(|v| v.as_str());
     state.ref_map.clear();
     state.iframe_sessions.clear();
     state.active_frame_id = None;
-    mgr.tab_new(url).await
+    mgr.tab_new(url, label).await
 }
 
 async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-    let tab_id = cmd
+    let tab_ref_str = cmd
         .get("tabId")
-        .and_then(|v| v.as_u64())
-        .ok_or("Missing 'tabId' parameter")? as u32;
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'tabId' parameter (expected `t<N>` or a label)")?;
+    let tab_ref = super::browser::TabRef::parse(tab_ref_str)?;
+    let tab_id = mgr.resolve_tab_ref(&tab_ref)?;
     state.ref_map.clear();
     state.iframe_sessions.clear();
     state.active_frame_id = None;
@@ -3777,7 +3792,13 @@ async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value
 
 async fn handle_tab_close(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-    let tab_id = cmd.get("tabId").and_then(|v| v.as_u64()).map(|i| i as u32);
+    let tab_id = match cmd.get("tabId").and_then(|v| v.as_str()) {
+        Some(s) => {
+            let tab_ref = super::browser::TabRef::parse(s)?;
+            Some(mgr.resolve_tab_ref(&tab_ref)?)
+        }
+        None => None,
+    };
     state.ref_map.clear();
     state.iframe_sessions.clear();
     state.active_frame_id = None;
@@ -4163,6 +4184,7 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         let tab_id = mgr.assign_tab_id();
         mgr.add_page(super::browser::PageInfo {
             tab_id,
+            label: None,
             target_id: create_result.target_id,
             session_id: new_session_id.clone(),
             url: nav_url.clone(),
@@ -6076,6 +6098,7 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
     let tab_id = mgr.assign_tab_id();
     mgr.add_page(super::browser::PageInfo {
         tab_id,
+        label: None,
         target_id: create_result.target_id,
         session_id: attach.session_id,
         url: "about:blank".to_string(),
@@ -6103,7 +6126,10 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
     let total = mgr.page_count();
     state.ref_map.clear();
 
-    Ok(json!({ "tabId": tab_id, "total": total }))
+    Ok(json!({
+        "tabId": super::browser::format_tab_id(tab_id),
+        "total": total,
+    }))
 }
 
 async fn handle_diff_screenshot(cmd: &Value, state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -159,11 +159,88 @@ pub fn to_ai_friendly_error(error: &str) -> String {
 #[derive(Debug, Clone)]
 pub struct PageInfo {
     pub tab_id: u32,
+    /// Optional user-assigned label (e.g. "docs", "app"). Set via
+    /// `tab new --label <name>`. Labels are agent-assigned and never
+    /// auto-generated, never rewritten on navigation, and unique within a
+    /// session. Agents use labels instead of `t<N>` for readable multi-tab
+    /// workflows.
+    pub label: Option<String>,
     pub target_id: String,
     pub session_id: String,
     pub url: String,
     pub title: String,
     pub target_type: String, // "page" or "webview"
+}
+
+/// Canonical string form of a stable tab id: `t1`, `t2`, ... The `t` prefix
+/// disambiguates stable ids from positional indices (which the CLI no longer
+/// accepts) and matches the `@e<N>` convention used for element refs.
+pub fn format_tab_id(tab_id: u32) -> String {
+    format!("t{}", tab_id)
+}
+
+/// A tab reference as parsed from CLI/JSON input. Either a stable id like
+/// `t2` or a user-assigned label like `docs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TabRef {
+    Id(u32),
+    Label(String),
+}
+
+impl TabRef {
+    /// Parse a user-supplied string tab reference. Rejects bare integers
+    /// with a teaching error so agents and scripts don't silently confuse
+    /// stable ids with positional indices.
+    pub fn parse(input: &str) -> Result<Self, String> {
+        let input = input.trim();
+        if input.is_empty() {
+            return Err("Empty tab reference; expected `t<N>` (e.g. `t2`) or a label".to_string());
+        }
+        if let Some(digits) = input.strip_prefix('t').or_else(|| input.strip_prefix('T')) {
+            if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()) {
+                let id: u32 = digits.parse().map_err(|_| {
+                    format!(
+                        "Tab id `{}` out of range; ids are incrementing positive integers",
+                        input
+                    )
+                })?;
+                if id == 0 {
+                    return Err(format!(
+                        "Tab id `{}` is invalid; tab ids start at t1",
+                        input
+                    ));
+                }
+                return Ok(TabRef::Id(id));
+            }
+        }
+        if input.chars().all(|c| c.is_ascii_digit()) {
+            return Err(format!(
+                "Expected a tab id like `t{}` or a label; positional integers are not accepted \
+                 (run `agent-browser tab` to list stable tab ids)",
+                input
+            ));
+        }
+        if !is_valid_label(input) {
+            return Err(format!(
+                "Invalid tab label `{}`; labels must start with a letter and contain only \
+                 letters, digits, `-`, and `_`",
+                input
+            ));
+        }
+        Ok(TabRef::Label(input.to_string()))
+    }
+}
+
+/// Labels must look like identifiers: start with a letter, contain only
+/// letters/digits/dashes/underscores. This keeps them distinguishable from
+/// `t<N>` ids at a glance and safe to pass through shells without quoting.
+pub fn is_valid_label(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -395,6 +472,7 @@ impl BrowserManager {
             let tab_id = manager.assign_tab_id();
             manager.pages.push(PageInfo {
                 tab_id,
+                label: None,
                 target_id: "provider-page".to_string(),
                 session_id: String::new(),
                 url: String::new(),
@@ -463,6 +541,7 @@ impl BrowserManager {
             self.next_tab_id += 1;
             self.pages.push(PageInfo {
                 tab_id,
+                label: None,
                 target_id: result.target_id,
                 session_id: attach_result.session_id.clone(),
                 url: "about:blank".to_string(),
@@ -489,6 +568,7 @@ impl BrowserManager {
                 self.next_tab_id += 1;
                 self.pages.push(PageInfo {
                     tab_id,
+                    label: None,
                     target_id: target.target_id.clone(),
                     session_id: attach_result.session_id.clone(),
                     url: target.url.clone(),
@@ -837,6 +917,7 @@ impl BrowserManager {
         self.next_tab_id += 1;
         self.pages.push(PageInfo {
             tab_id,
+            label: None,
             target_id: result.target_id,
             session_id: attach_result.session_id.clone(),
             url: "about:blank".to_string(),
@@ -879,7 +960,8 @@ impl BrowserManager {
             .enumerate()
             .map(|(i, p)| {
                 json!({
-                    "tabId": p.tab_id,
+                    "tabId": format_tab_id(p.tab_id),
+                    "label": p.label,
                     "title": p.title,
                     "url": p.url,
                     "type": p.target_type,
@@ -889,7 +971,61 @@ impl BrowserManager {
             .collect()
     }
 
-    pub async fn tab_new(&mut self, url: Option<&str>) -> Result<Value, String> {
+    /// Resolve a user-supplied `TabRef` (either `t<N>` or a label) to the
+    /// stable numeric `tab_id`. Returns a teaching error for unknown tabs.
+    pub fn resolve_tab_ref(&self, tab_ref: &TabRef) -> Result<u32, String> {
+        match tab_ref {
+            TabRef::Id(id) => {
+                if self.has_tab_id(*id) {
+                    Ok(*id)
+                } else {
+                    Err(format!(
+                        "Tab {} not found; run `agent-browser tab` to list open tabs",
+                        format_tab_id(*id)
+                    ))
+                }
+            }
+            TabRef::Label(name) => self
+                .pages
+                .iter()
+                .find(|p| p.label.as_deref() == Some(name.as_str()))
+                .map(|p| p.tab_id)
+                .ok_or_else(|| {
+                    format!(
+                        "No tab with label `{}`; run `agent-browser tab` to list open tabs",
+                        name
+                    )
+                }),
+        }
+    }
+
+    /// Returns true iff a tab already carries the given label.
+    pub fn has_label(&self, label: &str) -> bool {
+        self.pages.iter().any(|p| p.label.as_deref() == Some(label))
+    }
+
+    pub async fn tab_new(
+        &mut self,
+        url: Option<&str>,
+        label: Option<&str>,
+    ) -> Result<Value, String> {
+        if let Some(label) = label {
+            if !is_valid_label(label) {
+                return Err(format!(
+                    "Invalid tab label `{}`; labels must start with a letter and contain only \
+                     letters, digits, `-`, and `_`",
+                    label
+                ));
+            }
+            if self.has_label(label) {
+                return Err(format!(
+                    "Label `{}` is already used by another tab; labels must be unique within a \
+                     session",
+                    label
+                ));
+            }
+        }
+
         let target_url = url.unwrap_or("about:blank");
 
         let result: CreateTargetResult = self
@@ -920,8 +1056,10 @@ impl BrowserManager {
         let tab_id = self.next_tab_id;
         self.next_tab_id += 1;
         let index = self.pages.len();
+        let label = label.map(|s| s.to_string());
         self.pages.push(PageInfo {
             tab_id,
+            label: label.clone(),
             target_id: result.target_id,
             session_id: attach.session_id,
             url: target_url.to_string(),
@@ -930,7 +1068,12 @@ impl BrowserManager {
         });
         self.active_page_index = index;
 
-        Ok(json!({ "tabId": tab_id, "url": target_url, "total": self.pages.len() }))
+        Ok(json!({
+            "tabId": format_tab_id(tab_id),
+            "label": label,
+            "url": target_url,
+            "total": self.pages.len(),
+        }))
     }
 
     pub async fn tab_switch(&mut self, index: usize) -> Result<Value, String> {
@@ -960,8 +1103,13 @@ impl BrowserManager {
             page.title = title.clone();
         }
 
-        let tab_id = self.pages[index].tab_id;
-        Ok(json!({ "tabId": tab_id, "url": url, "title": title }))
+        let page = &self.pages[index];
+        Ok(json!({
+            "tabId": format_tab_id(page.tab_id),
+            "label": page.label,
+            "url": url,
+            "title": title,
+        }))
     }
 
     pub async fn tab_close(&mut self, index: Option<usize>) -> Result<Value, String> {
@@ -978,6 +1126,7 @@ impl BrowserManager {
         let page = self.pages.remove(target_index);
         self.update_active_page_after_removal(target_index);
         let closed_tab_id = page.tab_id;
+        let closed_label = page.label.clone();
         let _ = self
             .client
             .send_command_typed::<_, Value>(
@@ -992,7 +1141,11 @@ impl BrowserManager {
         let session_id = self.pages[self.active_page_index].session_id.clone();
         self.enable_domains(&session_id).await?;
 
-        Ok(json!({ "tabId": closed_tab_id, "closed": true }))
+        Ok(json!({
+            "tabId": format_tab_id(closed_tab_id),
+            "label": closed_label,
+            "closed": true,
+        }))
     }
 
     // -----------------------------------------------------------------------
@@ -1558,6 +1711,75 @@ mod tests {
     use tokio::time::sleep;
 
     #[test]
+    fn test_format_tab_id() {
+        assert_eq!(format_tab_id(1), "t1");
+        assert_eq!(format_tab_id(42), "t42");
+    }
+
+    #[test]
+    fn test_parse_tab_ref_id() {
+        assert_eq!(TabRef::parse("t1"), Ok(TabRef::Id(1)));
+        assert_eq!(TabRef::parse("t42"), Ok(TabRef::Id(42)));
+        assert_eq!(TabRef::parse("T7"), Ok(TabRef::Id(7)));
+    }
+
+    #[test]
+    fn test_parse_tab_ref_label() {
+        assert_eq!(TabRef::parse("docs"), Ok(TabRef::Label("docs".to_string())));
+        assert_eq!(
+            TabRef::parse("app-2"),
+            Ok(TabRef::Label("app-2".to_string()))
+        );
+        assert_eq!(
+            TabRef::parse("my_tab"),
+            Ok(TabRef::Label("my_tab".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_tab_ref_rejects_bare_integer() {
+        let err = TabRef::parse("2").unwrap_err();
+        assert!(
+            err.contains("positional integers are not accepted"),
+            "error should teach the user to use `t<N>`: {}",
+            err
+        );
+        assert!(err.contains("t2"));
+    }
+
+    #[test]
+    fn test_parse_tab_ref_rejects_empty() {
+        assert!(TabRef::parse("").is_err());
+        assert!(TabRef::parse("   ").is_err());
+    }
+
+    #[test]
+    fn test_parse_tab_ref_rejects_zero() {
+        let err = TabRef::parse("t0").unwrap_err();
+        assert!(err.contains("start at t1"));
+    }
+
+    #[test]
+    fn test_parse_tab_ref_rejects_invalid_label() {
+        assert!(TabRef::parse("2docs").is_err());
+        assert!(TabRef::parse("-docs").is_err());
+        assert!(TabRef::parse("docs!").is_err());
+        assert!(TabRef::parse("docs space").is_err());
+    }
+
+    #[test]
+    fn test_is_valid_label() {
+        assert!(is_valid_label("docs"));
+        assert!(is_valid_label("Docs"));
+        assert!(is_valid_label("app-2"));
+        assert!(is_valid_label("my_tab"));
+        assert!(!is_valid_label(""));
+        assert!(!is_valid_label("2docs"));
+        assert!(!is_valid_label("-docs"));
+        assert!(!is_valid_label("docs!"));
+    }
+
+    #[test]
     fn test_should_track_popup_target_with_empty_url() {
         let target = TargetInfo {
             target_id: "popup-1".to_string(),
@@ -1589,6 +1811,7 @@ mod tests {
     fn test_update_page_target_info_in_pages_updates_existing_page() {
         let mut pages = vec![PageInfo {
             tab_id: 1,
+            label: None,
             target_id: "popup-1".to_string(),
             session_id: "session-1".to_string(),
             url: String::new(),

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -911,7 +911,7 @@ async fn e2e_tabs() {
     let tabs = get_data(&resp)["tabs"].as_array().unwrap();
     assert_eq!(tabs.len(), 1);
     assert_eq!(tabs[0]["active"], true);
-    assert_eq!(tabs[0]["tabId"], 1, "First tab should have tabId 1");
+    assert_eq!(tabs[0]["tabId"], "t1", "First tab should have tabId t1");
 
     // Open new tab
     let resp = execute_command(
@@ -920,7 +920,11 @@ async fn e2e_tabs() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2, "New tab should have tabId 2");
+    assert_eq!(
+        get_data(&resp)["tabId"],
+        "t2",
+        "New tab should have tabId t2"
+    );
     assert_eq!(get_data(&resp)["total"], 2);
 
     // Tab list should show 2 tabs with distinct, incrementing tabIds
@@ -929,12 +933,12 @@ async fn e2e_tabs() {
     let tabs = get_data(&resp)["tabs"].as_array().unwrap();
     assert_eq!(tabs.len(), 2);
     assert_eq!(tabs[1]["active"], true);
-    assert_eq!(tabs[0]["tabId"], 1, "First tab should keep tabId 1");
-    assert_eq!(tabs[1]["tabId"], 2, "Second tab should have tabId 2");
+    assert_eq!(tabs[0]["tabId"], "t1", "First tab should keep tabId t1");
+    assert_eq!(tabs[1]["tabId"], "t2", "Second tab should have tabId t2");
 
     // Switch to first tab
     let resp = execute_command(
-        &json!({ "id": "6", "action": "tab_switch", "tabId": 1 }),
+        &json!({ "id": "6", "action": "tab_switch", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -950,7 +954,7 @@ async fn e2e_tabs() {
 
     // Close second tab
     let resp = execute_command(
-        &json!({ "id": "8", "action": "tab_close", "tabId": 2 }),
+        &json!({ "id": "8", "action": "tab_close", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -982,7 +986,7 @@ async fn e2e_tab_ids_not_reused() {
     let resp = execute_command(&json!({ "id": "2", "action": "tab_list" }), &mut state).await;
     assert_success(&resp);
     let tabs = get_data(&resp)["tabs"].as_array().unwrap();
-    assert_eq!(tabs[0]["tabId"], 1);
+    assert_eq!(tabs[0]["tabId"], "t1");
 
     // Open tab 2 and tab 3
     let resp = execute_command(
@@ -991,7 +995,7 @@ async fn e2e_tab_ids_not_reused() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
 
     let resp = execute_command(
         &json!({ "id": "4", "action": "tab_new", "url": "data:text/html,<h1>Tab 3</h1>" }),
@@ -999,11 +1003,11 @@ async fn e2e_tab_ids_not_reused() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 3);
+    assert_eq!(get_data(&resp)["tabId"], "t3");
 
     // Close tab 2
     let resp = execute_command(
-        &json!({ "id": "5", "action": "tab_close", "tabId": 2 }),
+        &json!({ "id": "5", "action": "tab_close", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1018,17 +1022,20 @@ async fn e2e_tab_ids_not_reused() {
     assert_success(&resp);
     assert_eq!(
         get_data(&resp)["tabId"],
-        4,
+        "t4",
         "Tab IDs must not be reused after closing"
     );
 
-    // Verify final state: tabs 1, 3, 4
+    // Verify final state: tabs t1, t3, t4
     let resp = execute_command(&json!({ "id": "7", "action": "tab_list" }), &mut state).await;
     assert_success(&resp);
     let tabs = get_data(&resp)["tabs"].as_array().unwrap();
     assert_eq!(tabs.len(), 3);
-    let ids: Vec<i64> = tabs.iter().map(|t| t["tabId"].as_i64().unwrap()).collect();
-    assert_eq!(ids, vec![1, 3, 4]);
+    let ids: Vec<String> = tabs
+        .iter()
+        .map(|t| t["tabId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, vec!["t1", "t3", "t4"]);
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
@@ -1061,12 +1068,12 @@ async fn e2e_tab_global_targeting() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
 
     // Use tabId to evaluate on tab 1 while tab 2 is active
     // (simulates --tab 1 evaluate ...)
     let resp = execute_command(
-        &json!({ "id": "4", "action": "evaluate", "tabId": 1, "script": "document.querySelector('h1').textContent" }),
+        &json!({ "id": "4", "action": "evaluate", "tabId": "t1", "script": "document.querySelector('h1').textContent" }),
         &mut state,
     )
     .await;
@@ -1079,7 +1086,7 @@ async fn e2e_tab_global_targeting() {
 
     // Verify tab 2 content is still accessible
     let resp = execute_command(
-        &json!({ "id": "5", "action": "evaluate", "tabId": 2, "script": "document.querySelector('h1').textContent" }),
+        &json!({ "id": "5", "action": "evaluate", "tabId": "t2", "script": "document.querySelector('h1').textContent" }),
         &mut state,
     )
     .await;
@@ -1128,11 +1135,11 @@ async fn e2e_tab_global_targeting_snapshot() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
 
     // Snapshot tab 1 via tabId while tab 2 is active
     let resp = execute_command(
-        &json!({ "id": "4", "action": "snapshot", "tabId": 1 }),
+        &json!({ "id": "4", "action": "snapshot", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -1151,7 +1158,7 @@ async fn e2e_tab_global_targeting_snapshot() {
 
     // Snapshot tab 2 via tabId
     let resp = execute_command(
-        &json!({ "id": "5", "action": "snapshot", "tabId": 2 }),
+        &json!({ "id": "5", "action": "snapshot", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1213,7 +1220,7 @@ async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
 
     // Open tab 3
     let resp = execute_command(
@@ -1222,11 +1229,11 @@ async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 3);
+    assert_eq!(get_data(&resp)["tabId"], "t3");
 
     // Close tab 2 to create non-contiguous IDs: [1, 3]
     let resp = execute_command(
-        &json!({ "id": "5", "action": "tab_close", "tabId": 2 }),
+        &json!({ "id": "5", "action": "tab_close", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1237,12 +1244,12 @@ async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
     assert_success(&resp);
     let tabs = get_data(&resp)["tabs"].as_array().unwrap();
     assert_eq!(tabs.len(), 2);
-    assert_eq!(tabs[0]["tabId"], 1);
-    assert_eq!(tabs[1]["tabId"], 3);
+    assert_eq!(tabs[0]["tabId"], "t1");
+    assert_eq!(tabs[1]["tabId"], "t3");
 
     // Switch active tab back to tab 1
     let resp = execute_command(
-        &json!({ "id": "7", "action": "tab_switch", "tabId": 1 }),
+        &json!({ "id": "7", "action": "tab_switch", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -1251,7 +1258,7 @@ async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
     // Snapshot tab 3 via tabId while tab 1 is active
     // (simulates: --tab 3 snapshot)
     let resp = execute_command(
-        &json!({ "id": "8", "action": "snapshot", "tabId": 3 }),
+        &json!({ "id": "8", "action": "snapshot", "tabId": "t3" }),
         &mut state,
     )
     .await;
@@ -1270,7 +1277,7 @@ async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
 
     // Snapshot tab 1 via tabId
     let resp = execute_command(
-        &json!({ "id": "9", "action": "snapshot", "tabId": 1 }),
+        &json!({ "id": "9", "action": "snapshot", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -1325,10 +1332,10 @@ async fn e2e_tab_scoped_command_preserves_outer_tab_state() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
 
     let resp = execute_command(
-        &json!({ "id": "4", "action": "tab_switch", "tabId": 1 }),
+        &json!({ "id": "4", "action": "tab_switch", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -1345,7 +1352,7 @@ async fn e2e_tab_scoped_command_preserves_outer_tab_state() {
     // Run a tabId-scoped command. Outer state must be preserved across the
     // peek so subsequent ref-based commands on tab 1 keep working.
     let resp = execute_command(
-        &json!({ "id": "6", "action": "title", "tabId": 2 }),
+        &json!({ "id": "6", "action": "title", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1410,7 +1417,7 @@ async fn e2e_tab_scoped_command_isolates_refs_from_outer_tab() {
     // Snapshot tab 2 is unnecessary; we want to verify tab 1's refs don't
     // bleed through. Switch to tab 1 and populate refs there.
     let resp = execute_command(
-        &json!({ "id": "4", "action": "tab_switch", "tabId": 1 }),
+        &json!({ "id": "4", "action": "tab_switch", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -1424,7 +1431,7 @@ async fn e2e_tab_scoped_command_isolates_refs_from_outer_tab() {
     // The scoped command sees an empty ref_map, so this fails cleanly with a
     // ref-resolution error rather than silently clicking something random.
     let resp = execute_command(
-        &json!({ "id": "6", "action": "click", "selector": "@e1", "tabId": 2 }),
+        &json!({ "id": "6", "action": "click", "selector": "@e1", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1473,11 +1480,11 @@ async fn e2e_tab_scoped_command_restores_active_tab() {
     )
     .await;
     assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], 2);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
 
     // Active tab is 2. Peek at tab 1 with a scoped command.
     let resp = execute_command(
-        &json!({ "id": "4", "action": "title", "tabId": 1 }),
+        &json!({ "id": "4", "action": "title", "tabId": "t1" }),
         &mut state,
     )
     .await;
@@ -1556,7 +1563,7 @@ async fn e2e_tab_scoped_command_outer_tab_closed_mid_dispatch() {
             "id": "5",
             "action": "evaluate",
             "script": "window.open('about:blank', '_blank'); 'ok'",
-            "tabId": 2,
+            "tabId": "t2",
         }),
         &mut state,
     )
@@ -1576,7 +1583,7 @@ async fn e2e_tab_scoped_command_outer_tab_closed_mid_dispatch() {
     // Set active tab to tab 2 (the outer for our scoped peek). Previous
     // scoped eval restored to tab 1; bring us back to tab 2 explicitly.
     let resp = execute_command(
-        &json!({ "id": "7", "action": "tab_switch", "tabId": 2 }),
+        &json!({ "id": "7", "action": "tab_switch", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1591,7 +1598,7 @@ async fn e2e_tab_scoped_command_outer_tab_closed_mid_dispatch() {
             "id": "8",
             "action": "evaluate",
             "script": "window.opener && window.opener.close(); 'closed'",
-            "tabId": 3,
+            "tabId": "t3",
         }),
         &mut state,
     )
@@ -1605,10 +1612,13 @@ async fn e2e_tab_scoped_command_outer_tab_closed_mid_dispatch() {
     let resp = execute_command(&json!({ "id": "9", "action": "tab_list" }), &mut state).await;
     assert_success(&resp);
     let tabs = get_data(&resp)["tabs"].as_array().unwrap();
-    let ids: Vec<i64> = tabs.iter().map(|t| t["tabId"].as_i64().unwrap()).collect();
+    let ids: Vec<String> = tabs
+        .iter()
+        .map(|t| t["tabId"].as_str().unwrap().to_string())
+        .collect();
     assert!(
-        !ids.contains(&2),
-        "outer tab 2 should be closed by window.opener.close(): {:?}",
+        !ids.iter().any(|id| id == "t2"),
+        "outer tab t2 should be closed by window.opener.close(): {:?}",
         tabs,
     );
     assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(3));
@@ -1655,7 +1665,7 @@ async fn e2e_tab_close_with_tab_id_closes_active_tab() {
     assert_success(&resp);
 
     let resp = execute_command(
-        &json!({ "id": "4", "action": "tab_close", "tabId": 2 }),
+        &json!({ "id": "4", "action": "tab_close", "tabId": "t2" }),
         &mut state,
     )
     .await;
@@ -1667,6 +1677,178 @@ async fn e2e_tab_close_with_tab_id_closes_active_tab() {
     assert!(state.ref_map.get("e1").is_none());
     assert!(state.iframe_sessions.is_empty());
     assert!(state.active_frame_id.is_none());
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Tabs can be opened with a user-assigned label and then addressed by that
+/// label anywhere a `t<N>` id is accepted. Labels are the agent-friendly way
+/// to write multi-tab workflows without memorizing ids.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_new_with_label_can_be_switched_and_peeked() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<title>Home</title>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Open a labeled tab and verify the response echoes the label and a
+    // `t<N>` style tabId.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "tab_new",
+            "url": "data:text/html,<title>Docs</title>",
+            "label": "docs",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["tabId"], "t2");
+    assert_eq!(get_data(&resp)["label"], "docs");
+
+    // tab_list exposes the label alongside the id.
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    let docs = tabs
+        .iter()
+        .find(|t| t["tabId"] == "t2")
+        .expect("docs tab should be present");
+    assert_eq!(docs["label"], "docs");
+
+    // Peek by label via the scoped `tabId` path; active tab (t1) is restored.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "title", "tabId": "docs" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "Docs");
+
+    // Unscoped `title` reflects the restored active tab (t1).
+    let resp = execute_command(&json!({ "id": "7", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "Home");
+
+    // Permanent switch by label too.
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "tab_switch", "tabId": "docs" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(2));
+
+    // Close by label.
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "tab_close", "tabId": "docs" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["label"], "docs");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Duplicate labels must be rejected so agents can treat a label as a unique
+/// handle. The first tab keeps the label; the second tab's creation errors.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_new_with_duplicate_label_errors() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "tab_new", "url": "about:blank", "label": "docs" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_new", "url": "about:blank", "label": "docs" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "duplicate label should error: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("already used"),
+        "error should explain the collision: {}",
+        err
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Positional integers must be rejected by CLI-layer parsing to prevent
+/// confusion with tab indices. The error should teach the user the correct
+/// form (`t<N>`).
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_scoped_command_rejects_bare_integer() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Scoped command with a bare integer `tabId` must error with a teaching
+    // message rather than silently accept or reject quietly.
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "title", "tabId": "2" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "bare integer tabId should error: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("t2") && err.contains("positional integers"),
+        "error should teach `t<N>` convention: {}",
+        err
+    );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1295,12 +1295,14 @@ async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
 // `--tab` / `tabId` scoped-command regression tests
 // ---------------------------------------------------------------------------
 
-/// `tabId`-scoped commands must clear `state.ref_map`, `state.iframe_sessions`,
-/// and `state.active_frame_id` when they temporarily switch tabs, otherwise
-/// refs from the outer tab would resolve against the scoped tab's DOM.
+/// `tabId`-scoped commands must preserve the outer tab's per-tab state
+/// (`ref_map`, `iframe_sessions`, `active_frame_id`) across the peek so agents
+/// can keep using `@eN` refs populated before the scoped command. They must
+/// also isolate per-tab state *during* the scoped command so refs from the
+/// outer tab can't resolve against the scoped tab's DOM.
 #[tokio::test]
 #[ignore]
-async fn e2e_tab_scoped_command_clears_state_on_switch() {
+async fn e2e_tab_scoped_command_preserves_outer_tab_state() {
     let mut state = DaemonState::new();
 
     let resp = execute_command(
@@ -1334,13 +1336,14 @@ async fn e2e_tab_scoped_command_clears_state_on_switch() {
 
     let resp = execute_command(&json!({ "id": "5", "action": "snapshot" }), &mut state).await;
     assert_success(&resp);
-    assert!(
-        state.ref_map.get("e1").is_some(),
-        "snapshot should populate @e1 on tab 1"
-    );
+    let outer_e1 = state
+        .ref_map
+        .get("e1")
+        .cloned()
+        .expect("snapshot should populate @e1 on tab 1");
 
-    // Run a tabId-scoped command. The pre-dispatch must clear per-tab state
-    // so nothing can leak into the scoped tab's context.
+    // Run a tabId-scoped command. Outer state must be preserved across the
+    // peek so subsequent ref-based commands on tab 1 keep working.
     let resp = execute_command(
         &json!({ "id": "6", "action": "title", "tabId": 2 }),
         &mut state,
@@ -1348,14 +1351,96 @@ async fn e2e_tab_scoped_command_clears_state_on_switch() {
     .await;
     assert_success(&resp);
 
-    assert!(
-        state.ref_map.get("e1").is_none(),
-        "ref_map must be cleared when a tabId-scoped command switches tabs, \
-         but @e1 is still present: {:?}",
-        state.ref_map.get("e1")
+    let restored_e1 = state
+        .ref_map
+        .get("e1")
+        .cloned()
+        .expect("tab 1's @e1 must survive a --tab 2 peek");
+    assert_eq!(
+        restored_e1.backend_node_id, outer_e1.backend_node_id,
+        "restored @e1 must point at the same backend node as before the peek"
     );
+    assert_eq!(restored_e1.role, outer_e1.role);
+    assert_eq!(restored_e1.name, outer_e1.name);
     assert!(state.iframe_sessions.is_empty());
     assert!(state.active_frame_id.is_none());
+
+    // And the ref still clicks — proves the backend node id wasn't staled by
+    // the tab switch round-trip.
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "click", "selector": "@e1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Refs from the outer tab must not resolve against the scoped tab's DOM, so
+/// a `--tab N click @eK` where `@eK` came from a different tab must fail
+/// cleanly rather than silently click the wrong element.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_scoped_command_isolates_refs_from_outer_tab() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<button>Alpha</button>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<p>Beta</p>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Snapshot tab 2 is unnecessary; we want to verify tab 1's refs don't
+    // bleed through. Switch to tab 1 and populate refs there.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "tab_switch", "tabId": 1 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "5", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    assert!(state.ref_map.get("e1").is_some());
+
+    // Scoped `--tab 2 click @e1` must not resolve tab 1's @e1 against tab 2.
+    // The scoped command sees an empty ref_map, so this fails cleanly with a
+    // ref-resolution error rather than silently clicking something random.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "click", "selector": "@e1", "tabId": 2 }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "scoped click with an outer-tab ref must fail (refs don't bleed \
+         across tabs): {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+
+    // And the outer tab's ref_map is still intact after the failed peek.
+    assert!(
+        state.ref_map.get("e1").is_some(),
+        "outer tab's refs must survive a failed scoped command too"
+    );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
@@ -1413,11 +1498,139 @@ async fn e2e_tab_scoped_command_restores_active_tab() {
     assert_success(&resp);
 }
 
-/// Restoration must be skipped (without error) if the scoped command closes
-/// the tab that was active before the switch.
+/// When the outer tab is closed by the scoped command's side effects (e.g. a
+/// script that calls `window.opener.close()`), the post-dispatch must take
+/// the `still_exists == false` branch: leave the scoped tab active, clear
+/// per-tab state (no stale refs from the vanished outer tab), and not error.
+///
+/// The setup uses a script-opened intermediate tab so Chrome allows
+/// `opener.close()` — Chrome refuses to close the initial user-opened tab
+/// via script, so we chain `window.open` to get a second script-opened tab
+/// that *can* be closed from its child.
 #[tokio::test]
 #[ignore]
-async fn e2e_tab_scoped_command_handles_outer_tab_closed() {
+async fn e2e_tab_scoped_command_outer_tab_closed_mid_dispatch() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "about:blank" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Tab 1 (initial) opens tab 2 via window.open — tab 2 is script-opened,
+    // so later calls to `close()` on it from a child will be allowed.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "window.open('about:blank', '_blank'); 'ok'",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    // Let Chrome fire the Target.targetCreated event.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["tabs"].as_array().map(|a| a.len()),
+        Some(2),
+        "tab 1's window.open should create tab 2: {:?}",
+        get_data(&resp)
+    );
+
+    // Tab 2 opens tab 3 via window.open — tab 3's opener is tab 2, and tab 2
+    // is script-opened so `window.opener.close()` from tab 3 can close it.
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "evaluate",
+            "script": "window.open('about:blank', '_blank'); 'ok'",
+            "tabId": 2,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let resp = execute_command(&json!({ "id": "6", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert_eq!(
+        tabs.len(),
+        3,
+        "tab 2's window.open should create tab 3: {:?}",
+        tabs,
+    );
+
+    // Set active tab to tab 2 (the outer for our scoped peek). Previous
+    // scoped eval restored to tab 1; bring us back to tab 2 explicitly.
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "tab_switch", "tabId": 2 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(2));
+
+    // --tab 3 evaluate "window.opener.close()" closes tab 2 (the outer)
+    // mid-dispatch. Post-dispatch should observe that tab 2 is gone and take
+    // the restore-skip branch rather than error.
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "evaluate",
+            "script": "window.opener && window.opener.close(); 'closed'",
+            "tabId": 3,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    // Let Chrome fire the Target.targetDestroyed event and reconcile.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Only tabs 1 and 3 remain; tab 2 is gone. The scoped tab (3) stays
+    // active since the outer (2) vanished.
+    let resp = execute_command(&json!({ "id": "9", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    let ids: Vec<i64> = tabs.iter().map(|t| t["tabId"].as_i64().unwrap()).collect();
+    assert!(
+        !ids.contains(&2),
+        "outer tab 2 should be closed by window.opener.close(): {:?}",
+        tabs,
+    );
+    assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(3));
+
+    // Per-tab state is cleared (no stale outer refs/iframe context).
+    assert!(state.ref_map.get("e1").is_none());
+    assert!(state.iframe_sessions.is_empty());
+    assert!(state.active_frame_id.is_none());
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// `tab_close` with an explicit `tabId` must close that tab regardless of
+/// whether it's active, and leave the remaining tab active without leaking
+/// per-tab state (refs, iframe sessions, frame id) from the closed tab.
+/// `tab_close` is in the scoped-dispatch exclusion list, so this path doesn't
+/// touch the save/restore machinery; the test pins that explicit-tabId closes
+/// behave correctly even when they close the currently-active tab.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_close_with_tab_id_closes_active_tab() {
     let mut state = DaemonState::new();
 
     let resp = execute_command(
@@ -1441,9 +1654,6 @@ async fn e2e_tab_scoped_command_handles_outer_tab_closed() {
     .await;
     assert_success(&resp);
 
-    // Active tab is 2. Peek at tab 1 with a command that also closes tab 2.
-    // The restoration path must not error when it discovers tab 2 is gone;
-    // we treat "outer tab vanished" as an implicit accept of the scoped tab.
     let resp = execute_command(
         &json!({ "id": "4", "action": "tab_close", "tabId": 2 }),
         &mut state,
@@ -1454,6 +1664,9 @@ async fn e2e_tab_scoped_command_handles_outer_tab_closed() {
     let resp = execute_command(&json!({ "id": "5", "action": "title" }), &mut state).await;
     assert_success(&resp);
     assert_eq!(get_data(&resp)["title"], "A");
+    assert!(state.ref_map.get("e1").is_none());
+    assert!(state.iframe_sessions.is_empty());
+    assert!(state.active_frame_id.is_none());
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1041,603 +1041,9 @@ async fn e2e_tab_ids_not_reused() {
     assert_success(&resp);
 }
 
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_global_targeting() {
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Navigate tab 1
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Page A</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Open tab 2 (becomes active)
-    let resp = execute_command(
-        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<h1>Page B</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], "t2");
-
-    // Use tabId to evaluate on tab 1 while tab 2 is active
-    // (simulates --tab 1 evaluate ...)
-    let resp = execute_command(
-        &json!({ "id": "4", "action": "evaluate", "tabId": "t1", "script": "document.querySelector('h1').textContent" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(
-        get_data(&resp)["result"],
-        "Page A",
-        "tabId should target tab 1 even though tab 2 was active"
-    );
-
-    // Verify tab 2 content is still accessible
-    let resp = execute_command(
-        &json!({ "id": "5", "action": "evaluate", "tabId": "t2", "script": "document.querySelector('h1').textContent" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["result"], "Page B");
-
-    // Without tabId, should use the current active tab (now tab 1 from the switch)
-    let resp = execute_command(
-        &json!({ "id": "6", "action": "evaluate", "script": "document.querySelector('h1').textContent" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    // Active tab was never changed by the scoped `tabId` commands
-    // (restoration semantics), so it's still tab 2 from the earlier `tab_new`.
-    assert_eq!(get_data(&resp)["result"], "Page B");
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_global_targeting_snapshot() {
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Navigate tab 1
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Page A</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Open tab 2 (becomes active)
-    let resp = execute_command(
-        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<h1>Page B</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], "t2");
-
-    // Snapshot tab 1 via tabId while tab 2 is active
-    let resp = execute_command(
-        &json!({ "id": "4", "action": "snapshot", "tabId": "t1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
-    assert!(
-        snapshot.contains("Page A"),
-        "Snapshot with tabId=1 should contain 'Page A', got: {}",
-        snapshot
-    );
-    assert!(
-        !snapshot.contains("Page B"),
-        "Snapshot with tabId=1 should NOT contain 'Page B', got: {}",
-        snapshot
-    );
-
-    // Snapshot tab 2 via tabId
-    let resp = execute_command(
-        &json!({ "id": "5", "action": "snapshot", "tabId": "t2" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
-    assert!(
-        snapshot.contains("Page B"),
-        "Snapshot with tabId=2 should contain 'Page B', got: {}",
-        snapshot
-    );
-    assert!(
-        !snapshot.contains("Page A"),
-        "Snapshot with tabId=2 should NOT contain 'Page A', got: {}",
-        snapshot
-    );
-
-    // Snapshot without tabId uses the still-active tab 2 (restoration
-    // semantics: scoped commands don't change the active tab).
-    let resp = execute_command(&json!({ "id": "6", "action": "snapshot" }), &mut state).await;
-    assert_success(&resp);
-    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
-    assert!(
-        snapshot.contains("Page B"),
-        "Snapshot without tabId should use active tab (Page B), got: {}",
-        snapshot
-    );
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_global_targeting_snapshot_non_contiguous() {
-    // Reproduces the bug where --tab 3 snapshot shows tab 1's content
-    // when tab IDs are non-contiguous (e.g. tabs [1] and [3] after
-    // closing tab [2]).
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Navigate tab 1 to Page A
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Page A</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Open tab 2
-    let resp = execute_command(
-        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<h1>Page B</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], "t2");
-
-    // Open tab 3
-    let resp = execute_command(
-        &json!({ "id": "4", "action": "tab_new", "url": "data:text/html,<h1>Page C</h1>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], "t3");
-
-    // Close tab 2 to create non-contiguous IDs: [1, 3]
-    let resp = execute_command(
-        &json!({ "id": "5", "action": "tab_close", "tabId": "t2" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Verify tab list shows [1] and [3]
-    let resp = execute_command(&json!({ "id": "6", "action": "tab_list" }), &mut state).await;
-    assert_success(&resp);
-    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
-    assert_eq!(tabs.len(), 2);
-    assert_eq!(tabs[0]["tabId"], "t1");
-    assert_eq!(tabs[1]["tabId"], "t3");
-
-    // Switch active tab back to tab 1
-    let resp = execute_command(
-        &json!({ "id": "7", "action": "tab_switch", "tabId": "t1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Snapshot tab 3 via tabId while tab 1 is active
-    // (simulates: --tab 3 snapshot)
-    let resp = execute_command(
-        &json!({ "id": "8", "action": "snapshot", "tabId": "t3" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
-    assert!(
-        snapshot.contains("Page C"),
-        "Snapshot with tabId=3 should contain 'Page C', got: {}",
-        snapshot
-    );
-    assert!(
-        !snapshot.contains("Page A"),
-        "Snapshot with tabId=3 should NOT contain 'Page A', got: {}",
-        snapshot
-    );
-
-    // Snapshot tab 1 via tabId
-    let resp = execute_command(
-        &json!({ "id": "9", "action": "snapshot", "tabId": "t1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
-    assert!(
-        snapshot.contains("Page A"),
-        "Snapshot with tabId=1 should contain 'Page A', got: {}",
-        snapshot
-    );
-    assert!(
-        !snapshot.contains("Page C"),
-        "Snapshot with tabId=1 should NOT contain 'Page C', got: {}",
-        snapshot
-    );
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
-// ---------------------------------------------------------------------------
-// `--tab` / `tabId` scoped-command regression tests
-// ---------------------------------------------------------------------------
-
-/// `tabId`-scoped commands must preserve the outer tab's per-tab state
-/// (`ref_map`, `iframe_sessions`, `active_frame_id`) across the peek so agents
-/// can keep using `@eN` refs populated before the scoped command. They must
-/// also isolate per-tab state *during* the scoped command so refs from the
-/// outer tab can't resolve against the scoped tab's DOM.
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_scoped_command_preserves_outer_tab_state() {
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<button>Alpha</button>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<p>Beta</p>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], "t2");
-
-    let resp = execute_command(
-        &json!({ "id": "4", "action": "tab_switch", "tabId": "t1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(&json!({ "id": "5", "action": "snapshot" }), &mut state).await;
-    assert_success(&resp);
-    let outer_e1 = state
-        .ref_map
-        .get("e1")
-        .cloned()
-        .expect("snapshot should populate @e1 on tab 1");
-
-    // Run a tabId-scoped command. Outer state must be preserved across the
-    // peek so subsequent ref-based commands on tab 1 keep working.
-    let resp = execute_command(
-        &json!({ "id": "6", "action": "title", "tabId": "t2" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let restored_e1 = state
-        .ref_map
-        .get("e1")
-        .cloned()
-        .expect("tab 1's @e1 must survive a --tab 2 peek");
-    assert_eq!(
-        restored_e1.backend_node_id, outer_e1.backend_node_id,
-        "restored @e1 must point at the same backend node as before the peek"
-    );
-    assert_eq!(restored_e1.role, outer_e1.role);
-    assert_eq!(restored_e1.name, outer_e1.name);
-    assert!(state.iframe_sessions.is_empty());
-    assert!(state.active_frame_id.is_none());
-
-    // And the ref still clicks — proves the backend node id wasn't staled by
-    // the tab switch round-trip.
-    let resp = execute_command(
-        &json!({ "id": "7", "action": "click", "selector": "@e1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
-/// Refs from the outer tab must not resolve against the scoped tab's DOM, so
-/// a `--tab N click @eK` where `@eK` came from a different tab must fail
-/// cleanly rather than silently click the wrong element.
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_scoped_command_isolates_refs_from_outer_tab() {
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<button>Alpha</button>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<p>Beta</p>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Snapshot tab 2 is unnecessary; we want to verify tab 1's refs don't
-    // bleed through. Switch to tab 1 and populate refs there.
-    let resp = execute_command(
-        &json!({ "id": "4", "action": "tab_switch", "tabId": "t1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(&json!({ "id": "5", "action": "snapshot" }), &mut state).await;
-    assert_success(&resp);
-    assert!(state.ref_map.get("e1").is_some());
-
-    // Scoped `--tab 2 click @e1` must not resolve tab 1's @e1 against tab 2.
-    // The scoped command sees an empty ref_map, so this fails cleanly with a
-    // ref-resolution error rather than silently clicking something random.
-    let resp = execute_command(
-        &json!({ "id": "6", "action": "click", "selector": "@e1", "tabId": "t2" }),
-        &mut state,
-    )
-    .await;
-    assert_eq!(
-        resp.get("success").and_then(|v| v.as_bool()),
-        Some(false),
-        "scoped click with an outer-tab ref must fail (refs don't bleed \
-         across tabs): {}",
-        serde_json::to_string_pretty(&resp).unwrap_or_default()
-    );
-
-    // And the outer tab's ref_map is still intact after the failed peek.
-    assert!(
-        state.ref_map.get("e1").is_some(),
-        "outer tab's refs must survive a failed scoped command too"
-    );
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
-/// `tabId`-scoped commands must restore the original active tab afterward so
-/// `--tab N` is a non-intrusive peek that doesn't change the user's context.
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_scoped_command_restores_active_tab() {
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<title>A</title>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<title>B</title>" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["tabId"], "t2");
-
-    // Active tab is 2. Peek at tab 1 with a scoped command.
-    let resp = execute_command(
-        &json!({ "id": "4", "action": "title", "tabId": "t1" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["title"], "A", "tabId should route to tab 1");
-
-    // No tabId: must reflect the originally active tab (tab 2).
-    let resp = execute_command(&json!({ "id": "5", "action": "title" }), &mut state).await;
-    assert_success(&resp);
-    assert_eq!(
-        get_data(&resp)["title"],
-        "B",
-        "active tab should be restored to tab 2 after the scoped command; \
-         got the scoped tab's title instead"
-    );
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
-/// When the outer tab is closed by the scoped command's side effects (e.g. a
-/// script that calls `window.opener.close()`), the post-dispatch must take
-/// the `still_exists == false` branch: leave the scoped tab active, clear
-/// per-tab state (no stale refs from the vanished outer tab), and not error.
-///
-/// The setup uses a script-opened intermediate tab so Chrome allows
-/// `opener.close()` — Chrome refuses to close the initial user-opened tab
-/// via script, so we chain `window.open` to get a second script-opened tab
-/// that *can* be closed from its child.
-#[tokio::test]
-#[ignore]
-async fn e2e_tab_scoped_command_outer_tab_closed_mid_dispatch() {
-    let mut state = DaemonState::new();
-
-    let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "about:blank" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-
-    // Tab 1 (initial) opens tab 2 via window.open — tab 2 is script-opened,
-    // so later calls to `close()` on it from a child will be allowed.
-    let resp = execute_command(
-        &json!({
-            "id": "3",
-            "action": "evaluate",
-            "script": "window.open('about:blank', '_blank'); 'ok'",
-        }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    // Let Chrome fire the Target.targetCreated event.
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
-    assert_success(&resp);
-    assert_eq!(
-        get_data(&resp)["tabs"].as_array().map(|a| a.len()),
-        Some(2),
-        "tab 1's window.open should create tab 2: {:?}",
-        get_data(&resp)
-    );
-
-    // Tab 2 opens tab 3 via window.open — tab 3's opener is tab 2, and tab 2
-    // is script-opened so `window.opener.close()` from tab 3 can close it.
-    let resp = execute_command(
-        &json!({
-            "id": "5",
-            "action": "evaluate",
-            "script": "window.open('about:blank', '_blank'); 'ok'",
-            "tabId": "t2",
-        }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let resp = execute_command(&json!({ "id": "6", "action": "tab_list" }), &mut state).await;
-    assert_success(&resp);
-    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
-    assert_eq!(
-        tabs.len(),
-        3,
-        "tab 2's window.open should create tab 3: {:?}",
-        tabs,
-    );
-
-    // Set active tab to tab 2 (the outer for our scoped peek). Previous
-    // scoped eval restored to tab 1; bring us back to tab 2 explicitly.
-    let resp = execute_command(
-        &json!({ "id": "7", "action": "tab_switch", "tabId": "t2" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(2));
-
-    // --tab 3 evaluate "window.opener.close()" closes tab 2 (the outer)
-    // mid-dispatch. Post-dispatch should observe that tab 2 is gone and take
-    // the restore-skip branch rather than error.
-    let resp = execute_command(
-        &json!({
-            "id": "8",
-            "action": "evaluate",
-            "script": "window.opener && window.opener.close(); 'closed'",
-            "tabId": "t3",
-        }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    // Let Chrome fire the Target.targetDestroyed event and reconcile.
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    // Only tabs 1 and 3 remain; tab 2 is gone. The scoped tab (3) stays
-    // active since the outer (2) vanished.
-    let resp = execute_command(&json!({ "id": "9", "action": "tab_list" }), &mut state).await;
-    assert_success(&resp);
-    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
-    let ids: Vec<String> = tabs
-        .iter()
-        .map(|t| t["tabId"].as_str().unwrap().to_string())
-        .collect();
-    assert!(
-        !ids.iter().any(|id| id == "t2"),
-        "outer tab t2 should be closed by window.opener.close(): {:?}",
-        tabs,
-    );
-    assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(3));
-
-    // Per-tab state is cleared (no stale outer refs/iframe context).
-    assert!(state.ref_map.get("e1").is_none());
-    assert!(state.iframe_sessions.is_empty());
-    assert!(state.active_frame_id.is_none());
-
-    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
-    assert_success(&resp);
-}
-
 /// `tab_close` with an explicit `tabId` must close that tab regardless of
 /// whether it's active, and leave the remaining tab active without leaking
 /// per-tab state (refs, iframe sessions, frame id) from the closed tab.
-/// `tab_close` is in the scoped-dispatch exclusion list, so this path doesn't
-/// touch the save/restore machinery; the test pins that explicit-tabId closes
-/// behave correctly even when they close the currently-active tab.
 #[tokio::test]
 #[ignore]
 async fn e2e_tab_close_with_tab_id_closes_active_tab() {
@@ -1683,11 +1089,12 @@ async fn e2e_tab_close_with_tab_id_closes_active_tab() {
 }
 
 /// Tabs can be opened with a user-assigned label and then addressed by that
-/// label anywhere a `t<N>` id is accepted. Labels are the agent-friendly way
-/// to write multi-tab workflows without memorizing ids.
+/// label anywhere a `t<N>` id is accepted (switch, close, and JSON `tabId`
+/// on `tab_switch` / `tab_close`). Labels are the agent-friendly way to
+/// write multi-tab workflows without memorizing ids.
 #[tokio::test]
 #[ignore]
-async fn e2e_tab_new_with_label_can_be_switched_and_peeked() {
+async fn e2e_tab_new_with_label_can_be_switched_and_closed() {
     let mut state = DaemonState::new();
 
     let resp = execute_command(
@@ -1730,38 +1137,32 @@ async fn e2e_tab_new_with_label_can_be_switched_and_peeked() {
         .expect("docs tab should be present");
     assert_eq!(docs["label"], "docs");
 
-    // Peek by label via the scoped `tabId` path; active tab (t1) is restored.
+    // tab_switch accepts the label.
     let resp = execute_command(
         &json!({ "id": "5", "action": "tab_switch", "tabId": "t1" }),
         &mut state,
     )
     .await;
     assert_success(&resp);
-    let resp = execute_command(
-        &json!({ "id": "6", "action": "title", "tabId": "docs" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["title"], "Docs");
+    assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(1));
 
-    // Unscoped `title` reflects the restored active tab (t1).
-    let resp = execute_command(&json!({ "id": "7", "action": "title" }), &mut state).await;
-    assert_success(&resp);
-    assert_eq!(get_data(&resp)["title"], "Home");
-
-    // Permanent switch by label too.
     let resp = execute_command(
-        &json!({ "id": "8", "action": "tab_switch", "tabId": "docs" }),
+        &json!({ "id": "6", "action": "tab_switch", "tabId": "docs" }),
         &mut state,
     )
     .await;
     assert_success(&resp);
     assert_eq!(state.browser.as_ref().unwrap().active_tab_id(), Some(2));
 
-    // Close by label.
+    // Once switched, the active tab is the labeled one and normal commands
+    // work against it.
+    let resp = execute_command(&json!({ "id": "7", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "Docs");
+
+    // tab_close accepts the label.
     let resp = execute_command(
-        &json!({ "id": "9", "action": "tab_close", "tabId": "docs" }),
+        &json!({ "id": "8", "action": "tab_close", "tabId": "docs" }),
         &mut state,
     )
     .await;
@@ -1815,12 +1216,12 @@ async fn e2e_tab_new_with_duplicate_label_errors() {
     assert_success(&resp);
 }
 
-/// Positional integers must be rejected by CLI-layer parsing to prevent
-/// confusion with tab indices. The error should teach the user the correct
-/// form (`t<N>`).
+/// Positional integers passed as `tabId` on tab-switch / tab-close must be
+/// rejected by the daemon-layer parser, not silently coerced. The error
+/// should teach the user the correct form (`t<N>`).
 #[tokio::test]
 #[ignore]
-async fn e2e_tab_scoped_command_rejects_bare_integer() {
+async fn e2e_tab_switch_rejects_bare_integer() {
     let mut state = DaemonState::new();
 
     let resp = execute_command(
@@ -1830,17 +1231,15 @@ async fn e2e_tab_scoped_command_rejects_bare_integer() {
     .await;
     assert_success(&resp);
 
-    // Scoped command with a bare integer `tabId` must error with a teaching
-    // message rather than silently accept or reject quietly.
     let resp = execute_command(
-        &json!({ "id": "2", "action": "title", "tabId": "2" }),
+        &json!({ "id": "2", "action": "tab_switch", "tabId": "2" }),
         &mut state,
     )
     .await;
     assert_eq!(
         resp.get("success").and_then(|v| v.as_bool()),
         Some(false),
-        "bare integer tabId should error: {}",
+        "bare integer tabId on tab_switch should error: {}",
         serde_json::to_string_pretty(&resp).unwrap_or_default()
     );
     let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -20,6 +20,12 @@ pub struct RefMap {
     next_ref: usize,
 }
 
+impl Default for RefMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RefMap {
     pub fn new() -> Self {
         Self {

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -20,12 +20,6 @@ pub struct RefMap {
     next_ref: usize,
 }
 
-impl Default for RefMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RefMap {
     pub fn new() -> Self {
         Self {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1057,7 +1057,7 @@ Aliases: goto, navigate
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
   --headers <json>     Set HTTP headers (scoped to this origin)
   --headed             Show browser window
 
@@ -1081,7 +1081,7 @@ the browser's back button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser back
@@ -1099,7 +1099,7 @@ the browser's forward button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser forward
@@ -1117,7 +1117,7 @@ the browser's reload button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser reload
@@ -1141,7 +1141,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser click "#submit-button"
@@ -1163,7 +1163,7 @@ or triggering double-click handlers.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser dblclick "#editable-text"
@@ -1182,7 +1182,7 @@ This replaces any existing content in the field.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser fill "#email" "user@example.com"
@@ -1202,7 +1202,7 @@ Unlike fill, this does not clear existing content first.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser type "#search" "hello"
@@ -1226,7 +1226,7 @@ triggering hover states or dropdown menus.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser hover "#dropdown-trigger"
@@ -1244,7 +1244,7 @@ Sets keyboard focus to the specified element.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser focus "#input-field"
@@ -1262,7 +1262,7 @@ Checks a checkbox element. If already checked, no action is taken.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser check "#terms-checkbox"
@@ -1280,7 +1280,7 @@ Unchecks a checkbox element. If already unchecked, no action is taken.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser uncheck "#newsletter-opt-in"
@@ -1298,7 +1298,7 @@ Selects one or more options in a <select> dropdown by value.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser select "#country" "US"
@@ -1317,7 +1317,7 @@ Drags an element from source to target location.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser drag "#draggable" "#drop-zone"
@@ -1335,7 +1335,7 @@ Uploads one or more files to a file input element.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser upload "#file-input" ./document.pdf
@@ -1357,7 +1357,7 @@ Arguments:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser download "#download-btn" ./file.pdf
@@ -1389,7 +1389,7 @@ Modifiers (combine with +):
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser press Enter
@@ -1411,7 +1411,7 @@ Useful for holding modifier keys.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser keydown Shift
@@ -1429,7 +1429,7 @@ Releases a key that was pressed with keydown.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser keyup Shift
@@ -1458,7 +1458,7 @@ directly — it already operates on the current focus.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser keyboard type "Hello, World!"
@@ -1493,7 +1493,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser scroll
@@ -1516,7 +1516,7 @@ Aliases: scrollinto
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser scrollintoview "#footer"
@@ -1554,7 +1554,7 @@ Wait for text to disappear:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser wait "#loading-spinner"
@@ -1596,7 +1596,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser screenshot
@@ -1620,7 +1620,7 @@ Saves the current page as a PDF file.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser pdf ./page.pdf
@@ -1649,7 +1649,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser snapshot
@@ -1676,7 +1676,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser eval "document.title"
@@ -1709,7 +1709,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser close
@@ -1761,7 +1761,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser get text @e1
@@ -1794,7 +1794,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser is visible "#modal"
@@ -1834,7 +1834,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser find role button click --name Submit
@@ -1865,7 +1865,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser mouse move 100 200
@@ -1899,7 +1899,7 @@ Settings:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser set viewport 1920 1080
@@ -1940,7 +1940,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser network route "**/api/*" --abort
@@ -1978,7 +1978,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser storage local
@@ -2018,7 +2018,7 @@ for the current page URL.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   # Simple cookie for current page
@@ -2062,7 +2062,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser tab
@@ -2090,7 +2090,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser window new
@@ -2113,7 +2113,7 @@ Arguments:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser frame "#embed-iframe"
@@ -2201,7 +2201,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser dialog accept
@@ -2227,7 +2227,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser trace start
@@ -2259,7 +2259,7 @@ Start Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   # Basic profiling
@@ -2299,7 +2299,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   # Record from current page (preserves login state)
@@ -2332,7 +2332,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser console
@@ -2353,7 +2353,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser errors
@@ -2373,7 +2373,7 @@ Visually highlights an element on the page for debugging.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser highlight "#target-element"
@@ -2399,7 +2399,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser clipboard read
@@ -2439,7 +2439,7 @@ State Encryption:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser state save ./auth-state.json
@@ -2472,7 +2472,7 @@ Environment:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser session
@@ -2570,7 +2570,7 @@ Supported URL formats:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   # Connect to local Chrome with remote debugging
@@ -2732,7 +2732,7 @@ URL Diff:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Target specific tab ID
+  --tab <id>           Run on tab <id> (peek; active tab restored)
 
 Examples:
   agent-browser diff snapshot
@@ -3027,7 +3027,7 @@ Authentication:
 
 Options:
   --session <name>           Isolated session (or AGENT_BROWSER_SESSION env)
-  --tab <id>                 Target specific tab ID for the command
+  --tab <id>                 Run on tab <id> for this command (peek; active tab restored)
   --executable-path <path>   Custom browser executable (or AGENT_BROWSER_EXECUTABLE_PATH)
   --extension <path>         Load browser extensions (repeatable)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -407,10 +407,8 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         // Tabs
         if let Some(tabs) = data.get("tabs").and_then(|v| v.as_array()) {
             for tab in tabs {
-                let tab_id = tab
-                    .get("tabId")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or_default();
+                let tab_id = tab.get("tabId").and_then(|v| v.as_str()).unwrap_or("?");
+                let tab_label = tab.get("label").and_then(|v| v.as_str());
                 let title = tab
                     .get("title")
                     .and_then(|v| v.as_str())
@@ -422,13 +420,17 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 } else {
                     " ".to_string()
                 };
-                println!("{} [{}] {} - {}", marker, tab_id, title, url);
+                if let Some(label) = tab_label {
+                    println!("{} [{}] {} {} - {}", marker, tab_id, label, title, url);
+                } else {
+                    println!("{} [{}] {} - {}", marker, tab_id, title, url);
+                }
             }
             return;
         }
         // Tab switch
         if action == Some("tab_switch") {
-            if let Some(tab_id) = data.get("tabId").and_then(|v| v.as_i64()) {
+            if let Some(tab_id) = data.get("tabId").and_then(|v| v.as_str()) {
                 if let Some(url) = data.get("url").and_then(|v| v.as_str()) {
                     println!(
                         "{} Switched to tab [{}] ({})",
@@ -447,19 +449,31 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
         }
         // New tab/window
-        if let Some(tab_id) = data.get("tabId").and_then(|v| v.as_i64()) {
+        if let Some(tab_id) = data.get("tabId").and_then(|v| v.as_str()) {
             if let Some(total) = data.get("total").and_then(|v| v.as_i64()) {
-                let label = match action {
+                let label_noun = match action {
                     Some("window_new") => "Window opened",
                     _ => "Tab opened",
                 };
-                println!(
-                    "{} {} [{}] ({} total)",
-                    color::success_indicator(),
-                    label,
-                    tab_id,
-                    total
-                );
+                let tab_label = data.get("label").and_then(|v| v.as_str());
+                if let Some(lbl) = tab_label {
+                    println!(
+                        "{} {} [{}] {} ({} total)",
+                        color::success_indicator(),
+                        label_noun,
+                        tab_id,
+                        lbl,
+                        total
+                    );
+                } else {
+                    println!(
+                        "{} {} [{}] ({} total)",
+                        color::success_indicator(),
+                        label_noun,
+                        tab_id,
+                        total
+                    );
+                }
                 return;
             }
         }
@@ -604,7 +618,7 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         if data.get("closed").is_some() {
             let label = match action {
                 Some("tab_close") => {
-                    if let Some(closed_id) = data.get("tabId").and_then(|v| v.as_i64()) {
+                    if let Some(closed_id) = data.get("tabId").and_then(|v| v.as_str()) {
                         println!("{} Tab [{}] closed", color::success_indicator(), closed_id);
                         return;
                     }
@@ -1057,7 +1071,7 @@ Aliases: goto, navigate
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
   --headers <json>     Set HTTP headers (scoped to this origin)
   --headed             Show browser window
 
@@ -1081,7 +1095,7 @@ the browser's back button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser back
@@ -1099,7 +1113,7 @@ the browser's forward button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser forward
@@ -1117,7 +1131,7 @@ the browser's reload button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser reload
@@ -1141,7 +1155,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser click "#submit-button"
@@ -1163,7 +1177,7 @@ or triggering double-click handlers.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser dblclick "#editable-text"
@@ -1182,7 +1196,7 @@ This replaces any existing content in the field.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser fill "#email" "user@example.com"
@@ -1202,7 +1216,7 @@ Unlike fill, this does not clear existing content first.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser type "#search" "hello"
@@ -1226,7 +1240,7 @@ triggering hover states or dropdown menus.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser hover "#dropdown-trigger"
@@ -1244,7 +1258,7 @@ Sets keyboard focus to the specified element.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser focus "#input-field"
@@ -1262,7 +1276,7 @@ Checks a checkbox element. If already checked, no action is taken.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser check "#terms-checkbox"
@@ -1280,7 +1294,7 @@ Unchecks a checkbox element. If already unchecked, no action is taken.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser uncheck "#newsletter-opt-in"
@@ -1298,7 +1312,7 @@ Selects one or more options in a <select> dropdown by value.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser select "#country" "US"
@@ -1317,7 +1331,7 @@ Drags an element from source to target location.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser drag "#draggable" "#drop-zone"
@@ -1335,7 +1349,7 @@ Uploads one or more files to a file input element.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser upload "#file-input" ./document.pdf
@@ -1357,7 +1371,7 @@ Arguments:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser download "#download-btn" ./file.pdf
@@ -1389,7 +1403,7 @@ Modifiers (combine with +):
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser press Enter
@@ -1411,7 +1425,7 @@ Useful for holding modifier keys.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser keydown Shift
@@ -1429,7 +1443,7 @@ Releases a key that was pressed with keydown.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser keyup Shift
@@ -1458,7 +1472,7 @@ directly — it already operates on the current focus.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser keyboard type "Hello, World!"
@@ -1493,7 +1507,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser scroll
@@ -1516,7 +1530,7 @@ Aliases: scrollinto
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser scrollintoview "#footer"
@@ -1554,7 +1568,7 @@ Wait for text to disappear:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser wait "#loading-spinner"
@@ -1596,7 +1610,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser screenshot
@@ -1620,7 +1634,7 @@ Saves the current page as a PDF file.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser pdf ./page.pdf
@@ -1649,7 +1663,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser snapshot
@@ -1676,7 +1690,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser eval "document.title"
@@ -1709,7 +1723,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser close
@@ -1761,7 +1775,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser get text @e1
@@ -1794,7 +1808,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser is visible "#modal"
@@ -1834,7 +1848,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser find role button click --name Submit
@@ -1865,7 +1879,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser mouse move 100 200
@@ -1899,7 +1913,7 @@ Settings:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser set viewport 1920 1080
@@ -1940,7 +1954,7 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser network route "**/api/*" --abort
@@ -1978,7 +1992,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser storage local
@@ -2018,7 +2032,7 @@ for the current page URL.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Simple cookie for current page
@@ -2051,27 +2065,35 @@ agent-browser tab - Manage browser tabs
 
 Usage: agent-browser tab [operation] [args]
 
-Manage browser tabs in the current window.
+Manage browser tabs in the current window. Stable tab ids look like `t1`,
+`t2`, `t3`. An id is never reused within a session, so scripts can keep
+referring to the same tab across commands. Optional user-assigned labels
+(e.g. `docs`, `app`) are interchangeable with ids everywhere a tab ref is
+accepted.
 
 Operations:
-  list                 List all tabs with tab IDs (default)
-  new [url]            Open new tab
-  close [id]           Close tab by ID (current if no ID)
-  <id>                 Switch to tab by ID
+  list                       List open tabs with their ids and labels (default)
+  new [url]                  Open a new tab
+  new --label <name> [url]   Open a new tab with a label like `docs` or `app`
+  close [t<N>|label]         Close a tab (current if no ref given)
+  <t<N>|label>               Switch to a tab by id or label
 
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser tab
   agent-browser tab list
   agent-browser tab new
   agent-browser tab new https://example.com
-  agent-browser tab 2
+  agent-browser tab new --label docs https://docs.example.com
+  agent-browser tab t2
+  agent-browser tab docs
   agent-browser tab close
-  agent-browser tab close 1
+  agent-browser tab close t1
+  agent-browser tab close docs
 "##
         }
 
@@ -2090,7 +2112,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser window new
@@ -2113,7 +2135,7 @@ Arguments:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser frame "#embed-iframe"
@@ -2201,7 +2223,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser dialog accept
@@ -2227,7 +2249,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser trace start
@@ -2259,7 +2281,7 @@ Start Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Basic profiling
@@ -2299,7 +2321,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Record from current page (preserves login state)
@@ -2332,7 +2354,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser console
@@ -2353,7 +2375,7 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser errors
@@ -2373,7 +2395,7 @@ Visually highlights an element on the page for debugging.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser highlight "#target-element"
@@ -2399,7 +2421,7 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser clipboard read
@@ -2439,7 +2461,7 @@ State Encryption:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser state save ./auth-state.json
@@ -2472,7 +2494,7 @@ Environment:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser session
@@ -2570,7 +2592,7 @@ Supported URL formats:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Connect to local Chrome with remote debugging
@@ -2732,7 +2754,7 @@ URL Diff:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <id>           Run on tab <id> (peek; active tab restored)
+  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser diff snapshot
@@ -3027,7 +3049,7 @@ Authentication:
 
 Options:
   --session <name>           Isolated session (or AGENT_BROWSER_SESSION env)
-  --tab <id>                 Run on tab <id> for this command (peek; active tab restored)
+  --tab <t<N>|label>         Run on this tab for this command (peek; active tab restored)
   --executable-path <path>   Custom browser executable (or AGENT_BROWSER_EXECUTABLE_PATH)
   --extension <path>         Load browser extensions (repeatable)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1071,7 +1071,6 @@ Aliases: goto, navigate
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
   --headers <json>     Set HTTP headers (scoped to this origin)
   --headed             Show browser window
 
@@ -1095,7 +1094,6 @@ the browser's back button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser back
@@ -1113,7 +1111,6 @@ the browser's forward button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser forward
@@ -1131,7 +1128,6 @@ the browser's reload button.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser reload
@@ -1155,7 +1151,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser click "#submit-button"
@@ -1177,7 +1172,6 @@ or triggering double-click handlers.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser dblclick "#editable-text"
@@ -1196,7 +1190,6 @@ This replaces any existing content in the field.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser fill "#email" "user@example.com"
@@ -1216,7 +1209,6 @@ Unlike fill, this does not clear existing content first.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser type "#search" "hello"
@@ -1240,7 +1232,6 @@ triggering hover states or dropdown menus.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser hover "#dropdown-trigger"
@@ -1258,7 +1249,6 @@ Sets keyboard focus to the specified element.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser focus "#input-field"
@@ -1276,7 +1266,6 @@ Checks a checkbox element. If already checked, no action is taken.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser check "#terms-checkbox"
@@ -1294,7 +1283,6 @@ Unchecks a checkbox element. If already unchecked, no action is taken.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser uncheck "#newsletter-opt-in"
@@ -1312,7 +1300,6 @@ Selects one or more options in a <select> dropdown by value.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser select "#country" "US"
@@ -1331,7 +1318,6 @@ Drags an element from source to target location.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser drag "#draggable" "#drop-zone"
@@ -1349,7 +1335,6 @@ Uploads one or more files to a file input element.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser upload "#file-input" ./document.pdf
@@ -1371,7 +1356,6 @@ Arguments:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser download "#download-btn" ./file.pdf
@@ -1403,7 +1387,6 @@ Modifiers (combine with +):
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser press Enter
@@ -1425,7 +1408,6 @@ Useful for holding modifier keys.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser keydown Shift
@@ -1443,7 +1425,6 @@ Releases a key that was pressed with keydown.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser keyup Shift
@@ -1472,7 +1453,6 @@ directly — it already operates on the current focus.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser keyboard type "Hello, World!"
@@ -1507,7 +1487,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser scroll
@@ -1530,7 +1509,6 @@ Aliases: scrollinto
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser scrollintoview "#footer"
@@ -1568,7 +1546,6 @@ Wait for text to disappear:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser wait "#loading-spinner"
@@ -1610,7 +1587,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser screenshot
@@ -1634,7 +1610,6 @@ Saves the current page as a PDF file.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser pdf ./page.pdf
@@ -1663,7 +1638,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser snapshot
@@ -1690,7 +1664,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser eval "document.title"
@@ -1723,7 +1696,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser close
@@ -1775,7 +1747,6 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser get text @e1
@@ -1808,7 +1779,6 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser is visible "#modal"
@@ -1848,7 +1818,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser find role button click --name Submit
@@ -1879,7 +1848,6 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser mouse move 100 200
@@ -1913,7 +1881,6 @@ Settings:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser set viewport 1920 1080
@@ -1954,7 +1921,6 @@ Subcommands:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser network route "**/api/*" --abort
@@ -1992,7 +1958,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser storage local
@@ -2032,7 +1997,6 @@ for the current page URL.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Simple cookie for current page
@@ -2081,7 +2045,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser tab
@@ -2112,7 +2075,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser window new
@@ -2135,7 +2097,6 @@ Arguments:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser frame "#embed-iframe"
@@ -2223,7 +2184,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser dialog accept
@@ -2249,7 +2209,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser trace start
@@ -2281,7 +2240,6 @@ Start Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Basic profiling
@@ -2321,7 +2279,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Record from current page (preserves login state)
@@ -2354,7 +2311,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser console
@@ -2375,7 +2331,6 @@ Options:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser errors
@@ -2395,7 +2350,6 @@ Visually highlights an element on the page for debugging.
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser highlight "#target-element"
@@ -2421,7 +2375,6 @@ Operations:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser clipboard read
@@ -2461,7 +2414,6 @@ State Encryption:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser state save ./auth-state.json
@@ -2494,7 +2446,6 @@ Environment:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser session
@@ -2592,7 +2543,6 @@ Supported URL formats:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   # Connect to local Chrome with remote debugging
@@ -2754,7 +2704,6 @@ URL Diff:
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
-  --tab <t<N>|label>   Run on this tab (peek; active tab restored)
 
 Examples:
   agent-browser diff snapshot
@@ -3049,7 +2998,6 @@ Authentication:
 
 Options:
   --session <name>           Isolated session (or AGENT_BROWSER_SESSION env)
-  --tab <t<N>|label>         Run on this tab for this command (peek; active tab restored)
   --executable-path <path>   Custom browser executable (or AGENT_BROWSER_EXECUTABLE_PATH)
   --extension <path>         Load browser extensions (repeatable)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -188,32 +188,51 @@ agent-browser network har stop [output.har]    # Stop and save HAR (temp path if
 ## Tabs & frames
 
 ```bash
-agent-browser tab                     # List tabs (each row includes a stable tabId)
-agent-browser tab new [url]           # New tab
-agent-browser tab <id>                # Switch to tab by tabId
-agent-browser tab close [id]          # Close tab by tabId (defaults to active)
-agent-browser window new              # Open new browser window
-agent-browser frame <sel>             # Switch to iframe by CSS selector
-agent-browser frame @e3               # Switch to iframe by element ref
-agent-browser frame main              # Back to main frame
+agent-browser tab                              # List tabs (each row shows tabId and label)
+agent-browser tab new [url]                    # New tab
+agent-browser tab new --label docs [url]       # New tab with a user-assigned label
+agent-browser tab <t<N>|label>                 # Switch to a tab by id or label
+agent-browser tab close [t<N>|label]           # Close a tab (defaults to active)
+agent-browser window new                       # Open new browser window
+agent-browser frame <sel>                      # Switch to iframe by CSS selector
+agent-browser frame @e3                        # Switch to iframe by element ref
+agent-browser frame main                       # Back to main frame
 ```
 
-### Stable tab IDs and `--tab`
+### Stable tab ids and `--tab`
 
-Tab IDs are assigned on creation and never reused within a session, so a given
-`tabId` keeps pointing at the same tab even when other tabs are opened or
-closed. The global `--tab <id>` flag runs a single command against a specific
-tab without changing the active tab. The active tab and its element refs
-(`@e1`, etc.) are preserved across the peek:
+Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused
+within a session, so `t2` keeps pointing at the same tab even as other tabs
+are opened or closed. The `t` prefix mirrors the `@e1` element-ref convention
+and is not interchangeable with positional integers — `agent-browser tab 2`
+and `--tab 2` both error with a teaching message; use `t2` instead.
+
+You can also assign a memorable label (`docs`, `app`, `admin`) at tab-creation
+time and use it anywhere an id is accepted:
 
 ```bash
-agent-browser tab new https://docs.example.com   # opens and activates tab 2
-agent-browser snapshot                           # refs @e1..@eN on tab 2
-agent-browser --tab 1 snapshot                   # peek at tab 1; tab 2 still active
-agent-browser click @e1                          # tab 2's refs still work
+agent-browser tab new --label docs https://docs.example.com
+agent-browser tab docs                    # switch by label
+agent-browser --tab docs snapshot         # peek by label
 ```
 
-#### When to use `--tab` vs `tab <id>`
+Labels are never auto-generated and never rewritten on navigation — an agent
+that names a tab `docs` keeps that name until it explicitly closes the tab.
+Labels are unique within a session; creating a second tab with an existing
+label errors.
+
+The global `--tab <t<N>|label>` flag runs a single command against a tab
+without changing the active tab. The active tab and its element refs (`@e1`,
+etc.) are preserved across the peek:
+
+```bash
+agent-browser tab new --label docs https://docs.example.com   # activates t2
+agent-browser snapshot                                        # refs @e1..@eN on t2
+agent-browser --tab t1 snapshot                               # peek t1; t2 still active
+agent-browser click @e1                                       # t2's refs still work
+```
+
+#### When to use `--tab` vs `tab <id|label>`
 
 <table>
   <thead>
@@ -221,12 +240,12 @@ agent-browser click @e1                          # tab 2's refs still work
   </thead>
   <tbody>
     <tr>
-      <td><code>--tab &lt;id&gt;</code></td>
-      <td>Peek: runs one command on tab, then restores the original active tab and its refs.</td>
+      <td><code>--tab &lt;id|label&gt;</code></td>
+      <td>Peek: runs one command on the tab, then restores the original active tab and its refs.</td>
       <td>Reading state from another tab (snapshot, screenshot, url, title, cookies) without disturbing the agent's current context.</td>
     </tr>
     <tr>
-      <td><code>tab &lt;id&gt;</code></td>
+      <td><code>tab &lt;id|label&gt;</code></td>
       <td>Switch: changes the active tab permanently until the next switch.</td>
       <td>Running multiple commands on another tab, or interacting with its elements by ref (which requires snapshotting the active tab first).</td>
     </tr>
@@ -234,14 +253,13 @@ agent-browser click @e1                          # tab 2's refs still work
 </table>
 
 Element refs are scoped to the tab that was active when the snapshot ran, so
-`--tab 3 click @e1` only works if `@e1` was populated on tab 3 before the
-current active tab. For ref-based interaction with another tab, switch to it
-first:
+`--tab docs click @e1` only works if `@e1` was populated on the `docs` tab
+earlier. For ref-based interaction with another tab, switch to it first:
 
 ```bash
-agent-browser tab 1                              # switch permanently
-agent-browser snapshot                           # refs for tab 1
-agent-browser click @e3                          # uses tab 1's refs
+agent-browser tab docs                           # switch permanently
+agent-browser snapshot                           # refs for docs
+agent-browser click @e3                          # uses docs's refs
 ```
 
 ### Iframe support

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -203,12 +203,45 @@ agent-browser frame main              # Back to main frame
 Tab IDs are assigned on creation and never reused within a session, so a given
 `tabId` keeps pointing at the same tab even when other tabs are opened or
 closed. The global `--tab <id>` flag runs a single command against a specific
-tab without changing the active tab:
+tab without changing the active tab. The active tab and its element refs
+(`@e1`, etc.) are preserved across the peek:
 
 ```bash
 agent-browser tab new https://docs.example.com   # opens and activates tab 2
-agent-browser --tab 1 snapshot                   # peek at tab 1; tab 2 stays active
-agent-browser click "#submit"                    # runs on tab 2 as expected
+agent-browser snapshot                           # refs @e1..@eN on tab 2
+agent-browser --tab 1 snapshot                   # peek at tab 1; tab 2 still active
+agent-browser click @e1                          # tab 2's refs still work
+```
+
+#### When to use `--tab` vs `tab <id>`
+
+<table>
+  <thead>
+    <tr><th>Flag</th><th>Behavior</th><th>Use when</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>--tab &lt;id&gt;</code></td>
+      <td>Peek: runs one command on tab, then restores the original active tab and its refs.</td>
+      <td>Reading state from another tab (snapshot, screenshot, url, title, cookies) without disturbing the agent's current context.</td>
+    </tr>
+    <tr>
+      <td><code>tab &lt;id&gt;</code></td>
+      <td>Switch: changes the active tab permanently until the next switch.</td>
+      <td>Running multiple commands on another tab, or interacting with its elements by ref (which requires snapshotting the active tab first).</td>
+    </tr>
+  </tbody>
+</table>
+
+Element refs are scoped to the tab that was active when the snapshot ran, so
+`--tab 3 click @e1` only works if `@e1` was populated on tab 3 before the
+current active tab. For ref-based interaction with another tab, switch to it
+first:
+
+```bash
+agent-browser tab 1                              # switch permanently
+agent-browser snapshot                           # refs for tab 1
+agent-browser click @e3                          # uses tab 1's refs
 ```
 
 ### Iframe support

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -199,67 +199,37 @@ agent-browser frame @e3                        # Switch to iframe by element ref
 agent-browser frame main                       # Back to main frame
 ```
 
-### Stable tab ids and `--tab`
+### Stable tab ids and labels
 
 Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused
 within a session, so `t2` keeps pointing at the same tab even as other tabs
 are opened or closed. The `t` prefix mirrors the `@e1` element-ref convention
 and is not interchangeable with positional integers — `agent-browser tab 2`
-and `--tab 2` both error with a teaching message; use `t2` instead.
+errors with a teaching message; use `t2`.
 
 You can also assign a memorable label (`docs`, `app`, `admin`) at tab-creation
 time and use it anywhere an id is accepted:
 
 ```bash
 agent-browser tab new --label docs https://docs.example.com
-agent-browser tab docs                    # switch by label
-agent-browser --tab docs snapshot         # peek by label
+agent-browser tab docs          # switch to the docs tab
+agent-browser snapshot          # populate refs for docs
+agent-browser click @e3         # click uses docs's refs
+agent-browser tab close docs    # close by label
 ```
 
 Labels are never auto-generated and never rewritten on navigation — an agent
-that names a tab `docs` keeps that name until it explicitly closes the tab.
-Labels are unique within a session; creating a second tab with an existing
-label errors.
+that names a tab `docs` keeps that name until the tab is closed. Labels are
+unique within a session; creating a second tab with an existing label
+errors.
 
-The global `--tab <t<N>|label>` flag runs a single command against a tab
-without changing the active tab. The active tab and its element refs (`@e1`,
-etc.) are preserved across the peek:
-
-```bash
-agent-browser tab new --label docs https://docs.example.com   # activates t2
-agent-browser snapshot                                        # refs @e1..@eN on t2
-agent-browser --tab t1 snapshot                               # peek t1; t2 still active
-agent-browser click @e1                                       # t2's refs still work
-```
-
-#### When to use `--tab` vs `tab <id|label>`
-
-<table>
-  <thead>
-    <tr><th>Flag</th><th>Behavior</th><th>Use when</th></tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>--tab &lt;id|label&gt;</code></td>
-      <td>Peek: runs one command on the tab, then restores the original active tab and its refs.</td>
-      <td>Reading state from another tab (snapshot, screenshot, url, title, cookies) without disturbing the agent's current context.</td>
-    </tr>
-    <tr>
-      <td><code>tab &lt;id|label&gt;</code></td>
-      <td>Switch: changes the active tab permanently until the next switch.</td>
-      <td>Running multiple commands on another tab, or interacting with its elements by ref (which requires snapshotting the active tab first).</td>
-    </tr>
-  </tbody>
-</table>
-
-Element refs are scoped to the tab that was active when the snapshot ran, so
-`--tab docs click @e1` only works if `@e1` was populated on the `docs` tab
-earlier. For ref-based interaction with another tab, switch to it first:
+Refs (`@e1`, etc.) are scoped to the tab that was active when the snapshot
+ran, so switch tabs first, then snapshot and interact:
 
 ```bash
-agent-browser tab docs                           # switch permanently
-agent-browser snapshot                           # refs for docs
-agent-browser click @e3                          # uses docs's refs
+agent-browser tab docs          # switch first
+agent-browser snapshot          # refs for docs
+agent-browser click @e3         # uses docs's refs
 ```
 
 ### Iframe support

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -63,7 +63,6 @@ Every CLI flag can be set in the config file using its camelCase equivalent:
     <tr><td><code>debug</code></td><td><code>--debug</code></td><td>boolean</td></tr>
     <tr><td><code>session</code></td><td><code>--session</code></td><td>string</td></tr>
     <tr><td><code>sessionName</code></td><td><code>--session-name</code></td><td>string</td></tr>
-    <tr><td><code>tab</code></td><td><code>--tab</code></td><td>string (e.g. <code>t2</code> or a label)</td></tr>
     <tr><td><code>executablePath</code></td><td><code>--executable-path</code></td><td>string</td></tr>
     <tr><td><code>extensions</code></td><td><code>--extension</code></td><td>string[]</td></tr>
     <tr><td><code>profile</code></td><td><code>--profile</code></td><td>string</td></tr>

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -63,7 +63,7 @@ Every CLI flag can be set in the config file using its camelCase equivalent:
     <tr><td><code>debug</code></td><td><code>--debug</code></td><td>boolean</td></tr>
     <tr><td><code>session</code></td><td><code>--session</code></td><td>string</td></tr>
     <tr><td><code>sessionName</code></td><td><code>--session-name</code></td><td>string</td></tr>
-    <tr><td><code>tab</code></td><td><code>--tab</code></td><td>number</td></tr>
+    <tr><td><code>tab</code></td><td><code>--tab</code></td><td>string (e.g. <code>t2</code> or a label)</td></tr>
     <tr><td><code>executablePath</code></td><td><code>--executable-path</code></td><td>string</td></tr>
     <tr><td><code>extensions</code></td><td><code>--extension</code></td><td>string[]</td></tr>
     <tr><td><code>profile</code></td><td><code>--profile</code></td><td>string</td></tr>

--- a/packages/dashboard/src/components/session-tree.tsx
+++ b/packages/dashboard/src/components/session-tree.tsx
@@ -160,7 +160,7 @@ function TabNode({ tab, isViewed, isSessionActive, onClose, onSwitch, onSelectSe
         >
           <TabFavicon url={tab.url} />
           <span className="min-w-0 flex-1 truncate">
-            {tab.title || tab.url || `Tab ${tab.index}`}
+            {tab.title || tab.url || `Tab ${tab.label ?? tab.tabId}`}
           </span>
           {tab.active && (
             <span className="shrink-0 rounded border border-border px-1 py-px text-[9px] leading-none text-muted-foreground">
@@ -199,9 +199,9 @@ function SessionNode({
   expanded: boolean;
   onSelect: () => void;
   onToggle: () => void;
-  onCloseTab: (tabIndex: number) => void;
+  onCloseTab: (tabRef: string) => void;
   onAddTab: () => void;
-  onSwitchTab: (tabIndex: number) => void;
+  onSwitchTab: (tabRef: string) => void;
   onClose: () => void;
   onKill: () => void;
 }) {
@@ -319,9 +319,20 @@ function SessionNode({
       </Dialog>
       <CollapsibleContent>
         <div className="overflow-hidden pb-1">
-          {tabs.map((tab) => (
-            <TabNode key={tab.index} tab={tab} isViewed={isActive && tab.active} isSessionActive={isActive} onClose={() => onCloseTab(tab.index)} onSwitch={() => onSwitchTab(tab.index)} onSelectSession={onSelect} />
-          ))}
+          {tabs.map((tab) => {
+            const tabRef = tab.label ?? tab.tabId;
+            return (
+              <TabNode
+                key={tab.tabId}
+                tab={tab}
+                isViewed={isActive && tab.active}
+                isSessionActive={isActive}
+                onClose={() => onCloseTab(tabRef)}
+                onSwitch={() => onSwitchTab(tabRef)}
+                onSelectSession={onSelect}
+              />
+            );
+          })}
           <button
             onClick={onAddTab}
             className="flex w-full items-center gap-2 py-1 pr-1 pl-7 text-xs text-muted-foreground hover:text-foreground"
@@ -447,9 +458,9 @@ export function SessionTree() {
                 expanded={isExpanded(s.port)}
                 onSelect={() => setActivePort(s.port)}
                 onToggle={() => toggleExpanded(s.port)}
-                onCloseTab={(tabIndex) => dispatchCloseTab({ port: s.port, tabIndex })}
+                onCloseTab={(tabRef) => dispatchCloseTab({ port: s.port, tabRef })}
                 onAddTab={() => dispatchAddTab(s.port)}
-                onSwitchTab={(tabIndex) => dispatchSwitchTab({ port: s.port, tabIndex })}
+                onSwitchTab={(tabRef) => dispatchSwitchTab({ port: s.port, tabRef })}
                 onClose={() => dispatchCloseSession(s.port)}
                 onKill={() => dispatchKillSession(s.port)}
               />

--- a/packages/dashboard/src/store/sessions.ts
+++ b/packages/dashboard/src/store/sessions.ts
@@ -160,10 +160,10 @@ export const closeAllSessionsAtom = atom(null, (get, set) => {
 
 export const closeTabAtom = atom(
   null,
-  (get, _set, { port, tabIndex }: { port: number; tabIndex: number }) => {
+  (get, _set, { port, tabRef }: { port: number; tabRef: string }) => {
     const sessions = get(sessionsAtom);
     const s = sessions.find((x) => x.port === port)?.session;
-    if (s) execCommand(sessionArgs(s, "tab", "close", String(tabIndex)));
+    if (s) execCommand(sessionArgs(s, "tab", "close", tabRef));
   },
 );
 
@@ -175,10 +175,10 @@ export const addTabAtom = atom(null, (get, _set, port: number) => {
 
 export const switchTabAtom = atom(
   null,
-  (get, _set, { port, tabIndex }: { port: number; tabIndex: number }) => {
+  (get, _set, { port, tabRef }: { port: number; tabRef: string }) => {
     const sessions = get(sessionsAtom);
     const s = sessions.find((x) => x.port === port)?.session;
-    if (s) execCommand(sessionArgs(s, "tab", String(tabIndex)));
+    if (s) execCommand(sessionArgs(s, "tab", tabRef));
   },
 );
 

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -67,7 +67,10 @@ export interface ErrorMessage {
 }
 
 export interface TabInfo {
-  index: number;
+  /** Stable tab id like `t1`, `t2`. Never reused within a session. */
+  tabId: string;
+  /** Optional user-assigned label (e.g. `docs`). Interchangeable with `tabId`. */
+  label?: string | null;
   title: string;
   url: string;
   type: string;

--- a/skills/agent-browser/references/commands.md
+++ b/skills/agent-browser/references/commands.md
@@ -175,14 +175,36 @@ agent-browser window new          # New window
 ```
 
 Tab IDs are stable and never reused within a session, so the same `tabId` keeps
-referring to the same tab even when other tabs are opened or closed. For a
-non-intrusive peek at another tab, use the global `--tab <id>` flag; the
-active tab is restored after the command:
+referring to the same tab even when other tabs are opened or closed.
 
-```bash
-agent-browser --tab 1 snapshot    # snapshot tab 1 without switching
-agent-browser --tab 3 click @e1   # click @e1 on tab 3 and return
-```
+### When to use `--tab <id>` vs `tab <id>`
+
+- `--tab <id>` runs one command on the given tab and then restores the
+  previous active tab and its element refs (`@e1`, etc.). Use for read-only
+  peeks at another tab without disturbing the current context:
+
+  ```bash
+  agent-browser --tab 1 snapshot              # read tab 1, active tab preserved
+  agent-browser --tab 3 screenshot out.png    # screenshot tab 3
+  agent-browser --tab 2 cookies get session   # read a cookie from tab 2
+  agent-browser --tab 3 click "#submit"       # click by CSS selector on tab 3
+  ```
+
+- `tab <id>` switches the active tab permanently until the next switch. Use
+  when you need multiple commands on another tab, especially ref-based
+  interactions (`@e1`):
+
+  ```bash
+  agent-browser tab 3            # switch to tab 3
+  agent-browser snapshot         # populate refs for tab 3
+  agent-browser click @e1        # ref click works
+  ```
+
+Element refs (`@eN`) are scoped to the tab that was active when the snapshot
+ran, so `--tab N click @e1` only works if `@e1` was populated on tab N
+earlier and still points there. For most ref-based workflows on a non-active
+tab, prefer a permanent `tab <id>` switch. CSS selectors and role-based
+selectors work with `--tab` without this restriction.
 
 ## Frames
 

--- a/skills/agent-browser/references/commands.md
+++ b/skills/agent-browser/references/commands.md
@@ -166,45 +166,64 @@ agent-browser network requests --filter api    # Filter requests
 ## Tabs and Windows
 
 ```bash
-agent-browser tab                 # List tabs (each row includes a stable tabId)
-agent-browser tab new [url]       # New tab
-agent-browser tab 2               # Switch to tab by tabId
-agent-browser tab close           # Close current tab
-agent-browser tab close 2         # Close tab by tabId
-agent-browser window new          # New window
+agent-browser tab                              # List tabs with tabId and label
+agent-browser tab new [url]                    # New tab
+agent-browser tab new --label docs [url]       # New tab with a memorable label
+agent-browser tab t2                           # Switch to tab by id
+agent-browser tab docs                         # Switch to tab by label
+agent-browser tab close                        # Close current tab
+agent-browser tab close t2                     # Close tab by id
+agent-browser tab close docs                   # Close tab by label
+agent-browser window new                       # New window
 ```
 
-Tab IDs are stable and never reused within a session, so the same `tabId` keeps
-referring to the same tab even when other tabs are opened or closed.
+Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused
+within a session, so the same id keeps referring to the same tab across
+commands. Positional integers are **not** accepted — `tab 2` errors with a
+teaching message; use `t2`.
 
-### When to use `--tab <id>` vs `tab <id>`
+User-assigned labels (`docs`, `app`, `admin`) are interchangeable with ids
+everywhere a tab ref is accepted. Labels are the agent-friendly way to write
+multi-tab workflows:
 
-- `--tab <id>` runs one command on the given tab and then restores the
+```bash
+agent-browser tab new --label docs https://docs.example.com
+agent-browser tab new --label app  https://app.example.com
+agent-browser tab docs && agent-browser snapshot   # work on docs
+agent-browser --tab app url                        # peek at app's url
+```
+
+Labels are never auto-generated, never rewritten on navigation, and must be
+unique within a session.
+
+### When to use `--tab <id|label>` vs `tab <id|label>`
+
+- `--tab <id|label>` runs one command on the given tab and then restores the
   previous active tab and its element refs (`@e1`, etc.). Use for read-only
   peeks at another tab without disturbing the current context:
 
   ```bash
-  agent-browser --tab 1 snapshot              # read tab 1, active tab preserved
-  agent-browser --tab 3 screenshot out.png    # screenshot tab 3
-  agent-browser --tab 2 cookies get session   # read a cookie from tab 2
-  agent-browser --tab 3 click "#submit"       # click by CSS selector on tab 3
+  agent-browser --tab t1 snapshot             # read t1, active tab preserved
+  agent-browser --tab docs screenshot out.png # screenshot by label
+  agent-browser --tab app cookies get session # read a cookie from app
+  agent-browser --tab docs click "#submit"    # click by CSS selector on docs
   ```
 
-- `tab <id>` switches the active tab permanently until the next switch. Use
-  when you need multiple commands on another tab, especially ref-based
+- `tab <id|label>` switches the active tab permanently until the next switch.
+  Use when you need multiple commands on another tab, especially ref-based
   interactions (`@e1`):
 
   ```bash
-  agent-browser tab 3            # switch to tab 3
-  agent-browser snapshot         # populate refs for tab 3
+  agent-browser tab docs         # switch to docs
+  agent-browser snapshot         # populate refs for docs
   agent-browser click @e1        # ref click works
   ```
 
 Element refs (`@eN`) are scoped to the tab that was active when the snapshot
-ran, so `--tab N click @e1` only works if `@e1` was populated on tab N
+ran, so `--tab X click @e1` only works if `@e1` was populated on tab X
 earlier and still points there. For most ref-based workflows on a non-active
-tab, prefer a permanent `tab <id>` switch. CSS selectors and role-based
-selectors work with `--tab` without this restriction.
+tab, prefer a permanent `tab <id|label>` switch. CSS selectors and
+role-based selectors work with `--tab` without this restriction.
 
 ## Frames
 

--- a/skills/agent-browser/references/commands.md
+++ b/skills/agent-browser/references/commands.md
@@ -189,41 +189,17 @@ multi-tab workflows:
 ```bash
 agent-browser tab new --label docs https://docs.example.com
 agent-browser tab new --label app  https://app.example.com
-agent-browser tab docs && agent-browser snapshot   # work on docs
-agent-browser --tab app url                        # peek at app's url
+agent-browser tab docs                   # switch to docs
+agent-browser snapshot                   # populate refs for docs
+agent-browser click @e1                  # ref click on docs
+agent-browser tab app                    # switch to app
+agent-browser tab close docs             # close by label
 ```
 
 Labels are never auto-generated, never rewritten on navigation, and must be
-unique within a session.
-
-### When to use `--tab <id|label>` vs `tab <id|label>`
-
-- `--tab <id|label>` runs one command on the given tab and then restores the
-  previous active tab and its element refs (`@e1`, etc.). Use for read-only
-  peeks at another tab without disturbing the current context:
-
-  ```bash
-  agent-browser --tab t1 snapshot             # read t1, active tab preserved
-  agent-browser --tab docs screenshot out.png # screenshot by label
-  agent-browser --tab app cookies get session # read a cookie from app
-  agent-browser --tab docs click "#submit"    # click by CSS selector on docs
-  ```
-
-- `tab <id|label>` switches the active tab permanently until the next switch.
-  Use when you need multiple commands on another tab, especially ref-based
-  interactions (`@e1`):
-
-  ```bash
-  agent-browser tab docs         # switch to docs
-  agent-browser snapshot         # populate refs for docs
-  agent-browser click @e1        # ref click works
-  ```
-
-Element refs (`@eN`) are scoped to the tab that was active when the snapshot
-ran, so `--tab X click @e1` only works if `@e1` was populated on tab X
-earlier and still points there. For most ref-based workflows on a non-active
-tab, prefer a permanent `tab <id|label>` switch. CSS selectors and
-role-based selectors work with `--tab` without this restriction.
+unique within a session. To interact with another tab, switch to it first:
+the daemon maintains a single active tab, so refs (`@eN`) belong to the tab
+that was active when the snapshot ran.
 
 ## Frames
 


### PR DESCRIPTION
## Summary

Reshape the unreleased tab handle surface before it ships. Three threads:

1. **Replace bare-integer tab ids with `t<N>`** so stable handles can't be mistaken for positional indices.
2. **Add user-assigned labels** for readable multi-tab agent workflows.
3. **Drop the `--tab <id>` scoped peek flag** — after fleshing it out across three PRs (#892, #1249, earlier commits in this PR), the machinery-to-value ratio doesn't hold up.

Every change here is pre-release. None of #892, #1249, or this PR has shipped, so we can break the serialization cleanly once and be done.

## Stable tab ids: `t1`, `t2`, `t3` (strings)

Canonical across JSON, CLI input, CLI output, and docs. Bare integer input is **rejected** with a teaching message (`Expected a tab id like \`t2\` or a label; positional integers are not accepted`) rather than silently coerced. The `t` prefix mirrors the `@e1` element-ref convention already in use.

```bash
agent-browser tab           # list
agent-browser tab t2        # switch
agent-browser tab close t2  # close by id
agent-browser tab 2         # errors with teaching message
```

## Labels for named tabs

Tabs can be created with a memorable label and then used interchangeably with the `t<N>` id:

```bash
agent-browser tab new --label docs https://docs.example.com
agent-browser tab docs           # switch by label
agent-browser tab close docs     # close by label
```

Design rules, kept small on purpose:
- Labels are never auto-generated.
- Labels never change when the tab navigates.
- Labels must be unique within a session (duplicate creation errors).
- Labels and `t<N>` ids are interchangeable everywhere a tab ref is accepted.

## Why `--tab` got dropped

Started this PR planning to make `--tab <id>` agent-friendly (preserve refs across peek, fix the review-bot gap). Got it working with `ScopedRestore` + pre/post-dispatch save/restore + outer-tab-closed edge case + full e2e coverage. Stepped back and the feature doesn't earn its keep:

- **Machinery tax.** Every new daemon feature touching per-tab state has to reason about scoped-dispatch interleaving. That's ongoing maintenance cost.
- **Three PRs to not leak.** #892 shipped with two bugs, #1249 fixed them, earlier commits here fixed the ref-clearing footgun. That pattern is a smell.
- **Naming collision.** `tab X` (switch) vs `--tab X` (peek) look identical but have opposite lifecycle. Every agent learns both.
- **Concurrency claim is partial.** The daemon actually swaps active tab during execution; a concurrent client landing between pre- and post-dispatch sees the scoped tab as active. "Non-disruptive" isn't really.
- **Ref-based scoped workflows never worked.** Refs are per-tab, so `--tab N click @e1` requires `@e1` on tab N, which requires a prior switch, which negates the peek.
- **Labels + `tab <id|label>` cover the ergonomic case.** `tab docs && snapshot && click @e1` is crisp enough.
- **Reversibility.** Adding a feature back is easy; removing a shipped API is hard. If per-tab `HashMap<tab_id, RefMap>` lands later, `--tab` can be reintroduced essentially for free. That's the right time.

## Drive-by fix

`packages/dashboard/src/types.ts` declared `TabInfo.index: number` but the daemon has been sending `tabId` since #892, making `tab.index` `undefined` and silently breaking the dashboard's close/switch buttons. TypeScript types and atoms now use `tabId: string` and `label?: string | null`, passing `tabRef: string` through to CLI construction.

## Surface touched

**Rust**
- `cli/src/native/browser.rs` — `TabRef::parse`, `format_tab_id`, `is_valid_label`, `PageInfo.label`, `BrowserManager::{resolve_tab_ref, has_label, active_tab_id, has_tab_id}`, `tab_new(url, label)`. All JSON responses use string ids + optional label.
- `cli/src/native/actions.rs` — `handle_tab_{new,switch,close}` parse string refs and resolve via `TabRef`.
- `cli/src/{flags,commands,main,output}.rs` — removed `--tab` flag, updated `tab` subcommand to parse `t<N>`/labels and support `tab new --label`, rewrote all `--help` entries.
- `agent-browser.schema.json` — removed `tab` property (flag is gone).

**TypeScript**
- `packages/dashboard/src/types.ts`, `session-tree.tsx`, `store/sessions.ts` — `TabInfo.{tabId,label}`, `closeTabAtom`/`switchTabAtom` take `tabRef: string`.

**Docs**
- `README.md`, `docs/src/app/commands/page.mdx`, `docs/src/app/configuration/page.mdx`, `skills/agent-browser/references/commands.md` — rewritten around switch + labels, no `--tab` vs `tab` disambiguation needed.

## Tests

Kept:
- `TabRef::parse` / `format_tab_id` / `is_valid_label` unit tests for the teaching error, label rules, and `t<N>` parsing.
- `test_tab_switch_by_id` / `_by_label` / `test_tab_new_with_label` / `_with_label_and_url` / `_with_url_then_label` in `commands.rs`.
- `e2e_tabs`, `e2e_tab_ids_not_reused`, `e2e_tab_close_with_tab_id_closes_active_tab`, `e2e_tab_new_with_duplicate_label_errors`, `e2e_tab_new_with_label_can_be_switched_and_closed`, `e2e_tab_switch_rejects_bare_integer`.

Removed with `--tab`:
- `e2e_tab_global_targeting{,_snapshot,_snapshot_non_contiguous}` and all `e2e_tab_scoped_command_*` tests (590 lines).

25/25 non-ignored tab unit tests pass. 6/6 tab e2e tests pass. `cargo clippy -- -D warnings`, `cargo fmt --check`, and dashboard `tsc --noEmit` all clean.

## Breaking (pre-release) changes

Only callers already consuming the unreleased `tabId`/`--tab` will notice:

- `tabId` in daemon JSON is a string (`"t2"`) instead of an integer.
- `tabId` as JSON input is a string; bare-integer input is rejected.
- CLI `tab 2` errors; use `tab t2` or a label.
- CLI `--tab <...>` no longer exists; use `tab <t<N>|label>` to switch permanently, then run your command.
- Config `"tab": N` removed from the schema.