### PR TITLE
Fix CDP reconnection when Chrome restarts (new webSocketDebuggerUrl)

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -323,6 +323,7 @@ pub struct Flags {
     pub cli_annotate: bool,
     pub cli_download_path: bool,
     pub cli_headed: bool,
+    pub cli_cdp: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -459,6 +460,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_annotate: false,
         cli_download_path: false,
         cli_headed: false,
+        cli_cdp: false,
     };
 
     let mut i = 0;
@@ -528,6 +530,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--cdp" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.cdp = Some(s.clone());
+                    flags.cli_cdp = true;
                     i += 1;
                 }
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -922,7 +922,9 @@ fn main() {
 
     // Connect via CDP if --cdp flag is set
     // Accepts either a port number (e.g., "9222") or a full URL (e.g., "ws://..." or "wss://...")
-    // Skip when daemon already running — it already holds the CDP connection.
+    // Skip when daemon already running unless --cdp was explicitly passed on the CLI —
+    // explicit --cdp means the user wants to (re)connect, e.g. after Chrome restarts with
+    // a new webSocketDebuggerUrl.
     if let Some(ref cdp_value) = flags.cdp {
         // Validate CDP value eagerly (even when daemon is already running) so
         // the user gets an immediate error for bad input instead of a silent no-op.
@@ -982,7 +984,10 @@ fn main() {
             })
         };
 
-        if !daemon_result.already_running {
+        // Always send the CDP launch command when --cdp was explicitly passed
+        // (reconnection scenario). Only skip when daemon is already running
+        // and --cdp came from config/env (not a user-initiated reconnect).
+        if !daemon_result.already_running || flags.cli_cdp {
             let mut launch_cmd = launch_cmd;
 
             if flags.ignore_https_errors {


### PR DESCRIPTION
Fixes #1272

When connecting to an external Chrome browser via CDP, if the browser is closed and restarted, the CDP connection fails silently. This is because Chrome generates a new webSocketDebuggerUrl UUID on each restart, but the agent-browser daemon does not rediscover the new URL.

This fix adds a cli_cdp flag to track when --cdp is explicitly passed on the CLI. The logic now always sends the CDP launch command when --cdp was explicitly passed (reconnection scenario), but only skips when the daemon is already running and --cdp came from config/env.

Changes:
- Added cli_cdp flag to Flags struct in cli/src/flags.rs
- Modified CDP connection logic in cli/src/main.rs to always reconnect when --cdp is explicitly passed
- Updated comments to clarify the reconnection behavior