### PR TITLE
fix(network): handle_route reads top-level body field as RouteRespons…

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7119,6 +7119,15 @@ async fn handle_route(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
                 })
             }),
         })
+    }).or_else(|| {
+        cmd.get("body").and_then(|v| v.as_str()).map(|body| {
+            RouteResponse {
+                status: Some(200),
+                body: Some(body.to_string()),
+                content_type: Some("application/json".to_string()),
+                headers: None,
+            }
+        })
     });
 
     {


### PR DESCRIPTION
## Fix: `network route --body` not working — handler reads top-level `body` as fallback
                                                                                                                                              
Closes #1353                                                                                                                                  
                                                                                                                                              
### Problem                                                                                                                                   
                                                                                                                                              
The `--body` flag on `network route` has no effect. Intercepted requests are passed through to the real backend instead of being stubbed with 
the provided response body.                                                                                                                   
                                                                                                                                              
### Root Cause                                                                                                                                
                                                                                                                                              
The CLI parser (`cli/src/commands.rs:2516`) stores the `--body` value as a top-level `"body"` field in the command JSON:                      
                                                                                                                                              
```json                                                                                                                                       
{ "id": "...", "action": "route", "url": "**/api/users", "abort": false, "body": "{\"users\":[]}" }                                           
```
                                                                                                                                              
However, handle_route (cli/src/native/actions.rs:7096-7109) only reads from the nested "response" object to construct a RouteResponse. The    
top-level "body" field is never accessed, so RouteEntry.response ends up as None, and resolve_fetch_paused skips Fetch.fulfillRequest —       
falling through to Fetch.continueRequest, which lets the request reach the real backend.                                                      
                                                                                                                                                                                                                                                                                   
Fix                                                                                                                                           
                                                                                                                                              
Added an or_else fallback in handle_route that reads the top-level "body" field when "response" is not present, constructing a RouteResponse  
with sensible defaults (status 200, content-type application/json):                                                                           
```                                                                                                                                              
}).or_else(|| {                                                                                                                               
    cmd.get("body").and_then(|v| v.as_str()).map(|body| {                                                                                     
        RouteResponse {                                                                                                                       
            status: Some(200),                                                                                                                
            body: Some(body.to_string()),                                                                                                     
            content_type: Some("application/json".to_string()),                                                                               
            headers: None,                                                                                                                    
        }                                                                                                                                     
    })                                                                                                                                        
});                                                                                                                                           
```
                                                                                                                                              
This approach:
- Preserves the existing nested "response" path for full control over status, headers, and content type                                       
- Does not modify the parser side, keeping the diff minimal                                                                                 
- Is complementary to the parser-side fix in open PR #381 (which wraps --body into a nested response object)
                                                                                                     
Verification                               
                                                                                                                                              
- cargo clippy — no warnings                                                                                                                  
- cargo test — all relevant tests pass 