### PR TITLE
feat(paths): support AGENT_BROWSER_ and XDG base directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,9 @@ Alternatively, use `--session-name` to automatically save and restore cookies an
 agent-browser --session-name twitter open twitter.com
 
 # Login once, then state persists automatically
-# State files stored in ~/.agent-browser/sessions/
+# State files stored in $AGENT_BROWSER_DATA_DIR/agent-browser/sessions/
+# or $XDG_DATA_HOME/agent-browser/sessions/
+# (usually ~/.local/share/agent-browser/sessions/)
 
 # Or via environment variable
 export AGENT_BROWSER_SESSION_NAME=twitter
@@ -626,7 +628,7 @@ agent-browser --session-name secure open example.com
 
 agent-browser includes security features for safe AI agent deployments. All features are opt-in -- existing workflows are unaffected until you explicitly enable a feature:
 
-- **Authentication Vault** -- Store credentials locally (always encrypted), reference by name. The LLM never sees passwords. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). A key is auto-generated at `~/.agent-browser/.encryption-key` if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
+- **Authentication Vault** -- Store credentials locally (always encrypted), reference by name. The LLM never sees passwords. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). A key is auto-generated at `$AGENT_BROWSER_DATA_DIR/agent-browser/.encryption-key` or `$XDG_DATA_HOME/agent-browser/.encryption-key` (usually `~/.local/share/agent-browser/.encryption-key`) if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
 - **Content Boundary Markers** -- Wrap page output in delimiters so LLMs can distinguish tool output from untrusted content: `--content-boundaries`
 - **Domain Allowlist** -- Restrict navigation to trusted domains (wildcards like `*.example.com` also match the bare domain): `--allowed-domains "example.com,*.example.com"`. Sub-resource requests (scripts, images, fetch) and WebSocket/EventSource connections to non-allowed domains are also blocked. Include any CDN domains your target pages depend on (e.g., `*.cdn.example.com`).
 - **Action Policy** -- Gate destructive actions with a static policy file: `--action-policy ./policy.json`
@@ -791,7 +793,7 @@ Create an `agent-browser.json` file to set persistent defaults instead of repeat
 
 **Locations (lowest to highest priority):**
 
-1. `~/.agent-browser/config.json` -- user-level defaults
+1. `$AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json`, else `$XDG_CONFIG_HOME/agent-browser/config.json` -- user-level defaults (usually `~/.config/agent-browser/config.json`)
 2. `./agent-browser.json` -- project-level overrides (in working directory)
 3. `AGENT_BROWSER_*` environment variables override config file values
 4. CLI flags override everything

--- a/benchmarks/bench.ts
+++ b/benchmarks/bench.ts
@@ -417,7 +417,7 @@ async function getDistributionSize(
       sandbox,
       [
         `size=0`,
-        `for d in "$HOME/.cache/agent-browser" "$HOME/.cache/ms-playwright" "$HOME/.agent-browser/chrome"; do`,
+        `for d in "$HOME/.cache/agent-browser" "$HOME/.cache/ms-playwright" "$HOME/.local/share/agent-browser/browsers"; do`,
         `  if [ -d "$d" ]; then size=$(du -sb "$d" 2>/dev/null | awk '{print $1}'); break; fi`,
         `done`,
         `echo $size`,

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -9,6 +9,8 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
+use crate::paths;
+
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 
@@ -89,7 +91,7 @@ impl Connection {
 }
 
 /// Get the base directory for socket/pid files.
-/// Priority: AGENT_BROWSER_SOCKET_DIR > XDG_RUNTIME_DIR > ~/.agent-browser > tmpdir
+/// Priority: AGENT_BROWSER_SOCKET_DIR > XDG_RUNTIME_DIR > platform data dir
 pub fn get_socket_dir() -> PathBuf {
     // 1. Explicit override (ignore empty string)
     if let Ok(dir) = env::var("AGENT_BROWSER_SOCKET_DIR") {
@@ -98,20 +100,8 @@ pub fn get_socket_dir() -> PathBuf {
         }
     }
 
-    // 2. XDG_RUNTIME_DIR (Linux standard, ignore empty string)
-    if let Ok(runtime_dir) = env::var("XDG_RUNTIME_DIR") {
-        if !runtime_dir.is_empty() {
-            return PathBuf::from(runtime_dir).join("agent-browser");
-        }
-    }
-
-    // 3. Home directory fallback (like Docker Desktop's ~/.docker/run/)
-    if let Some(home) = dirs::home_dir() {
-        return home.join(".agent-browser");
-    }
-
-    // 4. Last resort: temp dir
-    env::temp_dir().join("agent-browser")
+    // 2. Runtime dir / platform fallback.
+    paths::runtime_dir()
 }
 
 #[cfg(unix)]
@@ -872,7 +862,7 @@ mod tests {
 
         assert!(get_socket_dir()
             .to_string_lossy()
-            .ends_with(".agent-browser"));
+            .ends_with("agent-browser/run"));
     }
 
     #[test]
@@ -897,7 +887,7 @@ mod tests {
 
         assert!(get_socket_dir()
             .to_string_lossy()
-            .ends_with(".agent-browser"));
+            .ends_with("agent-browser/run"));
     }
 
     #[test]
@@ -908,7 +898,7 @@ mod tests {
         _guard.remove("XDG_RUNTIME_DIR");
 
         let result = get_socket_dir();
-        assert!(result.to_string_lossy().ends_with(".agent-browser"));
+        assert!(result.to_string_lossy().ends_with("agent-browser/run"));
         assert!(
             result.to_string_lossy().contains("home") || result.to_string_lossy().contains("Users")
         );

--- a/cli/src/doctor/config.rs
+++ b/cli/src/doctor/config.rs
@@ -1,4 +1,4 @@
-//! Check user config files: `~/.agent-browser/config.json`,
+//! Check user config files: `$XDG_CONFIG_HOME/agent-browser/config.json`,
 //! `./agent-browser.json`, and any file referenced by
 //! `AGENT_BROWSER_CONFIG`.
 
@@ -7,11 +7,12 @@ use std::path::PathBuf;
 
 use super::helpers::parse_json_file;
 use super::{Check, Status};
+use crate::paths;
 
 pub(super) fn check(checks: &mut Vec<Check>) {
     let category = "Config";
 
-    let user_path = dirs::home_dir().map(|d| d.join(".agent-browser").join("config.json"));
+    let user_path = Some(paths::user_config_file());
     if let Some(p) = user_path {
         if p.exists() {
             match parse_json_file(&p) {

--- a/cli/src/doctor/environment.rs
+++ b/cli/src/doctor/environment.rs
@@ -38,10 +38,9 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     let state_dir = get_state_dir();
     let socket_dir = get_socket_dir();
 
-    // Under the default setup, state and socket dirs are the same
-    // (~/.agent-browser). Collapse to a single line when they match;
-    // split when XDG_RUNTIME_DIR or AGENT_BROWSER_SOCKET_DIR diverts
-    // sockets elsewhere.
+    // Under the default setup, runtime files can live separately from
+    // persistent data. Collapse to a single line only when an override makes
+    // them identical.
     if state_dir == socket_dir {
         push_dir_check(
             checks,

--- a/cli/src/doctor/fix.rs
+++ b/cli/src/doctor/fix.rs
@@ -209,8 +209,8 @@ mod tests {
     #[test]
     fn test_run_fixes_generates_missing_encryption_key() {
         // Reaches the Info-status arm in run_fixes that was previously
-        // unreachable due to an early-continue guard. Overrides HOME so
-        // get_state_dir() resolves under a temp dir.
+        // unreachable due to an early-continue guard. Overrides HOME so the
+        // XDG-aware path helpers resolve under a temp dir.
         let guard = crate::test_utils::EnvGuard::new(&["HOME"]);
         let tmp = TempDir::new().unwrap();
         guard.set("HOME", tmp.path().to_str().unwrap());
@@ -240,8 +240,10 @@ mod tests {
             "fixed summary should mention the key generation"
         );
         assert!(
-            tmp.path().join(".agent-browser/.encryption-key").exists(),
-            "key file should exist at ~/.agent-browser/.encryption-key"
+            tmp.path()
+                .join(".local/share/agent-browser/.encryption-key")
+                .exists(),
+            "key file should exist at ~/.local/share/agent-browser/.encryption-key"
         );
     }
 }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -1,11 +1,10 @@
 use crate::color;
+use crate::paths;
 use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const CONFIG_DIR: &str = ".agent-browser";
-const CONFIG_FILENAME: &str = "config.json";
 const PROJECT_CONFIG_FILENAME: &str = "agent-browser.json";
 
 /// Parse idle timeout from user-friendly format.
@@ -273,10 +272,7 @@ pub fn load_config(args: &[String]) -> Result<Config, String> {
             .ok_or_else(|| format!("failed to load config from {}", path_str));
     }
 
-    let user_config = dirs::home_dir()
-        .map(|d| d.join(CONFIG_DIR).join(CONFIG_FILENAME))
-        .and_then(|p| read_config_file(&p))
-        .unwrap_or_default();
+    let user_config = read_config_file(&paths::user_config_file()).unwrap_or_default();
 
     let project_config = read_config_file(&PathBuf::from(PROJECT_CONFIG_FILENAME));
 

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -1,4 +1,5 @@
 use crate::color;
+use crate::paths;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -8,10 +9,7 @@ const LAST_KNOWN_GOOD_URL: &str =
     "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
 
 pub fn get_browsers_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".agent-browser")
-        .join("browsers")
+    paths::browsers_dir()
 }
 
 pub fn find_installed_chrome() -> Option<PathBuf> {
@@ -21,8 +19,8 @@ pub fn find_installed_chrome() -> Option<PathBuf> {
     if debug {
         let _ = writeln!(
             io::stderr(),
-            "[chrome-search] home_dir={:?} browsers_dir={}",
-            dirs::home_dir(),
+            "[chrome-search] data_dir={} browsers_dir={}",
+            paths::data_dir().display(),
             browsers_dir.display()
         );
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod flags;
 mod install;
 mod native;
 mod output;
+mod paths;
 mod skills;
 #[cfg(test)]
 mod test_utils;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10,6 +10,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::sync::{broadcast, oneshot, RwLock};
 
 use crate::connection::get_socket_dir;
+use crate::paths;
 
 use super::auth;
 use super::browser::{should_track_target, BrowserManager, WaitUntil};
@@ -4239,11 +4240,7 @@ async fn handle_pdf(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
     let save_path = match path {
         Some(p) => p.to_string(),
         None => {
-            let dir = dirs::home_dir()
-                .unwrap_or_else(std::env::temp_dir)
-                .join(".agent-browser")
-                .join("tmp")
-                .join("pdfs");
+            let dir = paths::cache_tmp_dir().join("pdfs");
             let _ = std::fs::create_dir_all(&dir);
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -6800,11 +6797,7 @@ fn har_output_path(explicit_path: Option<&str>) -> String {
 }
 
 fn get_har_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("har")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("har")
-    }
+    paths::cache_tmp_dir().join("har")
 }
 
 fn unix_timestamp_millis() -> u128 {

--- a/cli/src/native/auth.rs
+++ b/cli/src/native/auth.rs
@@ -1,3 +1,4 @@
+use crate::paths;
 use aes_gcm::{aead::Aead, aead::KeyInit, Aes256Gcm};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
@@ -43,11 +44,7 @@ fn validate_profile_name(name: &str) -> Result<(), String> {
 }
 
 fn get_auth_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("auth")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("auth")
-    }
+    paths::auth_dir()
 }
 
 fn get_profile_path(name: &str) -> PathBuf {
@@ -58,11 +55,7 @@ const ENCRYPTION_KEY_ENV: &str = "AGENT_BROWSER_ENCRYPTION_KEY";
 const KEY_FILE_NAME: &str = ".encryption-key";
 
 fn get_agent_browser_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser")
-    } else {
-        std::env::temp_dir().join("agent-browser")
-    }
+    paths::state_dir()
 }
 
 fn get_key_file_path() -> PathBuf {
@@ -80,8 +73,8 @@ fn parse_key_hex(hex_str: &str) -> Option<Vec<u8>> {
     Some(bytes)
 }
 
-/// Read the encryption key from AGENT_BROWSER_ENCRYPTION_KEY env var or
-/// ~/.agent-browser/.encryption-key file (matching the Node.js implementation).
+/// Read the encryption key from AGENT_BROWSER_ENCRYPTION_KEY env var or the
+/// platform data dir `.encryption-key` file.
 fn get_encryption_key() -> Result<Vec<u8>, String> {
     if let Ok(key_hex) = std::env::var(ENCRYPTION_KEY_ENV) {
         return parse_key_hex(&key_hex).ok_or_else(|| {

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -7,6 +7,8 @@ use std::process;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::paths;
+
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::signal;
 use tokio::sync::{mpsc, Notify, RwLock};
@@ -488,17 +490,7 @@ fn get_daemon_socket_dir() -> PathBuf {
         }
     }
 
-    if let Ok(xdg) = env::var("XDG_RUNTIME_DIR") {
-        if !xdg.is_empty() {
-            return PathBuf::from(xdg).join("agent-browser");
-        }
-    }
-
-    if let Some(home) = dirs::home_dir() {
-        return home.join(".agent-browser");
-    }
-
-    std::env::temp_dir().join("agent-browser")
+    paths::runtime_dir()
 }
 
 #[cfg(windows)]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -4991,10 +4991,7 @@ async fn e2e_session_name_auto_restores_cookies() {
     }
 
     // Clean up auto-saved state files
-    let sessions_dir = dirs::home_dir()
-        .unwrap()
-        .join(".agent-browser")
-        .join("sessions");
+    let sessions_dir = crate::paths::sessions_dir();
     if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
         for entry in entries.flatten() {
             let fname = entry.file_name().to_string_lossy().to_string();

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use std::collections::HashMap;
 
+use crate::paths;
+
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 use super::element::RefMap;
@@ -588,13 +590,7 @@ fn round(value: f64) -> i64 {
 }
 
 fn get_screenshot_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("screenshots")
-    } else {
-        std::env::temp_dir()
-            .join("agent-browser")
-            .join("screenshots")
-    }
+    paths::cache_tmp_dir().join("screenshots")
 }
 
 #[cfg(test)]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -1,4 +1,5 @@
 use aes_gcm::{aead::Aead, aead::KeyInit, Aes256Gcm};
+use crate::paths;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -714,19 +715,14 @@ pub fn dispatch_state_command(cmd: &Value) -> Option<Result<Value, String>> {
     }
 }
 
-/// Return the agent-browser state root (`~/.agent-browser`, falling back to
-/// `<tempdir>/agent-browser` when the home directory can't be resolved).
+/// Return the agent-browser state root under the platform data directory.
 /// This is the parent of `sessions/`, auth storage, and the encryption key.
 pub fn get_state_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser")
-    } else {
-        std::env::temp_dir().join("agent-browser")
-    }
+    paths::state_dir()
 }
 
 pub fn get_sessions_dir() -> PathBuf {
-    get_state_dir().join("sessions")
+    paths::sessions_dir()
 }
 
 #[cfg(test)]

--- a/cli/src/native/tracing.rs
+++ b/cli/src/native/tracing.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
 use std::path::PathBuf;
 
+use crate::paths;
+
 use super::cdp::client::CdpClient;
 
 const MAX_PROFILE_EVENTS: usize = 5_000_000;
@@ -357,17 +359,9 @@ fn get_clock_domain() -> Option<&'static str> {
 }
 
 fn get_traces_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("traces")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("traces")
-    }
+    paths::cache_tmp_dir().join("traces")
 }
 
 fn get_profiles_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("profiles")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("profiles")
-    }
+    paths::cache_tmp_dir().join("profiles")
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3120,7 +3120,9 @@ Options:
 
 Configuration:
   agent-browser looks for agent-browser.json in these locations (lowest to highest priority):
-    1. ~/.agent-browser/config.json      User-level defaults
+    1. $AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json,
+       else $XDG_CONFIG_HOME/agent-browser/config.json
+                                      User-level defaults
     2. ./agent-browser.json              Project-level overrides
     3. Environment variables             Override config file values
     4. CLI flags                         Override everything
@@ -3138,6 +3140,14 @@ Configuration:
     {{"headed": true, "proxy": "http://localhost:8080", "profile": "./browser-data"}}
 
 Environment:
+  AGENT_BROWSER_CONFIG_DIR       Base dir for default user config files
+  AGENT_BROWSER_DATA_DIR         Base dir for browsers, sessions, auth, and keys
+  AGENT_BROWSER_CACHE_DIR        Base dir for screenshots, traces, HAR, and PDFs
+  AGENT_BROWSER_RUNTIME_DIR      Base dir for daemon runtime files
+  XDG_CONFIG_HOME                Base dir for user config files
+  XDG_DATA_HOME                  Base dir for browsers, sessions, auth, and keys
+  XDG_CACHE_HOME                 Base dir for screenshots, traces, HAR, and PDFs
+  XDG_RUNTIME_DIR                Base dir for daemon sockets and pid files
   AGENT_BROWSER_CONFIG           Path to config file (or use --config)
   AGENT_BROWSER_SESSION          Session name (default: "default")
   AGENT_BROWSER_SESSION_NAME     Auto-save/restore state persistence name

--- a/cli/src/paths.rs
+++ b/cli/src/paths.rs
@@ -1,0 +1,86 @@
+use std::env;
+use std::path::PathBuf;
+
+const APP_DIR: &str = "agent-browser";
+
+fn env_dir(name: &str) -> Option<PathBuf> {
+    match env::var(name) {
+        Ok(value) if !value.is_empty() => Some(PathBuf::from(value)),
+        _ => None,
+    }
+}
+
+fn home_fallback(suffix: &[&str]) -> Option<PathBuf> {
+    let mut path = dirs::home_dir()?;
+    for part in suffix {
+        path = path.join(part);
+    }
+    Some(path)
+}
+
+/// Config files belong under the platform config directory.
+pub fn config_dir() -> PathBuf {
+    env_dir("AGENT_BROWSER_CONFIG_DIR")
+        .or_else(dirs::config_dir)
+        .or_else(|| home_fallback(&[".config"]))
+        .unwrap_or_else(env::temp_dir)
+        .join(APP_DIR)
+}
+
+/// Persistent application data belongs under the platform data directory.
+pub fn data_dir() -> PathBuf {
+    env_dir("AGENT_BROWSER_DATA_DIR")
+        .or_else(dirs::data_local_dir)
+        .or_else(|| home_fallback(&[".local", "share"]))
+        .unwrap_or_else(env::temp_dir)
+        .join(APP_DIR)
+}
+
+/// Re-creatable artifacts belong under the platform cache directory.
+pub fn cache_dir() -> PathBuf {
+    env_dir("AGENT_BROWSER_CACHE_DIR")
+        .or_else(dirs::cache_dir)
+        .or_else(|| home_fallback(&[".cache"]))
+        .unwrap_or_else(env::temp_dir)
+        .join(APP_DIR)
+}
+
+/// Runtime files prefer AGENT_BROWSER_RUNTIME_DIR, then XDG_RUNTIME_DIR, and
+/// otherwise fall back to app data.
+pub fn runtime_dir() -> PathBuf {
+    if let Some(dir) = env_dir("AGENT_BROWSER_RUNTIME_DIR") {
+        return dir.join(APP_DIR);
+    }
+
+    if let Ok(dir) = env::var("XDG_RUNTIME_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir).join(APP_DIR);
+        }
+    }
+
+    data_dir().join("run")
+}
+
+pub fn user_config_file() -> PathBuf {
+    config_dir().join("config.json")
+}
+
+pub fn browsers_dir() -> PathBuf {
+    data_dir().join("browsers")
+}
+
+pub fn state_dir() -> PathBuf {
+    data_dir()
+}
+
+pub fn sessions_dir() -> PathBuf {
+    state_dir().join("sessions")
+}
+
+pub fn auth_dir() -> PathBuf {
+    data_dir().join("auth")
+}
+
+pub fn cache_tmp_dir() -> PathBuf {
+    cache_dir().join("tmp")
+}

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -11,7 +11,7 @@ agent-browser checks two locations, merged in priority order:
     <tr><th>Priority</th><th>Location</th><th>Scope</th></tr>
   </thead>
   <tbody>
-    <tr><td>1 (lowest)</td><td><code>~/.agent-browser/config.json</code></td><td>User-level defaults</td></tr>
+    <tr><td>1 (lowest)</td><td><code>$AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json</code>, else <code>$XDG_CONFIG_HOME/agent-browser/config.json</code> (usually <code>~/.config/agent-browser/config.json</code>)</td><td>User-level defaults</td></tr>
     <tr><td>2</td><td><code>./agent-browser.json</code></td><td>Project-level overrides</td></tr>
     <tr><td>3</td><td><code>AGENT_BROWSER_*</code> env vars</td><td>Override config values</td></tr>
     <tr><td>4 (highest)</td><td>CLI flags</td><td>Override everything</td></tr>
@@ -160,7 +160,7 @@ This applies to all boolean flags: `--headed`, `--debug`, `--json`, `--ignore-ht
 
 ## Extensions Merging
 
-Extensions from user-level and project-level configs are **concatenated**, not replaced. For example, if `~/.agent-browser/config.json` specifies `["/ext1"]` and `./agent-browser.json` specifies `["/ext2"]`, the result is `["/ext1", "/ext2"]`.
+Extensions from user-level and project-level configs are **concatenated**, not replaced. For example, if `$AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json` or `$XDG_CONFIG_HOME/agent-browser/config.json` specifies `["/ext1"]` and `./agent-browser.json` specifies `["/ext2"]`, the result is `["/ext1", "/ext2"]`.
 
 The `AGENT_BROWSER_EXTENSIONS` environment variable and CLI `--extension` flags follow the standard priority rules (env replaces config, CLI appends).
 
@@ -173,6 +173,14 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><th>Variable</th><th>Description</th><th>Default</th></tr>
   </thead>
   <tbody>
+    <tr><td><code>AGENT_BROWSER_CONFIG_DIR</code></td><td>Override the base directory for the default user config file.</td><td>(unset)</td></tr>
+    <tr><td><code>AGENT_BROWSER_DATA_DIR</code></td><td>Override the base directory for installed browsers, saved sessions, auth profiles, and the generated encryption key.</td><td>(unset)</td></tr>
+    <tr><td><code>AGENT_BROWSER_CACHE_DIR</code></td><td>Override the base directory for screenshots, traces, HAR files, PDFs, and other re-creatable artifacts.</td><td>(unset)</td></tr>
+    <tr><td><code>AGENT_BROWSER_RUNTIME_DIR</code></td><td>Override the base directory for daemon runtime files before <code>XDG_RUNTIME_DIR</code> is considered.</td><td>(unset)</td></tr>
+    <tr><td><code>XDG_CONFIG_HOME</code></td><td>Base directory for the default user config file.</td><td><code>~/.config</code> on Linux</td></tr>
+    <tr><td><code>XDG_DATA_HOME</code></td><td>Base directory for installed browsers, saved sessions, auth profiles, and the generated encryption key.</td><td><code>~/.local/share</code> on Linux</td></tr>
+    <tr><td><code>XDG_CACHE_HOME</code></td><td>Base directory for screenshots, traces, HAR files, PDFs, and other re-creatable artifacts.</td><td><code>~/.cache</code> on Linux</td></tr>
+    <tr><td><code>XDG_RUNTIME_DIR</code></td><td>Base directory for daemon sockets and pid files.</td><td>OS/runtime provided</td></tr>
     <tr><td><code>AGENT_BROWSER_AUTO_CONNECT</code></td><td>Auto-discover and connect to a running Chrome instance.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_ALLOW_FILE_ACCESS</code></td><td>Allow <code>file://</code> URLs to access local files.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_COLOR_SCHEME</code></td><td>Color scheme preference (<code>dark</code>, <code>light</code>, <code>no-preference</code>).</td><td>(none)</td></tr>
@@ -204,7 +212,7 @@ These environment variables configure additional daemon and runtime behavior:
 
 ## Error Handling
 
-- **Auto-discovered config files** (`~/.agent-browser/config.json`, `./agent-browser.json`) that are missing are silently ignored.
+- **Auto-discovered config files** (`$AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json`, else `$XDG_CONFIG_HOME/agent-browser/config.json`, and `./agent-browser.json`) that are missing are silently ignored.
 - **`--config <path>`** with a missing or malformed file exits with an error.
 - **Malformed JSON** in auto-discovered files prints a warning to stderr and continues without that file.
 - **Unknown keys** are silently ignored for forward compatibility.

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -96,8 +96,8 @@ It checks:
 <tr><td>Environment</td><td>CLI version, platform, home directory, state and socket dirs, free disk space</td></tr>
 <tr><td>Chrome</td><td>Chrome install path and version, cache dir, Puppeteer fallback, user-data dir and profile count, optional <code>lightpanda</code> engine</td></tr>
 <tr><td>Daemons</td><td>Running daemons per session, stale <code>.sock</code> / <code>.pid</code> / <code>.version</code> / <code>.stream</code> files (auto-cleaned), version mismatch with the CLI, dashboard process liveness</td></tr>
-<tr><td>Config</td><td><code>~/.agent-browser/config.json</code>, <code>./agent-browser.json</code>, and any file at <code>AGENT_BROWSER_CONFIG</code> parse as valid JSON</td></tr>
-<tr><td>Security</td><td>Encryption key env var or <code>~/.agent-browser/.encryption-key</code> (with 0600 permissions on unix), state file count and age vs <code>AGENT_BROWSER_STATE_EXPIRE_DAYS</code>, action policy file</td></tr>
+<tr><td>Config</td><td><code>$AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json</code>, else <code>$XDG_CONFIG_HOME/agent-browser/config.json</code>, <code>./agent-browser.json</code>, and any file at <code>AGENT_BROWSER_CONFIG</code> parse as valid JSON</td></tr>
+<tr><td>Security</td><td>Encryption key env var or <code>$AGENT_BROWSER_DATA_DIR/agent-browser/.encryption-key</code> (else <code>$XDG_DATA_HOME/agent-browser/.encryption-key</code>) with 0600 permissions on unix, state file count and age vs <code>AGENT_BROWSER_STATE_EXPIRE_DAYS</code>, action policy file</td></tr>
 <tr><td>Providers</td><td>Env vars for Browserless, Browserbase, Browser Use, Kernel, AgentCore (AWS creds), Appium (for <code>--provider ios</code>), and <code>AI_GATEWAY_API_KEY</code> for chat</td></tr>
 <tr><td>Network</td><td>Reachability of the Chrome for Testing CDN, AI Gateway (if configured), and any currently selected provider endpoint (skipped under <code>--offline</code>)</td></tr>
 <tr><td>Launch test</td><td>Spawns a scratch session, launches headless Chrome, navigates to <code>about:blank</code>, then closes. Measures wall time (skipped under <code>--quick</code>)</td></tr>
@@ -114,7 +114,7 @@ Stale sidecar files are always cleaned. Destructive actions are opt-in via `--fi
 <tr><td>Chrome missing</td><td>Runs <code>agent-browser install</code></td></tr>
 <tr><td>Version-mismatched daemons</td><td>Sends <code>close</code> to each and cleans files</td></tr>
 <tr><td>Old state files</td><td>Deletes state files older than <code>AGENT_BROWSER_STATE_EXPIRE_DAYS</code> (default 30)</td></tr>
-<tr><td>Missing encryption key</td><td>Generates a new key at <code>~/.agent-browser/.encryption-key</code> (0600, unix); never overwrites an existing key</td></tr>
+<tr><td>Missing encryption key</td><td>Generates a new key at <code>$AGENT_BROWSER_DATA_DIR/agent-browser/.encryption-key</code> or <code>$XDG_DATA_HOME/agent-browser/.encryption-key</code> (0600, unix); never overwrites an existing key</td></tr>
 </tbody>
 </table>
 

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -60,7 +60,7 @@ agent-browser auth save myapp \
   --submit-selector "button.login"
 ```
 
-Profiles are stored in `~/.agent-browser/auth/` and always encrypted with AES-256-GCM. If `AGENT_BROWSER_ENCRYPTION_KEY` is not set, a key is auto-generated at `~/.agent-browser/.encryption-key` on first use. Back up this file or set the environment variable explicitly for portability.
+Profiles are stored in `$AGENT_BROWSER_DATA_DIR/agent-browser/auth/` or `$XDG_DATA_HOME/agent-browser/auth/` and always encrypted with AES-256-GCM. On most Linux systems that resolves to `~/.local/share/agent-browser/auth/`. If `AGENT_BROWSER_ENCRYPTION_KEY` is not set, a key is auto-generated at `$AGENT_BROWSER_DATA_DIR/agent-browser/.encryption-key` or `$XDG_DATA_HOME/agent-browser/.encryption-key` on first use. Back up this file or set the environment variable explicitly for portability.
 
 File permissions are enforced on both Unix (`chmod 600`/`700`) and Windows (`icacls` restricted to the current user) to prevent other users from reading encryption keys or auth profiles.
 

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -144,7 +144,7 @@ export AGENT_BROWSER_SESSION_NAME=twitter
 agent-browser open twitter.com
 ```
 
-State files are stored in `~/.agent-browser/sessions/` and automatically loaded on daemon start.
+State files are stored in `$AGENT_BROWSER_DATA_DIR/agent-browser/sessions/` or `$XDG_DATA_HOME/agent-browser/sessions/` and automatically loaded on daemon start. On most Linux systems that resolves to `~/.local/share/agent-browser/sessions/`.
 
 ### Session name rules
 

--- a/docs/src/components/diff-demo.tsx
+++ b/docs/src/components/diff-demo.tsx
@@ -263,7 +263,7 @@ export function DiffDemo() {
               &#x2717; 2.37% pixels differ
             </div>
             <div className="opacity-50">
-              Diff image: ~/.agent-browser/tmp/diffs/diff-1708473621.png
+              Diff image: ~/.cache/agent-browser/tmp/diffs/diff-1708473621.png
             </div>
             <div className="opacity-50">
               <span className="text-red-400">1,137</span> different /{" "}

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -54,6 +54,11 @@ agent-browser screenshot result.png
 The browser stays running across commands so these feel like a single
 session. Use `agent-browser close` (or `close --all`) when you're done.
 
+User config lives at `$AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json`
+or `$XDG_CONFIG_HOME/agent-browser/config.json`, and persistent browser/session
+data lives under `$AGENT_BROWSER_DATA_DIR/agent-browser` or
+`$XDG_DATA_HOME/agent-browser`.
+
 ## Reading a page
 
 ```bash

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -104,7 +104,8 @@ Use `--session-name` to auto-save and restore cookies + localStorage by name, wi
 # Auto-saves state on close, auto-restores on next launch
 agent-browser --session-name twitter open https://twitter.com
 # ... login flow ...
-agent-browser close  # state saved to ~/.agent-browser/sessions/
+agent-browser close  # state saved to $AGENT_BROWSER_DATA_DIR/agent-browser/sessions/
+                     # or $XDG_DATA_HOME/agent-browser/sessions/
 
 # Next time: state is automatically restored
 agent-browser --session-name twitter open https://twitter.com


### PR DESCRIPTION
## Summary
- add a shared path resolver so config, persistent data, cache artifacts, and runtime files stop defaulting to `~/.agent-browser`
- prefer `AGENT_BROWSER_*_DIR` overrides first, then fall back to the matching `XDG_*` directories for config, data, cache, and runtime locations
- update help text, README, skill docs, and docs pages so the new directory layout and precedence are documented consistently

---

Because... stop fricking polluting my HOME dir.

---

edit 3 after: closes #1361