### PR TITLE
docs(help): promote skills to the top of --help so agents discover them first

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2882,6 +2882,20 @@ agent-browser - fast browser automation CLI for AI agents
 
 Usage: agent-browser <command> [args] [options]
 
+Start here (for AI agents):
+  agent-browser skills get agent-browser --full
+
+  Skills ship with the CLI (always version-matched) and include workflow
+  patterns, ref/selector usage, and copy-paste examples. Prefer this over
+  guessing commands from flag docs alone. Specialized skills cover Electron
+  apps, Slack, exploratory testing, and cloud browser providers.
+
+  skills [list]                List available skills
+  skills get <name>            Get a skill's core content (overview + examples)
+  skills get <name> --full     Include references and templates
+  skills get --all             Get every skill
+  skills path [name]           Print skill directory path
+
 Core Commands:
   open <url>                 Navigate to URL
   click <sel>                Click element (or @ref)
@@ -3000,12 +3014,6 @@ Setup:
   upgrade                    Upgrade to the latest version
   dashboard start            Start the observability dashboard
   profiles                   List available Chrome profiles
-
-Skills:
-  skills [list]              List available skills
-  skills get <name> [--full] Get skill content (--full includes references)
-  skills get --all           Get all skill content
-  skills path [name]         Print skill directory path
 
 Snapshot Options:
   -i, --interactive          Only interactive elements


### PR DESCRIPTION
## Summary

The `Skills:` section was buried deep in the top-level `--help` output (between `Setup:` and `Snapshot Options:`). Agents skimming `--help` pass right over it on the way to flag docs, then waste turns guessing commands when a hand-written workflow guide is one command away.

Move it to a prominent "Start here (for AI agents)" block right under `Usage:`, and reframe the copy so it conveys what skills *are* (workflow patterns, ref usage, copy-paste examples) rather than just listing subcommand flags.

## Before

```
Usage: agent-browser <command> [args] [options]

Core Commands:
  open <url>                 Navigate to URL
  ...
  [~120 more lines]
  ...

Skills:
  skills [list]              List available skills
  skills get <name> [--full] Get skill content (--full includes references)
  skills get --all           Get all skill content
  skills path [name]         Print skill directory path
```

## After

```
Usage: agent-browser <command> [args] [options]

Start here (for AI agents):
  agent-browser skills get agent-browser --full

  Skills ship with the CLI (always version-matched) and include workflow
  patterns, ref/selector usage, and copy-paste examples. Prefer this over
  guessing commands from flag docs alone. Specialized skills cover Electron
  apps, Slack, exploratory testing, and cloud browser providers.

  skills [list]                List available skills
  skills get <name>            Get a skill's core content (overview + examples)
  skills get <name> --full     Include references and templates
  skills get --all             Get every skill
  skills path [name]           Print skill directory path

Core Commands:
  ...
```

## Notes

- Same commands, same behavior — only ordering and wording of `--help` output changes.
- Section includes the specialized-skills hint (Electron, Slack, dogfood, cloud providers) so agents know there's more than just the core skill.
- `cargo fmt --check` and `cargo clippy -- -D warnings` both clean.