### PR TITLE
feat(docs): add AI Gateway app attribution headers

### DIFF
--- a/docs/src/app/api/docs-chat/route.ts
+++ b/docs/src/app/api/docs-chat/route.ts
@@ -105,6 +105,10 @@ export async function POST(req: Request) {
   } = await createBashTool({ files: docsFiles });
 
   const result = streamText({
+    headers: {
+      "http-referer": "https://agent-browser.dev",
+      "x-title": "agent-browser",
+    },
     model: DEFAULT_MODEL,
     system: SYSTEM_PROMPT,
     messages: await convertToModelMessages(messages),


### PR DESCRIPTION
## Summary
- Adds `http-referer` and `x-title` headers to the docs chat `streamText` call for [AI Gateway app attribution](https://vercel.com/docs/ai-gateway/ecosystem/app-attribution)
- This is the only AI SDK inference call site in the codebase (evals use the Claude CLI subprocess, not the SDK)

## Test plan
- [ ] Verify docs chat still works end-to-end
- [ ] Confirm headers appear in AI Gateway request logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)