### PR TITLE
feat(paths): support XDG agent-browser directories (for linux)

### DIFF
--- a/cli/src/doctor/config.rs
+++ b/cli/src/doctor/config.rs
@@ -1,4 +1,4 @@
-//! Check user config files: `~/.agent-browser/config.json`,
+//! Check user config files: the XDG-aware user config,
 //! `./agent-browser.json`, and any file referenced by
 //! `AGENT_BROWSER_CONFIG`.
 
@@ -7,11 +7,12 @@ use std::path::PathBuf;
 
 use super::helpers::parse_json_file;
 use super::{Check, Status};
+use crate::paths;
 
 pub(super) fn check(checks: &mut Vec<Check>) {
     let category = "Config";
 
-    let user_path = dirs::home_dir().map(|d| d.join(".agent-browser").join("config.json"));
+    let user_path = Some(paths::user_config_file());
     if let Some(p) = user_path {
         if p.exists() {
             match parse_json_file(&p) {

--- a/cli/src/doctor/environment.rs
+++ b/cli/src/doctor/environment.rs
@@ -38,10 +38,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     let state_dir = get_state_dir();
     let socket_dir = get_socket_dir();
 
-    // Under the default setup, state and socket dirs are the same
-    // (~/.agent-browser). Collapse to a single line when they match;
-    // split when XDG_RUNTIME_DIR or AGENT_BROWSER_SOCKET_DIR diverts
-    // sockets elsewhere.
+    // Collapse to a single line only when an override makes these dirs match.
     if state_dir == socket_dir {
         push_dir_check(
             checks,

--- a/cli/src/doctor/fix.rs
+++ b/cli/src/doctor/fix.rs
@@ -209,10 +209,18 @@ mod tests {
     #[test]
     fn test_run_fixes_generates_missing_encryption_key() {
         // Reaches the Info-status arm in run_fixes that was previously
-        // unreachable due to an early-continue guard. Overrides HOME so
-        // get_state_dir() resolves under a temp dir.
-        let guard = crate::test_utils::EnvGuard::new(&["HOME"]);
+        // unreachable due to an early-continue guard. Overrides HOME so the
+        // XDG-aware state dir resolves under a temp dir.
+        let guard = crate::test_utils::EnvGuard::new(&[
+            "AGENT_BROWSER_HOME",
+            "AGENT_BROWSER_STATE_DIR",
+            "XDG_STATE_HOME",
+            "HOME",
+        ]);
         let tmp = TempDir::new().unwrap();
+        guard.remove("AGENT_BROWSER_HOME");
+        guard.remove("AGENT_BROWSER_STATE_DIR");
+        guard.remove("XDG_STATE_HOME");
         guard.set("HOME", tmp.path().to_str().unwrap());
 
         let mut checks = vec![Check::new(
@@ -240,8 +248,10 @@ mod tests {
             "fixed summary should mention the key generation"
         );
         assert!(
-            tmp.path().join(".agent-browser/.encryption-key").exists(),
-            "key file should exist at ~/.agent-browser/.encryption-key"
+            tmp.path()
+                .join(".local/state/agent-browser/.encryption-key")
+                .exists(),
+            "key file should exist at ~/.local/state/agent-browser/.encryption-key"
         );
     }
 }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -1,11 +1,10 @@
 use crate::color;
+use crate::paths;
 use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const CONFIG_DIR: &str = ".agent-browser";
-const CONFIG_FILENAME: &str = "config.json";
 const PROJECT_CONFIG_FILENAME: &str = "agent-browser.json";
 
 /// Parse idle timeout from user-friendly format.
@@ -273,10 +272,7 @@ pub fn load_config(args: &[String]) -> Result<Config, String> {
             .ok_or_else(|| format!("failed to load config from {}", path_str));
     }
 
-    let user_config = dirs::home_dir()
-        .map(|d| d.join(CONFIG_DIR).join(CONFIG_FILENAME))
-        .and_then(|p| read_config_file(&p))
-        .unwrap_or_default();
+    let user_config = read_config_file(&paths::user_config_file()).unwrap_or_default();
 
     let project_config = read_config_file(&PathBuf::from(PROJECT_CONFIG_FILENAME));
 

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -1,4 +1,5 @@
 use crate::color;
+use crate::paths;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -8,10 +9,7 @@ const LAST_KNOWN_GOOD_URL: &str =
     "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
 
 pub fn get_browsers_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".agent-browser")
-        .join("browsers")
+    paths::browsers_dir()
 }
 
 pub fn find_installed_chrome() -> Option<PathBuf> {
@@ -21,8 +19,8 @@ pub fn find_installed_chrome() -> Option<PathBuf> {
     if debug {
         let _ = writeln!(
             io::stderr(),
-            "[chrome-search] home_dir={:?} browsers_dir={}",
-            dirs::home_dir(),
+            "[chrome-search] data_dir={} browsers_dir={}",
+            paths::data_dir().display(),
             browsers_dir.display()
         );
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod flags;
 mod install;
 mod native;
 mod output;
+mod paths;
 mod skills;
 #[cfg(test)]
 mod test_utils;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10,6 +10,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::sync::{broadcast, oneshot, RwLock};
 
 use crate::connection::get_socket_dir;
+use crate::paths;
 
 use super::auth;
 use super::browser::{should_track_target, BrowserManager, WaitUntil};
@@ -4239,11 +4240,7 @@ async fn handle_pdf(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
     let save_path = match path {
         Some(p) => p.to_string(),
         None => {
-            let dir = dirs::home_dir()
-                .unwrap_or_else(std::env::temp_dir)
-                .join(".agent-browser")
-                .join("tmp")
-                .join("pdfs");
+            let dir = paths::tmp_dir().join("pdfs");
             let _ = std::fs::create_dir_all(&dir);
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -6800,11 +6797,7 @@ fn har_output_path(explicit_path: Option<&str>) -> String {
 }
 
 fn get_har_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("har")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("har")
-    }
+    paths::tmp_dir().join("har")
 }
 
 fn unix_timestamp_millis() -> u128 {

--- a/cli/src/native/auth.rs
+++ b/cli/src/native/auth.rs
@@ -1,3 +1,4 @@
+use crate::paths;
 use aes_gcm::{aead::Aead, aead::KeyInit, Aes256Gcm};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
@@ -43,11 +44,7 @@ fn validate_profile_name(name: &str) -> Result<(), String> {
 }
 
 fn get_auth_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("auth")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("auth")
-    }
+    paths::auth_dir()
 }
 
 fn get_profile_path(name: &str) -> PathBuf {
@@ -55,18 +52,13 @@ fn get_profile_path(name: &str) -> PathBuf {
 }
 
 const ENCRYPTION_KEY_ENV: &str = "AGENT_BROWSER_ENCRYPTION_KEY";
-const KEY_FILE_NAME: &str = ".encryption-key";
 
 fn get_agent_browser_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser")
-    } else {
-        std::env::temp_dir().join("agent-browser")
-    }
+    paths::state_dir()
 }
 
 fn get_key_file_path() -> PathBuf {
-    get_agent_browser_dir().join(KEY_FILE_NAME)
+    paths::encryption_key_file()
 }
 
 fn parse_key_hex(hex_str: &str) -> Option<Vec<u8>> {
@@ -81,7 +73,7 @@ fn parse_key_hex(hex_str: &str) -> Option<Vec<u8>> {
 }
 
 /// Read the encryption key from AGENT_BROWSER_ENCRYPTION_KEY env var or
-/// ~/.agent-browser/.encryption-key file (matching the Node.js implementation).
+/// the configured agent-browser encryption key file.
 fn get_encryption_key() -> Result<Vec<u8>, String> {
     if let Ok(key_hex) = std::env::var(ENCRYPTION_KEY_ENV) {
         return parse_key_hex(&key_hex).ok_or_else(|| {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5138,10 +5138,7 @@ async fn e2e_session_name_auto_restores_cookies() {
     }
 
     // Clean up auto-saved state files
-    let sessions_dir = dirs::home_dir()
-        .unwrap()
-        .join(".agent-browser")
-        .join("sessions");
+    let sessions_dir = crate::paths::sessions_dir();
     if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
         for entry in entries.flatten() {
             let fname = entry.file_name().to_string_lossy().to_string();

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use std::collections::HashMap;
 
+use crate::paths;
+
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 use super::element::RefMap;
@@ -588,13 +590,7 @@ fn round(value: f64) -> i64 {
 }
 
 fn get_screenshot_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("screenshots")
-    } else {
-        std::env::temp_dir()
-            .join("agent-browser")
-            .join("screenshots")
-    }
+    paths::tmp_dir().join("screenshots")
 }
 
 #[cfg(test)]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -1,3 +1,4 @@
+use crate::paths;
 use aes_gcm::{aead::Aead, aead::KeyInit, Aes256Gcm};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -714,19 +715,14 @@ pub fn dispatch_state_command(cmd: &Value) -> Option<Result<Value, String>> {
     }
 }
 
-/// Return the agent-browser state root (`~/.agent-browser`, falling back to
-/// `<tempdir>/agent-browser` when the home directory can't be resolved).
+/// Return the agent-browser state root.
 /// This is the parent of `sessions/`, auth storage, and the encryption key.
 pub fn get_state_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser")
-    } else {
-        std::env::temp_dir().join("agent-browser")
-    }
+    paths::state_dir()
 }
 
 pub fn get_sessions_dir() -> PathBuf {
-    get_state_dir().join("sessions")
+    paths::sessions_dir()
 }
 
 #[cfg(test)]

--- a/cli/src/native/tracing.rs
+++ b/cli/src/native/tracing.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
 use std::path::PathBuf;
 
+use crate::paths;
+
 use super::cdp::client::CdpClient;
 
 const MAX_PROFILE_EVENTS: usize = 5_000_000;
@@ -357,17 +359,9 @@ fn get_clock_domain() -> Option<&'static str> {
 }
 
 fn get_traces_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("traces")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("traces")
-    }
+    paths::tmp_dir().join("traces")
 }
 
 fn get_profiles_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".agent-browser").join("tmp").join("profiles")
-    } else {
-        std::env::temp_dir().join("agent-browser").join("profiles")
-    }
+    paths::tmp_dir().join("profiles")
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3125,7 +3125,10 @@ Options:
 
 Configuration:
   agent-browser looks for agent-browser.json in these locations (lowest to highest priority):
-    1. ~/.agent-browser/config.json      User-level defaults
+    1. $AGENT_BROWSER_HOME/config/config.json,
+       else $AGENT_BROWSER_CONFIG_DIR/agent-browser/config.json,
+       else $XDG_CONFIG_HOME/agent-browser/config.json
+                                      User-level defaults
     2. ./agent-browser.json              Project-level overrides
     3. Environment variables             Override config file values
     4. CLI flags                         Override everything
@@ -3143,6 +3146,11 @@ Configuration:
     {{"headed": true, "proxy": "http://localhost:8080", "profile": "./browser-data"}}
 
 Environment:
+  AGENT_BROWSER_HOME             Root for config, state, data, and cache dirs
+  AGENT_BROWSER_CONFIG_DIR       Base dir for user config files
+  AGENT_BROWSER_STATE_DIR        Base dir for sessions, auth, and keys
+  AGENT_BROWSER_DATA_DIR         Base dir for installed browsers
+  AGENT_BROWSER_CACHE_DIR        Base dir for screenshots, traces, HAR, and PDFs
   AGENT_BROWSER_CONFIG           Path to config file (or use --config)
   AGENT_BROWSER_SESSION          Session name (default: "default")
   AGENT_BROWSER_SESSION_NAME     Auto-save/restore state persistence name

--- a/cli/src/paths.rs
+++ b/cli/src/paths.rs
@@ -1,0 +1,154 @@
+use std::env;
+use std::path::PathBuf;
+
+const APP_DIR: &str = "agent-browser";
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    match env::var(name) {
+        Ok(value) if !value.is_empty() => Some(PathBuf::from(value)),
+        _ => None,
+    }
+}
+
+fn home_fallback(parts: &[&str]) -> PathBuf {
+    let mut path = dirs::home_dir().unwrap_or_else(env::temp_dir);
+    for part in parts {
+        path = path.join(part);
+    }
+    path
+}
+
+fn app_base(env_name: &str, xdg_name: &str, fallback: &[&str]) -> PathBuf {
+    env_path(env_name)
+        .or_else(|| env_path(xdg_name))
+        .unwrap_or_else(|| home_fallback(fallback))
+        .join(APP_DIR)
+}
+
+pub fn config_dir() -> PathBuf {
+    if let Some(home) = env_path("AGENT_BROWSER_HOME") {
+        return home.join("config");
+    }
+
+    app_base("AGENT_BROWSER_CONFIG_DIR", "XDG_CONFIG_HOME", &[".config"])
+}
+
+pub fn state_dir() -> PathBuf {
+    if let Some(home) = env_path("AGENT_BROWSER_HOME") {
+        return home.join("state");
+    }
+
+    app_base(
+        "AGENT_BROWSER_STATE_DIR",
+        "XDG_STATE_HOME",
+        &[".local", "state"],
+    )
+}
+
+pub fn data_dir() -> PathBuf {
+    if let Some(home) = env_path("AGENT_BROWSER_HOME") {
+        return home.join("data");
+    }
+
+    app_base(
+        "AGENT_BROWSER_DATA_DIR",
+        "XDG_DATA_HOME",
+        &[".local", "share"],
+    )
+}
+
+pub fn cache_dir() -> PathBuf {
+    if let Some(home) = env_path("AGENT_BROWSER_HOME") {
+        return home.join("cache");
+    }
+
+    app_base("AGENT_BROWSER_CACHE_DIR", "XDG_CACHE_HOME", &[".cache"])
+}
+
+pub fn user_config_file() -> PathBuf {
+    config_dir().join("config.json")
+}
+
+pub fn browsers_dir() -> PathBuf {
+    data_dir().join("browsers")
+}
+
+pub fn sessions_dir() -> PathBuf {
+    state_dir().join("sessions")
+}
+
+pub fn auth_dir() -> PathBuf {
+    state_dir().join("auth")
+}
+
+pub fn encryption_key_file() -> PathBuf {
+    state_dir().join(".encryption-key")
+}
+
+pub fn tmp_dir() -> PathBuf {
+    cache_dir().join("tmp")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VARS: &[&str] = &[
+        "AGENT_BROWSER_HOME",
+        "AGENT_BROWSER_CONFIG_DIR",
+        "AGENT_BROWSER_STATE_DIR",
+        "AGENT_BROWSER_DATA_DIR",
+        "AGENT_BROWSER_CACHE_DIR",
+        "XDG_CONFIG_HOME",
+        "XDG_STATE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+        "HOME",
+    ];
+
+    fn clear_vars(guard: &crate::test_utils::EnvGuard<'_>) {
+        for var in VARS {
+            guard.remove(var);
+        }
+    }
+
+    #[test]
+    fn agent_browser_home_owns_all_dirs() {
+        let guard = crate::test_utils::EnvGuard::new(VARS);
+        clear_vars(&guard);
+        guard.set("AGENT_BROWSER_HOME", "/tmp/ab-home");
+
+        assert_eq!(config_dir(), PathBuf::from("/tmp/ab-home/config"));
+        assert_eq!(state_dir(), PathBuf::from("/tmp/ab-home/state"));
+        assert_eq!(data_dir(), PathBuf::from("/tmp/ab-home/data"));
+        assert_eq!(cache_dir(), PathBuf::from("/tmp/ab-home/cache"));
+    }
+
+    #[test]
+    fn xdg_dirs_are_used_with_app_suffix() {
+        let guard = crate::test_utils::EnvGuard::new(VARS);
+        clear_vars(&guard);
+        guard.set("XDG_CONFIG_HOME", "/tmp/config");
+        guard.set("XDG_STATE_HOME", "/tmp/state");
+        guard.set("XDG_DATA_HOME", "/tmp/data");
+        guard.set("XDG_CACHE_HOME", "/tmp/cache");
+
+        assert_eq!(config_dir(), PathBuf::from("/tmp/config/agent-browser"));
+        assert_eq!(state_dir(), PathBuf::from("/tmp/state/agent-browser"));
+        assert_eq!(data_dir(), PathBuf::from("/tmp/data/agent-browser"));
+        assert_eq!(cache_dir(), PathBuf::from("/tmp/cache/agent-browser"));
+    }
+
+    #[test]
+    fn agent_browser_dir_overrides_win_over_xdg() {
+        let guard = crate::test_utils::EnvGuard::new(VARS);
+        clear_vars(&guard);
+        guard.set("AGENT_BROWSER_STATE_DIR", "/tmp/custom-state");
+        guard.set("XDG_STATE_HOME", "/tmp/xdg-state");
+
+        assert_eq!(
+            state_dir(),
+            PathBuf::from("/tmp/custom-state/agent-browser")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This replaces the previous broader PR (#1297) with a smaller implementation focused only on XDG-aware agent-browser paths. And closes #1361.

## Behavior

`AGENT_BROWSER_HOME` acts as a single root for all agent-browser-managed files:

- `$AGENT_BROWSER_HOME/config`
- `$AGENT_BROWSER_HOME/state`
- `$AGENT_BROWSER_HOME/data`
- `$AGENT_BROWSER_HOME/cache`

Without `AGENT_BROWSER_HOME`, each path category uses its dedicated override first, then the matching XDG base directory, then the XDG spec fallback:

- Config: `AGENT_BROWSER_CONFIG_DIR` / `XDG_CONFIG_HOME` / `~/.config`, then `/agent-browser`
- State: `AGENT_BROWSER_STATE_DIR` / `XDG_STATE_HOME` / `~/.local/state`, then `/agent-browser`
- Data: `AGENT_BROWSER_DATA_DIR` / `XDG_DATA_HOME` / `~/.local/share`, then `/agent-browser`
- Cache: `AGENT_BROWSER_CACHE_DIR` / `XDG_CACHE_HOME` / `~/.cache`, then `/agent-browser`

## File Placement

- User config goes under config.
- Sessions, auth profiles, and the generated encryption key go under state.
- Installed browser binaries go under data.
- Screenshots, traces, HAR files, PDFs, and other temporary artifacts go under cache.

Socket/runtime behavior is intentionally unchanged.

Closes #1361

## Tests

- `cargo check`
- `cargo test paths`
- `cargo test test_run_fixes_generates_missing_encryption_key`
