### PR TITLE
fix(cli): preserve commas inside Chrome flag values when parsing --args

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,47 @@ fn print_json_error_with_type(message: impl AsRef<str>, error_type: &str) {
     }));
 }
 
+fn parse_browser_args(s: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current = String::new();
+    let bytes = s.as_bytes();
+
+    for (byte_pos, c) in s.char_indices() {
+        match c {
+            '\n' => {
+                let trimmed = current.trim().to_string();
+                if !trimmed.is_empty() {
+                    result.push(trimmed);
+                }
+                current.clear();
+            }
+            ',' => {
+                // Only use comma as separator when the next non-space token starts a new flag.
+                // All lookahead chars (' ', '-') are ASCII so byte indexing is safe here.
+                let mut j = byte_pos + 1;
+                while j < bytes.len() && bytes[j] == b' ' {
+                    j += 1;
+                }
+                let trimmed = current.trim();
+                if j < bytes.len() && bytes[j] == b'-' && !trimmed.is_empty() {
+                    result.push(trimmed.to_string());
+                    current.clear();
+                } else {
+                    current.push(',');
+                }
+            }
+            _ => current.push(c),
+        }
+    }
+
+    let trimmed = current.trim().to_string();
+    if !trimmed.is_empty() {
+        result.push(trimmed);
+    }
+
+    result
+}
+
 struct ParsedProxy {
     server: String,
     username: Option<String>,
@@ -1116,13 +1157,7 @@ fn main() {
         }
 
         if let Some(ref a) = flags.args {
-            // Parse args (comma or newline separated)
-            let args_vec: Vec<String> = a
-                .split(&[',', '\n'][..])
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            cmd_obj.insert("args".to_string(), json!(args_vec));
+            cmd_obj.insert("args".to_string(), json!(parse_browser_args(a)));
         }
 
         if !flags.extensions.is_empty() {
@@ -1473,6 +1508,50 @@ mod tests {
         assert_eq!(result.server, "http://proxy.com:8080");
         assert_eq!(result.username.as_deref(), Some("user"));
         assert_eq!(result.password.as_deref(), Some("p@ss:w0rd"));
+    }
+
+    #[test]
+    fn test_parse_browser_args_simple_comma_separated() {
+        assert_eq!(
+            parse_browser_args("--no-sandbox,--disable-gpu"),
+            vec!["--no-sandbox", "--disable-gpu"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_preserves_comma_in_flag_value() {
+        assert_eq!(
+            parse_browser_args(
+                "--disable-features=HttpsUpgrades,HttpsFirstModeV2,HttpsFirstModeV2ForEngagedSites"
+            ),
+            vec![
+                "--disable-features=HttpsUpgrades,HttpsFirstModeV2,HttpsFirstModeV2ForEngagedSites"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_mixed_value_comma_and_flag_comma() {
+        assert_eq!(
+            parse_browser_args("--disable-features=A,B,C, --no-sandbox"),
+            vec!["--disable-features=A,B,C", "--no-sandbox"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_newline_separated() {
+        assert_eq!(
+            parse_browser_args("--no-sandbox\n--disable-gpu"),
+            vec!["--no-sandbox", "--disable-gpu"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_args_newline_with_value_commas() {
+        assert_eq!(
+            parse_browser_args("--disable-features=A,B\n--enable-features=C,D"),
+            vec!["--disable-features=A,B", "--enable-features=C,D"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`--args` was splitting on every comma, breaking Chrome flags whose values contain comma-separated lists.

**Example that failed before this fix:**
```bash
agent-browser --args "--disable-features=HttpsUpgrades,HttpsFirstModeV2,HttpsFirstModeV2ForEngagedSites" open example.com
```

The parser turned this into three broken arguments:
```
["--disable-features=HttpsUpgrades", "HttpsFirstModeV2", "HttpsFirstModeV2ForEngagedSites"]
```

Chrome's `--disable-features`, `--enable-features`, and similar list-valued flags all hit this bug.

## Root cause

`cli/src/main.rs` used `.split(&[',', '\n'][..])` — splitting on **every** comma unconditionally.

## Fix

Extract `parse_browser_args()` which:
- Always splits on `\n`
- Only splits on `,` when the next non-space character is `-` (i.e., starts a new flag)
- Preserves commas inside flag values

Existing usage like `--args "--no-sandbox,--disable-gpu"` continues to work unchanged.

## Test plan

- [x] `--no-sandbox,--disable-gpu` → `["--no-sandbox", "--disable-gpu"]` (existing behavior)
- [x] `--disable-features=A,B,C` → `["--disable-features=A,B,C"]` (core bug fix)
- [x] `--disable-features=A,B,C, --no-sandbox` → `["--disable-features=A,B,C", "--no-sandbox"]` (mixed)
- [x] `--no-sandbox\n--disable-gpu` → newline separation still works
- [x] `--disable-features=A,B\n--enable-features=C,D` → multiple value-comma flags, newline separated

Fixes #1284