### PR TITLE
fix: add shadow DOM piercing to semantic locators

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5376,7 +5376,17 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
 
     let js = format!(
         r#"(() => {{
-            const els = document.querySelectorAll('[role="{role}"], {role}');
+            function querySelectorAllShadowDOM(selector, root = document) {{
+                const results = [...root.querySelectorAll(selector)];
+                const allElements = root.querySelectorAll('*');
+                for (const host of allElements) {{
+                    if (host.shadowRoot) {{
+                        results.push(...querySelectorAllShadowDOM(selector, host.shadowRoot));
+                    }}
+                }}
+                return results;
+            }}
+            const els = querySelectorAllShadowDOM('[role="{role}"], {role}');
             for (const el of els) {{
                 if ({name_match}) {{
                     el.setAttribute('data-agent-browser-located', 'true');
@@ -5416,12 +5426,28 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     let selector = "[data-agent-browser-located='true']";
     let result = execute_subaction(cmd, state, selector).await;
 
-    // Clean up the marker attribute
+    // Clean up the marker attribute (shadow DOM aware)
     if let Some(ref browser) = state.browser {
         if browser.active_session_id().is_ok() {
             let _ = browser
                 .evaluate(
-                    "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
+                    r#"(() => {
+                        function removeMarker(root = document) {
+                            const el = root.querySelector('[data-agent-browser-located]');
+                            if (el) {
+                                el.removeAttribute('data-agent-browser-located');
+                                return true;
+                            }
+                            const allElements = root.querySelectorAll('*');
+                            for (const host of allElements) {
+                                if (host.shadowRoot && removeMarker(host.shadowRoot)) {
+                                    return true;
+                                }
+                            }
+                            return false;
+                        }
+                        removeMarker();
+                    })()"#,
                     None,
                 )
                 .await;
@@ -5460,10 +5486,47 @@ async fn handle_semantic_locator(
     let query = match strategy {
         "label" => format!(
             r#"(() => {{
-                const label = Array.from(document.querySelectorAll('label')).find(el => {match_fn});
+                function findLabelShadowDOM(root = document) {{
+                    const labels = Array.from(root.querySelectorAll('label'));
+                    const found = labels.find(el => {match_fn});
+                    if (found) return found;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const foundInShadow = findLabelShadowDOM(host.shadowRoot);
+                            if (foundInShadow) return foundInShadow;
+                        }}
+                    }}
+                    return null;
+                }}
+                function getElementByIdShadowDOM(id, root = document) {{
+                    const el = root.getElementById ? root.getElementById(id) : root.querySelector('#' + CSS.escape(id));
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = getElementByIdShadowDOM(id, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                function querySelectorShadowDOM(selector, root = document) {{
+                    const el = root.querySelector(selector);
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = querySelectorShadowDOM(selector, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                const label = findLabelShadowDOM();
                 if (!label) return false;
                 const forId = label.getAttribute('for');
-                const target = forId ? document.getElementById(forId) : label.querySelector('input,select,textarea');
+                const target = forId ? getElementByIdShadowDOM(forId) : label.querySelector('input,select,textarea');
                 if (target) {{ target.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
             }})()"#,
@@ -5471,7 +5534,19 @@ async fn handle_semantic_locator(
         ),
         "placeholder" => format!(
             r#"(() => {{
-                const el = document.querySelector('input[placeholder={val}], textarea[placeholder={val}]');
+                function querySelectorShadowDOM(selector, root = document) {{
+                    const el = root.querySelector(selector);
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = querySelectorShadowDOM(selector, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                const el = querySelectorShadowDOM('input[placeholder={val}], textarea[placeholder={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
             }})()"#,
@@ -5479,7 +5554,19 @@ async fn handle_semantic_locator(
         ),
         "alttext" => format!(
             r#"(() => {{
-                const el = document.querySelector('img[alt={val}], [alt={val}]');
+                function querySelectorShadowDOM(selector, root = document) {{
+                    const el = root.querySelector(selector);
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = querySelectorShadowDOM(selector, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                const el = querySelectorShadowDOM('img[alt={val}], [alt={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
             }})()"#,
@@ -5487,7 +5574,19 @@ async fn handle_semantic_locator(
         ),
         "title" => format!(
             r#"(() => {{
-                const el = document.querySelector('[title={val}]');
+                function querySelectorShadowDOM(selector, root = document) {{
+                    const el = root.querySelector(selector);
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = querySelectorShadowDOM(selector, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                const el = querySelectorShadowDOM('[title={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
             }})()"#,
@@ -5495,7 +5594,19 @@ async fn handle_semantic_locator(
         ),
         "testid" => format!(
             r#"(() => {{
-                const el = document.querySelector('[data-testid={val}]');
+                function querySelectorShadowDOM(selector, root = document) {{
+                    const el = root.querySelector(selector);
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = querySelectorShadowDOM(selector, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                const el = querySelectorShadowDOM('[data-testid={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
             }})()"#,
@@ -5505,13 +5616,24 @@ async fn handle_semantic_locator(
             // "text" strategy
             format!(
                 r#"(() => {{
-                    const all = document.querySelectorAll('*');
-                    for (const el of all) {{
-                        if (el.children.length === 0 && {match_fn}) {{
-                            el.setAttribute('data-agent-browser-located', 'true');
-                            return true;
+                    function findTextShadowDOM(root = document) {{
+                        const all = root.querySelectorAll('*');
+                        for (const el of all) {{
+                            if (el.children.length === 0 && {match_fn}) {{
+                                return el;
+                            }}
                         }}
+                        // Search in shadow roots
+                        for (const el of all) {{
+                            if (el.shadowRoot) {{
+                                const found = findTextShadowDOM(el.shadowRoot);
+                                if (found) return found;
+                            }}
+                        }}
+                        return null;
                     }}
+                    const el = findTextShadowDOM();
+                    if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                     return false;
                 }})()"#,
                 match_fn = match_fn,
@@ -5548,7 +5670,23 @@ async fn handle_semantic_locator(
     if let Some(ref browser) = state.browser {
         let _ = browser
             .evaluate(
-                "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
+                r#"(() => {
+                    function removeMarker(root = document) {
+                        const el = root.querySelector('[data-agent-browser-located]');
+                        if (el) {
+                            el.removeAttribute('data-agent-browser-located');
+                            return true;
+                        }
+                        const allElements = root.querySelectorAll('*');
+                        for (const host of allElements) {
+                            if (host.shadowRoot && removeMarker(host.shadowRoot)) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+                    removeMarker();
+                })()"#,
                 None,
             )
             .await;
@@ -5595,7 +5733,17 @@ async fn handle_nth(cmd: &Value, state: &mut DaemonState) -> Result<Value, Strin
 
     let js = format!(
         r#"(() => {{
-            const els = document.querySelectorAll({sel});
+            function querySelectorAllShadowDOM(selector, root = document) {{
+                const results = [...root.querySelectorAll(selector)];
+                const allElements = root.querySelectorAll('*');
+                for (const host of allElements) {{
+                    if (host.shadowRoot) {{
+                        results.push(...querySelectorAllShadowDOM(selector, host.shadowRoot));
+                    }}
+                }}
+                return results;
+            }}
+            const els = querySelectorAllShadowDOM({sel});
             const idx = {idx} < 0 ? els.length + {idx} : {idx};
             if (idx < 0 || idx >= els.length) return false;
             els[idx].setAttribute('data-agent-browser-located', 'true');
@@ -5637,7 +5785,23 @@ async fn handle_nth(cmd: &Value, state: &mut DaemonState) -> Result<Value, Strin
     if let Some(ref browser) = state.browser {
         let _ = browser
             .evaluate(
-                "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
+                r#"(() => {
+                    function removeMarker(root = document) {
+                        const el = root.querySelector('[data-agent-browser-located]');
+                        if (el) {
+                            el.removeAttribute('data-agent-browser-located');
+                            return true;
+                        }
+                        const allElements = root.querySelectorAll('*');
+                        for (const host of allElements) {
+                            if (host.shadowRoot && removeMarker(host.shadowRoot)) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+                    removeMarker();
+                })()"#,
                 None,
             )
             .await;
@@ -5655,7 +5819,17 @@ async fn handle_find(cmd: &Value, state: &DaemonState) -> Result<Value, String> 
 
     let js = format!(
         r#"(() => {{
-            const els = document.querySelectorAll({});
+            function querySelectorAllShadowDOM(selector, root = document) {{
+                const results = [...root.querySelectorAll(selector)];
+                const allElements = root.querySelectorAll('*');
+                for (const host of allElements) {{
+                    if (host.shadowRoot) {{
+                        results.push(...querySelectorAllShadowDOM(selector, host.shadowRoot));
+                    }}
+                }}
+                return results;
+            }}
+            const els = querySelectorAllShadowDOM({});
             return Array.from(els).map((el, i) => ({{
                 index: i,
                 tagName: el.tagName.toLowerCase(),

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -397,6 +397,7 @@ pub(super) fn extract_ax_string(value: &Option<AXValue>) -> String {
 }
 
 /// Build a JS expression that finds a DOM element by CSS selector or XPath.
+/// Pierces Shadow DOM to find elements inside shadow roots.
 fn build_find_element_js(selector: &str) -> String {
     if let Some(xpath) = selector.strip_prefix("xpath=") {
         format!(
@@ -405,7 +406,21 @@ fn build_find_element_js(selector: &str) -> String {
         )
     } else {
         format!(
-            "document.querySelector({})",
+            r#"(() => {{
+                function querySelectorShadowDOM(sel, root = document) {{
+                    const el = root.querySelector(sel);
+                    if (el) return el;
+                    const allElements = root.querySelectorAll('*');
+                    for (const host of allElements) {{
+                        if (host.shadowRoot) {{
+                            const found = querySelectorShadowDOM(sel, host.shadowRoot);
+                            if (found) return found;
+                        }}
+                    }}
+                    return null;
+                }}
+                return querySelectorShadowDOM({});
+            }})()"#,
             serde_json::to_string(selector).unwrap_or_default()
         )
     }


### PR DESCRIPTION
## Summary

Fixes [#1266](https://github.com/vercel-labs/agent-browser/issues/1266).

Semantic locators (`find`, `getbyplaceholder`, `getbytext`, `getbyrole`, `getbylabel`, etc.) were using `document.querySelector` and `document.querySelectorAll`, which cannot pierce Shadow DOM boundaries. This caused element searches to fail for Web Components that use Shadow DOM encapsulation.

This PR adds recursive Shadow DOM piercing to all semantic locators, enabling seamless interaction with elements inside shadow roots.

 ## Changes

- **Semantic locators** (`placeholder`, `label`, `text`, `alttext`, `title`, `testid`, `role`): Now recursively search through all shadow roots to find matching elements
- **`handle_nth`**: Shadow DOM support for index-based element selection  
- **`handle_find`**: Shadow DOM support for CSS selector queries returning element lists
- **`build_find_element_js`**: Shadow DOM piercing for element resolution used by all interaction commands
- **Marker cleanup**: All cleanup operations now properly remove `data-agent-browser-located` markers from elements inside shadow DOM
- **Pattern used**: Recursive `querySelectorShadowDOM` and `querySelectorAllShadowDOM` helpers that traverse shadow hosts
- 
## Functions Modified

| Function | File | Change |
|----------|------|--------|
| `handle_semantic_locator` (all strategies) | `actions.rs` | Added shadow DOM piercing |
| `handle_getbyrole` | `actions.rs` | Added `querySelectorAllShadowDOM` for role queries |
| `handle_nth` | `actions.rs` | Added shadow DOM support for indexed selection |
| `handle_find` | `actions.rs` | Added shadow DOM support for CSS queries |
| `build_find_element_js` | `element.rs` | Core shadow DOM piercing helper |
| Marker cleanup in handlers | `actions.rs` | Shadow DOM-aware cleanup |

## Testing

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo build --manifest-path cli/Cargo.toml --release`
- Local testing with Web Components
- Verified `find placeholder`, `find text`, `getbyrole` work inside nested shadow roots

## Example Usage (Now Works)

```bash
# Web Component with <input placeholder="Username"> inside shadow DOM
agent-browser open https://example.com/login
agent-browser find placeholder Username fill "testuser"
agent-browser find text Login click
Previously this would fail with "Element not found". Now it works transparently.