### PR TITLE
feat(agentcore): add proxy configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1510,6 +1510,7 @@ Optional configuration via environment variables:
 | `AGENTCORE_BROWSER_ID`     | Browser identifier                                                   | `aws.browser.v1` |
 | `AGENTCORE_PROFILE_ID`     | Browser profile for persistent state (cookies, localStorage)         | (none)           |
 | `AGENTCORE_PROXY_CONFIG`   | JSON proxy configuration for the browser session                     | (none)           |
+| `AGENTCORE_ENTERPRISE_POLICIES` | JSON array of enterprise policy configurations                  | (none)           |
 | `AGENTCORE_SESSION_TIMEOUT`| Session timeout in seconds                                           | `3600`           |
 | `AWS_PROFILE`              | AWS CLI profile for credential resolution                            | `default`        |
 
@@ -1535,6 +1536,23 @@ export AGENTCORE_PROXY_CONFIG='{
     }
   }]
 }'
+agent-browser -p agentcore open https://example.com
+```
+
+**Enterprise policies:** Use `AGENTCORE_ENTERPRISE_POLICIES` to apply enterprise browser policies from S3:
+
+```bash
+export AGENTCORE_ENTERPRISE_POLICIES='[
+  {
+    "type": "RECOMMENDED",
+    "location": {
+      "s3": {
+        "bucket": "my-policy-bucket",
+        "prefix": "policies/recommended-policies.json"
+      }
+    }
+  }
+]'
 agent-browser -p agentcore open https://example.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -1511,6 +1511,7 @@ Optional configuration via environment variables:
 | `AGENTCORE_PROFILE_ID`     | Browser profile for persistent state (cookies, localStorage)         | (none)           |
 | `AGENTCORE_PROXY_CONFIG`   | JSON proxy configuration for the browser session                     | (none)           |
 | `AGENTCORE_ENTERPRISE_POLICIES` | JSON array of enterprise policy configurations                  | (none)           |
+| `AGENTCORE_EXTENSION_CONFIG` | JSON browser extension configuration from S3                       | (none)           |
 | `AGENTCORE_SESSION_TIMEOUT`| Session timeout in seconds                                           | `3600`           |
 | `AWS_PROFILE`              | AWS CLI profile for credential resolution                            | `default`        |
 
@@ -1555,6 +1556,24 @@ export AGENTCORE_ENTERPRISE_POLICIES='[
 ]'
 agent-browser -p agentcore open https://example.com
 ```
+
+**Browser extensions:** Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3:
+
+```bash
+export AGENTCORE_EXTENSION_CONFIG='{
+  "extensions": [
+    {
+      "s3": {
+        "bucket": "my-extension-bucket",
+        "key": "extensions/my-extension.crx"
+      }
+    }
+  ]
+}'
+agent-browser -p agentcore open https://example.com
+```
+
+Note: The `--extension` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_EXTENSION_CONFIG` to load extensions from S3.
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
 

--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--enable <feature>` | Built-in init scripts: `react-devtools` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
 | `--args <args>` | Browser launch args, comma or newline separated (or `AGENT_BROWSER_ARGS` env) |
 | `--user-agent <ua>` | Custom User-Agent string (or `AGENT_BROWSER_USER_AGENT` env) |
-| `--proxy <url>` | Proxy server URL with optional auth (or `AGENT_BROWSER_PROXY` env) |
+| `--proxy <url>` | Proxy server URL with optional auth (local Chrome/Lightpanda only; or `AGENT_BROWSER_PROXY` env) |
 | `--proxy-bypass <hosts>` | Hosts to bypass proxy (or `AGENT_BROWSER_PROXY_BYPASS` env) |
 | `--ignore-https-errors` | Ignore HTTPS certificate errors (useful for self-signed certs) |
 | `--allow-file-access` | Allow file:// URLs to access local files (Chromium only) |
@@ -1509,10 +1509,34 @@ Optional configuration via environment variables:
 | `AGENTCORE_REGION`         | AWS region for the AgentCore endpoint                                | `us-east-1`      |
 | `AGENTCORE_BROWSER_ID`     | Browser identifier                                                   | `aws.browser.v1` |
 | `AGENTCORE_PROFILE_ID`     | Browser profile for persistent state (cookies, localStorage)         | (none)           |
+| `AGENTCORE_PROXY_CONFIG`   | JSON proxy configuration for the browser session                     | (none)           |
 | `AGENTCORE_SESSION_TIMEOUT`| Session timeout in seconds                                           | `3600`           |
 | `AWS_PROFILE`              | AWS CLI profile for credential resolution                            | `default`        |
 
 **Browser profiles:** When `AGENTCORE_PROFILE_ID` is set, browser state (cookies, localStorage) is persisted across sessions automatically.
+
+**Proxy configuration:** Use `AGENTCORE_PROXY_CONFIG` to configure proxy settings with authentication for the remote browser session. The value must be valid JSON matching the AgentCore proxy configuration schema.
+
+Note: The `--proxy` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_PROXY_CONFIG` to configure the cloud browser's proxy.
+
+Example:
+
+```bash
+export AGENTCORE_PROXY_CONFIG='{
+  "proxies": [{
+    "externalProxy": {
+      "server": "your-proxy.com",
+      "port": 8080,
+      "credentials": {
+        "basicAuth": {
+          "secretArn": "arn:aws:secretsmanager:region:account:secret:name"
+        }
+      }
+    }
+  }]
+}'
+agent-browser -p agentcore open https://example.com
+```
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
 

--- a/README.md
+++ b/README.md
@@ -1560,16 +1560,16 @@ agent-browser -p agentcore open https://example.com
 **Browser extensions:** Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3:
 
 ```bash
-export AGENTCORE_EXTENSION_CONFIG='{
-  "extensions": [
-    {
+export AGENTCORE_EXTENSION_CONFIG='[
+  {
+    "location": {
       "s3": {
         "bucket": "my-extension-bucket",
-        "key": "extensions/my-extension.zip"
+        "prefix": "extensions/my-extension.zip"
       }
     }
-  ]
-}'
+  }
+]'
 agent-browser -p agentcore open https://example.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,7 @@ export AGENTCORE_EXTENSION_CONFIG='{
     {
       "s3": {
         "bucket": "my-extension-bucket",
-        "key": "extensions/my-extension.crx"
+        "key": "extensions/my-extension.zip"
       }
     }
   ]
@@ -1573,7 +1573,7 @@ export AGENTCORE_EXTENSION_CONFIG='{
 agent-browser -p agentcore open https://example.com
 ```
 
-Note: The `--extension` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_EXTENSION_CONFIG` to load extensions from S3.
+Note: The `--extension` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_EXTENSION_CONFIG` to load extensions packaged as `.zip` files in S3.
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
 

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -469,6 +469,21 @@ mod agentcore {
                 }
             }
         }
+        if let Ok(extension_config) = env::var("AGENTCORE_EXTENSION_CONFIG") {
+            if !extension_config.is_empty() {
+                match serde_json::from_str::<serde_json::Value>(&extension_config) {
+                    Ok(extension_json) => {
+                        body_json.as_object_mut().unwrap().insert(
+                            "extensionConfiguration".to_string(),
+                            extension_json,
+                        );
+                    }
+                    Err(e) => {
+                        return Err(format!("Invalid AGENTCORE_EXTENSION_CONFIG JSON: {}", e));
+                    }
+                }
+            }
+        }
         let body = serde_json::to_string(&body_json)
             .map_err(|e| format!("Failed to serialize request body: {}", e))?;
 
@@ -885,6 +900,32 @@ mod tests {
         let parsed = result.unwrap();
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 1);
+
+        // Test invalid JSON
+        let invalid_json = "not valid json";
+        let result = serde_json::from_str::<serde_json::Value>(invalid_json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_agentcore_extension_config_parsing() {
+        // Test valid JSON
+        let valid_json = r#"{
+            "extensions": [
+                {
+                    "s3": {
+                        "bucket": "my-extension-bucket",
+                        "key": "extensions/my-extension.crx"
+                    }
+                }
+            ]
+        }"#;
+        let result = serde_json::from_str::<serde_json::Value>(valid_json);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert!(parsed.get("extensions").is_some());
+        let extensions = parsed.get("extensions").unwrap().as_array().unwrap();
+        assert_eq!(extensions.len(), 1);
 
         // Test invalid JSON
         let invalid_json = "not valid json";

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -454,6 +454,21 @@ mod agentcore {
                 }
             }
         }
+        if let Ok(enterprise_policies) = env::var("AGENTCORE_ENTERPRISE_POLICIES") {
+            if !enterprise_policies.is_empty() {
+                match serde_json::from_str::<serde_json::Value>(&enterprise_policies) {
+                    Ok(policies_json) => {
+                        body_json.as_object_mut().unwrap().insert(
+                            "enterprisePolicies".to_string(),
+                            policies_json,
+                        );
+                    }
+                    Err(e) => {
+                        return Err(format!("Invalid AGENTCORE_ENTERPRISE_POLICIES JSON: {}", e));
+                    }
+                }
+            }
+        }
         let body = serde_json::to_string(&body_json)
             .map_err(|e| format!("Failed to serialize request body: {}", e))?;
 
@@ -844,6 +859,32 @@ mod tests {
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert!(parsed.get("proxies").is_some());
+
+        // Test invalid JSON
+        let invalid_json = "not valid json";
+        let result = serde_json::from_str::<serde_json::Value>(invalid_json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_agentcore_enterprise_policies_parsing() {
+        // Test valid JSON
+        let valid_json = r#"[
+            {
+                "type": "RECOMMENDED",
+                "location": {
+                    "s3": {
+                        "bucket": "my-policy-bucket",
+                        "prefix": "policies/recommended-policies.json"
+                    }
+                }
+            }
+        ]"#;
+        let result = serde_json::from_str::<serde_json::Value>(valid_json);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
 
         // Test invalid JSON
         let invalid_json = "not valid json";

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -439,6 +439,21 @@ mod agentcore {
                 );
             }
         }
+        if let Ok(proxy_config) = env::var("AGENTCORE_PROXY_CONFIG") {
+            if !proxy_config.is_empty() {
+                match serde_json::from_str::<serde_json::Value>(&proxy_config) {
+                    Ok(proxy_json) => {
+                        body_json.as_object_mut().unwrap().insert(
+                            "proxyConfiguration".to_string(),
+                            proxy_json,
+                        );
+                    }
+                    Err(e) => {
+                        return Err(format!("Invalid AGENTCORE_PROXY_CONFIG JSON: {}", e));
+                    }
+                }
+            }
+        }
         let body = serde_json::to_string(&body_json)
             .map_err(|e| format!("Failed to serialize request body: {}", e))?;
 
@@ -812,5 +827,27 @@ mod tests {
         // Should be None after take
         let taken_again = take_agentcore_ws_headers();
         assert!(taken_again.is_none());
+    }
+
+    #[test]
+    fn test_agentcore_proxy_config_parsing() {
+        // Test valid JSON
+        let valid_json = r#"{
+            "proxies": [{
+                "externalProxy": {
+                    "server": "proxy.example.com",
+                    "port": 8080
+                }
+            }]
+        }"#;
+        let result = serde_json::from_str::<serde_json::Value>(valid_json);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert!(parsed.get("proxies").is_some());
+
+        // Test invalid JSON
+        let invalid_json = "not valid json";
+        let result = serde_json::from_str::<serde_json::Value>(invalid_json);
+        assert!(result.is_err());
     }
 }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -915,7 +915,7 @@ mod tests {
                 {
                     "s3": {
                         "bucket": "my-extension-bucket",
-                        "key": "extensions/my-extension.crx"
+                        "key": "extensions/my-extension.zip"
                     }
                 }
             ]

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -474,7 +474,7 @@ mod agentcore {
                 match serde_json::from_str::<serde_json::Value>(&extension_config) {
                     Ok(extension_json) => {
                         body_json.as_object_mut().unwrap().insert(
-                            "extensionConfiguration".to_string(),
+                            "extensions".to_string(),
                             extension_json,
                         );
                     }
@@ -909,22 +909,22 @@ mod tests {
 
     #[test]
     fn test_agentcore_extension_config_parsing() {
-        // Test valid JSON
-        let valid_json = r#"{
-            "extensions": [
-                {
+        // Test valid JSON - array of extension locations
+        let valid_json = r#"[
+            {
+                "location": {
                     "s3": {
                         "bucket": "my-extension-bucket",
-                        "key": "extensions/my-extension.zip"
+                        "prefix": "extensions/my-extension.zip"
                     }
                 }
-            ]
-        }"#;
+            }
+        ]"#;
         let result = serde_json::from_str::<serde_json::Value>(valid_json);
         assert!(result.is_ok());
         let parsed = result.unwrap();
-        assert!(parsed.get("extensions").is_some());
-        let extensions = parsed.get("extensions").unwrap().as_array().unwrap();
+        assert!(parsed.is_array());
+        let extensions = parsed.as_array().unwrap();
         assert_eq!(extensions.len(), 1);
 
         // Test invalid JSON

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3086,8 +3086,9 @@ Options:
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
                              e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
   --user-agent <ua>          Custom User-Agent (or AGENT_BROWSER_USER_AGENT)
-  --proxy <server>           Proxy server URL (or AGENT_BROWSER_PROXY, HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
+  --proxy <server>           Proxy server URL for local Chrome/Lightpanda (or AGENT_BROWSER_PROXY, HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
                              Supports authenticated proxies: --proxy "http://user:pass@127.0.0.1:7890"
+                             Note: For AgentCore provider, use AGENTCORE_PROXY_CONFIG instead
   --proxy-bypass <hosts>     Bypass proxy for these hosts (or AGENT_BROWSER_PROXY_BYPASS, NO_PROXY)
                              e.g., --proxy-bypass "localhost,*.internal.com"
   --ignore-https-errors      Ignore HTTPS certificate errors

--- a/docs/src/app/providers/agentcore/page.mdx
+++ b/docs/src/app/providers/agentcore/page.mdx
@@ -32,6 +32,7 @@ The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
     <tr><td><code>AGENTCORE_REGION</code></td><td>AWS region for the AgentCore endpoint</td><td><code>us-east-1</code></td></tr>
     <tr><td><code>AGENTCORE_BROWSER_ID</code></td><td>Browser identifier</td><td><code>aws.browser.v1</code></td></tr>
     <tr><td><code>AGENTCORE_PROFILE_ID</code></td><td>Browser profile for persistent state (cookies, localStorage)</td><td>(none)</td></tr>
+    <tr><td><code>AGENTCORE_PROXY_CONFIG</code></td><td>JSON proxy configuration for the browser session</td><td>(none)</td></tr>
     <tr><td><code>AGENTCORE_SESSION_TIMEOUT</code></td><td>Session timeout in seconds</td><td><code>3600</code></td></tr>
     <tr><td><code>AWS_PROFILE</code></td><td>AWS CLI profile for credential resolution</td><td><code>default</code></td></tr>
     <tr><td><code>AWS_ACCESS_KEY_ID</code></td><td>AWS access key (checked before AWS CLI fallback)</td><td>(none)</td></tr>
@@ -49,6 +50,41 @@ AGENTCORE_PROFILE_ID=my-profile agent-browser -p agentcore open https://example.
 ```
 
 When a profile is set, AgentCore stores and restores browser state automatically between sessions.
+
+## Proxy Configuration
+
+Use `AGENTCORE_PROXY_CONFIG` to configure proxy settings with authentication for the cloud browser session. The value must be valid JSON matching the AgentCore proxy configuration schema.
+
+<table>
+  <thead>
+    <tr><th>Scope</th><th>Configuration</th><th>Use Case</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Local browser</td><td><code>--proxy</code> flag</td><td>Proxy for Chrome/Lightpanda when launching locally</td></tr>
+    <tr><td>AgentCore browser</td><td><code>AGENTCORE_PROXY_CONFIG</code></td><td>Proxy for the remote AgentCore browser session</td></tr>
+  </tbody>
+</table>
+
+The `--proxy` flag does not apply to AgentCore. Use `AGENTCORE_PROXY_CONFIG` to configure the remote browser's proxy.
+
+```bash
+export AGENTCORE_PROXY_CONFIG='{
+  "proxies": [{
+    "externalProxy": {
+      "server": "your-proxy.com",
+      "port": 8080,
+      "credentials": {
+        "basicAuth": {
+          "secretArn": "arn:aws:secretsmanager:region:account:secret:name"
+        }
+      }
+    }
+  }]
+}'
+agent-browser -p agentcore open https://example.com
+```
+
+The proxy configuration is passed directly to the AgentCore session API. Credentials can reference AWS Secrets Manager ARNs for secure authentication.
 
 ## Live View
 

--- a/docs/src/app/providers/agentcore/page.mdx
+++ b/docs/src/app/providers/agentcore/page.mdx
@@ -34,6 +34,7 @@ The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
     <tr><td><code>AGENTCORE_PROFILE_ID</code></td><td>Browser profile for persistent state (cookies, localStorage)</td><td>(none)</td></tr>
     <tr><td><code>AGENTCORE_PROXY_CONFIG</code></td><td>JSON proxy configuration for the browser session</td><td>(none)</td></tr>
     <tr><td><code>AGENTCORE_ENTERPRISE_POLICIES</code></td><td>JSON array of enterprise policy configurations</td><td>(none)</td></tr>
+    <tr><td><code>AGENTCORE_EXTENSION_CONFIG</code></td><td>JSON browser extension configuration from S3</td><td>(none)</td></tr>
     <tr><td><code>AGENTCORE_SESSION_TIMEOUT</code></td><td>Session timeout in seconds</td><td><code>3600</code></td></tr>
     <tr><td><code>AWS_PROFILE</code></td><td>AWS CLI profile for credential resolution</td><td><code>default</code></td></tr>
     <tr><td><code>AWS_ACCESS_KEY_ID</code></td><td>AWS access key (checked before AWS CLI fallback)</td><td>(none)</td></tr>
@@ -107,6 +108,36 @@ agent-browser -p agentcore open https://example.com
 ```
 
 Policies are applied at session creation time and control browser behavior, security settings, and feature availability. The browser session must have IAM permissions to read from the specified S3 bucket.
+
+## Browser Extensions
+
+Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3. The value must be valid JSON:
+
+```bash
+export AGENTCORE_EXTENSION_CONFIG='{
+  "extensions": [
+    {
+      "s3": {
+        "bucket": "my-extension-bucket",
+        "key": "extensions/my-extension.crx"
+      }
+    }
+  ]
+}'
+agent-browser -p agentcore open https://example.com
+```
+
+<table>
+  <thead>
+    <tr><th>Scope</th><th>Configuration</th><th>Use Case</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Local browser</td><td><code>--extension</code> flag</td><td>Load extensions from local filesystem</td></tr>
+    <tr><td>AgentCore browser</td><td><code>AGENTCORE_EXTENSION_CONFIG</code></td><td>Load extensions from S3</td></tr>
+  </tbody>
+</table>
+
+Extensions must be packaged as `.crx` files and uploaded to S3. The browser session must have IAM permissions to read from the specified S3 bucket.
 
 ## Live View
 

--- a/docs/src/app/providers/agentcore/page.mdx
+++ b/docs/src/app/providers/agentcore/page.mdx
@@ -33,6 +33,7 @@ The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
     <tr><td><code>AGENTCORE_BROWSER_ID</code></td><td>Browser identifier</td><td><code>aws.browser.v1</code></td></tr>
     <tr><td><code>AGENTCORE_PROFILE_ID</code></td><td>Browser profile for persistent state (cookies, localStorage)</td><td>(none)</td></tr>
     <tr><td><code>AGENTCORE_PROXY_CONFIG</code></td><td>JSON proxy configuration for the browser session</td><td>(none)</td></tr>
+    <tr><td><code>AGENTCORE_ENTERPRISE_POLICIES</code></td><td>JSON array of enterprise policy configurations</td><td>(none)</td></tr>
     <tr><td><code>AGENTCORE_SESSION_TIMEOUT</code></td><td>Session timeout in seconds</td><td><code>3600</code></td></tr>
     <tr><td><code>AWS_PROFILE</code></td><td>AWS CLI profile for credential resolution</td><td><code>default</code></td></tr>
     <tr><td><code>AWS_ACCESS_KEY_ID</code></td><td>AWS access key (checked before AWS CLI fallback)</td><td>(none)</td></tr>
@@ -85,6 +86,27 @@ agent-browser -p agentcore open https://example.com
 ```
 
 The proxy configuration is passed directly to the AgentCore session API. Credentials can reference AWS Secrets Manager ARNs for secure authentication.
+
+## Enterprise Policies
+
+Use `AGENTCORE_ENTERPRISE_POLICIES` to apply enterprise browser policies stored in S3. The value must be a JSON array:
+
+```bash
+export AGENTCORE_ENTERPRISE_POLICIES='[
+  {
+    "type": "RECOMMENDED",
+    "location": {
+      "s3": {
+        "bucket": "my-policy-bucket",
+        "prefix": "policies/recommended-policies.json"
+      }
+    }
+  }
+]'
+agent-browser -p agentcore open https://example.com
+```
+
+Policies are applied at session creation time and control browser behavior, security settings, and feature availability. The browser session must have IAM permissions to read from the specified S3 bucket.
 
 ## Live View
 

--- a/docs/src/app/providers/agentcore/page.mdx
+++ b/docs/src/app/providers/agentcore/page.mdx
@@ -119,7 +119,7 @@ export AGENTCORE_EXTENSION_CONFIG='{
     {
       "s3": {
         "bucket": "my-extension-bucket",
-        "key": "extensions/my-extension.crx"
+        "key": "extensions/my-extension.zip"
       }
     }
   ]
@@ -137,7 +137,7 @@ agent-browser -p agentcore open https://example.com
   </tbody>
 </table>
 
-Extensions must be packaged as `.crx` files and uploaded to S3. The browser session must have IAM permissions to read from the specified S3 bucket.
+Extensions must be packaged as `.zip` files (standard Chrome extension format) and uploaded to S3. The browser session must have IAM permissions to read from the specified S3 bucket.
 
 ## Live View
 

--- a/docs/src/app/providers/agentcore/page.mdx
+++ b/docs/src/app/providers/agentcore/page.mdx
@@ -111,19 +111,19 @@ Policies are applied at session creation time and control browser behavior, secu
 
 ## Browser Extensions
 
-Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3. The value must be valid JSON:
+Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3. The value must be a JSON array:
 
 ```bash
-export AGENTCORE_EXTENSION_CONFIG='{
-  "extensions": [
-    {
+export AGENTCORE_EXTENSION_CONFIG='[
+  {
+    "location": {
       "s3": {
         "bucket": "my-extension-bucket",
-        "key": "extensions/my-extension.zip"
+        "prefix": "extensions/my-extension.zip"
       }
     }
-  ]
-}'
+  }
+]'
 agent-browser -p agentcore open https://example.com
 ```
 

--- a/skill-data/agentcore/SKILL.md
+++ b/skill-data/agentcore/SKILL.md
@@ -39,6 +39,7 @@ agent-browser close
 | `AGENTCORE_PROFILE_ID` | Persistent browser profile (cookies, localStorage) | (none) |
 | `AGENTCORE_PROXY_CONFIG` | JSON proxy configuration for the browser session | (none) |
 | `AGENTCORE_ENTERPRISE_POLICIES` | JSON array of enterprise policy configurations | (none) |
+| `AGENTCORE_EXTENSION_CONFIG` | JSON browser extension configuration from S3 | (none) |
 | `AGENTCORE_SESSION_TIMEOUT` | Session timeout in seconds | `3600` |
 | `AWS_PROFILE` | AWS CLI profile for credential resolution | `default` |
 
@@ -104,6 +105,26 @@ agent-browser -p agentcore open https://example.com
 ```
 
 Policies are applied at session creation time and control browser behavior, security settings, and feature availability.
+
+## Browser Extensions
+
+Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3. The value must be valid JSON:
+
+```bash
+export AGENTCORE_EXTENSION_CONFIG='{
+  "extensions": [
+    {
+      "s3": {
+        "bucket": "my-extension-bucket",
+        "key": "extensions/my-extension.crx"
+      }
+    }
+  ]
+}'
+agent-browser -p agentcore open https://example.com
+```
+
+**Important:** The `--extension` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_EXTENSION_CONFIG` to load extensions stored in S3. The browser session must have IAM permissions to read from the specified S3 bucket.
 
 ## Live View
 

--- a/skill-data/agentcore/SKILL.md
+++ b/skill-data/agentcore/SKILL.md
@@ -37,6 +37,7 @@ agent-browser close
 | `AGENTCORE_REGION` | AWS region | `us-east-1` |
 | `AGENTCORE_BROWSER_ID` | Browser identifier | `aws.browser.v1` |
 | `AGENTCORE_PROFILE_ID` | Persistent browser profile (cookies, localStorage) | (none) |
+| `AGENTCORE_PROXY_CONFIG` | JSON proxy configuration for the browser session | (none) |
 | `AGENTCORE_SESSION_TIMEOUT` | Session timeout in seconds | `3600` |
 | `AWS_PROFILE` | AWS CLI profile for credential resolution | `default` |
 
@@ -56,6 +57,31 @@ agent-browser close
 # Future runs: already authenticated
 AGENTCORE_PROFILE_ID=my-app agent-browser -p agentcore open https://app.example.com/dashboard
 ```
+
+## Proxy Configuration
+
+Use `AGENTCORE_PROXY_CONFIG` to configure proxy settings with authentication for the cloud browser session. The value must be valid JSON matching the AgentCore proxy configuration schema.
+
+**Important:** The `--proxy` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_PROXY_CONFIG` to configure the remote browser's proxy settings.
+
+```bash
+export AGENTCORE_PROXY_CONFIG='{
+  "proxies": [{
+    "externalProxy": {
+      "server": "your-proxy.com",
+      "port": 8080,
+      "credentials": {
+        "basicAuth": {
+          "secretArn": "arn:aws:secretsmanager:region:account:secret:name"
+        }
+      }
+    }
+  }]
+}'
+agent-browser -p agentcore open https://example.com
+```
+
+The proxy configuration is passed directly to the AgentCore session API. Credentials can reference AWS Secrets Manager ARNs for secure authentication.
 
 ## Live View
 

--- a/skill-data/agentcore/SKILL.md
+++ b/skill-data/agentcore/SKILL.md
@@ -38,6 +38,7 @@ agent-browser close
 | `AGENTCORE_BROWSER_ID` | Browser identifier | `aws.browser.v1` |
 | `AGENTCORE_PROFILE_ID` | Persistent browser profile (cookies, localStorage) | (none) |
 | `AGENTCORE_PROXY_CONFIG` | JSON proxy configuration for the browser session | (none) |
+| `AGENTCORE_ENTERPRISE_POLICIES` | JSON array of enterprise policy configurations | (none) |
 | `AGENTCORE_SESSION_TIMEOUT` | Session timeout in seconds | `3600` |
 | `AWS_PROFILE` | AWS CLI profile for credential resolution | `default` |
 
@@ -82,6 +83,27 @@ agent-browser -p agentcore open https://example.com
 ```
 
 The proxy configuration is passed directly to the AgentCore session API. Credentials can reference AWS Secrets Manager ARNs for secure authentication.
+
+## Enterprise Policies
+
+Use `AGENTCORE_ENTERPRISE_POLICIES` to apply enterprise browser policies stored in S3. The value must be a JSON array:
+
+```bash
+export AGENTCORE_ENTERPRISE_POLICIES='[
+  {
+    "type": "RECOMMENDED",
+    "location": {
+      "s3": {
+        "bucket": "my-policy-bucket",
+        "prefix": "policies/recommended-policies.json"
+      }
+    }
+  }
+]'
+agent-browser -p agentcore open https://example.com
+```
+
+Policies are applied at session creation time and control browser behavior, security settings, and feature availability.
 
 ## Live View
 

--- a/skill-data/agentcore/SKILL.md
+++ b/skill-data/agentcore/SKILL.md
@@ -116,7 +116,7 @@ export AGENTCORE_EXTENSION_CONFIG='{
     {
       "s3": {
         "bucket": "my-extension-bucket",
-        "key": "extensions/my-extension.crx"
+        "key": "extensions/my-extension.zip"
       }
     }
   ]
@@ -124,7 +124,7 @@ export AGENTCORE_EXTENSION_CONFIG='{
 agent-browser -p agentcore open https://example.com
 ```
 
-**Important:** The `--extension` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_EXTENSION_CONFIG` to load extensions stored in S3. The browser session must have IAM permissions to read from the specified S3 bucket.
+**Important:** The `--extension` flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use `AGENTCORE_EXTENSION_CONFIG` to load extensions packaged as `.zip` files in S3. The browser session must have IAM permissions to read from the specified S3 bucket.
 
 ## Live View
 

--- a/skill-data/agentcore/SKILL.md
+++ b/skill-data/agentcore/SKILL.md
@@ -108,19 +108,19 @@ Policies are applied at session creation time and control browser behavior, secu
 
 ## Browser Extensions
 
-Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3. The value must be valid JSON:
+Use `AGENTCORE_EXTENSION_CONFIG` to load browser extensions from S3. The value must be a JSON array:
 
 ```bash
-export AGENTCORE_EXTENSION_CONFIG='{
-  "extensions": [
-    {
+export AGENTCORE_EXTENSION_CONFIG='[
+  {
+    "location": {
       "s3": {
         "bucket": "my-extension-bucket",
-        "key": "extensions/my-extension.zip"
+        "prefix": "extensions/my-extension.zip"
       }
     }
-  ]
-}'
+  }
+]'
 agent-browser -p agentcore open https://example.com
 ```
 


### PR DESCRIPTION
Add AGENTCORE_PROXY_CONFIG environment variable to configure proxy settings with authentication for AgentCore cloud browser sessions.

The proxy configuration is passed as JSON to the AgentCore session creation API and supports AWS Secrets Manager ARNs for credentials.

Example:
export AGENTCORE_PROXY_CONFIG='{
  "proxies": [{
    "externalProxy": {
      "server": "proxy.example.com",
      "port": 8080,
      "credentials": {
        "basicAuth": {
          "secretArn": "arn:aws:secretsmanager:region:account:secret:name"
        }
      }
    }
  }]
}'

Note: The --proxy flag applies only to local Chrome/Lightpanda browsers. For AgentCore, use AGENTCORE_PROXY_CONFIG to configure the remote browser's proxy settings.

Changes:
- Added proxy config parsing in providers.rs following AGENTCORE_PROFILE_ID pattern
- Added validation with error message for invalid JSON
- Added test for proxy config JSON parsing
- Updated README.md, SKILL.md, docs, and CLI help output
- Clarified that --proxy and AGENTCORE_PROXY_CONFIG serve different purposes