### PR TITLE
Make tab switch foregrounding optional via --no-activate

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1261,11 +1261,29 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     }
                     Ok(cmd)
                 }
-                Some(tab_ref) => Ok(json!({
-                    "id": id,
-                    "action": "tab_switch",
-                    "tabId": tab_ref,
-                })),
+                Some(tab_ref) => {
+                    let mut cmd = json!({
+                        "id": id,
+                        "action": "tab_switch",
+                        "tabId": tab_ref,
+                    });
+                    let mut i = 1;
+                    while i < rest.len() {
+                        match rest[i] {
+                            "--no-activate" => {
+                                cmd["noActivate"] = json!(true);
+                                i += 1;
+                            }
+                            other => {
+                                return Err(ParseError::UnknownSubcommand {
+                                    subcommand: other.to_string(),
+                                    valid_options: &["--no-activate"],
+                                });
+                            }
+                        }
+                    }
+                    Ok(cmd)
+                }
                 None => Ok(json!({ "id": id, "action": "tab_list" })),
             }
         }
@@ -3412,6 +3430,27 @@ mod tests {
         let cmd = parse_command(&args("tab docs"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "tab_switch");
         assert_eq!(cmd["tabId"], "docs");
+    }
+
+    #[test]
+    fn test_tab_switch_no_activate() {
+        let cmd = parse_command(&args("tab t2 --no-activate"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_switch");
+        assert_eq!(cmd["tabId"], "t2");
+        assert_eq!(cmd["noActivate"], true);
+    }
+
+    #[test]
+    fn test_tab_switch_default_activates() {
+        let cmd = parse_command(&args("tab t2"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_switch");
+        assert!(cmd.get("noActivate").is_none() || cmd["noActivate"] == false);
+    }
+
+    #[test]
+    fn test_tab_switch_unknown_flag_errors() {
+        let result = parse_command(&args("tab t2 --bogus"), &default_flags());
+        assert!(result.is_err(), "unknown flag must error, got: {:?}", result);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3727,10 +3727,14 @@ async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .ok_or("Missing 'tabId' parameter (expected `t<N>` or a label)")?;
     let tab_ref = super::browser::TabRef::parse(tab_ref_str)?;
     let tab_id = mgr.resolve_tab_ref(&tab_ref)?;
+    let activate = !cmd
+        .get("noActivate")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     state.ref_map.clear();
     state.iframe_sessions.clear();
     state.active_frame_id = None;
-    let result = mgr.tab_switch_by_id(tab_id).await?;
+    let result = mgr.tab_switch_by_id(tab_id, activate).await?;
 
     if let Some(ref server) = state.stream_server {
         if let Ok(dims) = mgr

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1076,7 +1076,7 @@ impl BrowserManager {
         }))
     }
 
-    pub async fn tab_switch(&mut self, index: usize) -> Result<Value, String> {
+    pub async fn tab_switch(&mut self, index: usize, activate: bool) -> Result<Value, String> {
         if index >= self.pages.len() {
             return Err(format!(
                 "Tab index {} out of range (0-{})",
@@ -1089,11 +1089,13 @@ impl BrowserManager {
         let session_id = self.pages[index].session_id.clone();
         self.enable_domains(&session_id).await?;
 
-        // Bring tab to front
-        let _ = self
-            .client
-            .send_command("Page.bringToFront", None, Some(&session_id))
-            .await;
+        if activate {
+            // Bring tab to front
+            let _ = self
+                .client
+                .send_command("Page.bringToFront", None, Some(&session_id))
+                .await;
+        }
 
         let url = self.get_url().await.unwrap_or_default();
         let title = self.get_title().await.unwrap_or_default();
@@ -1398,13 +1400,17 @@ impl BrowserManager {
         Ok(())
     }
 
-    pub async fn tab_switch_by_id(&mut self, tab_id: u32) -> Result<Value, String> {
+    pub async fn tab_switch_by_id(
+        &mut self,
+        tab_id: u32,
+        activate: bool,
+    ) -> Result<Value, String> {
         let index = self
             .pages
             .iter()
             .position(|p| p.tab_id == tab_id)
             .ok_or_else(|| format!("Tab ID {} not found", tab_id))?;
-        self.tab_switch(index).await
+        self.tab_switch(index, activate).await
     }
 
     pub async fn tab_close_by_id(&mut self, tab_id: Option<u32>) -> Result<Value, String> {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2056,6 +2056,12 @@ Operations:
   close [t<N>|label]         Close a tab (current if no ref given)
   <t<N>|label>               Switch to a tab by id or label
 
+Switch options:
+  --no-activate              Make the tab current for subsequent commands
+                             without bringing it to the foreground. Useful
+                             for background syncers that need to address a
+                             tab without disturbing the user's focus.
+
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
@@ -2067,6 +2073,7 @@ Examples:
   agent-browser tab new https://example.com
   agent-browser tab new --label docs https://docs.example.com
   agent-browser tab t2
+  agent-browser tab t2 --no-activate
   agent-browser tab docs
   agent-browser tab close
   agent-browser tab close t1


### PR DESCRIPTION
## Problem

`tab <ref>` bundles two operations: it sets the session's active tab pointer (logical select) and brings the tab to the foreground via `Page.bringToFront` (physical activate). For interactive agents driving one tab at a time, that's the right default. For background syncers that need to address every tracked tab in turn (to read each one's snapshot), every poll cycle ends up calling `bringToFront` on every tab in sequence, fighting the user's foreground in headed mode.

## Change

Add a `--no-activate` flag to `tab <ref>` that skips the `Page.bringToFront` call but still updates `active_page_index` and re-enables CDP domains on the target session. Default behavior is unchanged.

## Mechanics

The infrastructure already exists: every tab is attached via `Target.attachToTarget` with its own `session_id` stored in `PageInfo`, and `active_session_id()` resolves through `active_page_index`. The flag just makes the existing `bringToFront` step optional.

- `commands.rs`: parser for `tab <ref>` accepts `--no-activate`, sets `noActivate: true` in the action JSON. Unknown flags still error.
- `actions.rs::handle_tab_switch`: reads `noActivate`, forwards inverse as `activate: bool` to `tab_switch_by_id`.
- `browser.rs::tab_switch` / `tab_switch_by_id`: take `activate: bool`; `Page.bringToFront` gated by `if activate { … }`.
- `output.rs`: `tab --help` documents the new flag.

## Use case

I'm building [preprint](https://github.com/Prasanna721/preprint), a file-system view of a real browser for agents. Every tab is projected as a markdown file kept in sync by a daemon. Without this flag the daemon refocuses every tab on every poll, which fights the user in `--preview` mode. With it the daemon can address each tab logically without touching foreground.

## Tests

New parser tests in `commands.rs`:
- `tab tN --no-activate` parses to `{action: tab_switch, tabId: tN, noActivate: true}`.
- `tab tN` defaults to no `noActivate` field (activates).
- Unknown flags on `tab tN` error.

Existing tab tests pass.