### PR TITLE
daemon: set default idle timeout to 30 minutes

### DIFF
--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -113,11 +113,12 @@ pub async fn run_daemon(session: &str) {
     }
 
     // Auto-shutdown the daemon after this many ms of inactivity (no commands received).
-    // Disabled when unset or 0.
+    // Defaults to 30 minutes (1,800,000 ms).  Set to 0 to disable.
     let idle_timeout_ms = env::var("AGENT_BROWSER_IDLE_TIMEOUT_MS")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
-        .filter(|&ms| ms > 0);
+        .unwrap_or(1_800_000);  // 30 minute default
+    let idle_timeout_ms = (idle_timeout_ms > 0).then_some(idle_timeout_ms);
 
     let result = run_socket_server(
         &socket_path,

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3120,7 +3120,7 @@ Environment:
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete saved states older than N days (default: 30)
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM session encryption
   AGENT_BROWSER_STREAM_PORT      Override WebSocket streaming port (default: OS-assigned)
-  AGENT_BROWSER_IDLE_TIMEOUT_MS  Auto-shutdown daemon after N ms of inactivity (disabled by default)
+  AGENT_BROWSER_IDLE_TIMEOUT_MS  Auto-shutdown daemon after N ms of inactivity (default: 1800000 = 30 min; 0 to disable)
   AGENT_BROWSER_IOS_DEVICE       Default iOS device name
   AGENT_BROWSER_IOS_UDID         Default iOS device UDID
   AGENT_BROWSER_CONTENT_BOUNDARIES Wrap page output in boundary markers


### PR DESCRIPTION
## Problem

`AGENT_BROWSER_IDLE_TIMEOUT_MS` previously defaulted to **disabled** (no auto-shutdown). The daemon relied entirely on callers like hermes-agent to set this env var. When a daemon was launched without it:

- The daemon lives **indefinitely**
- Chrome processes leak and can spin to 100% CPU
- Observed in the wild: 8 renderer/gpu/utility processes consuming all cores for **6+ days**

## Fix

Change the default from disabled to **30 minutes** (1,800,000 ms). Set to 0 to restore the old opt-in behaviour.

The idle timer resets on every command received, so active sessions are unaffected. This is a safety net — hermes-agent already sets a 5-minute idle timeout which overrides this default.

## Changes

- `cli/src/native/daemon.rs`: `.filter(|&ms| ms > 0)` → `.unwrap_or(1_800_000)` with zero-check
- `cli/src/output.rs`: update help text