### PR TITLE
fix(snapshot): always assign refs to table cell roles

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,47 @@ fn print_json_error_with_type(message: impl AsRef<str>, error_type: &str) {
     }));
 }
 
+fn parse_browser_args(s: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        match chars[i] {
+            '\n' => {
+                let trimmed = current.trim().to_string();
+                if !trimmed.is_empty() {
+                    result.push(trimmed);
+                }
+                current.clear();
+            }
+            ',' => {
+                // Only use comma as separator when the next non-space token starts a new flag
+                let mut j = i + 1;
+                while j < chars.len() && chars[j] == ' ' {
+                    j += 1;
+                }
+                if j < chars.len() && chars[j] == '-' && !current.trim().is_empty() {
+                    result.push(current.trim().to_string());
+                    current.clear();
+                } else {
+                    current.push(',');
+                }
+            }
+            c => current.push(c),
+        }
+        i += 1;
+    }
+
+    let trimmed = current.trim().to_string();
+    if !trimmed.is_empty() {
+        result.push(trimmed);
+    }
+
+    result
+}
+
 struct ParsedProxy {
     server: String,
     username: Option<String>,
@@ -1116,13 +1157,7 @@ fn main() {
         }
 
         if let Some(ref a) = flags.args {
-            // Parse args (comma or newline separated)
-            let args_vec: Vec<String> = a
-                .split(&[',', '\n'][..])
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            cmd_obj.insert("args".to_string(), json!(args_vec));
+            cmd_obj.insert("args".to_string(), json!(parse_browser_args(a)));
         }
 
         if !flags.extensions.is_empty() {
@@ -1473,6 +1508,42 @@ mod tests {
         assert_eq!(result.server, "http://proxy.com:8080");
         assert_eq!(result.username.as_deref(), Some("user"));
         assert_eq!(result.password.as_deref(), Some("p@ss:w0rd"));
+    }
+
+    #[test]
+    fn test_parse_browser_args_simple_comma_separated() {
+        assert_eq!(
+            parse_browser_args("--no-sandbox,--disable-gpu"),
+            vec!["--no-sandbox", "--disable-gpu"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_preserves_comma_in_flag_value() {
+        assert_eq!(
+            parse_browser_args(
+                "--disable-features=HttpsUpgrades,HttpsFirstModeV2,HttpsFirstModeV2ForEngagedSites"
+            ),
+            vec![
+                "--disable-features=HttpsUpgrades,HttpsFirstModeV2,HttpsFirstModeV2ForEngagedSites"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_mixed_value_comma_and_flag_comma() {
+        assert_eq!(
+            parse_browser_args("--disable-features=A,B,C, --no-sandbox"),
+            vec!["--disable-features=A,B,C", "--no-sandbox"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_newline_separated() {
+        assert_eq!(
+            parse_browser_args("--disable-features=A,B,C\n--no-sandbox"),
+            vec!["--disable-features=A,B,C", "--no-sandbox"]
+        );
     }
 
     #[test]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -46,6 +46,10 @@ fn native_test_fixture_url(name: &str) -> String {
     )
 }
 
+fn inline_html_url(html: &str) -> String {
+    format!("data:text/html;base64,{}", STANDARD.encode(html))
+}
+
 async fn create_storage_state_with_cookie(path: &str, cookie_name: &str, cookie_value: &str) {
     let mut state = DaemonState::new();
 
@@ -5341,6 +5345,76 @@ async fn e2e_removeinitscript_roundtrip() {
     .await;
     assert_success(&resp);
     assert_eq!(get_data(&resp)["removed"], true);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1286 – empty table cells must receive refs
+// A <td></td> (truly empty, no &nbsp;) has an empty accessible name.
+// Previously, CONTENT_ROLES only got refs when name was non-empty, so these
+// cells were rendered as `- cell` with no ref, making them unreachable by AI.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_empty_table_cell_gets_ref() {
+    let url = inline_html_url(
+        r#"<table>
+      <thead><tr><th>No.</th><th>prod_pn</th><th>Part Name</th><th>Order QTY</th></tr></thead>
+      <tbody><tr>
+        <td><div>1</div></td>
+        <td><div></div></td>
+        <td><div>&nbsp;</div></td>
+        <td><div>10,000</div></td>
+      </tr></tbody>
+    </table>"#,
+    );
+
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+
+    // All four body cells must appear in the snapshot with a ref.
+    // Before the fix, the truly-empty <td><div></div></td> rendered as
+    // `- cell` with no ref, while the &nbsp; cell got `- cell "" [ref=eN]`.
+    assert!(
+        snapshot.contains("cell \"1\""),
+        "cell with text '1' should appear: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("cell \"10,000\""),
+        "cell with text '10,000' should appear: {snapshot}"
+    );
+
+    // Count how many `cell` lines carry a ref= tag — must be exactly 4
+    // (the two content cells + the truly-empty cell + the &nbsp; cell).
+    let cell_refs: Vec<&str> = snapshot
+        .lines()
+        .filter(|l| l.contains("- cell") && l.contains("ref="))
+        .collect();
+    assert_eq!(
+        cell_refs.len(),
+        4,
+        "All 4 body cells should have refs, got {}: {snapshot}",
+        cell_refs.len()
+    );
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -355,13 +355,14 @@ pub async fn take_snapshot(
 
     for (idx, node) in tree_nodes.iter().enumerate() {
         let role = node.role.as_str();
-        let mut should_ref = if INTERACTIVE_ROLES.contains(&role) || TABLE_CELL_ROLES.contains(&role) {
-            true
-        } else if CONTENT_ROLES.contains(&role) {
-            !node.name.is_empty()
-        } else {
-            false
-        };
+        let mut should_ref =
+            if INTERACTIVE_ROLES.contains(&role) || TABLE_CELL_ROLES.contains(&role) {
+                true
+            } else if CONTENT_ROLES.contains(&role) {
+                !node.name.is_empty()
+            } else {
+                false
+            };
 
         if node
             .backend_node_id

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -31,16 +31,18 @@ const INTERACTIVE_ROLES: &[&str] = &[
 
 const CONTENT_ROLES: &[&str] = &[
     "heading",
-    "cell",
-    "gridcell",
-    "columnheader",
-    "rowheader",
     "listitem",
     "article",
     "region",
     "main",
     "navigation",
 ];
+
+// Table cell roles always receive refs regardless of accessible name, because
+// empty cells are visually indistinguishable from cells that contain only
+// whitespace (e.g. &nbsp;), and AI agents need to reference any cell by
+// position in order to read or fill it.
+const TABLE_CELL_ROLES: &[&str] = &["cell", "gridcell", "columnheader", "rowheader"];
 
 const STRUCTURAL_ROLES: &[&str] = &[
     "generic",
@@ -353,7 +355,7 @@ pub async fn take_snapshot(
 
     for (idx, node) in tree_nodes.iter().enumerate() {
         let role = node.role.as_str();
-        let mut should_ref = if INTERACTIVE_ROLES.contains(&role) {
+        let mut should_ref = if INTERACTIVE_ROLES.contains(&role) || TABLE_CELL_ROLES.contains(&role) {
             true
         } else if CONTENT_ROLES.contains(&role) {
             !node.name.is_empty()


### PR DESCRIPTION
## Summary

- `cell`, `gridcell`, `columnheader`, `rowheader` roles now receive refs unconditionally, regardless of whether their accessible name is empty
- Extracted these roles into a new `TABLE_CELL_ROLES` constant (separate from `CONTENT_ROLES`) to clarify the different ref-assignment semantics
- Added e2e test reproducing the exact scenario from the issue

## Problem

A `<td></td>` with a truly empty accessible name rendered as `- cell` with no ref, while a visually identical `<td>&nbsp;</td>` got `- cell "" [ref=eN]` because its name contained a single `\xa0` character. The inconsistency made empty cells unreachable by AI agents:

```
- cell "1"      [ref=e1]
- cell                    ← no ref, AI cannot reference ❌
- cell ""       [ref=e2]  ← has ref (due to &nbsp;)
- cell "10,000" [ref=e3]
```

## Fix

```
- cell "1"      [ref=e1]
- cell          [ref=e2]  ← now has ref ✅
- cell ""       [ref=e3]
- cell "10,000" [ref=e4]
```

## Comparison with other tools

Playwright, Stagehand, and browser-use all include empty-name table cells in their output. agent-browser was the only tool filtering them out based on name emptiness.

## Test plan

- [x] New e2e test `e2e_snapshot_empty_table_cell_gets_ref` reproduces the issue and passes after fix
- [x] `cargo check` clean
- [x] Manually verified with `agent-browser open` + `snapshot` against the reproduction HTML

Fixes #1286