### PR TITLE
feat(cli): add CSS cascade inspection to get styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,10 @@ agent-browser get cdp-url             # Get CDP WebSocket URL (for DevTools, deb
 agent-browser get count <sel>         # Count matching elements
 agent-browser get box <sel>           # Get bounding box
 agent-browser get styles <sel>        # Get computed styles
+agent-browser get styles <sel> --cascade --properties color,font-size
 ```
+
+`get styles` returns computed CSS properties by default. Add `--cascade` to include matched CSS rules, stylesheet identifiers, declaration values, `!important`, and active or overridden status for the selected properties. Use `--properties` with a comma-separated list to keep output focused. Cascade mode filters browser user-agent stylesheet rules by default; pass `--include-user-agent` to include them. Pass `--ancestors` to include layout-critical computed styles for nearby ancestors.
 
 ### Check State
 
@@ -711,6 +714,10 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `-p, --provider <name>` | Cloud browser provider (or `AGENT_BROWSER_PROVIDER` env) |
 | `--device <name>` | iOS device name, e.g. "iPhone 15 Pro" (or `AGENT_BROWSER_IOS_DEVICE` env) |
 | `--json` | JSON output (for agents) |
+| `--cascade` | For `get styles`, include matched CSS rules and active or overridden declarations |
+| `--properties <list>` | For `get styles`, return a comma-separated list of CSS properties |
+| `--ancestors` | For `get styles --cascade`, include layout-critical computed styles for ancestors |
+| `--include-user-agent` | For `get styles --cascade`, include browser user-agent stylesheet rules |
 | `--annotate` | Annotated screenshot with numbered element labels (or `AGENT_BROWSER_ANNOTATE` env) |
 | `--screenshot-dir <path>` | Default screenshot output directory (or `AGENT_BROWSER_SCREENSHOT_DIR` env) |
 | `--screenshot-quality <n>` | JPEG quality 0-100 (or `AGENT_BROWSER_SCREENSHOT_QUALITY` env) |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2092,9 +2092,9 @@ fn parse_get(rest: &[&str], id: &str) -> Result<Value, ParseError> {
         Some("styles") => {
             let sel = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                 context: "get styles".to_string(),
-                usage: "get styles <selector>",
+                usage: "get styles <selector> [--cascade] [--properties <name,...>] [--ancestors] [--include-user-agent]",
             })?;
-            Ok(json!({ "id": id, "action": "styles", "selector": sel }))
+            parse_get_styles(rest, id, sel)
         }
         Some(sub) => Err(ParseError::UnknownSubcommand {
             subcommand: sub.to_string(),
@@ -2105,6 +2105,62 @@ fn parse_get(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             usage: "get <text|html|value|attr|url|title|count|box|styles|cdp-url> [args...]",
         }),
     }
+}
+
+fn parse_get_styles(rest: &[&str], id: &str, selector: &str) -> Result<Value, ParseError> {
+    let mut cmd = json!({ "id": id, "action": "styles", "selector": selector });
+    let mut i = 2;
+
+    while i < rest.len() {
+        match rest[i] {
+            "--cascade" => {
+                cmd["cascade"] = json!(true);
+                i += 1;
+            }
+            "--ancestors" => {
+                cmd["ancestors"] = json!(true);
+                i += 1;
+            }
+            "--include-user-agent" => {
+                cmd["includeUserAgent"] = json!(true);
+                i += 1;
+            }
+            "--properties" => {
+                let raw = rest.get(i + 1).ok_or_else(|| ParseError::MissingArguments {
+                    context: "get styles --properties".to_string(),
+                    usage: "get styles <selector> [--cascade] [--properties <name,...>] [--ancestors] [--include-user-agent]",
+                })?;
+                let properties = raw
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|prop| !prop.is_empty())
+                    .map(String::from)
+                    .collect::<Vec<_>>();
+                if properties.is_empty() {
+                    return Err(ParseError::InvalidValue {
+                        message: "--properties requires at least one CSS property name".to_string(),
+                        usage: "get styles <selector> [--cascade] [--properties <name,...>] [--ancestors] [--include-user-agent]",
+                    });
+                }
+                cmd["properties"] = json!(properties);
+                i += 2;
+            }
+            flag if flag.starts_with("--") => {
+                return Err(ParseError::InvalidValue {
+                    message: format!("Unknown flag for get styles: {}", flag),
+                    usage: "get styles <selector> [--cascade] [--properties <name,...>] [--ancestors] [--include-user-agent]",
+                });
+            }
+            extra => {
+                return Err(ParseError::InvalidValue {
+                    message: format!("Unexpected argument for get styles: {}", extra),
+                    usage: "get styles <selector> [--cascade] [--properties <name,...>] [--ancestors] [--include-user-agent]",
+                });
+            }
+        }
+    }
+
+    Ok(cmd)
 }
 
 fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
@@ -4116,6 +4172,39 @@ mod tests {
         let err = result.unwrap_err();
         assert!(matches!(err, ParseError::MissingArguments { .. }));
         assert!(err.format().contains("get text"));
+    }
+
+    #[test]
+    fn test_get_styles_cascade_flags() {
+        let cmd = parse_command(
+            &args("get styles @e1 --cascade --properties color,font-size --ancestors --include-user-agent"),
+            &default_flags(),
+        )
+        .unwrap();
+
+        assert_eq!(cmd["action"], "styles");
+        assert_eq!(cmd["selector"], "@e1");
+        assert_eq!(cmd["cascade"], true);
+        assert_eq!(cmd["ancestors"], true);
+        assert_eq!(cmd["includeUserAgent"], true);
+        assert_eq!(cmd["properties"], json!(["color", "font-size"]));
+    }
+
+    #[test]
+    fn test_get_styles_default_shape_is_unchanged() {
+        let cmd = parse_command(&args("get styles button"), &default_flags()).unwrap();
+
+        assert_eq!(
+            cmd,
+            json!({ "id": cmd["id"], "action": "styles", "selector": "button" })
+        );
+    }
+
+    #[test]
+    fn test_get_styles_rejects_empty_properties() {
+        let result = parse_command(&args("get styles button --properties ,"), &default_flags());
+
+        assert!(matches!(result, Err(ParseError::InvalidValue { .. })));
     }
 
     // === Protocol alignment tests ===

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4541,6 +4541,18 @@ async fn handle_styles(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             .filter_map(|v| v.as_str().map(String::from))
             .collect()
     });
+    let cascade = cmd
+        .get("cascade")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let include_ancestors = cmd
+        .get("ancestors")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let include_user_agent = cmd
+        .get("includeUserAgent")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let styles = super::element::get_element_styles(
         &mgr.client,
@@ -4548,10 +4560,17 @@ async fn handle_styles(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         &state.ref_map,
         selector,
         properties,
+        cascade,
+        include_ancestors,
+        include_user_agent,
         &state.iframe_sessions,
     )
     .await?;
-    Ok(json!({ "styles": styles }))
+    if cascade {
+        Ok(styles)
+    } else {
+        Ok(json!({ "styles": styles }))
+    }
 }
 
 async fn handle_bringtofront(state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -105,7 +105,17 @@ async fn e2e_launch_navigate_evaluate_close() {
 
     // Launch headless Chrome
     let resp = execute_command(
-        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": [
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-crash-reporter",
+                "--disable-crashpad"
+            ]
+        }),
         &mut state,
     )
     .await;
@@ -420,6 +430,127 @@ async fn e2e_snapshot_and_click_ref() {
         url.contains("iana.org"),
         "Should have navigated to iana.org, got: {}",
         url
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_get_styles_cascade_selector_and_ref() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "setcontent",
+            "html": r##"
+                <html>
+                  <head>
+                    <style>
+                      .text-blue { color: blue; font-size: 12px; }
+                      .text-blue.large { font-size: 20px; }
+                      #target.text-blue { color: red; }
+                    </style>
+                  </head>
+                  <body>
+                    <h1 id="target" class="text-blue large">Cascade Title</h1>
+                  </body>
+                </html>
+            "##,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "styles",
+            "selector": "#target",
+            "cascade": true,
+            "properties": ["color", "font-size"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["selector"], "#target");
+    let first = &data["matches"][0];
+    assert_eq!(first["text"], "Cascade Title");
+    assert_eq!(first["computed"]["color"], "rgb(255, 0, 0)");
+    assert!(first["computed"].get("display").is_none());
+
+    let rules = first["rules"].as_array().expect("cascade rules");
+    assert!(rules.iter().any(|rule| {
+        rule["selector"] == ".text-blue"
+            && rule["properties"].as_array().unwrap().iter().any(|prop| {
+                prop["name"] == "color"
+                    && prop["value"] == "blue"
+                    && prop["status"] == "overridden"
+                    && prop["active"] == false
+            })
+    }));
+    assert!(rules.iter().any(|rule| {
+        rule["selector"] == "#target.text-blue"
+            && rule["properties"].as_array().unwrap().iter().any(|prop| {
+                prop["name"] == "color"
+                    && prop["value"] == "red"
+                    && prop["status"] == "active"
+                    && prop["active"] == true
+            })
+    }));
+    assert!(rules.iter().any(|rule| {
+        rule["selector"] == ".text-blue.large"
+            && rule["properties"].as_array().unwrap().iter().any(|prop| {
+                prop["name"] == "font-size" && prop["value"] == "20px" && prop["status"] == "active"
+            })
+    }));
+
+    let resp = execute_command(&json!({ "id": "4", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+    let heading_ref = snapshot
+        .lines()
+        .find_map(|line| {
+            if line.contains("Cascade Title") && line.contains("ref=") {
+                let start = line.find("ref=")? + 4;
+                let rest = &line[start..];
+                let end = rest
+                    .find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+                    .unwrap_or(rest.len());
+                Some(format!("@{}", &rest[..end]))
+            } else {
+                None
+            }
+        })
+        .expect("snapshot should include heading ref");
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "styles",
+            "selector": heading_ref,
+            "cascade": true,
+            "properties": ["color"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["matches"][0]["computed"]["color"],
+        "rgb(255, 0, 0)"
     );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -1,9 +1,33 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
+
+const CASCADE_DEFAULT_PROPERTIES: &[&str] = &[
+    "display",
+    "position",
+    "top",
+    "right",
+    "bottom",
+    "left",
+    "z-index",
+    "width",
+    "height",
+    "margin",
+    "padding",
+    "font-size",
+    "font-weight",
+    "line-height",
+    "color",
+    "background-color",
+    "border",
+    "border-radius",
+    "opacity",
+    "transform",
+];
 
 #[derive(Debug, Clone)]
 pub struct RefEntry {
@@ -919,23 +943,452 @@ pub async fn get_element_count(
     Ok(result.result.value.and_then(|v| v.as_i64()).unwrap_or(0))
 }
 
-pub async fn get_element_styles(
-    client: &CdpClient,
-    session_id: &str,
-    ref_map: &RefMap,
-    selector_or_ref: &str,
-    properties: Option<Vec<String>>,
-    iframe_sessions: &HashMap<String, String>,
-) -> Result<Value, String> {
-    let (object_id, effective_session_id) = resolve_element_object_id(
-        client,
-        session_id,
-        ref_map,
-        selector_or_ref,
-        iframe_sessions,
-    )
-    .await?;
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DomRequestNodeParams {
+    object_id: String,
+}
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DomRequestNodeResult {
+    node_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CssGetMatchedStylesForNodeParams {
+    node_id: i64,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+struct Specificity {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+impl Specificity {
+    fn zero() -> Self {
+        Self { a: 0, b: 0, c: 0 }
+    }
+
+    fn inline() -> Self {
+        Self {
+            a: 1_000_000,
+            b: 0,
+            c: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CascadeDeclaration {
+    selector: String,
+    source: String,
+    origin: String,
+    name: String,
+    value: String,
+    important: bool,
+    active: bool,
+    inline: bool,
+    specificity: Specificity,
+    source_order: usize,
+}
+
+fn normalize_property_list(properties: Option<Vec<String>>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for prop in properties
+        .unwrap_or_else(|| {
+            CASCADE_DEFAULT_PROPERTIES
+                .iter()
+                .map(|prop| prop.to_string())
+                .collect()
+        })
+        .into_iter()
+    {
+        let prop = prop.trim().to_ascii_lowercase();
+        if !prop.is_empty() && seen.insert(prop.clone()) {
+            normalized.push(prop);
+        }
+    }
+
+    normalized
+}
+
+fn property_allowed(name: &str, properties: &[String]) -> bool {
+    properties
+        .iter()
+        .any(|prop| prop.eq_ignore_ascii_case(name.trim()))
+}
+
+fn selector_specificity(selector: &Value) -> Specificity {
+    let Some(specificity) = selector.get("specificity") else {
+        return selector
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(compute_specificity_fallback)
+            .unwrap_or_else(Specificity::zero);
+    };
+
+    Specificity {
+        a: specificity.get("a").and_then(|v| v.as_i64()).unwrap_or(0),
+        b: specificity.get("b").and_then(|v| v.as_i64()).unwrap_or(0),
+        c: specificity.get("c").and_then(|v| v.as_i64()).unwrap_or(0),
+    }
+}
+
+fn compute_specificity_fallback(selector: &str) -> Specificity {
+    let mut a = 0;
+    let mut b = 0;
+    let mut c = 0;
+    let chars = selector.chars().collect::<Vec<_>>();
+    let mut i = 0;
+    let mut expect_type = true;
+
+    while i < chars.len() {
+        let ch = chars[i];
+        match ch {
+            '\\' => {
+                i += 2;
+            }
+            '#' => {
+                a += 1;
+                i += 1;
+                while i < chars.len() && is_selector_ident_char(chars[i]) {
+                    i += 1;
+                }
+                expect_type = false;
+            }
+            '.' => {
+                b += 1;
+                i += 1;
+                while i < chars.len() && is_selector_ident_char(chars[i]) {
+                    i += 1;
+                }
+                expect_type = false;
+            }
+            '[' => {
+                b += 1;
+                i += 1;
+                while i < chars.len() && chars[i] != ']' {
+                    if chars[i] == '\\' {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                i += 1;
+                expect_type = false;
+            }
+            ':' => {
+                if chars.get(i + 1) == Some(&':') {
+                    c += 1;
+                    i += 2;
+                } else {
+                    b += 1;
+                    i += 1;
+                }
+                while i < chars.len() && is_selector_ident_char(chars[i]) {
+                    i += 1;
+                }
+                expect_type = false;
+            }
+            '*' => {
+                i += 1;
+                expect_type = false;
+            }
+            '>' | '+' | '~' | ',' => {
+                i += 1;
+                expect_type = true;
+            }
+            ch if ch.is_whitespace() => {
+                i += 1;
+                expect_type = true;
+            }
+            ch if expect_type && is_selector_ident_start(ch) => {
+                c += 1;
+                i += 1;
+                while i < chars.len() && is_selector_ident_char(chars[i]) {
+                    i += 1;
+                }
+                expect_type = false;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    Specificity { a, b, c }
+}
+
+fn is_selector_ident_start(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || ch == '_' || ch == '-'
+}
+
+fn is_selector_ident_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '\\'
+}
+
+fn matched_selector(rule_match: &Value) -> (String, Specificity) {
+    let selectors = rule_match
+        .get("rule")
+        .and_then(|rule| rule.get("selectorList"))
+        .and_then(|list| list.get("selectors"))
+        .and_then(|selectors| selectors.as_array());
+    let matching = rule_match
+        .get("matchingSelectors")
+        .and_then(|matches| matches.as_array());
+
+    if let (Some(selectors), Some(matching)) = (selectors, matching) {
+        let mut texts = Vec::new();
+        let mut specificity = Specificity::zero();
+        for idx in matching.iter().filter_map(|idx| idx.as_u64()) {
+            if let Some(selector) = selectors.get(idx as usize) {
+                if let Some(text) = selector.get("text").and_then(|v| v.as_str()) {
+                    texts.push(text.to_string());
+                }
+                specificity = specificity.max(selector_specificity(selector));
+            }
+        }
+        if !texts.is_empty() {
+            return (texts.join(", "), specificity);
+        }
+    }
+
+    let text = rule_match
+        .get("rule")
+        .and_then(|rule| rule.get("selectorList"))
+        .and_then(|list| list.get("text"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>")
+        .to_string();
+    let specificity = compute_specificity_fallback(&text);
+    (text, specificity)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_style_declarations(
+    style: Option<&Value>,
+    selector: &str,
+    source: &str,
+    origin: &str,
+    specificity: Specificity,
+    inline: bool,
+    base_order: usize,
+    properties: &[String],
+    declarations: &mut Vec<CascadeDeclaration>,
+) {
+    let Some(style) = style else {
+        return;
+    };
+    let Some(css_properties) = style.get("cssProperties").and_then(|v| v.as_array()) else {
+        return;
+    };
+
+    for (property_order, property) in css_properties.iter().enumerate() {
+        if property
+            .get("disabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        if !property
+            .get("parsedOk")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true)
+        {
+            continue;
+        }
+
+        let Some(name) = property.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !property_allowed(name, properties) {
+            continue;
+        }
+        let value = property
+            .get("value")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        declarations.push(CascadeDeclaration {
+            selector: selector.to_string(),
+            source: source.to_string(),
+            origin: origin.to_string(),
+            name: name.to_ascii_lowercase(),
+            value,
+            important: property
+                .get("important")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            active: false,
+            inline,
+            specificity,
+            source_order: base_order + property_order,
+        });
+    }
+}
+
+fn declaration_wins(candidate: &CascadeDeclaration, current: &CascadeDeclaration) -> bool {
+    (
+        candidate.important,
+        candidate.inline,
+        candidate.specificity,
+        candidate.source_order,
+    ) > (
+        current.important,
+        current.inline,
+        current.specificity,
+        current.source_order,
+    )
+}
+
+fn mark_active_declarations(declarations: &mut [CascadeDeclaration]) {
+    let mut winners: HashMap<String, usize> = HashMap::new();
+
+    for idx in 0..declarations.len() {
+        let name = declarations[idx].name.clone();
+        match winners.get(&name).copied() {
+            Some(current_idx)
+                if declaration_wins(&declarations[idx], &declarations[current_idx]) =>
+            {
+                winners.insert(name, idx);
+            }
+            Some(_) => {}
+            None => {
+                winners.insert(name, idx);
+            }
+        }
+    }
+
+    for idx in winners.values() {
+        declarations[*idx].active = true;
+    }
+}
+
+fn declarations_to_rules(declarations: &[CascadeDeclaration]) -> Vec<Value> {
+    let mut rules: Vec<Value> = Vec::new();
+    let mut rule_index: BTreeMap<(String, String), usize> = BTreeMap::new();
+
+    for declaration in declarations {
+        let key = (declaration.selector.clone(), declaration.source.clone());
+        let idx = match rule_index.get(&key).copied() {
+            Some(idx) => idx,
+            None => {
+                let idx = rules.len();
+                rule_index.insert(key, idx);
+                rules.push(serde_json::json!({
+                    "selector": declaration.selector,
+                    "source": declaration.source,
+                    "origin": declaration.origin,
+                    "properties": []
+                }));
+                idx
+            }
+        };
+
+        if let Some(properties) = rules[idx]
+            .get_mut("properties")
+            .and_then(|v| v.as_array_mut())
+        {
+            properties.push(serde_json::json!({
+                "name": declaration.name,
+                "value": declaration.value,
+                "important": declaration.important,
+                "active": declaration.active,
+                "status": if declaration.active { "active" } else { "overridden" },
+            }));
+        }
+    }
+
+    rules
+}
+
+fn cascade_rules_from_matched_styles(
+    matched_styles: &Value,
+    properties: &[String],
+    include_user_agent: bool,
+) -> Vec<Value> {
+    let mut declarations = Vec::new();
+
+    collect_style_declarations(
+        matched_styles.get("attributesStyle"),
+        "attribute style",
+        "attributes",
+        "attribute",
+        Specificity::zero(),
+        false,
+        0,
+        properties,
+        &mut declarations,
+    );
+
+    if let Some(matches) = matched_styles
+        .get("matchedCSSRules")
+        .and_then(|v| v.as_array())
+    {
+        for (rule_order, rule_match) in matches.iter().enumerate() {
+            let Some(rule) = rule_match.get("rule") else {
+                continue;
+            };
+            let origin = rule
+                .get("origin")
+                .and_then(|v| v.as_str())
+                .unwrap_or("regular");
+            if origin == "user-agent" && !include_user_agent {
+                continue;
+            }
+            let (selector, specificity) = matched_selector(rule_match);
+            let source = rule
+                .get("styleSheetId")
+                .or_else(|| {
+                    rule.get("style")
+                        .and_then(|style| style.get("styleSheetId"))
+                })
+                .and_then(|v| v.as_str())
+                .unwrap_or(origin);
+
+            collect_style_declarations(
+                rule.get("style"),
+                &selector,
+                source,
+                origin,
+                specificity,
+                false,
+                10_000 + (rule_order * 1_000),
+                properties,
+                &mut declarations,
+            );
+        }
+    }
+
+    collect_style_declarations(
+        matched_styles.get("inlineStyle"),
+        "element.style",
+        "inline",
+        "inline",
+        Specificity::inline(),
+        true,
+        usize::MAX / 2,
+        properties,
+        &mut declarations,
+    );
+
+    mark_active_declarations(&mut declarations);
+    declarations_to_rules(&declarations)
+}
+
+async fn get_computed_styles_for_object(
+    client: &CdpClient,
+    effective_session_id: &str,
+    object_id: String,
+    properties: Option<Vec<String>>,
+) -> Result<Value, String> {
     let js = match properties {
         Some(props) => {
             let props_json = serde_json::to_string(&props).unwrap_or("[]".to_string());
@@ -972,16 +1425,171 @@ pub async fn get_element_styles(
                 return_by_value: Some(true),
                 await_promise: Some(false),
             },
-            Some(&effective_session_id),
+            Some(effective_session_id),
         )
         .await?;
 
     Ok(result.result.value.unwrap_or(Value::Null))
 }
 
+async fn get_cascade_element_summary(
+    client: &CdpClient,
+    effective_session_id: &str,
+    object_id: String,
+    properties: &[String],
+    include_ancestors: bool,
+) -> Result<Value, String> {
+    let props_json = serde_json::to_string(properties).unwrap_or("[]".to_string());
+    let ancestors_json = if include_ancestors { "true" } else { "false" };
+    let js = format!(
+        r#"function() {{
+            const props = {};
+            const includeAncestors = {};
+            const readComputed = (el, names) => {{
+                const style = window.getComputedStyle(el);
+                const out = {{}};
+                for (const name of names) out[name] = style.getPropertyValue(name);
+                return out;
+            }};
+            const compactText = (el) => (el.innerText || el.textContent || "")
+                .replace(/\s+/g, " ")
+                .trim()
+                .slice(0, 200);
+            const rect = this.getBoundingClientRect();
+            const result = {{
+                tag: this.tagName ? this.tagName.toLowerCase() : "",
+                text: compactText(this),
+                box: {{ x: rect.x, y: rect.y, width: rect.width, height: rect.height }},
+                computed: readComputed(this, props),
+            }};
+
+            if (includeAncestors) {{
+                const ancestorProps = ["display", "position", "overflow", "overflow-x", "overflow-y", "z-index", "opacity", "transform"];
+                result.ancestors = [];
+                let node = this.parentElement;
+                while (node && node.nodeType === Node.ELEMENT_NODE && result.ancestors.length < 5) {{
+                    const ancestorRect = node.getBoundingClientRect();
+                    result.ancestors.push({{
+                        tag: node.tagName ? node.tagName.toLowerCase() : "",
+                        id: node.id || "",
+                        class: typeof node.className === "string" ? node.className : "",
+                        text: compactText(node),
+                        box: {{ x: ancestorRect.x, y: ancestorRect.y, width: ancestorRect.width, height: ancestorRect.height }},
+                        computed: readComputed(node, ancestorProps),
+                    }});
+                    node = node.parentElement;
+                }}
+            }}
+
+            return result;
+        }}"#,
+        props_json, ancestors_json
+    );
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: js,
+                object_id: Some(object_id),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(effective_session_id),
+        )
+        .await?;
+
+    Ok(result.result.value.unwrap_or(Value::Null))
+}
+
+/// Return computed styles by default, or a focused DevTools-style CSS cascade
+/// report when cascade mode is enabled.
+#[allow(clippy::too_many_arguments)]
+pub async fn get_element_styles(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    selector_or_ref: &str,
+    properties: Option<Vec<String>>,
+    cascade: bool,
+    include_ancestors: bool,
+    include_user_agent: bool,
+    iframe_sessions: &HashMap<String, String>,
+) -> Result<Value, String> {
+    let (object_id, effective_session_id) = resolve_element_object_id(
+        client,
+        session_id,
+        ref_map,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await?;
+
+    if !cascade {
+        return get_computed_styles_for_object(
+            client,
+            &effective_session_id,
+            object_id,
+            properties,
+        )
+        .await;
+    }
+
+    let properties = normalize_property_list(properties);
+    let summary = get_cascade_element_summary(
+        client,
+        &effective_session_id,
+        object_id.clone(),
+        &properties,
+        include_ancestors,
+    )
+    .await?;
+
+    client
+        .send_command_no_params("DOM.enable", Some(&effective_session_id))
+        .await?;
+    client
+        .send_command_no_params("CSS.enable", Some(&effective_session_id))
+        .await?;
+    client
+        .send_command_no_params("DOM.getDocument", Some(&effective_session_id))
+        .await?;
+
+    let node: DomRequestNodeResult = client
+        .send_command_typed(
+            "DOM.requestNode",
+            &DomRequestNodeParams { object_id },
+            Some(&effective_session_id),
+        )
+        .await?;
+    let matched_styles: Value = client
+        .send_command_typed(
+            "CSS.getMatchedStylesForNode",
+            &CssGetMatchedStylesForNodeParams {
+                node_id: node.node_id,
+            },
+            Some(&effective_session_id),
+        )
+        .await?;
+
+    let rules = cascade_rules_from_matched_styles(&matched_styles, &properties, include_user_agent);
+    let mut match_obj = summary
+        .as_object()
+        .cloned()
+        .unwrap_or_else(serde_json::Map::new);
+    match_obj.insert("rules".to_string(), Value::Array(rules));
+
+    Ok(serde_json::json!({
+        "selector": selector_or_ref,
+        "matches": [Value::Object(match_obj)]
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_parse_ref_at_prefix() {
@@ -1035,6 +1643,148 @@ mod tests {
     fn test_build_selector_js_xpath_empty() {
         let js = build_selector_js("xpath=");
         assert!(js.contains("document.evaluate"));
+    }
+
+    #[test]
+    fn test_cascade_marks_competing_rules_active_and_overridden() {
+        let matched_styles = json!({
+            "matchedCSSRules": [{
+                "matchingSelectors": [0],
+                "rule": {
+                    "styleSheetId": "style-sheet-1",
+                    "origin": "regular",
+                    "selectorList": {
+                        "text": ".text-blue",
+                        "selectors": [{
+                            "text": ".text-blue",
+                            "specificity": { "a": 0, "b": 1, "c": 0 }
+                        }]
+                    },
+                    "style": {
+                        "cssProperties": [{
+                            "name": "color",
+                            "value": "blue",
+                            "important": false,
+                            "parsedOk": true
+                        }]
+                    }
+                }
+            }, {
+                "matchingSelectors": [0],
+                "rule": {
+                    "styleSheetId": "style-sheet-1",
+                    "origin": "regular",
+                    "selectorList": {
+                        "text": "#target.text-blue",
+                        "selectors": [{
+                            "text": "#target.text-blue",
+                            "specificity": { "a": 1, "b": 1, "c": 0 }
+                        }]
+                    },
+                    "style": {
+                        "cssProperties": [{
+                            "name": "color",
+                            "value": "red",
+                            "important": false,
+                            "parsedOk": true
+                        }]
+                    }
+                }
+            }]
+        });
+
+        let rules =
+            cascade_rules_from_matched_styles(&matched_styles, &["color".to_string()], false);
+        let declarations = rules
+            .iter()
+            .flat_map(|rule| {
+                let selector = rule
+                    .get("selector")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                rule.get("properties")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(move |prop| (selector.clone(), prop))
+            })
+            .collect::<Vec<_>>();
+
+        assert!(declarations.iter().any(|(selector, prop)| {
+            selector == ".text-blue"
+                && prop.get("value").and_then(|v| v.as_str()) == Some("blue")
+                && prop.get("active").and_then(|v| v.as_bool()) == Some(false)
+                && prop.get("status").and_then(|v| v.as_str()) == Some("overridden")
+        }));
+        assert!(declarations.iter().any(|(selector, prop)| {
+            selector == "#target.text-blue"
+                && prop.get("value").and_then(|v| v.as_str()) == Some("red")
+                && prop.get("active").and_then(|v| v.as_bool()) == Some(true)
+                && prop.get("status").and_then(|v| v.as_str()) == Some("active")
+        }));
+    }
+
+    #[test]
+    fn test_cascade_properties_filter_and_user_agent_default() {
+        let matched_styles = json!({
+            "matchedCSSRules": [{
+                "matchingSelectors": [0],
+                "rule": {
+                    "origin": "user-agent",
+                    "selectorList": {
+                        "text": "h1",
+                        "selectors": [{
+                            "text": "h1",
+                            "specificity": { "a": 0, "b": 0, "c": 1 }
+                        }]
+                    },
+                    "style": {
+                        "cssProperties": [{
+                            "name": "display",
+                            "value": "block"
+                        }]
+                    }
+                }
+            }, {
+                "matchingSelectors": [0],
+                "rule": {
+                    "styleSheetId": "style-sheet-1",
+                    "origin": "regular",
+                    "selectorList": {
+                        "text": ".title",
+                        "selectors": [{
+                            "text": ".title",
+                            "specificity": { "a": 0, "b": 1, "c": 0 }
+                        }]
+                    },
+                    "style": {
+                        "cssProperties": [{
+                            "name": "color",
+                            "value": "black"
+                        }, {
+                            "name": "font-size",
+                            "value": "20px"
+                        }]
+                    }
+                }
+            }]
+        });
+
+        let rules =
+            cascade_rules_from_matched_styles(&matched_styles, &["color".to_string()], false);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0]["selector"], ".title");
+        assert_eq!(rules[0]["properties"].as_array().unwrap().len(), 1);
+        assert_eq!(rules[0]["properties"][0]["name"], "color");
+
+        let rules = cascade_rules_from_matched_styles(
+            &matched_styles,
+            &["display".to_string(), "color".to_string()],
+            true,
+        );
+        assert!(rules.iter().any(|rule| rule["selector"] == "h1"));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -130,6 +130,129 @@ fn format_stream_status_text(action: Option<&str>, data: &serde_json::Value) -> 
     }
 }
 
+fn format_json_scalar(value: &serde_json::Value) -> String {
+    value
+        .as_str()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn format_cascade_styles_text(data: &serde_json::Value) -> Option<String> {
+    let matches = data.get("matches").and_then(|v| v.as_array())?;
+    let mut lines = Vec::new();
+
+    for (idx, element) in matches.iter().enumerate() {
+        if idx > 0 {
+            lines.push(String::new());
+        }
+
+        let tag = element.get("tag").and_then(|v| v.as_str()).unwrap_or("");
+        let text = element.get("text").and_then(|v| v.as_str()).unwrap_or("");
+        let label = if text.is_empty() {
+            tag.to_string()
+        } else {
+            format!("{} \"{}\"", tag, text)
+        };
+        lines.push(label);
+
+        lines.push("computed:".to_string());
+        if let Some(computed) = element.get("computed").and_then(|v| v.as_object()) {
+            if computed.is_empty() {
+                lines.push("  (none)".to_string());
+            } else {
+                for (name, value) in computed {
+                    lines.push(format!("  {}: {}", name, format_json_scalar(value)));
+                }
+            }
+        } else {
+            lines.push("  (none)".to_string());
+        }
+
+        lines.push(String::new());
+        lines.push("matched rules:".to_string());
+        if let Some(rules) = element.get("rules").and_then(|v| v.as_array()) {
+            if rules.is_empty() {
+                lines.push("  (none)".to_string());
+            }
+            for rule in rules {
+                let selector = rule
+                    .get("selector")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>");
+                let source = rule
+                    .get("source")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>");
+                lines.push(format!("  {}  {}", selector, source));
+
+                if let Some(properties) = rule.get("properties").and_then(|v| v.as_array()) {
+                    for property in properties {
+                        let name = property
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("<unknown>");
+                        let value = property.get("value").and_then(|v| v.as_str()).unwrap_or("");
+                        let important = property
+                            .get("important")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let status = property
+                            .get("status")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_else(|| {
+                                if property
+                                    .get("active")
+                                    .and_then(|v| v.as_bool())
+                                    .unwrap_or(false)
+                                {
+                                    "active"
+                                } else {
+                                    "overridden"
+                                }
+                            });
+                        let important_label = if important { " !important" } else { "" };
+                        lines.push(format!(
+                            "    {}: {}{}  {}",
+                            name, value, important_label, status
+                        ));
+                    }
+                }
+            }
+        } else {
+            lines.push("  (none)".to_string());
+        }
+
+        if let Some(ancestors) = element.get("ancestors").and_then(|v| v.as_array()) {
+            if !ancestors.is_empty() {
+                lines.push(String::new());
+                lines.push("ancestors:".to_string());
+                for ancestor in ancestors {
+                    let tag = ancestor.get("tag").and_then(|v| v.as_str()).unwrap_or("");
+                    let id = ancestor.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                    let class = ancestor.get("class").and_then(|v| v.as_str()).unwrap_or("");
+                    let mut label = tag.to_string();
+                    if !id.is_empty() {
+                        label.push('#');
+                        label.push_str(id);
+                    }
+                    if !class.is_empty() {
+                        label.push('.');
+                        label.push_str(&class.split_whitespace().collect::<Vec<_>>().join("."));
+                    }
+                    lines.push(format!("  {}", label));
+                    if let Some(computed) = ancestor.get("computed").and_then(|v| v.as_object()) {
+                        for (name, value) in computed {
+                            lines.push(format!("    {}: {}", name, format_json_scalar(value)));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Some(lines.join("\n"))
+}
+
 pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &OutputOptions) {
     if opts.json {
         if opts.content_boundaries {
@@ -309,6 +432,13 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 println!("height: {}", h);
             }
             return;
+        }
+        // CSS cascade (get styles --cascade)
+        if action == Some("styles") {
+            if let Some(output) = format_cascade_styles_text(data) {
+                println!("{}", output);
+                return;
+            }
         }
         // Computed styles (get styles)
         if let Some(styles) = data.get("styles").and_then(|v| v.as_object()) {
@@ -1762,6 +1892,12 @@ Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
 
+Styles Options:
+  --cascade            Include matched CSS rules and active/overridden declarations
+  --properties <list>  Comma-separated CSS properties to return
+  --ancestors          Include layout-critical computed styles for ancestors
+  --include-user-agent Include user-agent stylesheet rules in cascade output
+
 Examples:
   agent-browser get text @e1
   agent-browser get html "#content"
@@ -1773,6 +1909,7 @@ Examples:
   agent-browser get box "#header"
   agent-browser get styles "button"
   agent-browser get styles @e1
+  agent-browser get styles "h1" --cascade --properties color,font-size
 "##
         }
 
@@ -2949,6 +3086,7 @@ Navigation:
 
 Get Info:  agent-browser get <what> [selector]
   text, html, value, attr <name>, title, url, count, box, styles, cdp-url
+  styles supports --cascade, --properties, --ancestors, --include-user-agent
 
 Check State:  agent-browser is <what> <selector>
   visible, enabled, checked
@@ -3311,7 +3449,7 @@ pub fn print_version() {
 
 #[cfg(test)]
 mod tests {
-    use super::format_storage_text;
+    use super::{format_cascade_styles_text, format_storage_text};
     use serde_json::json;
 
     #[test]
@@ -3376,5 +3514,51 @@ mod tests {
         let rendered = format_storage_text(&data).unwrap();
 
         assert_eq!(rendered, "No storage entries");
+    }
+
+    #[test]
+    fn test_format_cascade_styles_text() {
+        let data = json!({
+            "selector": "h1",
+            "matches": [{
+                "tag": "h1",
+                "text": "Building useful software.",
+                "computed": {
+                    "color": "rgb(10, 10, 10)",
+                    "font-size": "128px"
+                },
+                "rules": [{
+                    "selector": ".text-ink",
+                    "source": "style-sheet-1",
+                    "origin": "regular",
+                    "properties": [{
+                        "name": "color",
+                        "value": "rgb(10, 10, 10)",
+                        "important": false,
+                        "active": true,
+                        "status": "active"
+                    }]
+                }, {
+                    "selector": ".text-muted",
+                    "source": "style-sheet-1",
+                    "origin": "regular",
+                    "properties": [{
+                        "name": "color",
+                        "value": "rgb(100, 100, 100)",
+                        "important": true,
+                        "active": false,
+                        "status": "overridden"
+                    }]
+                }]
+            }]
+        });
+
+        let rendered = format_cascade_styles_text(&data).unwrap();
+
+        assert!(rendered.contains("h1 \"Building useful software.\""));
+        assert!(rendered.contains("computed:\n  color: rgb(10, 10, 10)"));
+        assert!(rendered.contains(".text-ink  style-sheet-1"));
+        assert!(rendered.contains("color: rgb(10, 10, 10)  active"));
+        assert!(rendered.contains("color: rgb(100, 100, 100) !important  overridden"));
     }
 }

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -51,7 +51,10 @@ agent-browser get cdp-url             # Get CDP WebSocket URL
 agent-browser get count <sel>         # Count matching elements
 agent-browser get box <sel>           # Get bounding box
 agent-browser get styles <sel>        # Get computed styles
+agent-browser get styles <sel> --cascade --properties color,font-size
 ```
+
+`get styles` returns computed CSS properties by default. Add `--cascade` to include matched CSS rules, stylesheet identifiers, declaration values, `!important`, and active or overridden status. Use `--properties` with a comma-separated property list to keep output focused. Cascade output filters browser user-agent stylesheet rules unless `--include-user-agent` is set. Use `--ancestors` to include layout-critical computed styles for nearby ancestors.
 
 ## Check state
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -90,7 +90,10 @@ agent-browser get value @e1               # input value
 agent-browser get title                   # page title
 agent-browser get url                     # current URL
 agent-browser get count ".item"           # count matching elements
+agent-browser get styles @e1 --cascade --properties color,font-size
 ```
+
+Use `get styles <selector|@ref> --cascade` when you need to explain where a CSS value came from. Cascade mode returns computed values for the selected properties plus matched rules with selector text, stylesheet identifier, declaration value, `!important`, and active or overridden status. It filters browser user-agent rules by default; add `--include-user-agent` only when browser defaults matter. Add `--ancestors` when ancestor layout styles are part of the question.
 
 ## Interacting
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -84,7 +84,10 @@ agent-browser get cdp-url         # Get CDP WebSocket URL
 agent-browser get count ".item"   # Count matching elements
 agent-browser get box @e1         # Get bounding box
 agent-browser get styles @e1      # Get computed styles (font, color, bg, etc.)
+agent-browser get styles @e1 --cascade --properties color,font-size
 ```
+
+`get styles --cascade` is opt-in. It keeps normal computed-style output unchanged unless requested, then returns computed values for the selected properties plus matched CSS rules. Each rule includes selector text, a stylesheet/source identifier, declaration value, `!important`, and active or overridden status. Browser user-agent stylesheet rules are filtered by default; add `--include-user-agent` to include them. Use `--ancestors` to include layout-critical computed styles for nearby ancestors.
 
 ## Check State
 


### PR DESCRIPTION
## Summary

Adds opt-in CSS cascade inspection to `agent-browser get styles`:

- `--cascade` returns computed values plus matched CSS rules
- `--properties color,font-size` narrows computed values and matched declarations
- `--ancestors` includes layout-critical computed styles for nearby ancestors
- `--include-user-agent` includes browser user-agent stylesheet rules (filtered by default)
- `--json` preserves structured output for cascade data

The default `get styles <selector>` path is unchanged.

## Motivation

Before this change, `get styles` resolved the element and called `window.getComputedStyle(this)` from `cli/src/native/element.rs`, returning final computed values only. It did not call `CSS.getMatchedStylesForNode` and could not expose selector or source attribution or active-vs-overridden declarations — which is what AI agents debugging CSS issues actually need ("why is this `color` value winning?", "did my Tailwind utility apply?", "is a component-library runtime class overriding my rule?").

## Implementation

Cascade mode bridges from the resolved Runtime object to CSS rules with:

1. `DOM.enable`
2. `CSS.enable`
3. `DOM.getDocument` (required to materialize the front-end node tree before `nodeId` lookups resolve)
4. `DOM.requestNode { objectId }`
5. `CSS.getMatchedStylesForNode { nodeId }`

Matched declarations include selector text, source/`styleSheetId`, value, `important`, `active`, and `status`. Active-vs-overridden is computed in the CLI layer from importance, inline precedence, selector specificity, and source order.

User-agent rules are filtered by default to keep output token-efficient; `--include-user-agent` opts them back in.

## Tests

- 4 unit tests covering text formatting, CLI flag parsing, properties filter + UA default behavior, and competing-rules active/overridden logic
- 1 `#[ignore]`'d e2e test covering selector and `@e` ref inputs against a real Chromium

## Validation

Verified locally on Linux x86_64 against a real Chromium, running the same invocations as `.github/workflows/ci.yml`:

| Command | Result |
|---|---|
| `cargo fmt --manifest-path cli/Cargo.toml -- --check` | clean |
| `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings` | clean |
| `cargo test --profile ci --manifest-path cli/Cargo.toml` | **703 passed, 0 failed, 71 ignored** (+ `doctor_cli` 2 passed) |
| `cargo test --profile ci --manifest-path cli/Cargo.toml e2e -- --ignored --test-threads=1` | **70 passed, 0 failed** (entire e2e suite, not just the new cascade test) |

Cross-platform CI (macOS, Windows targets) will run via GitHub Actions on this PR.
