### PR TITLE
feat: add install download timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm install -g agent-browser
 agent-browser install  # Download Chrome from Chrome for Testing (first time only)
 ```
 
+Slow networks can extend the browser download timeout:
+
+```bash
+agent-browser install --timeout 600
+```
+
 ### Project Installation (local dependency)
 
 For projects that want to pin the version in `package.json`:
@@ -445,6 +451,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 ```bash
 agent-browser install                 # Download Chrome from Chrome for Testing (Google's official automation channel)
 agent-browser install --with-deps     # Also install system deps (Linux)
+agent-browser install --timeout 600   # Extend Chrome download timeout for slow networks
 agent-browser upgrade                 # Upgrade agent-browser to the latest version
 agent-browser doctor                  # Diagnose the install and auto-clean stale daemon files
 agent-browser doctor --fix            # Also run destructive repairs (reinstall Chrome, purge old state, ...)

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -6,6 +6,42 @@ use std::process::{exit, Command, Stdio};
 
 const LAST_KNOWN_GOOD_URL: &str =
     "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
+const DEFAULT_INSTALL_TIMEOUT_SECS: u64 = 120;
+
+pub struct InstallOptions {
+    pub with_deps: bool,
+    pub timeout_secs: u64,
+}
+
+pub fn parse_install_timeout_secs(args: &[String]) -> Result<u64, String> {
+    let mut timeout_secs = DEFAULT_INSTALL_TIMEOUT_SECS;
+    let mut i = 0;
+
+    while i < args.len() {
+        let arg = &args[i];
+        let value = if arg == "--timeout" || arg == "-t" {
+            i += 1;
+            args.get(i)
+                .ok_or_else(|| format!("{} requires a value in seconds", arg))?
+        } else if let Some(value) = arg.strip_prefix("--timeout=") {
+            value
+        } else {
+            i += 1;
+            continue;
+        };
+
+        timeout_secs = value
+            .parse::<u64>()
+            .map_err(|_| format!("Invalid install timeout: {}", value))?;
+        if timeout_secs == 0 {
+            return Err("Install timeout must be greater than 0 seconds".to_string());
+        }
+
+        i += 1;
+    }
+
+    Ok(timeout_secs)
+}
 
 pub fn get_browsers_dir() -> PathBuf {
     dirs::home_dir()
@@ -182,8 +218,8 @@ fn platform_key() -> &'static str {
     }
 }
 
-async fn fetch_download_url() -> Result<(String, String), String> {
-    let client = http_client()?;
+async fn fetch_download_url(timeout_secs: u64) -> Result<(String, String), String> {
+    let client = http_client(timeout_secs)?;
     let resp = client
         .get(LAST_KNOWN_GOOD_URL)
         .send()
@@ -236,17 +272,20 @@ fn format_reqwest_error(e: &reqwest::Error) -> String {
     msg
 }
 
-fn http_client() -> Result<reqwest::Client, String> {
+fn http_client(timeout_secs: u64) -> Result<reqwest::Client, String> {
+    let timeout = std::time::Duration::from_secs(timeout_secs);
+    let connect_timeout = std::time::Duration::from_secs(timeout_secs.min(30));
+
     reqwest::Client::builder()
         .user_agent(format!("agent-browser/{}", env!("CARGO_PKG_VERSION")))
-        .timeout(std::time::Duration::from_secs(120))
-        .connect_timeout(std::time::Duration::from_secs(30))
+        .timeout(timeout)
+        .connect_timeout(connect_timeout)
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", format_reqwest_error(&e)))
 }
 
-async fn download_bytes(url: &str) -> Result<Vec<u8>, String> {
-    let client = http_client()?;
+async fn download_bytes(url: &str, timeout_secs: u64) -> Result<Vec<u8>, String> {
+    let client = http_client(timeout_secs)?;
     let max_retries = 3;
     let mut last_err = String::new();
 
@@ -397,7 +436,7 @@ fn extract_zip(bytes: Vec<u8>, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
-pub fn run_install(with_deps: bool) {
+pub fn run_install(options: InstallOptions) {
     if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
         eprintln!(
             "{} Chrome for Testing does not provide Linux ARM64 builds.",
@@ -413,7 +452,7 @@ pub fn run_install(with_deps: bool) {
     let is_linux = cfg!(target_os = "linux");
 
     if is_linux {
-        if with_deps {
+        if options.with_deps {
             install_linux_deps();
         } else {
             println!(
@@ -439,7 +478,7 @@ pub fn run_install(with_deps: bool) {
             exit(1);
         });
 
-    let (version, url) = match rt.block_on(fetch_download_url()) {
+    let (version, url) = match rt.block_on(fetch_download_url(options.timeout_secs)) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{} {}", color::error_indicator(), e);
@@ -463,7 +502,7 @@ pub fn run_install(with_deps: bool) {
     println!("  Downloading Chrome {} for {}", version, platform_key());
     println!("  {}", url);
 
-    let bytes = match rt.block_on(download_bytes(&url)) {
+    let bytes = match rt.block_on(download_bytes(&url, options.timeout_secs)) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("{} {}", color::error_indicator(), e);
@@ -480,7 +519,7 @@ pub fn run_install(with_deps: bool) {
             );
             println!("  Location: {}", dest.display());
 
-            if is_linux && !with_deps {
+            if is_linux && !options.with_deps {
                 println!();
                 println!(
                     "{} If you see \"shared library\" errors when running, use:",
@@ -778,6 +817,10 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
+    fn args(input: &[&str]) -> Vec<String> {
+        input.iter().map(|s| s.to_string()).collect()
+    }
+
     fn http_response(status: u16, reason: &str, body: &[u8]) -> Vec<u8> {
         let header = format!(
             "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -806,6 +849,53 @@ mod tests {
         request
     }
 
+    #[test]
+    fn parse_install_timeout_defaults_to_120_seconds() {
+        assert_eq!(
+            parse_install_timeout_secs(&args(&["install"])).unwrap(),
+            120
+        );
+    }
+
+    #[test]
+    fn parse_install_timeout_accepts_long_flag() {
+        assert_eq!(
+            parse_install_timeout_secs(&args(&["install", "--timeout", "600"])).unwrap(),
+            600
+        );
+    }
+
+    #[test]
+    fn parse_install_timeout_accepts_long_flag_equals() {
+        assert_eq!(
+            parse_install_timeout_secs(&args(&["install", "--timeout=600"])).unwrap(),
+            600
+        );
+    }
+
+    #[test]
+    fn parse_install_timeout_accepts_short_flag() {
+        assert_eq!(
+            parse_install_timeout_secs(&args(&["install", "-t", "600"])).unwrap(),
+            600
+        );
+    }
+
+    #[test]
+    fn parse_install_timeout_rejects_missing_value() {
+        assert!(parse_install_timeout_secs(&args(&["install", "--timeout"])).is_err());
+    }
+
+    #[test]
+    fn parse_install_timeout_rejects_zero() {
+        assert!(parse_install_timeout_secs(&args(&["install", "--timeout", "0"])).is_err());
+    }
+
+    #[test]
+    fn parse_install_timeout_rejects_non_numeric_value() {
+        assert!(parse_install_timeout_secs(&args(&["install", "--timeout", "slow"])).is_err());
+    }
+
     #[tokio::test]
     async fn download_bytes_returns_body_on_200() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -818,7 +908,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), body);
         server.await.unwrap();
@@ -835,7 +925,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -862,7 +952,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(
             result.is_ok(),
             "expected success after retries: {:?}",
@@ -886,7 +976,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -909,7 +999,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("HTTP 403"));
         server.await.unwrap();
@@ -926,7 +1016,7 @@ mod tests {
             req
         });
 
-        let client = http_client().unwrap();
+        let client = http_client(DEFAULT_INSTALL_TIMEOUT_SECS).unwrap();
         let url = format!("http://127.0.0.1:{}/test", port);
         let _ = client.get(&url).send().await;
         let request_text = server.await.unwrap();
@@ -946,7 +1036,10 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let result = rt.block_on(download_bytes("http://127.0.0.1:1/test.zip"));
+        let result = rt.block_on(download_bytes(
+            "http://127.0.0.1:1/test.zip",
+            DEFAULT_INSTALL_TIMEOUT_SECS,
+        ));
         assert!(result.is_err());
         let err = result.unwrap_err();
         // The new code should include the root cause (connection refused)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,7 +29,7 @@ use connection::{
     DaemonOptions,
 };
 use flags::{clean_args, parse_flags, Flags};
-use install::run_install;
+use install::{parse_install_timeout_secs, run_install, InstallOptions};
 use output::{
     print_command_help, print_help, print_response_with_opts, print_version, OutputOptions,
 };
@@ -540,7 +540,17 @@ fn main() {
     // Handle install separately
     if clean.first().map(|s| s.as_str()) == Some("install") {
         let with_deps = args.iter().any(|a| a == "--with-deps" || a == "-d");
-        run_install(with_deps);
+        let timeout_secs = match parse_install_timeout_secs(&args) {
+            Ok(timeout_secs) => timeout_secs,
+            Err(e) => {
+                eprintln!("{} {}", color::error_indicator(), e);
+                exit(1);
+            }
+        };
+        run_install(InstallOptions {
+            with_deps,
+            timeout_secs,
+        });
         return;
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2473,16 +2473,18 @@ Examples:
             r##"
 agent-browser install - Install browser binaries
 
-Usage: agent-browser install [--with-deps]
+Usage: agent-browser install [--with-deps] [--timeout <seconds>]
 
 Downloads and installs browser binaries required for automation.
 
 Options:
   -d, --with-deps      Also install system dependencies (Linux only)
+  -t, --timeout <sec>  Download timeout in seconds (default: 120)
 
 Examples:
   agent-browser install
   agent-browser install --with-deps
+  agent-browser install --timeout 600
 "##
         }
 
@@ -3052,6 +3054,7 @@ Dashboard:
 Setup:
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
+  install --timeout <sec>    Set browser download timeout (default: 120)
   upgrade                    Upgrade to the latest version
   doctor [--fix]             Diagnose install; auto-clean stale files
   dashboard start            Start the observability dashboard

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -9,7 +9,13 @@ npm install -g agent-browser
 agent-browser install  # Download Chrome from Chrome for Testing (first time)
 ```
 
-This is the fastest option -- commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
+This is the fastest option because commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
+
+For slow or high-latency networks, extend the Chrome download timeout:
+
+```bash
+agent-browser install --timeout 600
+```
 
 ## Quick start (no install)
 
@@ -63,6 +69,12 @@ On Linux, install system dependencies:
 
 ```bash
 agent-browser install --with-deps
+```
+
+Combine it with a longer download timeout when needed:
+
+```bash
+agent-browser install --with-deps --timeout 600
 ```
 
 ## Updating

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -34,6 +34,8 @@ next ref interaction.
 ```bash
 # Install once
 npm i -g agent-browser && agent-browser install
+# Use a longer timeout on slow networks
+agent-browser install --timeout 600
 
 # Take a screenshot of a page
 agent-browser open https://example.com
@@ -347,6 +349,9 @@ agent-browser doctor --json              # structured output for programmatic co
 `doctor` auto-cleans stale socket/pid/version sidecar files on every run.
 Destructive actions require `--fix`. Exit code is `0` if all checks pass
 (warnings OK), `1` if any fail.
+
+If Chrome for Testing downloads time out on slow networks, run
+`agent-browser install --timeout <seconds>` before retrying `doctor`.
 
 ## Troubleshooting
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -387,3 +387,11 @@ AGENT_BROWSER_PROVIDER="browserbase"         # Cloud browser provider
 AGENT_BROWSER_STREAM_PORT="9223"             # Override WebSocket streaming port (default: OS-assigned)
 AGENT_BROWSER_HOME="/path/to/agent-browser"  # Custom install location
 ```
+
+## Install
+
+```bash
+agent-browser install                 # Download Chrome for Testing
+agent-browser install --with-deps     # Also install system dependencies on Linux
+agent-browser install --timeout 600   # Extend the browser download timeout in seconds
+```


### PR DESCRIPTION
## Summary

Adds a configurable timeout for `agent-browser install` so users on slow or high-latency networks can extend Chrome for Testing download requests beyond the 120-second default.

Closes #1285.

## Changes

- Parse `agent-browser install --timeout <seconds>`, `--timeout=<seconds>`, and `-t <seconds>`
- Apply the timeout to the HTTP client used for Chrome metadata and browser downloads
- Keep the default at 120 seconds and reject missing, non-numeric, or zero timeout values
- Update CLI help, README, docs, and core skill command references

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `cargo test --manifest-path cli/Cargo.toml install`

Note: a full `cargo test --manifest-path cli/Cargo.toml` run was started, but did not complete locally because `native::parity_tests::test_all_documented_actions_are_handled` kept cycling through Chrome launch failure paths in this environment. The process was stopped after the focused install tests and CI formatting/lint checks had passed.