### PR TITLE
fix: respect executablePath in doctor

### DIFF
--- a/cli/src/doctor/chrome.rs
+++ b/cli/src/doctor/chrome.rs
@@ -7,26 +7,56 @@ use std::path::{Path, PathBuf};
 use super::helpers::which_exists;
 use super::{Check, Status};
 
-pub(super) fn check(checks: &mut Vec<Check>) {
+pub(super) fn check(checks: &mut Vec<Check>, executable_path: Option<&str>) {
     let category = "Chrome";
 
-    let chrome = crate::native::cdp::chrome::find_chrome();
+    let configured_path = executable_path.filter(|path| !path.trim().is_empty());
+    let using_configured_path = configured_path.is_some();
+    let chrome = configured_path
+        .map(PathBuf::from)
+        .or_else(crate::native::cdp::chrome::find_chrome);
+
     match chrome {
         Some(path) => {
             let label = path.display().to_string();
-            match query_chrome_version(&path) {
-                Some(version) => checks.push(Check::new(
+            if !path.exists() {
+                checks.push(
+                    Check::new(
+                        "chrome.installed",
+                        category,
+                        Status::Fail,
+                        format!("Configured browser executable not found at {}", label),
+                    )
+                    .with_fix("update executablePath or AGENT_BROWSER_EXECUTABLE_PATH"),
+                );
+            } else if let Some(version) = query_chrome_version(&path) {
+                checks.push(Check::new(
                     "chrome.installed",
                     category,
                     Status::Pass,
                     format!("{} at {}", version, label),
-                )),
-                None => checks.push(Check::new(
+                ));
+            } else {
+                let status = if using_configured_path {
+                    Status::Warn
+                } else {
+                    Status::Pass
+                };
+                let mut check = Check::new(
                     "chrome.installed",
                     category,
-                    Status::Pass,
-                    format!("Chrome at {} (version unknown)", label),
-                )),
+                    status,
+                    if using_configured_path {
+                        format!("Browser executable at {} (version unknown)", label)
+                    } else {
+                        format!("Chrome at {} (version unknown)", label)
+                    },
+                );
+                if using_configured_path {
+                    check = check
+                        .with_fix("verify executablePath points to a runnable browser executable");
+                }
+                checks.push(check);
             }
         }
         None => checks.push(
@@ -140,6 +170,89 @@ pub(super) fn puppeteer_cache_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn known_executable_path() -> &'static str {
+        if cfg!(target_os = "windows") {
+            "C:\\Windows\\System32\\cmd.exe"
+        } else {
+            "/bin/sh"
+        }
+    }
+
+    #[test]
+    fn check_reports_configured_executable_path() {
+        let executable = known_executable_path();
+        let mut checks = Vec::new();
+
+        check(&mut checks, Some(executable));
+
+        let chrome_check = checks
+            .iter()
+            .find(|check| check.id == "chrome.installed")
+            .expect("chrome check should be present");
+        assert!(
+            matches!(chrome_check.status, Status::Pass | Status::Warn),
+            "configured executable path should not fail: {}",
+            chrome_check.message
+        );
+        assert!(
+            chrome_check.message.contains(executable),
+            "configured executable path should appear in message: {}",
+            chrome_check.message
+        );
+    }
+
+    #[test]
+    fn check_warns_when_configured_executable_version_is_unknown() {
+        let dir = TempDir::new().expect("temp dir should be created");
+        let executable = dir.path().join("not-a-browser");
+        let mut file = std::fs::File::create(&executable).expect("file should be created");
+        writeln!(file, "not executable").expect("file should be written");
+        let mut checks = Vec::new();
+
+        check(&mut checks, executable.to_str());
+
+        let chrome_check = checks
+            .iter()
+            .find(|check| check.id == "chrome.installed")
+            .expect("chrome check should be present");
+        assert_eq!(chrome_check.status, Status::Warn);
+        assert!(
+            chrome_check.message.contains("version unknown"),
+            "unknown version should produce a warning message: {}",
+            chrome_check.message
+        );
+        assert!(
+            chrome_check.fix.is_some(),
+            "unknown configured executable should include a fix"
+        );
+    }
+
+    #[test]
+    fn check_fails_when_configured_executable_path_is_missing() {
+        let missing = std::env::temp_dir().join(format!(
+            "agent-browser-missing-browser-{}",
+            std::process::id()
+        ));
+        let mut checks = Vec::new();
+
+        check(&mut checks, missing.to_str());
+
+        let chrome_check = checks
+            .iter()
+            .find(|check| check.id == "chrome.installed")
+            .expect("chrome check should be present");
+        assert_eq!(chrome_check.status, Status::Fail);
+        assert!(
+            chrome_check
+                .message
+                .contains("Configured browser executable"),
+            "missing executable should produce a targeted message: {}",
+            chrome_check.message
+        );
+    }
 
     #[test]
     fn test_puppeteer_cache_dir_returns_sensible_default() {

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -13,7 +13,7 @@ use super::helpers::new_id;
 use super::{Check, Status};
 use crate::connection::{cleanup_stale_files, ensure_daemon, send_command, DaemonOptions};
 
-pub(super) fn check(checks: &mut Vec<Check>) {
+pub(super) fn check(checks: &mut Vec<Check>, executable_path: Option<&str>) {
     let category = "Launch test";
 
     if env::var("AGENT_BROWSER_PROVIDER").is_ok() {
@@ -53,7 +53,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     let opts = DaemonOptions {
         headed: false,
         debug: false,
-        executable_path: None,
+        executable_path,
         extensions: &[],
         init_scripts: &[],
         enable: &[],

--- a/cli/src/doctor/mod.rs
+++ b/cli/src/doctor/mod.rs
@@ -23,12 +23,13 @@ use serde_json::{json, Value};
 
 use crate::color;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone)]
 pub struct DoctorOptions {
     pub offline: bool,
     pub quick: bool,
     pub fix: bool,
     pub json: bool,
+    pub executable_path: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -97,7 +98,7 @@ pub fn run_doctor(opts: DoctorOptions) -> i32 {
     let mut fixed: Vec<String> = Vec::new();
 
     environment::check(&mut checks);
-    chrome::check(&mut checks);
+    chrome::check(&mut checks, opts.executable_path.as_deref());
     daemon::check(&mut checks);
     config::check(&mut checks);
     security::check(&mut checks);
@@ -108,7 +109,7 @@ pub fn run_doctor(opts: DoctorOptions) -> i32 {
     }
 
     if !opts.quick {
-        launch::check(&mut checks);
+        launch::check(&mut checks, opts.executable_path.as_deref());
     }
 
     if opts.fix {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -558,6 +558,7 @@ fn main() {
             quick: args.iter().any(|a| a == "--quick"),
             fix: args.iter().any(|a| a == "--fix"),
             json: flags.json,
+            executable_path: flags.executable_path.clone(),
         };
         exit(doctor::run_doctor(opts));
     }

--- a/cli/tests/doctor_cli.rs
+++ b/cli/tests/doctor_cli.rs
@@ -24,6 +24,7 @@ fn build_doctor_cmd(tmp: &TempDir, args: &[&str]) -> Command {
         // Keep the launch test's skip-logic deterministic across hosts.
         .env_remove("AGENT_BROWSER_PROVIDER")
         .env_remove("AGENT_BROWSER_CDP")
+        .env_remove("AGENT_BROWSER_EXECUTABLE_PATH")
         // Don't emit color codes into captured stdout.
         .env("NO_COLOR", "1");
     cmd
@@ -105,6 +106,43 @@ fn doctor_offline_quick_json_emits_valid_payload() {
             stdout
         );
     }
+}
+
+#[test]
+fn doctor_uses_configured_executable_path() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("home").join(".agent-browser");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.json"),
+        serde_json::json!({ "executablePath": BIN }).to_string(),
+    )
+    .unwrap();
+
+    let output = build_doctor_cmd(&tmp, &["doctor", "--offline", "--quick", "--json"])
+        .output()
+        .expect("failed to invoke agent-browser doctor");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout was not JSON: {}\n---\n{}", e, stdout));
+
+    let checks = payload["checks"]
+        .as_array()
+        .expect("checks should be an array");
+    let chrome_check = checks
+        .iter()
+        .find(|check| check["id"] == "chrome.installed")
+        .expect("chrome check should be present");
+
+    assert_eq!(chrome_check["status"], "pass");
+    assert!(
+        chrome_check["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(BIN)),
+        "chrome check should mention configured executable path: {}",
+        chrome_check
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- pass the configured `executablePath` into `agent-browser doctor`
- use that executable for both the Chrome install check and the live launch test
- add regression coverage for `doctor` reading `executablePath` from config

Fixes #1310.

## Testing

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path cli/Cargo.toml --profile ci doctor::chrome::tests`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path cli/Cargo.toml --profile ci --test doctor_cli`