### PR TITLE
feat(providers): add Steel cloud browser provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1516,6 +1516,44 @@ Optional configuration via environment variables:
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
 
+### Steel
+
+[Steel](https://steel.dev) provides cloud browser infrastructure for AI agents with built-in proxy support, CAPTCHA solving, and persistent profiles.
+
+To enable Steel, use the `-p` flag:
+
+```bash
+export STEEL_API_KEY="your-api-key"
+agent-browser -p steel open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=steel
+export STEEL_API_KEY="your-api-key"
+agent-browser open https://example.com
+```
+
+Optional configuration via environment variables:
+
+| Variable                 | Description                                                              | Default            |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------ |
+| `STEEL_TIMEOUT_MS`       | Session timeout in milliseconds (positive integer)                       | (provider default) |
+| `STEEL_HEADLESS`         | Run browser headless (`true`/`false`/`1`/`0`)                            | (provider default) |
+| `STEEL_SOLVE_CAPTCHA`    | Enable Steel's automatic CAPTCHA solving                                 | (provider default) |
+| `STEEL_USE_PROXY`        | Route session through Steel's residential proxy                          | (provider default) |
+| `STEEL_PROXY_URL`        | Custom proxy URL (overrides Steel's built-in proxy)                      | (none)             |
+| `STEEL_REGION`           | Datacenter region (e.g. `lax`, `ord`, `iad`)                             | (provider default) |
+| `STEEL_BLOCK_ADS`        | Enable ad blocking for the session                                       | (provider default) |
+| `STEEL_PROFILE_ID`       | UUID of an existing Steel profile to load                                | (none)             |
+| `STEEL_PERSIST_PROFILE`  | Persist profile changes across runs                                      | (provider default) |
+| `STEEL_DEVICE`           | Device emulation profile (`desktop` or `mobile`)                         | `desktop`          |
+
+When enabled, agent-browser creates a Steel session via `POST /v1/sessions`, connects over CDP, and explicitly releases the session on close. All commands work identically.
+
+Get your API key from the [Steel Dashboard](https://app.steel.dev/settings/api-keys).
+
 ## License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ The dashboard displays:
 - **Live viewport** -- real-time JPEG frames from the browser
 - **Activity feed** -- chronological command/result stream with timing and expandable details
 - **Console output** -- browser console messages (log, warn, error)
-- **Session creation** -- create new sessions from the UI with local engines (Chrome, Lightpanda) or cloud providers (AgentCore, Browserbase, Browserless, Browser Use, Kernel)
+- **Session creation** — create new sessions from the UI with local engines (Chrome, Lightpanda) or cloud providers (AgentCore, Browserbase, Browserless, Browser Use, Kernel, Steel)
 - **AI Chat** -- chat with an AI assistant directly in the dashboard (requires Vercel AI Gateway configuration)
 
 ### AI Chat

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ The dashboard displays:
 - **Live viewport** -- real-time JPEG frames from the browser
 - **Activity feed** -- chronological command/result stream with timing and expandable details
 - **Console output** -- browser console messages (log, warn, error)
-- **Session creation** -- create new sessions from the UI with local engines (Chrome, Lightpanda) or cloud providers (AgentCore, Browserbase, Browserless, Browser Use, Kernel)
+- **Session creation** — create new sessions from the UI with local engines (Chrome, Lightpanda) or cloud providers (AgentCore, Browserbase, Browserless, Browser Use, Kernel, Steel)
 - **AI Chat** -- chat with an AI assistant directly in the dashboard (requires Vercel AI Gateway configuration)
 
 ### AI Chat

--- a/README.md
+++ b/README.md
@@ -1521,6 +1521,44 @@ Optional configuration via environment variables:
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
 
+### Steel
+
+[Steel](https://steel.dev) provides cloud browser infrastructure for AI agents with built-in proxy support, CAPTCHA solving, and persistent profiles.
+
+To enable Steel, use the `-p` flag:
+
+```bash
+export STEEL_API_KEY="your-api-key"
+agent-browser -p steel open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=steel
+export STEEL_API_KEY="your-api-key"
+agent-browser open https://example.com
+```
+
+Optional configuration via environment variables:
+
+| Variable                 | Description                                                              | Default            |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------ |
+| `STEEL_TIMEOUT_MS`       | Session timeout in milliseconds (positive integer)                       | (provider default) |
+| `STEEL_HEADLESS`         | Run browser headless (`true`/`false`/`1`/`0`)                            | (provider default) |
+| `STEEL_SOLVE_CAPTCHA`    | Enable Steel's automatic CAPTCHA solving                                 | (provider default) |
+| `STEEL_USE_PROXY`        | Route session through Steel's residential proxy                          | (provider default) |
+| `STEEL_PROXY_URL`        | Custom proxy URL (overrides Steel's built-in proxy)                      | (none)             |
+| `STEEL_REGION`           | Datacenter region (e.g. `lax`, `ord`, `iad`)                             | (provider default) |
+| `STEEL_BLOCK_ADS`        | Enable ad blocking for the session                                       | (provider default) |
+| `STEEL_PROFILE_ID`       | UUID of an existing Steel profile to load                                | (none)             |
+| `STEEL_PERSIST_PROFILE`  | Persist profile changes across runs                                      | (provider default) |
+| `STEEL_DEVICE`           | Device emulation profile (`desktop` or `mobile`)                         | `desktop`          |
+
+When enabled, agent-browser creates a Steel session via `POST /v1/sessions`, connects over CDP, and explicitly releases the session on close. All commands work identically.
+
+Get your API key from the [Steel Dashboard](https://app.steel.dev/settings/api-keys).
+
 ## License
 
 Apache-2.0

--- a/cli/src/doctor/network.rs
+++ b/cli/src/doctor/network.rs
@@ -82,6 +82,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
                 env::var("KERNEL_ENDPOINT")
                     .unwrap_or_else(|_| "https://api.onkernel.com".to_string()),
             ),
+            "steel" => Some("https://api.steel.dev".to_string()),
             _ => None,
         };
         if let Some(url) = url {

--- a/cli/src/doctor/providers.rs
+++ b/cli/src/doctor/providers.rs
@@ -1,5 +1,5 @@
 //! Check remote browser providers: API key presence for Browserless,
-//! Browserbase, Browser Use, Kernel, AgentCore (AWS), Appium for iOS, and
+//! Browserbase, Browser Use, Kernel, Steel, AgentCore (AWS), Appium for iOS, and
 //! the AI Gateway chat key. Info-level unless the provider is selected
 //! via `AGENT_BROWSER_PROVIDER`.
 
@@ -34,6 +34,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         ("browserbase", &["BROWSERBASE_API_KEY"], "Browserbase"),
         ("browseruse", &["BROWSER_USE_API_KEY"], "Browser Use"),
         ("kernel", &["KERNEL_API_KEY"], "Kernel"),
+        ("steel", &["STEEL_API_KEY"], "Steel"),
     ];
 
     for (id, env_keys, label) in providers {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -201,6 +201,7 @@ fn launch_hash(opts: &LaunchOptions) -> u64 {
 
 pub struct DaemonState {
     pub browser: Option<BrowserManager>,
+    pub provider_session: Option<providers::ProviderSession>,
     pub appium: Option<AppiumManager>,
     pub safari_driver: Option<safari::SafariDriverProcess>,
     pub webdriver_backend: Option<super::webdriver::backend::WebDriverBackend>,
@@ -266,6 +267,7 @@ impl DaemonState {
     pub fn new() -> Self {
         Self {
             browser: None,
+            provider_session: None,
             appium: None,
             safari_driver: None,
             webdriver_backend: None,
@@ -1150,6 +1152,20 @@ impl Drop for DaemonState {
     }
 }
 
+async fn close_provider_session_if_present(state: &mut DaemonState) {
+    if let Some(session) = state.provider_session.take() {
+        providers::close_provider_session(&session).await;
+    }
+}
+
+pub async fn close_browser_for_shutdown(state: &mut DaemonState) {
+    if let Some(ref mut mgr) = state.browser {
+        let _ = mgr.close().await;
+    }
+    state.browser = None;
+    close_provider_session_if_present(state).await;
+}
+
 pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
     let id = cmd
@@ -1542,6 +1558,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
     if let Ok(cdp) = env::var("AGENT_BROWSER_CDP") {
         let mgr = BrowserManager::connect_cdp(&cdp).await?;
         state.reset_input_state();
+        state.provider_session = None;
         state.browser = Some(mgr);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -1555,6 +1572,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
 
     if env::var("AGENT_BROWSER_AUTO_CONNECT").is_ok() {
         state.reset_input_state();
+        state.provider_session = None;
         state.browser = Some(connect_auto_with_fresh_tab().await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -1590,6 +1608,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
             match connect_result {
                 Ok(mgr) => {
                     state.reset_input_state();
+                    state.provider_session = conn.session;
                     state.browser = Some(mgr);
                     state.subscribe_to_browser_events();
                     state.start_fetch_handler();
@@ -1614,6 +1633,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
     let hash = launch_hash(&options);
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
+    state.provider_session = None;
     state.browser = Some(mgr);
     state.launch_hash = Some(hash);
     state.subscribe_to_browser_events();
@@ -1763,6 +1783,7 @@ async fn rollback_failed_launch(state: &mut DaemonState) -> Result<(), String> {
     } else {
         None
     };
+    close_provider_session_if_present(state).await;
 
     state.launch_hash = None;
     state.screencasting = false;
@@ -1915,8 +1936,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if needs_relaunch {
         if let Some(ref mut b) = state.browser {
-            b.close().await?;
+            let close_result = b.close().await;
             state.browser = None;
+            close_provider_session_if_present(state).await;
+            close_result?;
             state.launch_hash = None;
             state.screencasting = false;
             state.reset_input_state();
@@ -1940,6 +1963,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(url) = cdp_url {
         state.reset_input_state();
+        state.provider_session = None;
         state.browser = Some(BrowserManager::connect_cdp(url).await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -1952,6 +1976,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(port) = cdp_port {
         state.reset_input_state();
+        state.provider_session = None;
         state.browser = Some(BrowserManager::connect_cdp(&port.to_string()).await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -1964,6 +1989,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if auto_connect {
         state.reset_input_state();
+        state.provider_session = None;
         state.browser = Some(connect_auto_with_fresh_tab().await?);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -2001,6 +2027,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                 match connect_result {
                     Ok(mgr) => {
                         state.reset_input_state();
+                        state.provider_session = conn.session;
                         state.browser = Some(mgr);
                         state.subscribe_to_browser_events();
                         state.start_fetch_handler();
@@ -2062,6 +2089,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     write_extensions_file(&state.session_id);
     state.reset_input_state();
     state.browser = Some(BrowserManager::launch(launch_options, engine.as_deref()).await?);
+    state.provider_session = None;
     state.launch_hash = Some(new_hash);
     state.subscribe_to_browser_events();
     state.start_fetch_handler();
@@ -2403,10 +2431,13 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
             }
         }
     }
-    if let Some(ref mut mgr) = state.browser {
-        mgr.close().await?;
-    }
+    let close_error = if let Some(ref mut mgr) = state.browser {
+        mgr.close().await.err()
+    } else {
+        None
+    };
     state.browser = None;
+    close_provider_session_if_present(state).await;
     state.launch_hash = None;
     state.screencasting = false;
     state.reset_input_state();
@@ -2441,6 +2472,9 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
     }
 
     state.ref_map.clear();
+    if let Some(err) = close_error {
+        return Err(err);
+    }
     Ok(json!({ "closed": true }))
 }
 

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::signal;
 use tokio::sync::{mpsc, Notify, RwLock};
 
-use super::actions::{execute_command, DaemonState};
+use super::actions::{close_browser_for_shutdown, execute_command, DaemonState};
 use super::cdp::client::CdpClient;
 use super::state;
 use super::stream::StreamServer;
@@ -207,15 +207,17 @@ async fn run_socket_server(
             }
             _ = drain_interval.tick() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    if mgr.has_process_exited() {
-                        let _ = mgr.close().await;
-                        s.browser = None;
-                        s.screencasting = false;
-                        s.update_stream_client().await;
-                    } else {
-                        s.drain_cdp_events_background().await;
-                    }
+                let process_exited = s
+                    .browser
+                    .as_mut()
+                    .map(|mgr| mgr.has_process_exited())
+                    .unwrap_or(false);
+                if process_exited {
+                    close_browser_for_shutdown(&mut s).await;
+                    s.screencasting = false;
+                    s.update_stream_client().await;
+                } else if s.browser.is_some() {
+                    s.drain_cdp_events_background().await;
                 }
             }
             _ = async {
@@ -225,9 +227,7 @@ async fn run_socket_server(
                 }
             }, if idle_timeout_ms.is_some() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                close_browser_for_shutdown(&mut s).await;
                 break;
             }
             _ = reset_rx.recv(), if idle_timeout_ms.is_some() => {
@@ -243,9 +243,7 @@ async fn run_socket_server(
             }
             _ = shutdown_signal() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                close_browser_for_shutdown(&mut s).await;
                 break;
             }
         }
@@ -325,9 +323,7 @@ async fn run_socket_server(
                 }
             }, if idle_timeout_ms.is_some() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                close_browser_for_shutdown(&mut s).await;
                 let _ = fs::remove_file(&port_path);
                 break;
             }
@@ -342,9 +338,7 @@ async fn run_socket_server(
             }
             _ = shutdown_signal() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                close_browser_for_shutdown(&mut s).await;
                 let _ = fs::remove_file(&port_path);
                 break;
             }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -1,6 +1,6 @@
 //! Browser provider connections for remote CDP sessions.
 //!
-//! Supports AgentCore, Browserbase, Browserless, Browser Use, and Kernel providers.
+//! Supports AgentCore, Browserbase, Browserless, Browser Use, Kernel, and Steel providers.
 //! Each provider returns a CDP WebSocket URL for connecting via BrowserManager.
 
 use serde_json::{json, Value};
@@ -65,8 +65,16 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 direct_page: false,
             })
         }
+        "steel" => {
+            let (url, session) = connect_steel().await?;
+            Ok(ProviderConnection {
+                ws_url: url,
+                session,
+                direct_page: false,
+            })
+        }
         _ => Err(format!(
-            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore",
+            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, steel",
             provider_name
         )),
     }
@@ -126,6 +134,20 @@ pub async fn close_provider_session(session: &ProviderSession) {
         "agentcore" => {
             // AgentCore session cleanup is handled via signed DELETE request
             let _ = close_agentcore_session(&session.session_id).await;
+        }
+        "steel" => {
+            if let Ok(api_key) = env::var("STEEL_API_KEY") {
+                let _ = client
+                    .post(format!(
+                        "https://api.steel.dev/v1/sessions/{}/release",
+                        session.session_id
+                    ))
+                    .header("steel-api-key", &api_key)
+                    .header("Content-Type", "application/json")
+                    .json(&serde_json::json!({}))
+                    .send()
+                    .await;
+            }
         }
         _ => {}
     }
@@ -747,6 +769,159 @@ async fn close_agentcore_session(session_id: &str) -> Result<(), String> {
     agentcore::close_session(session_id).await
 }
 
+fn parse_steel_bool(name: &str, value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        _ => Err(format!("{} must be one of: true, false, 1, 0", name)),
+    }
+}
+
+fn parse_steel_positive_int(name: &str, value: &str) -> Result<u64, String> {
+    let n: u64 = value
+        .trim()
+        .parse()
+        .map_err(|_| format!("{} must be a positive integer", name))?;
+    if n == 0 {
+        return Err(format!("{} must be a positive integer", name));
+    }
+    Ok(n)
+}
+
+fn parse_steel_device(value: &str) -> Result<String, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "desktop" => Ok("desktop".to_string()),
+        "mobile" => Ok("mobile".to_string()),
+        _ => Err("STEEL_DEVICE must be either \"desktop\" or \"mobile\"".to_string()),
+    }
+}
+
+fn build_steel_cdp_url(ws_url: &str, api_key: &str) -> String {
+    match url::Url::parse(ws_url) {
+        Ok(mut parsed) => {
+            let already_has_key = parsed.query_pairs().any(|(k, _)| k == "apiKey");
+            if !already_has_key {
+                parsed.query_pairs_mut().append_pair("apiKey", api_key);
+            }
+            parsed.to_string()
+        }
+        Err(_) => {
+            if ws_url.contains("apiKey=") {
+                ws_url.to_string()
+            } else {
+                let sep = if ws_url.contains('?') { '&' } else { '?' };
+                format!("{}{}apiKey={}", ws_url, sep, urlencoding::encode(api_key))
+            }
+        }
+    }
+}
+
+async fn connect_steel() -> Result<(String, Option<ProviderSession>), String> {
+    let api_key = env::var("STEEL_API_KEY")
+        .map_err(|_| "STEEL_API_KEY environment variable is not set".to_string())?;
+    if api_key.trim().is_empty() {
+        return Err("STEEL_API_KEY environment variable is not set".to_string());
+    }
+
+    let mut body = serde_json::Map::new();
+    if let Ok(v) = env::var("STEEL_TIMEOUT_MS") {
+        body.insert(
+            "timeout".into(),
+            json!(parse_steel_positive_int("STEEL_TIMEOUT_MS", &v)?),
+        );
+    }
+    if let Ok(v) = env::var("STEEL_HEADLESS") {
+        body.insert(
+            "headless".into(),
+            json!(parse_steel_bool("STEEL_HEADLESS", &v)?),
+        );
+    }
+    if let Ok(v) = env::var("STEEL_SOLVE_CAPTCHA") {
+        body.insert(
+            "solveCaptcha".into(),
+            json!(parse_steel_bool("STEEL_SOLVE_CAPTCHA", &v)?),
+        );
+    }
+    if let Ok(v) = env::var("STEEL_USE_PROXY") {
+        body.insert(
+            "useProxy".into(),
+            json!(parse_steel_bool("STEEL_USE_PROXY", &v)?),
+        );
+    }
+    if let Ok(v) = env::var("STEEL_PROXY_URL") {
+        body.insert("proxyUrl".into(), json!(v));
+    }
+    if let Ok(v) = env::var("STEEL_REGION") {
+        body.insert("region".into(), json!(v));
+    }
+    if let Ok(v) = env::var("STEEL_BLOCK_ADS") {
+        body.insert(
+            "blockAds".into(),
+            json!(parse_steel_bool("STEEL_BLOCK_ADS", &v)?),
+        );
+    }
+    if let Ok(v) = env::var("STEEL_PROFILE_ID") {
+        body.insert("profileId".into(), json!(v));
+    }
+    if let Ok(v) = env::var("STEEL_PERSIST_PROFILE") {
+        body.insert(
+            "persistProfile".into(),
+            json!(parse_steel_bool("STEEL_PERSIST_PROFILE", &v)?),
+        );
+    }
+    if let Ok(v) = env::var("STEEL_DEVICE") {
+        let device = parse_steel_device(&v)?;
+        body.insert("deviceConfig".into(), json!({ "device": device }));
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post("https://api.steel.dev/v1/sessions")
+        .header("steel-api-key", &api_key)
+        .header("Content-Type", "application/json")
+        .json(&Value::Object(body))
+        .send()
+        .await
+        .map_err(|e| format!("Steel request failed: {}", e))?;
+
+    let status = response.status();
+    let resp_body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Steel response: {}", e))?;
+    if !status.is_success() {
+        return Err(format!(
+            "Steel API error ({}): {}",
+            status.as_u16(),
+            resp_body
+        ));
+    }
+
+    let parsed: Value =
+        serde_json::from_str(&resp_body).map_err(|e| format!("Invalid Steel response: {}", e))?;
+
+    let session_id = parsed
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Steel response missing 'id'".to_string())?;
+
+    let websocket_url = parsed
+        .get("websocketUrl")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Steel response missing 'websocketUrl'".to_string())?;
+
+    let connect_url = build_steel_cdp_url(websocket_url, &api_key);
+
+    Ok((
+        connect_url,
+        Some(ProviderSession {
+            provider: "steel".to_string(),
+            session_id,
+        }),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -812,5 +987,95 @@ mod tests {
         // Should be None after take
         let taken_again = take_agentcore_ws_headers();
         assert!(taken_again.is_none());
+    }
+
+    #[test]
+    fn test_steel_missing_api_key() {
+        std::env::remove_var("STEEL_API_KEY");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(connect_steel());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("STEEL_API_KEY"));
+    }
+
+    #[test]
+    fn test_steel_bool_parser_accepts() {
+        assert!(parse_steel_bool("X", "true").unwrap());
+        assert!(parse_steel_bool("X", "TRUE").unwrap());
+        assert!(parse_steel_bool("X", "1").unwrap());
+        assert!(!parse_steel_bool("X", "false").unwrap());
+        assert!(!parse_steel_bool("X", "FALSE").unwrap());
+        assert!(!parse_steel_bool("X", "0").unwrap());
+        // whitespace tolerated
+        assert!(parse_steel_bool("X", "  true  ").unwrap());
+    }
+
+    #[test]
+    fn test_steel_bool_parser_rejects() {
+        let err = parse_steel_bool("MY_VAR", "yes").unwrap_err();
+        assert!(err.contains("MY_VAR"));
+        assert!(err.contains("true, false, 1, 0"));
+    }
+
+    #[test]
+    fn test_steel_int_parser_accepts() {
+        assert_eq!(parse_steel_positive_int("X", "60000").unwrap(), 60000);
+        assert_eq!(parse_steel_positive_int("X", "1").unwrap(), 1);
+    }
+
+    #[test]
+    fn test_steel_int_parser_rejects() {
+        assert!(parse_steel_positive_int("X", "0").is_err());
+        assert!(parse_steel_positive_int("X", "-1").is_err());
+        assert!(parse_steel_positive_int("X", "abc").is_err());
+        assert!(parse_steel_positive_int("X", "").is_err());
+        let err = parse_steel_positive_int("STEEL_TIMEOUT_MS", "0").unwrap_err();
+        assert!(err.contains("STEEL_TIMEOUT_MS must be a positive integer"));
+    }
+
+    #[test]
+    fn test_steel_device_parser() {
+        assert_eq!(parse_steel_device("desktop").unwrap(), "desktop");
+        assert_eq!(parse_steel_device("Desktop").unwrap(), "desktop");
+        assert_eq!(parse_steel_device("MOBILE").unwrap(), "mobile");
+        let err = parse_steel_device("tablet").unwrap_err();
+        assert!(err.contains("desktop"));
+        assert!(err.contains("mobile"));
+    }
+
+    #[test]
+    fn test_steel_cdp_url_appends_api_key() {
+        let out = build_steel_cdp_url("wss://connect.steel.dev/v1/devtools/browser/abc", "secret");
+        assert!(out.contains("apiKey=secret"));
+    }
+
+    #[test]
+    fn test_steel_cdp_url_preserves_existing_api_key() {
+        let input = "wss://connect.steel.dev/v1/devtools/browser/abc?apiKey=existing";
+        let out = build_steel_cdp_url(input, "different");
+        assert_eq!(out.matches("apiKey=").count(), 1);
+        assert!(out.contains("apiKey=existing"));
+    }
+
+    #[test]
+    fn test_steel_cdp_url_preserves_other_query_params() {
+        let input = "wss://connect.steel.dev/v1/devtools/browser/abc?foo=bar";
+        let out = build_steel_cdp_url(input, "k");
+        assert!(out.contains("foo=bar"));
+        assert!(out.contains("apiKey=k"));
+    }
+
+    #[test]
+    fn test_steel_cdp_url_url_encodes_api_key() {
+        let out = build_steel_cdp_url("wss://x.example/y", "a b+c");
+        // url::Url percent-encodes spaces as %20 and + as %2B in query values
+        assert!(out.contains("apiKey=a%20b%2Bc") || out.contains("apiKey=a+b%2Bc"));
+    }
+
+    #[test]
+    fn test_connect_provider_unknown_lists_steel() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(connect_provider("nope")).unwrap_err();
+        assert!(err.contains("steel"));
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3092,7 +3092,7 @@ Options:
                              e.g., --proxy-bypass "localhost,*.internal.com"
   --ignore-https-errors      Ignore HTTPS certificate errors
   --allow-file-access        Allow file:// URLs to access local files (Chromium only)
-  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore
+  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore, steel
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
   --json                     JSON output
   --annotate                 Annotated screenshot with numbered labels and legend
@@ -3152,7 +3152,7 @@ Environment:
   AGENT_BROWSER_ANNOTATE         Annotated screenshot with numbered labels and legend
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
-  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore)
+  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, steel)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3097,7 +3097,7 @@ Options:
                              e.g., --proxy-bypass "localhost,*.internal.com"
   --ignore-https-errors      Ignore HTTPS certificate errors
   --allow-file-access        Allow file:// URLs to access local files (Chromium only)
-  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore
+  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore, steel
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
   --json                     JSON output
   --annotate                 Annotated screenshot with numbered labels and legend
@@ -3157,7 +3157,7 @@ Environment:
   AGENT_BROWSER_ANNOTATE         Annotated screenshot with numbered labels and legend
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
-  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore)
+  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, steel)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -91,7 +91,7 @@ This enables control of:
   <tbody>
     <tr><td><code>--session &lt;name&gt;</code></td><td>Use isolated session</td></tr>
     <tr><td><code>--profile &lt;path&gt;</code></td><td>Persistent browser profile directory</td></tr>
-    <tr><td><code>-p &lt;provider&gt;</code></td><td>Cloud browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>)</td></tr>
+    <tr><td><code>-p &lt;provider&gt;</code></td><td>Cloud browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>, <code>agentcore</code>, <code>steel</code>)</td></tr>
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>
     <tr><td><code>--executable-path</code></td><td>Custom browser executable</td></tr>
     <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (comma-separated)</td></tr>
@@ -117,4 +117,4 @@ Use the `-p` flag to connect to a cloud browser provider instead of launching a 
 agent-browser -p browserbase open https://example.com
 ```
 
-See the [Providers](/providers/browser-use) section for setup and configuration of each supported provider: [Browser Use](/providers/browser-use), [Browserbase](/providers/browserbase), [Browserless](/providers/browserless), and [Kernel](/providers/kernel).
+See the [Providers](/providers/browser-use) section for setup and configuration of each supported provider: [Browser Use](/providers/browser-use), [Browserbase](/providers/browserbase), [Browserless](/providers/browserless), [Kernel](/providers/kernel), [AgentCore](/providers/agentcore), and [Steel](/providers/steel).

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- **Steel provider** - Added [Steel](https://steel.dev) as a cloud browser provider. Use with `-p steel` or `AGENT_BROWSER_PROVIDER=steel`; requires `STEEL_API_KEY`. Optional env vars (`STEEL_TIMEOUT_MS`, `STEEL_HEADLESS`, `STEEL_SOLVE_CAPTCHA`, `STEEL_USE_PROXY`, `STEEL_PROXY_URL`, `STEEL_REGION`, `STEEL_BLOCK_ADS`, `STEEL_PROFILE_ID`, `STEEL_PERSIST_PROFILE`, `STEEL_DEVICE`) configure session behavior. Sessions are explicitly released on close.
+
+---
+
 ## v0.26.0
 
 <p className="text-[#888] text-sm">April 16, 2026</p>

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- **Steel provider** - Added [Steel](https://steel.dev) as a cloud browser provider. Use with `-p steel` or `AGENT_BROWSER_PROVIDER=steel`; requires `STEEL_API_KEY`. Optional env vars (`STEEL_TIMEOUT_MS`, `STEEL_HEADLESS`, `STEEL_SOLVE_CAPTCHA`, `STEEL_USE_PROXY`, `STEEL_PROXY_URL`, `STEEL_REGION`, `STEEL_BLOCK_ADS`, `STEEL_PROFILE_ID`, `STEEL_PERSIST_PROFILE`, `STEEL_DEVICE`) configure session behavior. Sessions are explicitly released on close.
+
+---
+
 ## v0.27.0
 
 <p className="text-[#888] text-sm">May 7, 2026</p>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -487,7 +487,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 --proxy-bypass <hosts>   # Hosts to bypass proxy
 --ignore-https-errors    # Ignore HTTPS certificate errors
 --allow-file-access      # Allow file:// URLs to access local files (Chromium only)
--p, --provider <name>    # Browser provider (ios, browserbase, kernel, browseruse, browserless)
+-p, --provider <name>    # Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, steel)
 --device <name>          # iOS device name (e.g., "iPhone 15 Pro")
 --json                   # JSON output (for scripts)
 --annotate               # Annotated screenshot with numbered element labels

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -489,7 +489,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 --proxy-bypass <hosts>   # Hosts to bypass proxy
 --ignore-https-errors    # Ignore HTTPS certificate errors
 --allow-file-access      # Allow file:// URLs to access local files (Chromium only)
--p, --provider <name>    # Browser provider (ios, browserbase, kernel, browseruse, browserless)
+-p, --provider <name>    # Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, steel)
 --device <name>          # iOS device name (e.g., "iPhone 15 Pro")
 --json                   # JSON output (for scripts)
 --annotate               # Annotated screenshot with numbered element labels

--- a/docs/src/app/dashboard/page.mdx
+++ b/docs/src/app/dashboard/page.mdx
@@ -53,7 +53,7 @@ The dashboard is a single-page web app with three areas:
     </tr>
     <tr>
       <td><strong>Session creation</strong></td>
-      <td>Create new sessions from the dashboard with local engines (Chrome, Lightpanda) or cloud providers (AgentCore, Browserbase, Browserless, Browser Use, Kernel)</td>
+      <td>Create new sessions from the dashboard with local engines (Chrome, Lightpanda) or cloud providers (AgentCore, Browserbase, Browserless, Browser Use, Kernel, Steel)</td>
     </tr>
     <tr>
       <td><strong>Status bar</strong></td>

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -98,7 +98,7 @@ It checks:
 <tr><td>Daemons</td><td>Running daemons per session, stale <code>.sock</code> / <code>.pid</code> / <code>.version</code> / <code>.stream</code> files (auto-cleaned), version mismatch with the CLI, dashboard process liveness</td></tr>
 <tr><td>Config</td><td><code>~/.agent-browser/config.json</code>, <code>./agent-browser.json</code>, and any file at <code>AGENT_BROWSER_CONFIG</code> parse as valid JSON</td></tr>
 <tr><td>Security</td><td>Encryption key env var or <code>~/.agent-browser/.encryption-key</code> (with 0600 permissions on unix), state file count and age vs <code>AGENT_BROWSER_STATE_EXPIRE_DAYS</code>, action policy file</td></tr>
-<tr><td>Providers</td><td>Env vars for Browserless, Browserbase, Browser Use, Kernel, AgentCore (AWS creds), Appium (for <code>--provider ios</code>), and <code>AI_GATEWAY_API_KEY</code> for chat</td></tr>
+<tr><td>Providers</td><td>Env vars for Browserless, Browserbase, Browser Use, Kernel, Steel, AgentCore (AWS creds), Appium (for <code>--provider ios</code>), and <code>AI_GATEWAY_API_KEY</code> for chat</td></tr>
 <tr><td>Network</td><td>Reachability of the Chrome for Testing CDN, AI Gateway (if configured), and any currently selected provider endpoint (skipped under <code>--offline</code>)</td></tr>
 <tr><td>Launch test</td><td>Spawns a scratch session, launches headless Chrome, navigates to <code>about:blank</code>, then closes. Measures wall time (skipped under <code>--quick</code>)</td></tr>
 </tbody>

--- a/docs/src/app/providers/steel/layout.tsx
+++ b/docs/src/app/providers/steel/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("providers/steel");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/providers/steel/page.mdx
+++ b/docs/src/app/providers/steel/page.mdx
@@ -1,0 +1,47 @@
+# Steel
+
+[Steel](https://steel.dev) provides cloud browser infrastructure for AI agents with built-in proxy support, CAPTCHA solving, and persistent profiles. Use it when running agent-browser in environments where a local browser isn't available.
+
+## Setup
+
+```bash
+export STEEL_API_KEY="your-api-key"
+agent-browser -p steel open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=steel
+export STEEL_API_KEY="your-api-key"
+agent-browser open https://example.com
+```
+
+The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
+
+## Configuration
+
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Description</th><th>Default</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>STEEL_API_KEY</code></td><td>API key (required)</td><td></td></tr>
+    <tr><td><code>STEEL_TIMEOUT_MS</code></td><td>Session timeout in milliseconds (positive integer)</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_HEADLESS</code></td><td>Run browser headless (<code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>)</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_SOLVE_CAPTCHA</code></td><td>Enable Steel's automatic CAPTCHA solving</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_USE_PROXY</code></td><td>Route session through Steel's residential proxy</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_PROXY_URL</code></td><td>Custom proxy URL (overrides Steel's built-in proxy)</td><td></td></tr>
+    <tr><td><code>STEEL_REGION</code></td><td>Datacenter region (e.g. <code>lax</code>, <code>ord</code>, <code>iad</code>)</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_BLOCK_ADS</code></td><td>Enable ad blocking for the session</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_PROFILE_ID</code></td><td>UUID of an existing Steel profile to load</td><td></td></tr>
+    <tr><td><code>STEEL_PERSIST_PROFILE</code></td><td>Persist profile changes across runs</td><td>provider default</td></tr>
+    <tr><td><code>STEEL_DEVICE</code></td><td>Device emulation profile (<code>desktop</code> or <code>mobile</code>)</td><td><code>desktop</code></td></tr>
+  </tbody>
+</table>
+
+Boolean variables accept `true`, `false`, `1`, or `0` (case-insensitive). `STEEL_TIMEOUT_MS` must be a positive integer. `STEEL_DEVICE` must be exactly `desktop` or `mobile`.
+
+When enabled, agent-browser creates a Steel session via `POST https://api.steel.dev/v1/sessions`, connects over CDP, and explicitly releases the session on close via `POST /v1/sessions/{id}/release`. All commands work identically to a local browser.
+
+Get your API key from the [Steel Dashboard](https://app.steel.dev/settings/api-keys). See the [Steel API docs](https://docs.steel.dev) for the full provider feature reference.

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -50,6 +50,7 @@ export const navigation: NavSection[] = [
       { name: "Browserbase", href: "/providers/browserbase" },
       { name: "Browserless", href: "/providers/browserless" },
       { name: "Kernel", href: "/providers/kernel" },
+      { name: "Steel", href: "/providers/steel" },
     ],
   },
   {

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -24,6 +24,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "providers/browserbase": "Browserbase",
   "providers/browserless": "Browserless",
   "providers/kernel": "Kernel",
+  "providers/steel": "Steel",
   changelog: "Changelog",
 };
 

--- a/packages/dashboard/src/components/session-tree.tsx
+++ b/packages/dashboard/src/components/session-tree.tsx
@@ -73,6 +73,7 @@ const BROWSER_OPTIONS: { id: string; label: string; engine?: string; provider?: 
   { id: "browserless", label: "Browserless", provider: "browserless" },
   { id: "browser-use", label: "Browser Use", provider: "browser-use" },
   { id: "kernel", label: "Kernel", provider: "kernel" },
+  { id: "steel", label: "Steel", provider: "steel" },
 ];
 
 function BrandLogo({ name, logos }: { name: string; logos: Record<string, string> }) {

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -424,6 +424,7 @@ and [references/authentication.md](references/authentication.md).
 - **Exploratory testing / QA / bug hunts**: `agent-browser skills get dogfood`
 - **Vercel Sandbox microVMs**: `agent-browser skills get vercel-sandbox`
 - **AWS Bedrock AgentCore cloud browser**: `agent-browser skills get agentcore`
+- **Steel cloud browser**: use `-p steel` or `AGENT_BROWSER_PROVIDER=steel` with `STEEL_API_KEY`; configure sessions with `STEEL_TIMEOUT_MS`, `STEEL_HEADLESS`, `STEEL_SOLVE_CAPTCHA`, `STEEL_USE_PROXY`, `STEEL_PROXY_URL`, `STEEL_REGION`, `STEEL_BLOCK_ADS`, `STEEL_PROFILE_ID`, `STEEL_PERSIST_PROFILE`, and `STEEL_DEVICE`
 
 ## React / Web Vitals (built-in, any React app)
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -303,6 +303,7 @@ agent-browser --headed ...            # Show browser window (not headless)
 agent-browser --full ...              # Full page screenshot (-f)
 agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
 agent-browser -p <provider> ...       # Cloud browser provider (--provider)
+# Providers: browserbase, browserless, browseruse, kernel, agentcore, steel
 agent-browser --proxy <url> ...       # Use proxy server
 agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy
 agent-browser --headers <json> ...    # HTTP headers scoped to URL's origin
@@ -384,6 +385,10 @@ AGENT_BROWSER_EXTENSIONS="/ext1,/ext2"       # Comma-separated extension paths
 AGENT_BROWSER_INIT_SCRIPTS="/a.js,/b.js"     # Comma-separated init script paths
 AGENT_BROWSER_ENABLE="react-devtools"        # Comma-separated built-in init script features
 AGENT_BROWSER_PROVIDER="browserbase"         # Cloud browser provider
+# Cloud providers: browserbase, browserless, browseruse, kernel, agentcore, steel
+# Steel: set STEEL_API_KEY; optional STEEL_TIMEOUT_MS, STEEL_HEADLESS,
+# STEEL_SOLVE_CAPTCHA, STEEL_USE_PROXY, STEEL_PROXY_URL, STEEL_REGION,
+# STEEL_BLOCK_ADS, STEEL_PROFILE_ID, STEEL_PERSIST_PROFILE, STEEL_DEVICE
 AGENT_BROWSER_STREAM_PORT="9223"             # Override WebSocket streaming port (default: OS-assigned)
 AGENT_BROWSER_HOME="/path/to/agent-browser"  # Custom install location
 ```


### PR DESCRIPTION
## Summary
- Adds Steel (https://steel.dev) as a native cloud browser provider, selectable via `-p steel` or `AGENT_BROWSER_PROVIDER=steel`.
- New `connect_steel()` in `cli/src/native/providers.rs` mirrors the Browserless/Kernel pattern: reads `STEEL_*` env vars, POSTs to `api.steel.dev/v1/sessions`, returns the CDP WS URL with `apiKey` appended.
- Cleanup arm in `close_provider_session()` POSTs to `/v1/sessions/{id}/release` on connect failure (best-effort, mirrors Kernel).

## Env vars
| Name | Required | Description |
|------|----------|-------------|
| `STEEL_API_KEY` | yes | Steel API key |
| `STEEL_TIMEOUT_MS` | no | Session timeout in ms (positive int) |
| `STEEL_HEADLESS` | no | Run headless (true/false/1/0) |
| `STEEL_SOLVE_CAPTCHA` | no | Auto-solve captchas |
| `STEEL_USE_PROXY` | no | Route through Steel proxy |
| `STEEL_PROXY_URL` | no | Custom proxy URL |
| `STEEL_REGION` | no | Region hint |
| `STEEL_BLOCK_ADS` | no | Block ads |
| `STEEL_PROFILE_ID` | no | Persistent profile UUID |
| `STEEL_PERSIST_PROFILE` | no | Persist profile across runs |
| `STEEL_DEVICE` | no | \`desktop\` or \`mobile\` |

## Context
Reimplementation of #532 against the post-`8e43469` ("full native") provider system. The original PR targeted `src/browser.ts` which no longer exists; this version lives entirely in `cli/src/native/providers.rs`. Behavioral spec (env var names, request/response shapes, apiKey-on-WS handling) is preserved verbatim from #532.

## Test plan
- [x] `cargo build` clean
- [x] `cargo fmt --check` & `cargo clippy -- -D warnings` clean
- [x] 11 new unit tests for parsers, WS URL builder, missing-key path, and updated unknown-provider error — all pass alongside existing 4
- [x] Live smoke: `STEEL_API_KEY=... agent-browser -p steel open https://example.com` connects, navigates, returns title; `close --all` releases cleanly
- [ ] Reviewer with Steel credentials verifies a session against their account

## Notes
End-to-end HTTP-mocked test from the TS PR was not ported — `providers.rs` has no mock framework today, and adding one was out of scope. Unit tests cover env-var parsing and WS URL builder; integration is covered by the smoke run above.

Closes #532 (superseded).