### PR TITLE
fix: active tab loss with persistent Chrome profiles

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -663,7 +663,7 @@ impl DaemonState {
                     }
 
                     let tab_id = mgr.assign_tab_id();
-                    mgr.add_page(super::browser::PageInfo {
+                    mgr.add_page_background(super::browser::PageInfo {
                         tab_id,
                         label: None,
                         target_id: te.target_info.target_id.clone(),

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -111,6 +111,20 @@ fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo)
     false
 }
 
+fn add_page_and_activate(pages: &mut Vec<PageInfo>, active_page_index: &mut usize, page: PageInfo) {
+    let index = pages.len();
+    pages.push(page);
+    *active_page_index = index;
+}
+
+fn add_page_preserving_active(
+    pages: &mut Vec<PageInfo>,
+    _active_page_index: &mut usize,
+    page: PageInfo,
+) {
+    pages.push(page);
+}
+
 fn active_page_index_after_removal(
     active_page_index: usize,
     removed_index: usize,
@@ -1415,9 +1429,13 @@ impl BrowserManager {
     }
 
     pub fn add_page(&mut self, page: PageInfo) {
-        let index = self.pages.len();
-        self.pages.push(page);
-        self.active_page_index = index;
+        add_page_and_activate(&mut self.pages, &mut self.active_page_index, page);
+    }
+
+    /// Register a page discovered in the background (e.g. `Target.targetCreated`)
+    /// without changing the active tab.
+    pub fn add_page_background(&mut self, page: PageInfo) {
+        add_page_preserving_active(&mut self.pages, &mut self.active_page_index, page);
     }
 
     pub fn update_page_target_info(&mut self, target: &TargetInfo) -> bool {
@@ -1830,6 +1848,71 @@ mod tests {
         assert!(update_page_target_info_in_pages(&mut pages, &target));
         assert_eq!(pages[0].url, "https://example.com/popup");
         assert_eq!(pages[0].title, "Popup");
+    }
+
+    #[test]
+    fn test_add_page_and_activate_switches_active_page() {
+        let mut pages = vec![PageInfo {
+            tab_id: 1,
+            label: None,
+            target_id: "existing".to_string(),
+            session_id: "session-existing".to_string(),
+            url: "https://example.com/".to_string(),
+            title: "Example".to_string(),
+            target_type: "page".to_string(),
+        }];
+        let mut active_page_index = 0;
+
+        add_page_and_activate(
+            &mut pages,
+            &mut active_page_index,
+            PageInfo {
+                tab_id: 2,
+                label: None,
+                target_id: "explicit-new-tab".to_string(),
+                session_id: "session-new".to_string(),
+                url: "https://vercel.com/".to_string(),
+                title: "Vercel".to_string(),
+                target_type: "page".to_string(),
+            },
+        );
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(active_page_index, 1);
+        assert_eq!(pages[active_page_index].target_id, "explicit-new-tab");
+    }
+
+    #[test]
+    fn test_add_page_preserving_active_keeps_existing_active_page() {
+        let mut pages = vec![PageInfo {
+            tab_id: 1,
+            label: None,
+            target_id: "navigated-page".to_string(),
+            session_id: "session-navigated".to_string(),
+            url: "https://example.com/".to_string(),
+            title: "Example".to_string(),
+            target_type: "page".to_string(),
+        }];
+        let mut active_page_index = 0;
+
+        add_page_preserving_active(
+            &mut pages,
+            &mut active_page_index,
+            PageInfo {
+                tab_id: 2,
+                label: None,
+                target_id: "late-about-blank".to_string(),
+                session_id: "session-about-blank".to_string(),
+                url: "about:blank".to_string(),
+                title: String::new(),
+                target_type: "page".to_string(),
+            },
+        );
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(active_page_index, 0);
+        assert_eq!(pages[active_page_index].target_id, "navigated-page");
+        assert_eq!(pages[active_page_index].url, "https://example.com/");
     }
 
     #[test]

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -155,6 +155,8 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         "--disable-popup-blocking".to_string(),
         "--disable-prompt-on-repost".to_string(),
         "--disable-sync".to_string(),
+        "--disable-session-crashed-bubble".to_string(),
+        "--hide-crash-restore-bubble".to_string(),
         "--disable-features=Translate".to_string(),
         "--enable-features=NetworkService,NetworkServiceInProcess".to_string(),
         "--metrics-recording-only".to_string(),
@@ -232,6 +234,10 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
 
     args.extend(options.args.iter().cloned());
 
+    if !has_startup_target_arg(&options.args) {
+        args.push("about:blank".to_string());
+    }
+
     if should_disable_sandbox(&args) {
         args.push("--no-sandbox".to_string());
     }
@@ -244,6 +250,16 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         args,
         user_data_dir,
         temp_user_data_dir,
+    })
+}
+
+fn has_startup_target_arg(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        let lower = arg.to_ascii_lowercase();
+        lower == "--app"
+            || lower.starts_with("--app=")
+            || lower == "--no-startup-window"
+            || !arg.starts_with('-')
     })
 }
 
@@ -1369,6 +1385,47 @@ mod tests {
     }
 
     #[test]
+    fn test_build_args_adds_default_startup_target() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result.args.iter().any(|a| a == "about:blank"));
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_preserves_custom_startup_target() {
+        let opts = LaunchOptions {
+            args: vec!["https://example.com".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert_eq!(
+            result.args.iter().filter(|a| *a == "about:blank").count(),
+            0
+        );
+        assert!(result.args.iter().any(|a| a == "https://example.com"));
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_skips_default_startup_target_for_app_mode() {
+        let opts = LaunchOptions {
+            args: vec!["--app=https://example.com".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert_eq!(
+            result.args.iter().filter(|a| *a == "about:blank").count(),
+            0
+        );
+        assert!(result.args.iter().any(|a| a == "--app=https://example.com"));
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn test_build_args_headed_no_headless_flag() {
         let opts = LaunchOptions {
             headless: false,
@@ -1453,6 +1510,23 @@ mod tests {
             .args
             .iter()
             .any(|a| a.contains("--disable-features") && a.contains("Translate")));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_hides_crash_restore_ui() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--disable-session-crashed-bubble"));
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--hide-crash-restore-bubble"));
         if let Some(ref dir) = result.temp_user_data_dir {
             let _ = std::fs::remove_dir_all(dir);
         }


### PR DESCRIPTION

  ## Summary

  Fixes a bug where headed sessions using a persistent Chrome profile could lose the active page after navigation. In that case, a follow-
  up command such as `tab list` could report `about:blank` instead of the page that was just opened.

  Persistent Chrome profiles can create or update startup targets after launch. Agent Browser was treating those background-discovered
  targets the same way as tabs created by an explicit user action, which allowed a late startup target to become the active tab.

  This change keeps background target discovery from changing the active tab, while preserving the existing behavior for explicit tab
  creation commands.

  ## What Changed

  - Register background-discovered page targets without switching the active tab
  - Keep `tab new` and `window new` behavior unchanged, so explicit new tabs still become active
  - Start Chrome with an explicit `about:blank` target when no startup target was provided
  - Respect user-provided startup targets passed through `--args`, including direct URLs, `--app=...`, and `--no-startup-window`
  - Hide Chrome crash/session restore prompts during launch
  - Add regression coverage for active tab preservation and Chrome startup argument handling

  ## Why

  The previous behavior made headed persistent-profile sessions fragile because Chrome startup or profile restore targets could appear
  after the user had already navigated to a page. When that happened, Agent Browser could switch its internal active tab pointer to the
  late `about:blank` target.

  Separating background target registration from explicit tab creation keeps the active page stable across commands.

  ## Related Issue

  Fixes #1211
