### PR TITLE
fix: fall back to x64 binary on Windows ARM64

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -33,7 +33,10 @@ function isMusl() {
 
 // Platform detection
 const osKey = platform() === 'linux' && isMusl() ? 'linux-musl' : platform();
-const platformKey = `${osKey}-${arch()}`;
+// Windows ARM64 falls back to x64 binary (no native ARM64 build available).
+// x64 binaries run via Windows' built-in emulation on ARM64.
+const effectiveArch = platform() === 'win32' && arch() === 'arm64' ? 'x64' : arch();
+const platformKey = `${osKey}-${effectiveArch}`;
 const ext = platform() === 'win32' ? '.exe' : '';
 const binaryName = `agent-browser-${platformKey}${ext}`;
 const binaryPath = join(binDir, binaryName);
@@ -129,6 +132,9 @@ async function main() {
   }
 
   console.log(`Downloading native binary for ${platformKey}...`);
+  if (platform() === 'win32' && arch() === 'arm64') {
+    console.log(`  Note: Using x64 binary on ARM64 Windows (runs via emulation)`);
+  }
   console.log(`URL: ${DOWNLOAD_URL}`);
 
   try {
@@ -288,7 +294,8 @@ async function fixWindowsShims() {
   }
 
   // Detect architecture so ARM64 Windows is handled correctly
-  const cpuArch = arch() === 'arm64' ? 'arm64' : 'x64';
+  // (falls back to x64 binary — see platform detection above)
+  const cpuArch = effectiveArch;
   const relativeBinaryPath = `node_modules\\agent-browser\\bin\\agent-browser-win32-${cpuArch}.exe`;
   const absoluteBinaryPath = join(npmBinDir, relativeBinaryPath);
 


### PR DESCRIPTION
﻿## Summary

Fixes #1256

On Windows ARM64, the postinstall script previously tried to download `agent-browser-win32-arm64.exe` from GitHub releases. Since there's no native ARM64 build in CI, this resulted in a 0-byte file and a broken install.

## Changes

- **Platform detection**: When running on Windows ARM64, the postinstall script now falls back to the x64 binary (`agent-browser-win32-x64.exe`). x64 binaries run fine on ARM64 via Windows' built-in emulation.
- **Shim fix**: Unified the architecture detection in `fixWindowsShims()` to use the same `effectiveArch` variable, eliminating the redundant local arch check.
- **User-facing hint**: Added a log message when the fallback is active so users know they're running the x64 binary.

## Testing

- Verified that Chrome for Testing does not provide a `win-arm64` platform (only `win32` and `win64`).
- Confirmed the x64 binary `agent-browser-win32-x64.exe` exists in all recent releases (v0.26.0, etc.).
- On Windows ARM64, the script will now:
  1. Resolve `effectiveArch` to `x64`
  2. Download `agent-browser-win32-x64.exe`
  3. Fix `.cmd`/`.ps1` shims to point to the x64 binary
