### PR TITLE
fix: harden dashboard and inspect local control planes

### DIFF
--- a/cli/src/native/inspect_server.rs
+++ b/cli/src/native/inspect_server.rs
@@ -6,6 +6,8 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::http::StatusCode;
 use tokio_tungstenite::tungstenite::Message;
 
 use super::cdp::client::InspectProxyHandle;
@@ -45,6 +47,7 @@ impl InspectServer {
             .port();
 
         let proxy = Arc::new(proxy_handle);
+        let ws_token = uuid::Uuid::new_v4().to_string();
 
         let handle = tokio::spawn(accept_loop(
             listener,
@@ -52,6 +55,7 @@ impl InspectServer {
             target_id,
             chrome_host_port,
             port,
+            ws_token,
         ));
 
         Ok(Self {
@@ -75,6 +79,7 @@ async fn accept_loop(
     target_id: String,
     chrome_host_port: String,
     proxy_port: u16,
+    ws_token: String,
 ) {
     loop {
         let (stream, _) = match listener.accept().await {
@@ -85,9 +90,10 @@ async fn accept_loop(
         let proxy = proxy.clone();
         let tid = target_id.clone();
         let chp = chrome_host_port.clone();
+        let token = ws_token.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, proxy, tid, chp, proxy_port).await {
+            if let Err(e) = handle_connection(stream, proxy, tid, chp, proxy_port, token).await {
                 let _ = writeln!(std::io::stderr(), "[inspect] connection error: {}", e);
             }
         });
@@ -100,9 +106,10 @@ async fn handle_connection(
     target_id: String,
     chrome_host_port: String,
     proxy_port: u16,
+    ws_token: String,
 ) -> Result<(), String> {
     // Peek at the request line to determine routing WITHOUT consuming bytes.
-    // This is critical: tokio_tungstenite::accept_async needs to read the full
+    // This is critical: tokio_tungstenite::accept_hdr_async needs to read the full
     // HTTP upgrade request itself, so we must not consume anything for WS paths.
     let mut peek_buf = [0u8; 32];
     let n = stream
@@ -112,12 +119,12 @@ async fn handle_connection(
     let peek = String::from_utf8_lossy(&peek_buf[..n]);
 
     if peek.starts_with("GET /ws") {
-        return handle_ws_proxy(stream, proxy, target_id).await;
+        return handle_ws_proxy(stream, proxy, target_id, ws_token).await;
     }
 
     if peek.starts_with("GET / ") {
         let buf_reader = BufReader::new(stream);
-        return handle_http_redirect(buf_reader, chrome_host_port, proxy_port).await;
+        return handle_http_redirect(buf_reader, chrome_host_port, proxy_port, ws_token).await;
     }
 
     // Unknown request -- consume and respond 404
@@ -138,6 +145,7 @@ async fn handle_http_redirect(
     buf_reader: BufReader<tokio::net::TcpStream>,
     chrome_host_port: String,
     proxy_port: u16,
+    ws_token: String,
 ) -> Result<(), String> {
     let mut br = buf_reader;
     let mut total_bytes = 0usize;
@@ -150,10 +158,7 @@ async fn handle_http_redirect(
         }
     }
 
-    let location = format!(
-        "http://{}/devtools/devtools_app.html?ws=127.0.0.1:{}/ws",
-        chrome_host_port, proxy_port
-    );
+    let location = inspect_devtools_location(&chrome_host_port, proxy_port, &ws_token);
     let body = format!(
         "<html><body>Redirecting to <a href=\"{url}\">{url}</a></body></html>",
         url = location
@@ -172,12 +177,19 @@ async fn handle_http_redirect(
     Ok(())
 }
 
+#[allow(clippy::result_large_err)]
 async fn handle_ws_proxy(
     stream: tokio::net::TcpStream,
     proxy: Arc<InspectProxyHandle>,
     target_id: String,
+    ws_token: String,
 ) -> Result<(), String> {
-    let ws_stream = tokio_tungstenite::accept_async(stream)
+    let expected_token = ws_token;
+    let callback = move |req: &Request, resp: Response| {
+        inspect_ws_handshake_response(req, resp, &expected_token)
+    };
+
+    let ws_stream = tokio_tungstenite::accept_hdr_async(stream, callback)
         .await
         .map_err(|e| format!("WebSocket handshake failed: {}", e))?;
 
@@ -295,6 +307,54 @@ async fn handle_ws_proxy(
     Ok(())
 }
 
+#[allow(clippy::result_large_err)]
+fn inspect_ws_handshake_response(
+    req: &Request,
+    resp: Response,
+    expected_token: &str,
+) -> Result<Response, ErrorResponse> {
+    if inspect_ws_request_authorized(req, expected_token) {
+        Ok(resp)
+    } else {
+        Err(forbidden_ws_response(
+            "Inspect WebSocket request not authorized",
+        ))
+    }
+}
+
+fn inspect_ws_request_authorized(req: &Request, expected_token: &str) -> bool {
+    if !inspect_ws_path_matches_token(req.uri().path(), expected_token) {
+        return false;
+    }
+
+    let origin = req.headers().get("origin").and_then(|v| v.to_str().ok());
+    super::stream::is_allowed_origin(origin)
+}
+
+fn inspect_ws_path_matches_token(path: &str, expected_token: &str) -> bool {
+    if expected_token.is_empty() {
+        return false;
+    }
+
+    match path.strip_prefix("/ws/") {
+        Some(provided_token) => provided_token == expected_token,
+        None => false,
+    }
+}
+
+fn forbidden_ws_response(reason: &str) -> ErrorResponse {
+    let mut reject = ErrorResponse::new(Some(reason.to_string()));
+    *reject.status_mut() = StatusCode::FORBIDDEN;
+    reject
+}
+
+fn inspect_devtools_location(chrome_host_port: &str, proxy_port: u16, ws_token: &str) -> String {
+    format!(
+        "http://{}/devtools/devtools_app.html?ws=127.0.0.1:{}/ws/{}",
+        chrome_host_port, proxy_port, ws_token
+    )
+}
+
 fn inject_session_id(json: &str, session_id: &str) -> String {
     if let Ok(mut val) = serde_json::from_str::<serde_json::Value>(json) {
         if let Some(obj) = val.as_object_mut() {
@@ -323,6 +383,53 @@ fn strip_session_id(json: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ws_request(path: &str, origin: Option<&str>) -> Request {
+        let mut builder = Request::builder().uri(path);
+        if let Some(origin) = origin {
+            builder = builder.header("origin", origin);
+        }
+        builder.body(()).expect("valid websocket request")
+    }
+
+    #[test]
+    fn test_inspect_ws_request_allows_tokenized_local_origin() {
+        let req = ws_request("/ws/secret-token", Some("http://127.0.0.1:9222"));
+        assert!(inspect_ws_request_authorized(&req, "secret-token"));
+    }
+
+    #[test]
+    fn test_inspect_ws_request_allows_tokenized_missing_origin() {
+        let req = ws_request("/ws/secret-token", None);
+        assert!(inspect_ws_request_authorized(&req, "secret-token"));
+    }
+
+    #[test]
+    fn test_inspect_ws_request_rejects_missing_token_path() {
+        let req = ws_request("/ws", Some("http://127.0.0.1:9222"));
+        assert!(!inspect_ws_request_authorized(&req, "secret-token"));
+    }
+
+    #[test]
+    fn test_inspect_ws_request_rejects_wrong_token() {
+        let req = ws_request("/ws/other-token", Some("http://127.0.0.1:9222"));
+        assert!(!inspect_ws_request_authorized(&req, "secret-token"));
+    }
+
+    #[test]
+    fn test_inspect_ws_request_rejects_non_local_origin() {
+        let req = ws_request("/ws/secret-token", Some("https://evil.example"));
+        assert!(!inspect_ws_request_authorized(&req, "secret-token"));
+    }
+
+    #[test]
+    fn test_inspect_redirect_uses_tokenized_websocket_path() {
+        let location = inspect_devtools_location("127.0.0.1:9222", 12345, "secret-token");
+        assert_eq!(
+            location,
+            "http://127.0.0.1:9222/devtools/devtools_app.html?ws=127.0.0.1:12345/ws/secret-token"
+        );
+    }
 
     #[test]
     fn test_inject_session_id() {

--- a/cli/src/native/stream/dashboard.rs
+++ b/cli/src/native/stream/dashboard.rs
@@ -8,7 +8,9 @@ use crate::connection::get_socket_dir;
 
 use super::chat::{chat_status_json, handle_chat_request, handle_models_request};
 use super::discovery::discover_sessions;
-use super::http::{is_same_origin_http_request, serve_embedded_file, CORS_HEADERS};
+use super::http::{
+    is_same_origin_http_request, request_header_matches_host, serve_embedded_file, CORS_HEADERS,
+};
 
 /// Dashboard same-origin proxy endpoints for session metadata and streams.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,58 +128,10 @@ fn request_header_value<'a>(request: &'a str, name: &str) -> Option<&'a str> {
     })
 }
 
-fn normalize_origin_authority(origin: &str) -> Option<String> {
-    let url = url::Url::parse(origin).ok()?;
-    let host = url.host_str()?.to_ascii_lowercase();
-    let host = if host.contains(':') {
-        format!("[{host}]")
-    } else {
-        host
-    };
-    Some(match url.port() {
-        Some(port) => format!("{host}:{port}"),
-        None => host,
-    })
-}
-
-fn normalize_host_authority(host: &str) -> String {
-    let host = host.trim().to_ascii_lowercase();
-
-    if let Some(bracket_end) = host.rfind(']') {
-        if bracket_end == host.len() - 1 {
-            return host;
-        }
-
-        if host.as_bytes().get(bracket_end + 1) == Some(&b':') {
-            let port = &host[bracket_end + 2..];
-            if port == "80" || port == "443" {
-                return host[..=bracket_end].to_string();
-            }
-        }
-
-        return host;
-    }
-
-    if let Some((name, port)) = host.rsplit_once(':') {
-        if !name.contains(':') && (port == "80" || port == "443") {
-            return name.to_string();
-        }
-    }
-
-    host
-}
-
-fn header_matches_host(request: &str, header_name: &str) -> Option<bool> {
-    let authority =
-        request_header_value(request, header_name).and_then(normalize_origin_authority)?;
-    let host = request_header_value(request, "host").map(normalize_host_authority)?;
-    Some(authority == host)
-}
-
 /// Validates that a proxied WebSocket request either has no Origin header or
-/// presents an Origin whose authority matches the request Host header.
+/// presents a DNS-rebinding-hardened Origin matching the request Host header.
 fn is_same_origin_ws_request(request: &str) -> bool {
-    match header_matches_host(request, "origin") {
+    match request_header_matches_host(request, "origin") {
         Some(matches) => matches,
         None => request_header_value(request, "origin").is_none(),
     }
@@ -830,14 +784,6 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_origin_authority_https_without_port() {
-        assert_eq!(
-            normalize_origin_authority("https://dashboard.agent-browser.localhost"),
-            Some("dashboard.agent-browser.localhost".to_string())
-        );
-    }
-
-    #[test]
     fn test_same_origin_ws_request_default_https_port() {
         let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: dashboard.agent-browser.localhost:443\r\nOrigin: https://dashboard.agent-browser.localhost\r\nUpgrade: websocket\r\n\r\n";
         assert!(is_same_origin_ws_request(req));
@@ -876,6 +822,12 @@ mod tests {
     #[test]
     fn test_cross_origin_ws_request_rejected() {
         let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: localhost:4848\r\nOrigin: https://evil.com\r\nUpgrade: websocket\r\n\r\n";
+        assert!(!is_same_origin_ws_request(req));
+    }
+
+    #[test]
+    fn test_same_origin_ws_request_rejects_http_dns_rebind_origin() {
+        let req = "GET /api/session/9222/stream HTTP/1.1\r\nHost: evil.example:4848\r\nOrigin: http://evil.example:4848\r\nUpgrade: websocket\r\n\r\n";
         assert!(!is_same_origin_ws_request(req));
     }
 

--- a/cli/src/native/stream/dashboard.rs
+++ b/cli/src/native/stream/dashboard.rs
@@ -8,7 +8,7 @@ use crate::connection::get_socket_dir;
 
 use super::chat::{chat_status_json, handle_chat_request, handle_models_request};
 use super::discovery::discover_sessions;
-use super::http::{serve_embedded_file, CORS_HEADERS};
+use super::http::{is_same_origin_http_request, serve_embedded_file, CORS_HEADERS};
 
 /// Dashboard same-origin proxy endpoints for session metadata and streams.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,7 +70,7 @@ async fn write_http_response(
     content_type: &str,
     body: &[u8],
 ) {
-    write_http_response_inner(stream, status, content_type, body, true).await;
+    write_http_response_inner(stream, status, content_type, body, false).await;
 }
 
 async fn write_http_response_no_cors(
@@ -181,16 +181,6 @@ fn is_same_origin_ws_request(request: &str) -> bool {
         Some(matches) => matches,
         None => request_header_value(request, "origin").is_none(),
     }
-}
-
-/// Validates that an HTTP session-proxy request came from a same-origin page.
-///
-/// For GET requests we require either a same-origin `Origin` or a same-origin
-/// `Referer` so browsers cannot hit the proxy routes via side-channel tags or
-/// arbitrary cross-origin fetches.
-fn is_same_origin_http_request(request: &str) -> bool {
-    matches!(header_matches_host(request, "origin"), Some(true))
-        || matches!(header_matches_host(request, "referer"), Some(true))
 }
 
 /// Parse a dashboard route of the form `/api/session/<port>/<endpoint>`.
@@ -521,6 +511,17 @@ async fn handle_dashboard_connection(mut stream: tokio::net::TcpStream) {
     let origin = request_header_value(&request, "origin").map(|value| value.to_string());
 
     if method == "OPTIONS" {
+        if (path == "/api/sessions" || path == "/api/exec" || path == "/api/kill")
+            && !is_same_origin_http_request(&request)
+        {
+            write_json_error_response_no_cors(
+                &mut stream,
+                "403 Forbidden",
+                "Origin or Referer does not match Host header.",
+            )
+            .await;
+            return;
+        }
         let response = format!(
             "HTTP/1.1 204 No Content\r\n{CORS_HEADERS}Access-Control-Max-Age: 86400\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         );
@@ -540,6 +541,15 @@ async fn handle_dashboard_connection(mut stream: tokio::net::TcpStream) {
     }
 
     if method == "POST" && (path == "/api/sessions" || path == "/api/exec" || path == "/api/kill") {
+        if !is_same_origin_http_request(&request) {
+            write_json_error_response_no_cors(
+                &mut stream,
+                "403 Forbidden",
+                "Origin or Referer does not match Host header.",
+            )
+            .await;
+            return;
+        }
         let body_str = read_post_body(&mut stream, &buf, n).await;
         let result = if path == "/api/exec" {
             exec_cli(&body_str).await

--- a/cli/src/native/stream/http.rs
+++ b/cli/src/native/stream/http.rs
@@ -106,7 +106,7 @@ fn normalize_host_authority(host: &str) -> String {
     host
 }
 
-fn header_matches_host(request: &str, header_name: &str) -> Option<bool> {
+pub(super) fn request_header_matches_host(request: &str, header_name: &str) -> Option<bool> {
     let (authority, is_trusted_local_or_proxy) =
         request_header_value(request, header_name).and_then(normalize_origin_authority)?;
     let host = request_header_value(request, "host").map(normalize_host_authority)?;
@@ -114,8 +114,8 @@ fn header_matches_host(request: &str, header_name: &str) -> Option<bool> {
 }
 
 pub(super) fn is_same_origin_http_request(request: &str) -> bool {
-    matches!(header_matches_host(request, "origin"), Some(true))
-        || matches!(header_matches_host(request, "referer"), Some(true))
+    matches!(request_header_matches_host(request, "origin"), Some(true))
+        || matches!(request_header_matches_host(request, "referer"), Some(true))
 }
 
 async fn write_json_error_response_no_cors(

--- a/cli/src/native/stream/http.rs
+++ b/cli/src/native/stream/http.rs
@@ -43,6 +43,98 @@ fn parse_origin(peeked: &[u8]) -> Option<String> {
     None
 }
 
+fn request_header_value<'a>(request: &'a str, name: &str) -> Option<&'a str> {
+    request.lines().find_map(|line| {
+        let (header_name, value) = line.split_once(':')?;
+        if header_name.trim().eq_ignore_ascii_case(name) {
+            Some(value.trim())
+        } else {
+            None
+        }
+    })
+}
+
+fn is_localhost_host(host: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    host == "localhost"
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]"
+        || host.ends_with(".localhost")
+}
+
+fn normalize_origin_authority(origin: &str) -> Option<(String, bool)> {
+    let url = url::Url::parse(origin).ok()?;
+    let host = url.host_str()?.to_ascii_lowercase();
+    let is_trusted_local_or_proxy = url.scheme() == "https" || is_localhost_host(&host);
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    let authority = match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host,
+    };
+    Some((authority, is_trusted_local_or_proxy))
+}
+
+fn normalize_host_authority(host: &str) -> String {
+    let host = host.trim().to_ascii_lowercase();
+
+    if let Some(bracket_end) = host.rfind(']') {
+        if bracket_end == host.len() - 1 {
+            return host;
+        }
+
+        if host.as_bytes().get(bracket_end + 1) == Some(&b':') {
+            let port = &host[bracket_end + 2..];
+            if port == "80" || port == "443" {
+                return host[..=bracket_end].to_string();
+            }
+        }
+
+        return host;
+    }
+
+    if let Some((name, port)) = host.rsplit_once(':') {
+        if !name.contains(':') && (port == "80" || port == "443") {
+            return name.to_string();
+        }
+    }
+
+    host
+}
+
+fn header_matches_host(request: &str, header_name: &str) -> Option<bool> {
+    let (authority, is_trusted_local_or_proxy) =
+        request_header_value(request, header_name).and_then(normalize_origin_authority)?;
+    let host = request_header_value(request, "host").map(normalize_host_authority)?;
+    Some(is_trusted_local_or_proxy && authority == host)
+}
+
+pub(super) fn is_same_origin_http_request(request: &str) -> bool {
+    matches!(header_matches_host(request, "origin"), Some(true))
+        || matches!(header_matches_host(request, "referer"), Some(true))
+}
+
+async fn write_json_error_response_no_cors(
+    stream: &mut tokio::net::TcpStream,
+    status: &'static str,
+    error: &str,
+) {
+    let body = format!(
+        r#"{{"success":false,"error":{}}}"#,
+        serde_json::to_string(error).unwrap_or_else(|_| format!("\"{}\"", error))
+    );
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.write_all(body.as_bytes()).await;
+}
+
 pub(super) async fn handle_http_request(
     mut stream: tokio::net::TcpStream,
     peeked: &[u8],
@@ -61,6 +153,17 @@ pub(super) async fn handle_http_request(
     let origin = parse_origin(peeked);
 
     if method == "OPTIONS" {
+        if (path == "/api/sessions" || path == "/api/command")
+            && !is_same_origin_http_request(&request)
+        {
+            write_json_error_response_no_cors(
+                &mut stream,
+                "403 Forbidden",
+                "Origin or Referer does not match Host header.",
+            )
+            .await;
+            return;
+        }
         let response = format!(
             "HTTP/1.1 204 No Content\r\n{CORS_HEADERS}Access-Control-Max-Age: 86400\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         );
@@ -85,6 +188,15 @@ pub(super) async fn handle_http_request(
         let body_str = full_body.as_deref().unwrap_or("");
 
         if path == "/api/sessions" {
+            if !is_same_origin_http_request(&request) {
+                write_json_error_response_no_cors(
+                    &mut stream,
+                    "403 Forbidden",
+                    "Origin or Referer does not match Host header.",
+                )
+                .await;
+                return;
+            }
             let result = spawn_session(body_str).await;
             let (status, resp_body) = match result {
                 Ok(msg) => ("200 OK", msg),
@@ -106,6 +218,15 @@ pub(super) async fn handle_http_request(
         }
 
         if path == "/api/command" {
+            if !is_same_origin_http_request(&request) {
+                write_json_error_response_no_cors(
+                    &mut stream,
+                    "403 Forbidden",
+                    "Origin or Referer does not match Host header.",
+                )
+                .await;
+                return;
+            }
             let result = relay_command_to_daemon(session_name, body_str).await;
             let (status, resp_body) = match result {
                 Ok(resp) => ("200 OK", resp),
@@ -311,5 +432,52 @@ pub(super) fn serve_embedded_file(url_path: &str) -> (&'static str, &'static str
             "text/html; charset=utf-8",
             b"<html><body><p>404 Not Found</p></body></html>".to_vec(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_origin_http_request_allows_matching_origin() {
+        let req = "POST /api/command HTTP/1.1\r\nHost: localhost:4848\r\nOrigin: http://localhost:4848\r\n\r\n";
+        assert!(is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn same_origin_http_request_allows_matching_referer() {
+        let req = "GET /api/sessions HTTP/1.1\r\nHost: dashboard.agent-browser.localhost:443\r\nReferer: https://dashboard.agent-browser.localhost/sessions\r\n\r\n";
+        assert!(is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn same_origin_http_request_allows_https_proxy_origin() {
+        let req = "POST /api/command HTTP/1.1\r\nHost: workspace.coder.example\r\nOrigin: https://workspace.coder.example\r\n\r\n";
+        assert!(is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn same_origin_http_request_allows_http_localhost_subdomain() {
+        let req = "POST /api/command HTTP/1.1\r\nHost: dashboard.agent-browser.localhost:4848\r\nOrigin: http://dashboard.agent-browser.localhost:4848\r\n\r\n";
+        assert!(is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn same_origin_http_request_rejects_cross_origin() {
+        let req = "POST /api/command HTTP/1.1\r\nHost: localhost:4848\r\nOrigin: https://evil.example\r\n\r\n";
+        assert!(!is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn same_origin_http_request_rejects_http_dns_rebind_origin() {
+        let req = "POST /api/command HTTP/1.1\r\nHost: evil.example:4848\r\nOrigin: http://evil.example:4848\r\n\r\n";
+        assert!(!is_same_origin_http_request(req));
+    }
+
+    #[test]
+    fn same_origin_http_request_rejects_missing_origin_and_referer() {
+        let req = "POST /api/command HTTP/1.1\r\nHost: localhost:4848\r\n\r\n";
+        assert!(!is_same_origin_http_request(req));
     }
 }


### PR DESCRIPTION
## Summary

- build on upstream #1355, which already fixed the per-session `/api/command` relay issue from #1344
- reject cross-origin requests before dispatching dashboard control-plane POST routes (`/api/exec`, `/api/sessions`, `/api/kill`)
- stop emitting wildcard CORS on standalone dashboard API responses
- require same-origin `Origin` or `Referer` before `/api/sessions` can spawn browser sessions
- require same-origin `Origin` for dashboard WebSocket proxy routes when a browser Origin is present
- require a generated capability token and local browser Origin for inspect-mode DevTools WebSocket handshakes
- add unit coverage for shared same-origin HTTP helpers, dashboard WebSocket origin checks, `/api/sessions` rejection, and inspect-mode token/origin checks

Fixes #1345.
Fixes #1347.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml native::stream::http::tests -- --test-threads=1 --nocapture`
- `cargo test --manifest-path cli/Cargo.toml native::stream:: -- --test-threads=1 --nocapture`
- `cargo test --manifest-path cli/Cargo.toml native::inspect_server::tests -- --nocapture`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- Runtime dashboard smoke on port 4860: evil-origin preflight and POST to `/api/exec` now return 403 without CORS; same-origin POST still returns 200.
