### PR TITLE
feat: add install timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ On Linux, install system dependencies:
 agent-browser install --with-deps
 ```
 
+For slow or high-latency networks, increase the Chrome download timeout:
+
+```bash
+agent-browser install --timeout 600
+```
+
 ### Updating
 
 Upgrade to the latest version:
@@ -447,6 +453,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 ```bash
 agent-browser install                 # Download Chrome from Chrome for Testing (Google's official automation channel)
 agent-browser install --with-deps     # Also install system deps (Linux)
+agent-browser install --timeout 600   # Extend Chrome download timeout for slow networks
 agent-browser upgrade                 # Upgrade agent-browser to the latest version
 agent-browser doctor                  # Diagnose the install and auto-clean stale daemon files
 agent-browser doctor --fix            # Also run destructive repairs (reinstall Chrome, purge old state, ...)

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -6,6 +6,66 @@ use std::process::{exit, Command, Stdio};
 
 const LAST_KNOWN_GOOD_URL: &str =
     "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
+pub const DEFAULT_INSTALL_TIMEOUT_SECS: u64 = 120;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InstallOptions {
+    pub with_deps: bool,
+    /// HTTP request timeout for Chrome for Testing metadata and binary downloads.
+    pub timeout_secs: u64,
+}
+
+impl Default for InstallOptions {
+    fn default() -> Self {
+        Self {
+            with_deps: false,
+            timeout_secs: DEFAULT_INSTALL_TIMEOUT_SECS,
+        }
+    }
+}
+
+pub fn parse_install_args(args: &[String]) -> Result<InstallOptions, String> {
+    let mut options = InstallOptions::default();
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "-d" | "--with-deps" => {
+                options.with_deps = true;
+            }
+            "-t" | "--timeout" => {
+                let Some(raw) = args.get(i + 1) else {
+                    return Err("install --timeout requires a value in seconds".to_string());
+                };
+                options.timeout_secs = parse_install_timeout(raw)?;
+                i += 1;
+            }
+            arg => {
+                if let Some(raw) = arg.strip_prefix("--timeout=") {
+                    options.timeout_secs = parse_install_timeout(raw)?;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    Ok(options)
+}
+
+fn parse_install_timeout(raw: &str) -> Result<u64, String> {
+    let timeout_secs = raw.parse::<u64>().map_err(|_| {
+        format!(
+            "invalid install timeout '{}': expected a positive number of seconds",
+            raw
+        )
+    })?;
+
+    if timeout_secs == 0 {
+        return Err("install timeout must be greater than 0 seconds".to_string());
+    }
+
+    Ok(timeout_secs)
+}
 
 pub fn get_browsers_dir() -> PathBuf {
     dirs::home_dir()
@@ -182,8 +242,8 @@ fn platform_key() -> &'static str {
     }
 }
 
-async fn fetch_download_url() -> Result<(String, String), String> {
-    let client = http_client()?;
+async fn fetch_download_url(timeout_secs: u64) -> Result<(String, String), String> {
+    let client = http_client(timeout_secs)?;
     let resp = client
         .get(LAST_KNOWN_GOOD_URL)
         .send()
@@ -236,17 +296,17 @@ fn format_reqwest_error(e: &reqwest::Error) -> String {
     msg
 }
 
-fn http_client() -> Result<reqwest::Client, String> {
+fn http_client(timeout_secs: u64) -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
         .user_agent(format!("agent-browser/{}", env!("CARGO_PKG_VERSION")))
-        .timeout(std::time::Duration::from_secs(120))
+        .timeout(std::time::Duration::from_secs(timeout_secs))
         .connect_timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", format_reqwest_error(&e)))
 }
 
-async fn download_bytes(url: &str) -> Result<Vec<u8>, String> {
-    let client = http_client()?;
+async fn download_bytes(url: &str, timeout_secs: u64) -> Result<Vec<u8>, String> {
+    let client = http_client(timeout_secs)?;
     let max_retries = 3;
     let mut last_err = String::new();
 
@@ -397,7 +457,7 @@ fn extract_zip(bytes: Vec<u8>, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
-pub fn run_install(with_deps: bool) {
+pub fn run_install(options: InstallOptions) {
     if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
         eprintln!(
             "{} Chrome for Testing does not provide Linux ARM64 builds.",
@@ -413,7 +473,7 @@ pub fn run_install(with_deps: bool) {
     let is_linux = cfg!(target_os = "linux");
 
     if is_linux {
-        if with_deps {
+        if options.with_deps {
             install_linux_deps();
         } else {
             println!(
@@ -439,7 +499,7 @@ pub fn run_install(with_deps: bool) {
             exit(1);
         });
 
-    let (version, url) = match rt.block_on(fetch_download_url()) {
+    let (version, url) = match rt.block_on(fetch_download_url(options.timeout_secs)) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{} {}", color::error_indicator(), e);
@@ -463,7 +523,7 @@ pub fn run_install(with_deps: bool) {
     println!("  Downloading Chrome {} for {}", version, platform_key());
     println!("  {}", url);
 
-    let bytes = match rt.block_on(download_bytes(&url)) {
+    let bytes = match rt.block_on(download_bytes(&url, options.timeout_secs)) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("{} {}", color::error_indicator(), e);
@@ -480,7 +540,7 @@ pub fn run_install(with_deps: bool) {
             );
             println!("  Location: {}", dest.display());
 
-            if is_linux && !with_deps {
+            if is_linux && !options.with_deps {
                 println!();
                 println!(
                     "{} If you see \"shared library\" errors when running, use:",
@@ -806,6 +866,54 @@ mod tests {
         request
     }
 
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| v.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_install_args_defaults_timeout() {
+        let options = parse_install_args(&args(&[])).unwrap();
+        assert_eq!(options, InstallOptions::default());
+    }
+
+    #[test]
+    fn parse_install_args_accepts_timeout() {
+        let options = parse_install_args(&args(&["--timeout", "600"])).unwrap();
+        assert_eq!(options.timeout_secs, 600);
+        assert!(!options.with_deps);
+    }
+
+    #[test]
+    fn parse_install_args_accepts_short_timeout_and_with_deps() {
+        let options = parse_install_args(&args(&["-d", "-t", "300"])).unwrap();
+        assert_eq!(options.timeout_secs, 300);
+        assert!(options.with_deps);
+    }
+
+    #[test]
+    fn parse_install_args_accepts_equals_timeout() {
+        let options = parse_install_args(&args(&["--timeout=450"])).unwrap();
+        assert_eq!(options.timeout_secs, 450);
+    }
+
+    #[test]
+    fn parse_install_args_rejects_missing_timeout() {
+        let err = parse_install_args(&args(&["--timeout"])).unwrap_err();
+        assert!(err.contains("requires a value"));
+    }
+
+    #[test]
+    fn parse_install_args_rejects_invalid_timeout() {
+        let err = parse_install_args(&args(&["--timeout", "slow"])).unwrap_err();
+        assert!(err.contains("expected a positive number"));
+    }
+
+    #[test]
+    fn parse_install_args_rejects_zero_timeout() {
+        let err = parse_install_args(&args(&["--timeout", "0"])).unwrap_err();
+        assert!(err.contains("greater than 0"));
+    }
+
     #[tokio::test]
     async fn download_bytes_returns_body_on_200() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -818,7 +926,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), body);
         server.await.unwrap();
@@ -835,7 +943,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -862,7 +970,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(
             result.is_ok(),
             "expected success after retries: {:?}",
@@ -886,7 +994,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -909,7 +1017,7 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{}/test.zip", port);
-        let result = download_bytes(&url).await;
+        let result = download_bytes(&url, DEFAULT_INSTALL_TIMEOUT_SECS).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("HTTP 403"));
         server.await.unwrap();
@@ -926,7 +1034,7 @@ mod tests {
             req
         });
 
-        let client = http_client().unwrap();
+        let client = http_client(DEFAULT_INSTALL_TIMEOUT_SECS).unwrap();
         let url = format!("http://127.0.0.1:{}/test", port);
         let _ = client.get(&url).send().await;
         let request_text = server.await.unwrap();
@@ -946,7 +1054,10 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let result = rt.block_on(download_bytes("http://127.0.0.1:1/test.zip"));
+        let result = rt.block_on(download_bytes(
+            "http://127.0.0.1:1/test.zip",
+            DEFAULT_INSTALL_TIMEOUT_SECS,
+        ));
         assert!(result.is_err());
         let err = result.unwrap_err();
         // The new code should include the root cause (connection refused)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,7 +29,7 @@ use connection::{
     DaemonOptions,
 };
 use flags::{clean_args, parse_flags, Flags};
-use install::run_install;
+use install::{parse_install_args, run_install};
 use output::{
     print_command_help, print_help, print_response_with_opts, print_version, OutputOptions,
 };
@@ -539,8 +539,14 @@ fn main() {
 
     // Handle install separately
     if clean.first().map(|s| s.as_str()) == Some("install") {
-        let with_deps = args.iter().any(|a| a == "--with-deps" || a == "-d");
-        run_install(with_deps);
+        let install_options = match parse_install_args(&clean[1..]) {
+            Ok(options) => options,
+            Err(e) => {
+                eprintln!("{} {}", color::error_indicator(), e);
+                exit(1);
+            }
+        };
+        run_install(install_options);
         return;
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2473,16 +2473,18 @@ Examples:
             r##"
 agent-browser install - Install browser binaries
 
-Usage: agent-browser install [--with-deps]
+Usage: agent-browser install [--with-deps] [--timeout <seconds>]
 
 Downloads and installs browser binaries required for automation.
 
 Options:
   -d, --with-deps      Also install system dependencies (Linux only)
+  -t, --timeout <s>    HTTP download timeout in seconds (default: 120)
 
 Examples:
   agent-browser install
   agent-browser install --with-deps
+  agent-browser install --timeout 600
 "##
         }
 
@@ -3057,6 +3059,7 @@ Dashboard:
 Setup:
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
+  install --timeout <s>      Set Chrome download timeout in seconds
   upgrade                    Upgrade to the latest version
   doctor [--fix]             Diagnose install; auto-clean stale files
   dashboard start            Start the observability dashboard

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -383,6 +383,16 @@ agent-browser dashboard stop          # Stop the dashboard server
 
 Open the dashboard through `http://localhost:4848` or a proxied/forwarded dashboard URL such as `https://dashboard.agent-browser.localhost`. The browser stays on the dashboard origin; per-session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.
 
+## Install
+
+Download Chrome for Testing and optional Linux system dependencies.
+
+```bash
+agent-browser install                 # Download Chrome
+agent-browser install --with-deps     # Also install system dependencies on Linux
+agent-browser install --timeout 600   # Extend the Chrome download timeout for slow networks
+```
+
 ## Doctor
 
 Diagnose your install, auto-clean stale daemon files, and optionally repair common problems.

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -9,7 +9,7 @@ npm install -g agent-browser
 agent-browser install  # Download Chrome from Chrome for Testing (first time)
 ```
 
-This is the fastest option -- commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
+This is the fastest option because commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
 
 ## Quick start (no install)
 
@@ -63,6 +63,12 @@ On Linux, install system dependencies:
 
 ```bash
 agent-browser install --with-deps
+```
+
+For slow or high-latency networks, increase the Chrome download timeout:
+
+```bash
+agent-browser install --timeout 600
 ```
 
 ## Updating

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -34,6 +34,7 @@ next ref interaction.
 ```bash
 # Install once
 npm i -g agent-browser && agent-browser install
+# Slow network: agent-browser install --timeout 600
 
 # Take a screenshot of a page
 agent-browser open https://example.com
@@ -343,6 +344,9 @@ agent-browser doctor --offline --quick   # fast, local-only
 agent-browser doctor --fix               # also run destructive repairs (reinstall Chrome, purge old state, ...)
 agent-browser doctor --json              # structured output for programmatic consumption
 ```
+
+If Chrome for Testing downloads time out on a slow network, retry with
+`agent-browser install --timeout 600` to extend the HTTP timeout in seconds.
 
 `doctor` auto-cleans stale socket/pid/version sidecar files on every run.
 Destructive actions require `--fix`. Exit code is `0` if all checks pass

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -2,6 +2,16 @@
 
 Complete reference for all agent-browser commands. For quick start and common patterns, see SKILL.md.
 
+## Setup
+
+```bash
+agent-browser install                 # Download Chrome for Testing
+agent-browser install --with-deps     # Also install Linux system dependencies
+agent-browser install --timeout 600   # Extend Chrome download timeout for slow networks
+agent-browser doctor                  # Diagnose install and stale daemon state
+agent-browser upgrade                 # Upgrade agent-browser
+```
+
 ## Navigation
 
 ```bash


### PR DESCRIPTION
## Summary

- add `agent-browser install --timeout/-t <seconds>` with the existing 120 second default
- pass the configured timeout to Chrome for Testing metadata and binary download HTTP requests
- keep `--with-deps` behavior unchanged
- update CLI help, README, docs, and core skill references

Fixes #1285.

## Testing

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path cli/Cargo.toml --profile ci install::tests -- --test-threads=1`