### PR TITLE
feat(chrome): add Helium browser auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Detects your installation method (npm, Homebrew, or Cargo) and runs the appropri
 
 ### Requirements
 
-- **Chrome** - Run `agent-browser install` to download Chrome from [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) (Google's official automation channel). Existing Chrome, Brave, Playwright, and Puppeteer installations are detected automatically. No Playwright or Node.js required for the daemon.
+- **Chrome** - Run `agent-browser install` to download Chrome from [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) (Google's official automation channel). Existing Chrome, Brave, Helium, Playwright, and Puppeteer installations are detected automatically. No Playwright or Node.js required for the daemon.
 - **Rust** - Only needed when building from source (see From Source above).
 
 ## Quick Start

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -569,6 +569,7 @@ pub fn find_chrome() -> Option<PathBuf> {
             "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
             "/Applications/Chromium.app/Contents/MacOS/Chromium",
             "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            "/Applications/Helium.app/Contents/MacOS/Helium",
         ];
         for c in &candidates {
             let p = PathBuf::from(c);
@@ -587,6 +588,7 @@ pub fn find_chrome() -> Option<PathBuf> {
             "chromium",
             "brave-browser",
             "brave-browser-stable",
+            "helium",
         ];
         for name in &candidates {
             if let Ok(output) = Command::new("which").arg(name).output() {
@@ -615,6 +617,10 @@ pub fn find_chrome() -> Option<PathBuf> {
                 PathBuf::from(&local).join(r"BraveSoftware\Brave-Browser\Application\brave.exe");
             if brave.exists() {
                 return Some(brave);
+            }
+            let helium = PathBuf::from(&local).join(r"imput\Helium\Application\chrome.exe");
+            if helium.exists() {
+                return Some(helium);
             }
         }
         for c in &candidates {
@@ -724,7 +730,7 @@ async fn verify_ws_endpoint(ws_url: &str) -> bool {
 }
 
 /// Returns the default Chrome user-data directory paths for the current platform.
-/// Includes Chrome, Chrome Canary, Chromium, and Brave.
+/// Includes Chrome, Chrome Canary, Chromium, Brave, and Helium.
 pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
@@ -737,6 +743,7 @@ pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
                 "Google/Chrome Canary",
                 "Chromium",
                 "BraveSoftware/Brave-Browser",
+                "Helium",
             ] {
                 dirs.push(base.join(name));
             }
@@ -752,6 +759,7 @@ pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
                 "google-chrome-unstable",
                 "chromium",
                 "BraveSoftware/Brave-Browser",
+                "helium",
             ] {
                 dirs.push(config.join(name));
             }
@@ -767,6 +775,7 @@ pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
                 r"Google\Chrome SxS\User Data",
                 r"Chromium\User Data",
                 r"BraveSoftware\Brave-Browser\User Data",
+                r"imput\Helium\User Data",
             ] {
                 dirs.push(base.join(name));
             }
@@ -1272,6 +1281,70 @@ mod tests {
             if let Some(path) = result {
                 assert!(path.exists());
             }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_get_chrome_user_data_dirs_includes_helium_on_macos() {
+        let dirs = get_chrome_user_data_dirs();
+        assert!(dirs.iter().any(|dir| dir.ends_with("Library/Application Support/Helium")));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_get_chrome_user_data_dirs_includes_helium_on_linux() {
+        let guard = EnvGuard::new(&["HOME"]);
+        let home = TempDir::new("helium-home-linux");
+        std::fs::create_dir_all(&*home).unwrap();
+        guard.set("HOME", &home.to_string_lossy());
+
+        let dirs = get_chrome_user_data_dirs();
+        assert!(dirs.iter().any(|dir| dir == &home.join(".config/helium")));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_get_chrome_user_data_dirs_includes_helium_on_windows() {
+        let guard = EnvGuard::new(&["LOCALAPPDATA"]);
+        let local = TempDir::new("helium-localappdata");
+        std::fs::create_dir_all(&*local).unwrap();
+        guard.set("LOCALAPPDATA", &local.to_string_lossy());
+
+        let dirs = get_chrome_user_data_dirs();
+        assert!(dirs
+            .iter()
+            .any(|dir| dir == &local.join(r"imput\Helium\User Data")));
+    }
+
+    #[test]
+    fn test_find_chrome_user_data_dir_can_resolve_helium_style_dir() {
+        let guard = EnvGuard::new(&["HOME", "LOCALAPPDATA"]);
+
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        {
+            let home = TempDir::new("find-helium-profile-home");
+            std::fs::create_dir_all(&*home).unwrap();
+            guard.set("HOME", &home.to_string_lossy());
+
+            #[cfg(target_os = "macos")]
+            let helium_dir = home.join("Library/Application Support/Helium");
+            #[cfg(target_os = "linux")]
+            let helium_dir = home.join(".config/helium");
+
+            create_fake_local_state(&helium_dir, &[("Default", "Person 1")]);
+            assert_eq!(find_chrome_user_data_dir(), Some(helium_dir));
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let local = TempDir::new("find-helium-profile-local");
+            std::fs::create_dir_all(&*local).unwrap();
+            guard.set("LOCALAPPDATA", &local.to_string_lossy());
+
+            let helium_dir = local.join(r"imput\Helium\User Data");
+            create_fake_local_state(&helium_dir, &[("Default", "Person 1")]);
+            assert_eq!(find_chrome_user_data_dir(), Some(helium_dir));
         }
     }
 

--- a/docs/src/app/engines/chrome/page.mdx
+++ b/docs/src/app/engines/chrome/page.mdx
@@ -18,6 +18,7 @@ When no `--executable-path` is provided, agent-browser searches for Chrome in th
         <code>/Applications/Google Chrome Canary.app</code>,
         <code>/Applications/Chromium.app</code>,
         <code>/Applications/Brave Browser.app</code>,
+        <code>/Applications/Helium.app</code>,
         Puppeteer cache (<code>~/.cache/puppeteer/chrome/</code> or <code>PUPPETEER_CACHE_DIR</code>),
         Chrome for Testing cache
       </td>
@@ -28,7 +29,9 @@ When no `--executable-path` is provided, agent-browser searches for Chrome in th
         <code>google-chrome</code>,
         <code>google-chrome-stable</code>,
         <code>chromium-browser</code>,
-        <code>chromium</code> in PATH,
+        <code>chromium</code>,
+        <code>brave-browser</code>,
+        <code>helium</code> in PATH,
         Puppeteer cache (<code>~/.cache/puppeteer/chrome/</code> or <code>PUPPETEER_CACHE_DIR</code>),
         Chrome for Testing cache
       </td>
@@ -37,6 +40,8 @@ When no `--executable-path` is provided, agent-browser searches for Chrome in th
       <td>Windows</td>
       <td>
         <code>%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe</code>,
+        <code>%LOCALAPPDATA%\BraveSoftware\Brave-Browser\Application\brave.exe</code>,
+        <code>%LOCALAPPDATA%\imput\Helium\Application\chrome.exe</code>,
         <code>C:\Program Files\Google\Chrome\Application\chrome.exe</code>,
         <code>C:\Program Files (x86)\...\chrome.exe</code>
       </td>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -53,7 +53,7 @@ AGENT_BROWSER_PROFILE=Default agent-browser open https://gmail.com
     <tr><th>Detail</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td>Supported browsers</td><td>Chrome, Chrome Canary, Chromium, Brave</td></tr>
+    <tr><td>Supported browsers</td><td>Chrome, Chrome Canary, Chromium, Brave, Helium</td></tr>
     <tr><td>What's copied</td><td>Cookies, local storage, extensions state (cache dirs excluded for speed)</td></tr>
     <tr><td>Original profile</td><td>Never modified (read-only snapshot)</td></tr>
     <tr><td>Cleanup</td><td>Temp copy deleted when browser closes</td></tr>

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -28,15 +28,21 @@ The fastest way to authenticate is to reuse cookies from a Chrome session you ar
 ```bash
 # macOS
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222
+# Or Helium:
+"/Applications/Helium.app/Contents/MacOS/Helium" --remote-debugging-port=9222
 
 # Linux
 google-chrome --remote-debugging-port=9222
+# Or Helium:
+helium --remote-debugging-port=9222
 
 # Windows
 "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+# Or Helium:
+"%LOCALAPPDATA%\imput\Helium\Application\chrome.exe" --remote-debugging-port=9222
 ```
 
-Log in to your target site(s) in this Chrome window as you normally would.
+Log in to your target site(s) in this browser window as you normally would.
 
 > **Security note:** `--remote-debugging-port` exposes full browser control on localhost. Any local process can connect and read cookies, execute JS, etc. Only use on trusted machines and close Chrome when done.
 


### PR DESCRIPTION
## Summary

Add Helium as a supported Chromium-family browser anywhere agent-browser currently auto-detects Chrome and Brave for local launch, `--auto-connect`, profile reuse, and install-time browser detection.

## Changes

- add Helium executable detection to the native CDP path on macOS, Linux, and Windows
- add Helium user-data directory discovery so `--auto-connect`, `profiles`, and `--profile <name>` can resolve Helium installs that use Chromium-style `Local State`
- extend `scripts/postinstall.js` so an installed Helium browser suppresses the local-browser warning
- update README, CLI help, docs site pages, and core skill references to describe `--auto-connect` and profile reuse in Chrome-family terms and explicitly include Helium
- add focused unit tests covering Helium user-data directory enumeration and `find_chrome_user_data_dir()` resolution

## Test plan

- [x] `cargo test chrome:: --manifest-path cli/Cargo.toml`

## Notes

- This keeps Helium on the existing `chrome` engine path rather than introducing a new engine type.
- Windows support follows Helium's `%LOCALAPPDATA%\\imput\\Helium` layout, and Linux support includes the `helium` command plus Helium config directories.
