### PR TITLE
fix: preserve commas inside browser arg values

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--extension <path>` | Load browser extension (repeatable; or `AGENT_BROWSER_EXTENSIONS` env) |
 | `--init-script <path>` | Register a page init script before the first navigation (repeatable; or `AGENT_BROWSER_INIT_SCRIPTS` env) |
 | `--enable <feature>` | Built-in init scripts: `react-devtools` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
-| `--args <args>` | Browser launch args, comma or newline separated (or `AGENT_BROWSER_ARGS` env) |
+| `--args <args>` | Browser launch args, newline separated or comma-separated before another flag. Commas inside flag values are preserved. Also `AGENT_BROWSER_ARGS` env. |
 | `--user-agent <ua>` | Custom User-Agent string (or `AGENT_BROWSER_USER_AGENT` env) |
 | `--proxy <url>` | Proxy server URL with optional auth (or `AGENT_BROWSER_PROXY` env) |
 | `--proxy-bypass <hosts>` | Hosts to bypass proxy (or `AGENT_BROWSER_PROXY_BYPASS` env) |

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,55 @@ fn print_json_error_with_type(message: impl AsRef<str>, error_type: &str) {
     }));
 }
 
+/// Parse browser launch args while preserving list-valued Chrome flag values.
+fn parse_browser_launch_args(input: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let ch = chars[i];
+
+        if ch == '\n' || ch == '\r' {
+            let trimmed = current.trim();
+            if !trimmed.is_empty() {
+                args.push(trimmed.to_string());
+            }
+            current.clear();
+            i += 1;
+            continue;
+        }
+
+        if ch == ',' {
+            let mut j = i + 1;
+            while j < chars.len() && matches!(chars[j], ' ' | '\t') {
+                j += 1;
+            }
+
+            if j < chars.len() && chars[j] == '-' && !current.trim().is_empty() {
+                let trimmed = current.trim();
+                if !trimmed.is_empty() {
+                    args.push(trimmed.to_string());
+                }
+                current.clear();
+                i += 1;
+                continue;
+            }
+        }
+
+        current.push(ch);
+        i += 1;
+    }
+
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        args.push(trimmed.to_string());
+    }
+
+    args
+}
+
 struct ParsedProxy {
     server: String,
     username: Option<String>,
@@ -1116,12 +1165,7 @@ fn main() {
         }
 
         if let Some(ref a) = flags.args {
-            // Parse args (comma or newline separated)
-            let args_vec: Vec<String> = a
-                .split(&[',', '\n'][..])
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
+            let args_vec = parse_browser_launch_args(a);
             cmd_obj.insert("args".to_string(), json!(args_vec));
         }
 
@@ -1420,6 +1464,54 @@ fn run_batch(flags: &Flags, bail: bool, arg_commands: Option<Vec<Vec<String>>>) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_browser_launch_args_splits_simple_comma_args() {
+        assert_eq!(
+            parse_browser_launch_args("--no-sandbox,--disable-gpu"),
+            vec!["--no-sandbox", "--disable-gpu"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_launch_args_preserves_comma_delimited_flag_value() {
+        assert_eq!(
+            parse_browser_launch_args("--disable-features=HttpsUpgrades,HttpsFirstModeV2"),
+            vec!["--disable-features=HttpsUpgrades,HttpsFirstModeV2"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_launch_args_splits_mixed_feature_and_flag_args() {
+        assert_eq!(
+            parse_browser_launch_args("--disable-features=A,B,C, --no-sandbox"),
+            vec!["--disable-features=A,B,C", "--no-sandbox"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_launch_args_splits_newline_args() {
+        assert_eq!(
+            parse_browser_launch_args("--disable-features=A,B,C\n--no-sandbox"),
+            vec!["--disable-features=A,B,C", "--no-sandbox"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_launch_args_splits_crlf_args() {
+        assert_eq!(
+            parse_browser_launch_args("--disable-features=A,B,C\r\n--no-sandbox"),
+            vec!["--disable-features=A,B,C", "--no-sandbox"]
+        );
+    }
+
+    #[test]
+    fn test_parse_browser_launch_args_ignores_empty_segments() {
+        assert_eq!(
+            parse_browser_launch_args("  --no-sandbox  ,   --disable-gpu  \n\n"),
+            vec!["--no-sandbox", "--disable-gpu"]
+        );
+    }
 
     #[test]
     fn test_parse_proxy_simple() {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3083,8 +3083,9 @@ Options:
                              (or AGENT_BROWSER_INIT_SCRIPTS env, comma-separated)
   --enable <feature>         Built-in init scripts: react-devtools (repeatable or comma-separated)
                              (or AGENT_BROWSER_ENABLE env)
-  --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
-                             e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
+  --args <args>              Browser launch args, newline separated or comma-separated before another flag
+                             (or AGENT_BROWSER_ARGS). Commas inside flag values are preserved.
+                             e.g., --args "--no-sandbox,--disable-features=A,B,C"
   --user-agent <ua>          Custom User-Agent (or AGENT_BROWSER_USER_AGENT)
   --proxy <server>           Proxy server URL (or AGENT_BROWSER_PROXY, HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
                              Supports authenticated proxies: --proxy "http://user:pass@127.0.0.1:7890"

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -94,7 +94,7 @@ This enables control of:
     <tr><td><code>-p &lt;provider&gt;</code></td><td>Cloud browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>)</td></tr>
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>
     <tr><td><code>--executable-path</code></td><td>Custom browser executable</td></tr>
-    <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (comma-separated)</td></tr>
+    <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args. Commas inside flag values are preserved.</td></tr>
     <tr><td><code>--user-agent &lt;ua&gt;</code></td><td>Custom User-Agent string</td></tr>
     <tr><td><code>--proxy &lt;url&gt;</code></td><td>Proxy server URL</td></tr>
     <tr><td><code>--proxy-bypass &lt;hosts&gt;</code></td><td>Hosts to bypass proxy</td></tr>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -481,7 +481,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 --extension <path>       # Load browser extension (repeatable)
 --init-script <path>     # Register a page init script before first navigation (repeatable)
 --enable <feature>       # Built-in init scripts: react-devtools (repeatable or comma-list)
---args <args>            # Browser launch args (comma separated)
+--args <args>            # Browser launch args; commas inside flag values are preserved
 --user-agent <ua>        # Custom User-Agent string
 --proxy <url>            # Proxy server URL
 --proxy-bypass <hosts>   # Hosts to bypass proxy

--- a/docs/src/app/engines/chrome/page.mdx
+++ b/docs/src/app/engines/chrome/page.mdx
@@ -101,4 +101,12 @@ In Docker, CI runners, or other sandboxed environments, Chrome's user namespace 
 agent-browser --args "--no-sandbox" open example.com
 ```
 
+Use newline-separated args, or separate args with commas before another flag.
+Commas inside a single flag value are preserved, so list-valued Chrome flags
+work as expected:
+
+```bash
+agent-browser --args "--disable-features=A,B,C, --no-sandbox" open example.com
+```
+
 agent-browser automatically adds `--no-sandbox` when it detects a container environment (Docker, Podman, running as root).

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -350,6 +350,14 @@ Destructive actions require `--fix`. Exit code is `0` if all checks pass
 
 ## Troubleshooting
 
+**Passing Chrome launch args with comma-delimited values**
+Use `--args` for Chrome flags. Newlines always separate args, and commas
+separate args only before another flag, so list-valued flags stay intact:
+
+```bash
+agent-browser --args "--disable-features=A,B,C, --no-sandbox" open example.com
+```
+
 **"Ref not found" / "Element not found: @eN"**
 Page changed since the snapshot. Run `agent-browser snapshot -i` again,
 then use the new refs.

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -306,6 +306,7 @@ agent-browser -p <provider> ...       # Cloud browser provider (--provider)
 agent-browser --proxy <url> ...       # Use proxy server
 agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy
 agent-browser --headers <json> ...    # HTTP headers scoped to URL's origin
+agent-browser --args <args> ...       # Browser launch args; commas inside values are preserved
 agent-browser --executable-path <p>   # Custom browser executable
 agent-browser --extension <path> ...  # Load browser extension (repeatable)
 agent-browser --ignore-https-errors   # Ignore SSL certificate errors


### PR DESCRIPTION
## Summary

- parse `--args` so newlines always separate arguments
- split commas only when they introduce another flag
- preserve commas inside list-valued Chrome flags like `--disable-features=A,B,C`
- update CLI help, README, docs, and core skill references

Fixes #1284.

## Testing

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path cli/Cargo.toml --profile ci parse_browser_launch_args`