### PR TITLE
feat: add stream bind address option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ agent-browser pdf <path>              # Save as PDF
 agent-browser snapshot                # Accessibility tree with refs (best for AI)
 agent-browser eval <js>               # Run JavaScript (-b for base64, --stdin for piped input)
 agent-browser connect <port>          # Connect to browser via CDP
-agent-browser stream enable [--port <port>]  # Start runtime WebSocket streaming
+agent-browser stream enable [--addr <addr>] [--port <port>]  # Start runtime WebSocket streaming
 agent-browser stream status           # Show runtime streaming state and bound port
 agent-browser stream disable          # Stop runtime WebSocket streaming
 agent-browser close                   # Close browser (aliases: quit, exit)
@@ -1142,6 +1142,7 @@ You can also manage streaming at runtime with `stream enable`, `stream disable`,
 
 ```bash
 agent-browser stream enable --port 9223   # Re-enable on a specific port
+agent-browser stream enable --addr 0.0.0.0 --port 9223  # Bind for container access
 agent-browser stream disable              # Stop streaming for the session
 ```
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,6 +1,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde_json::{json, Value};
 use std::io::{self, BufRead};
+use std::net::IpAddr;
 
 use crate::color;
 use crate::flags::Flags;
@@ -992,7 +993,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 rest.get(i + 1)
                                     .ok_or_else(|| ParseError::MissingArguments {
                                         context: "stream enable --port".to_string(),
-                                        usage: "stream enable [--port <port>]",
+                                        usage: "stream enable [--addr <addr>] [--port <port>]",
                                     })?;
                             let port =
                                 value.parse::<u32>().map_err(|_| ParseError::InvalidValue {
@@ -1000,7 +1001,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                         "Invalid port: '{}' is not a valid integer",
                                         value
                                     ),
-                                    usage: "stream enable [--port <port>]",
+                                    usage: "stream enable [--addr <addr>] [--port <port>]",
                                 })?;
                             if port > u16::MAX as u32 {
                                 return Err(ParseError::InvalidValue {
@@ -1008,16 +1009,36 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                         "Invalid port: {} is out of range (valid range: 0-65535)",
                                         port
                                     ),
-                                    usage: "stream enable [--port <port>]",
+                                    usage: "stream enable [--addr <addr>] [--port <port>]",
                                 });
                             }
                             cmd["port"] = json!(port);
                             i += 2;
                         }
+                        "--addr" | "-a" => {
+                            let value =
+                                rest.get(i + 1)
+                                    .ok_or_else(|| ParseError::MissingArguments {
+                                        context: "stream enable --addr".to_string(),
+                                        usage: "stream enable [--addr <addr>] [--port <port>]",
+                                    })?;
+                            let addr =
+                                value
+                                    .parse::<IpAddr>()
+                                    .map_err(|_| ParseError::InvalidValue {
+                                        message: format!(
+                                            "Invalid address: '{}' is not a valid IP address",
+                                            value
+                                        ),
+                                        usage: "stream enable [--addr <addr>] [--port <port>]",
+                                    })?;
+                            cmd["addr"] = json!(addr.to_string());
+                            i += 2;
+                        }
                         flag => {
                             return Err(ParseError::InvalidValue {
                                 message: format!("Unknown flag for stream enable: {}", flag),
-                                usage: "stream enable [--port <port>]",
+                                usage: "stream enable [--addr <addr>] [--port <port>]",
                             });
                         }
                     }
@@ -4489,6 +4510,25 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_enable_with_addr_and_port() {
+        let cmd = parse_command(
+            &args("stream enable --addr 0.0.0.0 --port 9223"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "stream_enable");
+        assert_eq!(cmd["addr"], "0.0.0.0");
+        assert_eq!(cmd["port"], 9223);
+    }
+
+    #[test]
+    fn test_stream_enable_with_short_addr() {
+        let cmd = parse_command(&args("stream enable -a ::1"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "stream_enable");
+        assert_eq!(cmd["addr"], "::1");
+    }
+
+    #[test]
     fn test_stream_status() {
         let cmd = parse_command(&args("stream status"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "stream_status");
@@ -4503,6 +4543,12 @@ mod tests {
     #[test]
     fn test_stream_enable_invalid_port() {
         let result = parse_command(&args("stream enable --port abc"), &default_flags());
+        assert!(matches!(result, Err(ParseError::InvalidValue { .. })));
+    }
+
+    #[test]
+    fn test_stream_enable_invalid_addr() {
+        let result = parse_command(&args("stream enable --addr localhost"), &default_flags());
         assert!(matches!(result, Err(ParseError::InvalidValue { .. })));
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -5247,6 +5248,11 @@ async fn current_stream_status(state: &DaemonState) -> Value {
 
     json!({
         "enabled": state.stream_server.is_some(),
+        "addr": state
+            .stream_server
+            .as_ref()
+            .map(|server| Value::from(server.bind_addr().to_string()))
+            .unwrap_or(Value::Null),
         "port": state
             .stream_server
             .as_ref()
@@ -5267,9 +5273,20 @@ async fn handle_stream_enable(cmd: &Value, state: &mut DaemonState) -> Result<Va
             .map_err(|_| format!("Invalid stream port '{}': expected 0-65535", raw))?,
         None => 0,
     };
+    let bind_addr = match cmd.get("addr").and_then(|value| value.as_str()) {
+        Some(raw) => raw
+            .parse::<IpAddr>()
+            .map_err(|_| format!("Invalid stream address '{}': expected an IP address", raw))?,
+        None => IpAddr::from(Ipv4Addr::LOCALHOST),
+    };
 
-    let (server, client_slot) =
-        StreamServer::start_without_client(requested_port, state.session_id.clone(), false).await?;
+    let (server, client_slot) = StreamServer::start_without_client_on_addr(
+        requested_port,
+        bind_addr,
+        state.session_id.clone(),
+        false,
+    )
+    .await?;
     let port = server.port();
     if let Err(err) = write_stream_file(&state.session_id, port) {
         server.shutdown().await;
@@ -8147,6 +8164,7 @@ mod tests {
             .expect("runtime stream should report a bound port");
         assert!(port > 0, "runtime stream should bind a non-zero port");
         assert_eq!(enabled_status["enabled"], true);
+        assert_eq!(enabled_status["addr"], "127.0.0.1");
         assert_eq!(enabled_status["connected"], false);
         assert_eq!(enabled_status["screencasting"], false);
 
@@ -8164,6 +8182,7 @@ mod tests {
             .await
             .expect("status should work after enable");
         assert_eq!(status["enabled"], true);
+        assert_eq!(status["addr"], "127.0.0.1");
         assert_eq!(status["port"], port);
 
         let disabled = handle_stream_disable(&mut state)
@@ -8181,6 +8200,7 @@ mod tests {
             .await
             .expect("status should work after disable");
         assert_eq!(final_status["enabled"], false);
+        assert_eq!(final_status["addr"], Value::Null);
         assert_eq!(final_status["port"], Value::Null);
 
         let disable_err = handle_stream_disable(&mut state)
@@ -8189,6 +8209,48 @@ mod tests {
         assert!(disable_err.contains("not enabled"));
 
         let _ = fs::remove_dir_all(&socket_dir);
+    }
+
+    #[tokio::test]
+    async fn test_stream_enable_uses_requested_addr() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+        let socket_dir = unique_socket_dir("stream-addr");
+        fs::create_dir_all(&socket_dir).expect("socket dir should be created");
+        guard.set(
+            "AGENT_BROWSER_SOCKET_DIR",
+            socket_dir.to_str().expect("socket dir should be utf-8"),
+        );
+        guard.set("AGENT_BROWSER_SESSION", "stream-addr-session");
+
+        let mut state = DaemonState::new();
+        let enabled_status =
+            handle_stream_enable(&json!({ "addr": "0.0.0.0", "port": 0 }), &mut state)
+                .await
+                .expect("stream enable should bind the requested address");
+
+        assert_eq!(enabled_status["enabled"], true);
+        assert_eq!(enabled_status["addr"], "0.0.0.0");
+        assert!(
+            enabled_status["port"].as_u64().is_some_and(|port| port > 0),
+            "runtime stream should report a bound port"
+        );
+
+        handle_stream_disable(&mut state)
+            .await
+            .expect("stream disable should clean up custom address stream");
+        let _ = fs::remove_dir_all(&socket_dir);
+    }
+
+    #[tokio::test]
+    async fn test_stream_enable_rejects_invalid_addr() {
+        let mut state = DaemonState::new();
+        let err = handle_stream_enable(&json!({ "addr": "localhost", "port": 0 }), &mut state)
+            .await
+            .expect_err("non-IP bind address should be rejected");
+
+        assert!(err.contains("Invalid stream address"));
+        assert!(state.stream_server.is_none());
+        assert!(state.stream_client.is_none());
     }
 
     #[tokio::test]

--- a/cli/src/native/stream/mod.rs
+++ b/cli/src/native/stream/mod.rs
@@ -9,6 +9,7 @@ pub use cdp_loop::{ack_screencast_frame, start_screencast, stop_screencast};
 pub use dashboard::run_dashboard_server;
 
 use serde_json::{json, Value};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
@@ -44,6 +45,7 @@ impl Default for FrameMetadata {
 
 pub struct StreamServer {
     port: u16,
+    bind_addr: IpAddr,
     session_name: String,
     frame_tx: broadcast::Sender<String>,
     client_count: Arc<Mutex<usize>>,
@@ -64,13 +66,24 @@ pub struct StreamServer {
 }
 
 impl StreamServer {
+    fn default_bind_addr() -> IpAddr {
+        IpAddr::from(Ipv4Addr::LOCALHOST)
+    }
+
     pub async fn start(
         preferred_port: u16,
         client: Arc<CdpClient>,
         session_id: String,
     ) -> Result<Self, String> {
         let client_slot = Arc::new(RwLock::new(Some(client)));
-        let (server, _) = Self::start_inner(preferred_port, client_slot, session_id, true).await?;
+        let (server, _) = Self::start_inner(
+            preferred_port,
+            Self::default_bind_addr(),
+            client_slot,
+            session_id,
+            true,
+        )
+        .await?;
         Ok(server)
     }
 
@@ -85,8 +98,31 @@ impl StreamServer {
         session_id: String,
         allow_port_fallback: bool,
     ) -> Result<(Self, Arc<RwLock<Option<Arc<CdpClient>>>>), String> {
+        Self::start_without_client_on_addr(
+            preferred_port,
+            Self::default_bind_addr(),
+            session_id,
+            allow_port_fallback,
+        )
+        .await
+    }
+
+    /// Start the stream server on an explicit bind address.
+    pub async fn start_without_client_on_addr(
+        preferred_port: u16,
+        bind_addr: IpAddr,
+        session_id: String,
+        allow_port_fallback: bool,
+    ) -> Result<(Self, Arc<RwLock<Option<Arc<CdpClient>>>>), String> {
         let client_slot = Arc::new(RwLock::new(None::<Arc<CdpClient>>));
-        Self::start_inner(preferred_port, client_slot, session_id, allow_port_fallback).await
+        Self::start_inner(
+            preferred_port,
+            bind_addr,
+            client_slot,
+            session_id,
+            allow_port_fallback,
+        )
+        .await
     }
 
     /// Notify the background CDP listener that the client has changed (browser launched/closed).
@@ -156,15 +192,16 @@ impl StreamServer {
 
     async fn start_inner(
         preferred_port: u16,
+        bind_addr: IpAddr,
         client_slot: Arc<RwLock<Option<Arc<CdpClient>>>>,
         session_id: String,
         allow_port_fallback: bool,
     ) -> Result<(Self, Arc<RwLock<Option<Arc<CdpClient>>>>), String> {
-        let addr = format!("127.0.0.1:{}", preferred_port);
+        let addr = SocketAddr::new(bind_addr, preferred_port);
         let listener = match TcpListener::bind(&addr).await {
             Ok(l) => l,
             Err(_) if allow_port_fallback && preferred_port != 0 => {
-                TcpListener::bind("127.0.0.1:0")
+                TcpListener::bind(SocketAddr::new(bind_addr, 0))
                     .await
                     .map_err(|e| format!("Failed to bind stream server: {}", e))?
             }
@@ -175,6 +212,7 @@ impl StreamServer {
             .local_addr()
             .map_err(|e| format!("Failed to get stream address: {}", e))?;
         let port = actual_addr.port();
+        let bind_addr = actual_addr.ip();
 
         let (frame_tx, _) = broadcast::channel::<String>(64);
         let client_count = Arc::new(Mutex::new(0usize));
@@ -259,6 +297,7 @@ impl StreamServer {
         Ok((
             Self {
                 port,
+                bind_addr,
                 session_name: session_id,
                 frame_tx,
                 client_count,
@@ -282,6 +321,10 @@ impl StreamServer {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    pub fn bind_addr(&self) -> IpAddr {
+        self.bind_addr
     }
 
     /// Broadcast a raw frame string (legacy).

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -112,6 +112,11 @@ fn format_stream_status_text(action: Option<&str>, data: &serde_json::Value) -> 
                 return Some("Streaming disabled".to_string());
             }
 
+            let addr = data
+                .get("addr")
+                .and_then(|v| v.as_str())
+                .unwrap_or("127.0.0.1");
+            let host = format_ws_host(addr);
             let port = data.get("port").and_then(|v| v.as_u64())?;
             let connected = data
                 .get("connected")
@@ -123,10 +128,18 @@ fn format_stream_status_text(action: Option<&str>, data: &serde_json::Value) -> 
                 .unwrap_or(false);
 
             Some(format!(
-                "Streaming enabled on ws://127.0.0.1:{port}\nConnected: {connected}\nScreencasting: {screencasting}"
+                "Streaming enabled on ws://{host}:{port}\nConnected: {connected}\nScreencasting: {screencasting}"
             ))
         }
         _ => None,
+    }
+}
+
+fn format_ws_host(addr: &str) -> String {
+    if addr.contains(':') && !addr.starts_with('[') {
+        format!("[{addr}]")
+    } else {
+        addr.to_string()
     }
 }
 
@@ -2614,13 +2627,14 @@ Examples:
 agent-browser stream - Manage live WebSocket browser streaming
 
 Usage:
-  agent-browser stream enable [--port <port>]
+  agent-browser stream enable [--addr <addr>] [--port <port>]
   agent-browser stream disable
   agent-browser stream status
 
 Enables or disables the session-scoped WebSocket stream server without restarting
 an already-running daemon. If --port is omitted, agent-browser binds an
-available localhost port automatically and reports it back.
+available port automatically and reports it back. If --addr is omitted,
+agent-browser binds to 127.0.0.1.
 
 Notes:
   - 'stream enable' creates the WebSocket server.
@@ -2637,6 +2651,7 @@ Examples:
   agent-browser stream status
   agent-browser stream enable
   agent-browser stream enable --port 9223
+  agent-browser stream enable --addr 0.0.0.0 --port 9223
   agent-browser stream disable
 "##
         }
@@ -2995,7 +3010,8 @@ Debug:
   clipboard <op> [text]      Read/write clipboard (read, write, copy, paste)
 
 Streaming:
-  stream enable [--port <n>] Start runtime WebSocket streaming for this session
+  stream enable [--addr <addr>] [--port <n>]
+                             Start runtime WebSocket streaming for this session
   stream disable             Stop runtime WebSocket streaming
   stream status              Show streaming status and active port
 
@@ -3202,6 +3218,7 @@ Examples:
   agent-browser --cdp 9222 snapshot      # Connect via CDP port
   agent-browser --auto-connect snapshot  # Auto-discover running Chrome
   agent-browser stream enable            # Start runtime streaming on an auto-selected port
+  agent-browser stream enable --addr 0.0.0.0 --port 9223  # Bind for container access
   agent-browser stream status            # Inspect runtime streaming state
   agent-browser --color-scheme dark open example.com  # Dark mode
   agent-browser --profile Default open gmail.com        # Reuse Chrome login state
@@ -3318,6 +3335,7 @@ mod tests {
     fn test_format_stream_status_text_for_enabled_stream() {
         let data = json!({
             "enabled": true,
+            "addr": "127.0.0.1",
             "port": 9223,
             "connected": true,
             "screencasting": false
@@ -3328,6 +3346,24 @@ mod tests {
         assert_eq!(
             rendered,
             "Streaming enabled on ws://127.0.0.1:9223\nConnected: true\nScreencasting: false"
+        );
+    }
+
+    #[test]
+    fn test_format_stream_status_text_for_ipv6_addr() {
+        let data = json!({
+            "enabled": true,
+            "addr": "::1",
+            "port": 9223,
+            "connected": false,
+            "screencasting": false
+        });
+
+        let rendered = super::format_stream_status_text(Some("stream_enable"), &data).unwrap();
+
+        assert_eq!(
+            rendered,
+            "Streaming enabled on ws://[::1]:9223\nConnected: false\nScreencasting: false"
         );
     }
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -31,7 +31,7 @@ agent-browser pdf <path>              # Save page as PDF
 agent-browser snapshot                # Accessibility tree with refs
 agent-browser eval <js>               # Run JavaScript
 agent-browser connect <port|url>      # Connect to browser via CDP
-agent-browser stream enable [--port <port>]  # Start runtime WebSocket streaming
+agent-browser stream enable [--addr <addr>] [--port <port>]  # Start runtime WebSocket streaming
 agent-browser stream status           # Show runtime streaming state and bound port
 agent-browser stream disable          # Stop runtime WebSocket streaming
 agent-browser close                   # Close browser (aliases: quit, exit)
@@ -275,11 +275,12 @@ When a JavaScript dialog (`alert`, `confirm`, `prompt`) is pending, all command 
 ```bash
 agent-browser stream enable           # Start runtime WebSocket streaming on an auto-selected port
 agent-browser stream enable --port 9223  # Bind a specific localhost port
+agent-browser stream enable --addr 0.0.0.0 --port 9223  # Bind for container access
 agent-browser stream status           # Show enabled state, port, browser connection, screencasting
 agent-browser stream disable          # Stop runtime streaming and remove the .stream metadata file
 ```
 
-Streaming is enabled automatically for all sessions. Use these commands to check status, re-enable on a specific port, or disable streaming.
+Streaming is enabled automatically for all sessions. Use these commands to check status, re-enable on a specific address or port, or disable streaming. Runtime streaming binds to `127.0.0.1` unless `--addr` is provided.
 
 ## Debug
 

--- a/docs/src/app/dashboard/page.mdx
+++ b/docs/src/app/dashboard/page.mdx
@@ -27,9 +27,12 @@ You can also use the runtime commands to control streaming on a running session:
 
 ```bash
 agent-browser stream enable --port 9223
+agent-browser stream enable --addr 0.0.0.0 --port 9223
 agent-browser stream status
 agent-browser stream disable
 ```
+
+Runtime streaming binds to `127.0.0.1` by default. Use `--addr 0.0.0.0` only when the stream must be reachable through a container port mapping or another trusted network boundary.
 
 ## Dashboard features
 

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -18,10 +18,11 @@ You can also manage streaming at runtime:
 ```bash
 agent-browser stream status            # Show streaming state and bound port
 agent-browser stream enable --port 9223  # Re-enable on a specific port
+agent-browser stream enable --addr 0.0.0.0 --port 9223  # Bind for container access
 agent-browser stream disable           # Stop streaming for the session
 ```
 
-`stream status` returns the enabled state, active port, browser connection state, and whether screencasting is active. `stream disable` tears the server down and removes the session's `.stream` metadata file.
+`stream enable` binds to `127.0.0.1` by default. Use `--addr 0.0.0.0` when the stream must be reachable through a container port mapping or another network namespace. `stream status` returns the enabled state, bind address, active port, browser connection state, and whether screencasting is active. `stream disable` tears the server down and removes the session's `.stream` metadata file.
 
 ## Runtime status response
 
@@ -30,13 +31,14 @@ agent-browser stream disable           # Stop streaming for the session
 ```json
 {
   "enabled": true,
+  "addr": "127.0.0.1",
   "port": 9223,
   "connected": true,
   "screencasting": true
 }
 ```
 
-`connected` reports whether the daemon currently has a browser attached. `screencasting` reports whether frames are actively being produced for the stream server.
+`addr` is the IP address the stream server is bound to. `connected` reports whether the daemon currently has a browser attached. `screencasting` reports whether frames are actively being produced for the stream server.
 
 ## Relationship to screencast commands
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -54,6 +54,10 @@ agent-browser screenshot result.png
 The browser stays running across commands so these feel like a single
 session. Use `agent-browser close` (or `close --all`) when you're done.
 
+`agent-browser stream status` reports the session WebSocket stream endpoint.
+Use `stream enable --addr 0.0.0.0 --port <n>` only when a trusted container or
+network boundary must reach the stream.
+
 ## Reading a page
 
 ```bash

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -86,6 +86,16 @@ agent-browser get box @e1         # Get bounding box
 agent-browser get styles @e1      # Get computed styles (font, color, bg, etc.)
 ```
 
+## Streaming
+
+```bash
+agent-browser stream status                         # Show stream address, port, connection, screencast state
+agent-browser stream enable                         # Re-enable stream on 127.0.0.1 with an OS-assigned port
+agent-browser stream enable --port 9223             # Re-enable stream on a specific localhost port
+agent-browser stream enable --addr 0.0.0.0 --port 9223  # Bind for trusted container access
+agent-browser stream disable                        # Stop runtime streaming for the session
+```
+
 ## Check State
 
 ```bash


### PR DESCRIPTION
## Summary

- add `stream enable --addr/-a` with the existing `127.0.0.1` default
- bind the runtime stream server to the requested IP address and report it in stream status
- render status endpoints with the configured address, including bracketed IPv6 hosts
- update CLI help, docs, README, and skill command references

Fixes #1290.

## Testing

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path cli/Cargo.toml --profile ci stream_enable -- --test-threads=1`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path cli/Cargo.toml --profile ci format_stream_status_text -- --test-threads=1`