### PR TITLE
[codex] Fix native test determinism

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -8691,16 +8691,17 @@ mod tests {
     #[test]
     fn test_default_timeout_ms_from_env() {
         // When AGENT_BROWSER_DEFAULT_TIMEOUT is set, DaemonState should use it
-        env::set_var("AGENT_BROWSER_DEFAULT_TIMEOUT", "3000");
+        let guard = EnvGuard::new(&["AGENT_BROWSER_DEFAULT_TIMEOUT"]);
+        guard.set("AGENT_BROWSER_DEFAULT_TIMEOUT", "3000");
         let state = DaemonState::new();
         assert_eq!(state.default_timeout_ms, 3000);
-        env::remove_var("AGENT_BROWSER_DEFAULT_TIMEOUT");
     }
 
     #[test]
     fn test_default_timeout_ms_fallback() {
         // When AGENT_BROWSER_DEFAULT_TIMEOUT is unset, DaemonState uses 30000
-        env::remove_var("AGENT_BROWSER_DEFAULT_TIMEOUT");
+        let guard = EnvGuard::new(&["AGENT_BROWSER_DEFAULT_TIMEOUT"]);
+        guard.remove("AGENT_BROWSER_DEFAULT_TIMEOUT");
         let state = DaemonState::new();
         assert_eq!(state.default_timeout_ms, 30_000);
     }

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -201,6 +201,9 @@ fn minimal_command(action: &str, id: &str) -> Value {
     match action {
         "navigate" | "diff_url" | "waitforurl" => {
             obj.insert("url".to_string(), json!("https://example.com"));
+            if action == "waitforurl" {
+                obj.insert("timeout".to_string(), json!(1));
+            }
         }
         "evaluate" | "expose" => {
             obj.insert("script".to_string(), json!("1"));
@@ -265,10 +268,11 @@ fn minimal_command(action: &str, id: &str) -> Value {
             obj.insert("offline".to_string(), json!(false));
         }
         "wait" => {
-            obj.insert("timeout".to_string(), json!(100));
+            obj.insert("timeout".to_string(), json!(1));
         }
         "waitforloadstate" => {
             obj.insert("state".to_string(), json!("load"));
+            obj.insert("timeout".to_string(), json!(1));
         }
         "waitforfunction" => {
             obj.insert("script".to_string(), json!("() => true"));
@@ -301,7 +305,7 @@ fn minimal_command(action: &str, id: &str) -> Value {
             obj.insert("password".to_string(), json!("p"));
         }
         "auth_login" => {
-            obj.insert("name".to_string(), json!("parity-test-cred"));
+            obj.insert("name".to_string(), json!("parity-test-missing-cred"));
         }
         "route" => {
             obj.insert("url".to_string(), json!("*"));
@@ -331,9 +335,11 @@ fn minimal_command(action: &str, id: &str) -> Value {
         }
         "responsebody" => {
             obj.insert("url".to_string(), json!("https://example.com"));
+            obj.insert("timeout".to_string(), json!(1));
         }
         "waitfordownload" => {
             obj.insert("path".to_string(), json!("/tmp/parity-download"));
+            obj.insert("timeout".to_string(), json!(1));
         }
         "styles" => {
             obj.insert("selector".to_string(), json!("body"));
@@ -397,6 +403,12 @@ async fn test_all_documented_actions_are_handled() {
             action
         );
     }
+
+    let _ = execute_command(
+        &json!({ "action": "close", "id": "parity-cleanup" }),
+        &mut state,
+    )
+    .await;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- shorten dispatch-only parity commands that were spending real default timeouts in browser wait handlers
- avoid navigating through `auth_login` in the parity coverage test by using a missing profile
- close the browser at the end of the parity coverage test
- guard `AGENT_BROWSER_DEFAULT_TIMEOUT` env mutation in timeout tests with `EnvGuard`

## Root Cause

`test_all_documented_actions_are_handled` is a dispatch coverage test, but several minimal commands were exercising real wait paths with the default timeout. That made `cargo test` look hung and left Chrome alive while the test slowly timed out. Separately, default timeout tests mutated `AGENT_BROWSER_DEFAULT_TIMEOUT` without the shared env guard, so parallel test execution could leak the value between tests.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- `cargo test native::parity_tests::test_all_documented_actions_are_handled`
- `cargo test native::actions::tests::test_default_timeout_ms`
- `cargo test`
