### PR TITLE
fix(cli, react): honour --json on react/vitals; classify opaque-Promise client suspensions as client-hook

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1657,12 +1657,16 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         }
 
         // === React (requires `open --enable react-devtools`) ===
-        "react" => parse_react(&rest, &id),
+        "react" => parse_react(&rest, &id, flags),
 
         // === Core Web Vitals + hydration ===
         "vitals" | "web-vitals" => {
             let mut cmd = json!({ "id": id, "action": "vitals" });
-            let json_out = rest.contains(&"--json");
+            // `--json` is stripped by `clean_args` before we see `rest`;
+            // consult `flags.json` (set by `parse_flags`) so the per-command
+            // JSON output mode still works. The `rest` check is kept for
+            // unit tests that call `parse_command` directly.
+            let json_out = flags.json || rest.contains(&"--json");
             if json_out {
                 cmd["json"] = json!(true);
             }
@@ -1696,13 +1700,16 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
     }
 }
 
-fn parse_react(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+fn parse_react(rest: &[&str], id: &str, flags: &Flags) -> Result<Value, ParseError> {
     const VALID: &[&str] = &["tree", "inspect", "renders", "suspense"];
     let sub = rest.first().copied().ok_or(ParseError::MissingArguments {
         context: "react".to_string(),
         usage: "react <tree|inspect|renders|suspense>",
     })?;
-    let json_out = rest.contains(&"--json");
+    // `--json` is in `clean_args`'s GLOBAL_BOOL_FLAGS list, so it's stripped
+    // from `rest` before we see it. Read the parsed flag too — and keep the
+    // `rest` check as a fallback for unit tests that call this directly.
+    let json_out = flags.json || rest.contains(&"--json");
     let flag = |key: &str| -> Value {
         if json_out {
             json!({ "id": id, "action": key, "json": true })
@@ -2921,6 +2928,31 @@ mod tests {
         assert_eq!(cmd["action"], "react_suspense");
         assert_eq!(cmd["onlyDynamic"], true);
         assert_eq!(cmd["json"], true);
+    }
+
+    // Regression: in the real call path, `clean_args` strips `--json` from
+    // the args before `parse_command` sees them, but `parse_flags` has
+    // already set `flags.json = true`. The react subcommand parser must
+    // honour `flags.json` — otherwise `agent-browser react suspense --json`
+    // silently falls back to the formatted report.
+    #[test]
+    fn test_react_subcommands_honour_global_json_flag() {
+        let mut flags = default_flags();
+        flags.json = true;
+
+        // `--json` is intentionally absent from the args slice here.
+        let tree = parse_command(&args("react tree"), &flags).unwrap();
+        assert_eq!(tree["json"], true);
+
+        let inspect = parse_command(&args("react inspect 7"), &flags).unwrap();
+        assert_eq!(inspect["json"], true);
+
+        let renders = parse_command(&args("react renders stop"), &flags).unwrap();
+        assert_eq!(renders["json"], true);
+
+        let suspense = parse_command(&args("react suspense --only-dynamic"), &flags).unwrap();
+        assert_eq!(suspense["json"], true);
+        assert_eq!(suspense["onlyDynamic"], true);
     }
 
     #[test]

--- a/cli/src/native/react/suspense.rs
+++ b/cli/src/native/react/suspense.rs
@@ -372,7 +372,32 @@ fn classify_blocker(s: &Suspender, source_frame: Option<&StackFrame>) -> Blocker
             return BlockerKind::Framework;
         }
     }
+    // When a client component calls `use(somePromise)` with an opaque
+    // user-created Promise (e.g. `fetch().then(r => r.json())` stashed in
+    // useState), React reports the suspender name as a generic "Promise".
+    // It doesn't match any of the name-based cases above, so without this
+    // fallback the suspension lands on `Unknown` — even though semantically
+    // it's the prototypical client-hook scenario.
+    //
+    // The discriminator is `env`: React tags server-tracked awaits with
+    // env="Server" (the suspenders named "rsc stream", "_Response.json",
+    // anonymous fetches, etc. that come back from RSC), while client-side
+    // suspensions show up with env unset or "Client". We bail out on
+    // anything that explicitly says it's server-side so this doesn't steal
+    // classifications from server promises that happen to be unnamed.
+    if is_client_promise_suspension(s, &name) {
+        return BlockerKind::ClientHook;
+    }
     BlockerKind::Unknown
+}
+
+fn is_client_promise_suspension(s: &Suspender, lowercase_name: &str) -> bool {
+    if !matches!(lowercase_name, "promise" | "") {
+        return false;
+    }
+    !s.env
+        .as_deref()
+        .is_some_and(|e| e.eq_ignore_ascii_case("server"))
 }
 
 fn suggest_blocker_fix(kind: BlockerKind) -> String {
@@ -630,4 +655,65 @@ fn format_report(report: &AnalysisReport, only_dynamic: bool) -> String {
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn suspender(name: &str, env: Option<&str>, awaiter_stack: Option<Vec<StackFrame>>) -> Suspender {
+        Suspender {
+            name: name.to_string(),
+            description: String::new(),
+            duration: 0,
+            env: env.map(String::from),
+            owner_name: None,
+            owner_stack: None,
+            awaiter_name: None,
+            awaiter_stack,
+        }
+    }
+
+    fn frame(file: &str) -> StackFrame {
+        (String::new(), file.to_string(), 1, 1)
+    }
+
+    // Real shape captured from the demo app: a client component calls
+    // `use(fetch().then(r => r.json()))`. React reports `awaited.name`
+    // as the generic "Promise" with `env` unset (server-tracked awaits
+    // carry env="Server"). The heuristic classifies this as ClientHook.
+    #[test]
+    fn classify_blocker_recognises_client_use_promise() {
+        let s = suspender("Promise", None, None);
+        assert_eq!(classify_blocker(&s, None), BlockerKind::ClientHook);
+    }
+
+    // Explicit `Client` env should classify the same way (and not just by
+    // virtue of being unset).
+    #[test]
+    fn classify_blocker_recognises_client_env_promise() {
+        let s = suspender("Promise", Some("Client"), None);
+        assert_eq!(classify_blocker(&s, None), BlockerKind::ClientHook);
+    }
+
+    // The heuristic must not steal classifications from server-side
+    // awaits: those carry env="Server".
+    #[test]
+    fn classify_blocker_does_not_steal_server_promise() {
+        let s = suspender(
+            "Promise",
+            Some("Server"),
+            Some(vec![frame(
+                "about://React/Server/file:///app/.next/server/chunks/x.js",
+            )]),
+        );
+        assert_eq!(classify_blocker(&s, None), BlockerKind::Unknown);
+    }
+
+    // Regression: existing named-hook classifications must still work.
+    #[test]
+    fn classify_blocker_recognises_use_router() {
+        let s = suspender("useRouter", None, None);
+        assert_eq!(classify_blocker(&s, None), BlockerKind::ClientHook);
+    }
 }


### PR DESCRIPTION
Two small fixes for the React features shipped in #1257. Pushed as draft so we can iterate on the description / scope.

## 1. `--json` is silently stripped from `react` and `vitals` subcommands

**File:** `cli/src/commands.rs`

`--json` is registered as a global boolean in `clean_args`'s `GLOBAL_BOOL_FLAGS`, so it's removed from the args slice before `parse_command` sees them. The per-command parsers for `react <sub>` and `vitals` then check `rest.contains(\"--json\")` on the already-stripped args, so the flag silently no-ops and the action returns the formatted `report` instead of the raw structured payload (`boundaries` for suspense, the inspector JSON for the others).

The fix reads ` flags.json ` — which `parse_flags` populates from the pre-strip args — in both parsers. The existing `rest.contains` check is kept as a fallback so the unit tests that call `parse_command` directly with `--json` in the args slice continue to work.

Repro before the fix:

\`\`\`shell
$ agent-browser react suspense --json | jq 'keys'
[
  \"report\"   # expected: \"boundaries\"
]
\`\`\`

A regression test asserts that with \`flags.json = true\` and \`--json\` absent from \`rest\` (the real call path), all four react subcommands emit \`cmd.json = true\`.

## 2. \`use(opaquePromise)\` in a client component lands on \`Unknown\` instead of \`ClientHook\`

**File:** \`cli/src/native/react/suspense.rs\`

A client component calling \`use(somePromise)\` where the promise is an opaque user-created \`Promise\` (e.g. \`fetch().then(r => r.json())\` stashed in \`useState\`) was classified as \`BlockerKind::Unknown\`. React reports the suspender as \`awaited.name = \"Promise\"\` with no other identifying signal in the name, so none of the existing name-based checks fire — yet this is the prototypical \"client-hook\" scenario the classifier advertises.

The discriminator I landed on is \`env\`. React tags server-tracked awaits with \`env=\"Server\"\` (the suspenders named \`rsc stream\`, \`_Response.json\`, anonymous fetches, etc. that come back from RSC), while client-side suspensions arrive with \`env\` unset or \`\"Client\"\`. Adding a fallback that reclassifies opaque-Promise suspenders as \`ClientHook\` when \`env\` is not explicitly \`\"Server\"\` resolves the case without stealing classifications from server-side awaits.

Verified against a Next.js App Router demo with two Suspense boundaries:

| Boundary | Before | After |
| --- | --- | --- |
| \`<ServerFetchChild>\` (server component awaiting \`fetch\`) | \`rsc stream (stream)\` | \`rsc stream (stream)\` (unchanged) |
| \`<ClientUseChild>\` (client component awaiting \`use(promise)\`) | \`Promise (unknown)\` | \`Promise (client-hook)\` |

Tests cover: client-side opaque Promise → ClientHook, explicit \`env=\"Client\"\` Promise → ClientHook, \`env=\"Server\"\` Promise → Unknown (no regression on server awaits), and existing named-hook handling.

## Test plan

- [x] \`cargo test\` — 722 passed, 0 failed, 70 ignored (locally on \`stable-aarch64-apple-darwin\`)
- [x] End-to-end smoke test against a Next.js 16 / React 19 App Router demo (\`use(fetch().then(json))\` client component + \`await fetch\` server component), verified before/after classifications match the table above
- [ ] CI

## Out of scope

While verifying, I noticed that \`agent-browser react suspense\` (no \`--json\`) prints \`✓ Done\` instead of the formatted report — the daemon returns \`{\"report\": \"...\"}\` but the response printer doesn't render the \`report\` key for these subcommands. Separate bug; happy to follow up if you'd like it in this PR or a separate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)