### PR TITLE
Broadcast `tabs` on implicit target lifecycle events

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -687,6 +687,19 @@ impl DaemonState {
                 mgr.update_page_target_info(&te.target_info);
             }
         }
+
+        // Broadcast the tab list whenever the tab set changes via implicit
+        // CDP events (popups, target=_blank, window.open, Cmd-click) so stream
+        // clients can react without polling. CLI-driven changes
+        // (tab_new / tab_switch / tab_close / open / navigate) already
+        // broadcast at the end of the action handler below.
+        let tab_set_changed =
+            !drained.new_targets.is_empty() || !drained.destroyed_targets.is_empty();
+        if tab_set_changed {
+            if let (Some(ref server), Some(ref mgr)) = (&self.stream_server, &self.browser) {
+                server.broadcast_tabs(&mgr.tab_list()).await;
+            }
+        }
     }
 
     fn drain_cdp_events(&mut self) -> DrainedEvents {


### PR DESCRIPTION
# Broadcast `tabs` on implicit target lifecycle events

## Problem

The stream-server WS broadcasts `{type:"tabs",...}` to connected clients **only** on:

1. Browser connect / disconnect — `update_stream_client` (`actions.rs:549,551`).
2. After CLI verbs `tab_new` / `tab_switch` / `tab_close` / `open` / `navigate` — the action handler (`actions.rs:1480`).

Tab changes that happen via direct Chrome activity — clicks on `target=_blank` links, `window.open()`, middle-click, Cmd-click — go through `Target.targetCreated`, which `apply_drained_events` already attaches and registers as a new `page`. But it never broadcasts `tab_list()` afterward, so external WS consumers have no signal that the tab set changed.

The current workaround is to poll `tab list` on a timer. That's wasteful — the daemon already knows the exact moment a tab appears.

## Fix

When `apply_drained_events` processes a non-empty `new_targets` or `destroyed_targets`, call `server.broadcast_tabs(&mgr.tab_list())` once. The branch is gated on the changed flags, so idle ticks don't broadcast.

```rust
let tab_set_changed =
    !drained.new_targets.is_empty() || !drained.destroyed_targets.is_empty();
if tab_set_changed {
    if let (Some(ref server), Some(ref mgr)) = (&self.stream_server, &self.browser) {
        server.broadcast_tabs(&mgr.tab_list()).await;
    }
}
```

13 lines added, including the comment block. No new allocations on idle ticks.

## Use case

We run agent-browser sessions per user behind a streaming viewer. When a user clicks a link that opens in a new tab, the screencast currently stays stuck on the old tab. With this PR, our viewer service listens for the `tabs` broadcast, diffs against its known set, and calls `tab tN` to follow — sub-100ms instead of needing a 1-2s poll.

## Interaction with CLI-initiated tab changes

Worth being explicit about this since the new branch lives alongside the existing CLI-side broadcast at `actions.rs:1493`:

- **`tab_new`** — no duplicate. `Browser::tab_new` pushes the `PageInfo` synchronously before the CDP `Target.targetCreated` event arrives. When that event is later drained, the `already_tracked` guard in the `targetCreated` arm filters it out, so `drained.new_targets` is empty and the new branch doesn't fire.
- **`open` / `navigate` / `tab_switch`** — no duplicate. These don't create or destroy targets, so `new_targets`/`destroyed_targets` stay empty.
- **`tab_close`** — one redundant broadcast. `Browser::tab_close` removes the page from `mgr.pages` synchronously, the action handler broadcasts once, and then the later `Target.targetDestroyed` event still pushes the target_id into `destroyed_targets` (the destroyed arm has no symmetric "still tracked?" guard), triggering a second broadcast with identical content. Harmless — clients receive the same payload twice — but worth noting. If we want symmetry later, the fix is to gate `destroyed_targets.push(...)` on `has_target(&te.target_id)` the same way `targetCreated` is gated.
