### PR TITLE
feat(dashboard): live annotation toggle in viewport toolbar

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -741,6 +741,13 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             Ok(cmd)
         }
 
+        // === Annotate overlay (dashboard live-view toggle) ===
+        "annotate-overlay" => {
+            let arg = rest.first().copied().unwrap_or("on");
+            let on = matches!(arg, "on" | "true" | "1" | "show" | "enable");
+            Ok(json!({ "id": id, "action": "annotate_overlay", "on": on }))
+        }
+
         // === Eval ===
         "eval" => {
             // Check for flags: -b/--base64 or --stdin

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1293,6 +1293,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "close" => handle_close(state).await,
         "snapshot" => handle_snapshot(cmd, state).await,
         "screenshot" => handle_screenshot(cmd, state).await,
+        "annotate_overlay" => handle_annotate_overlay(cmd, state).await,
         "click" => handle_click(cmd, state).await,
         "dblclick" => handle_dblclick(cmd, state).await,
         "fill" => handle_fill(cmd, state).await,
@@ -2447,6 +2448,44 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
 // ---------------------------------------------------------------------------
 // Phase 2 handlers
 // ---------------------------------------------------------------------------
+
+/// Toggle the live element-annotation overlay in the active page so the dashboard
+/// stream shows numbered boxes (same labels as `screenshot --annotate`).
+async fn handle_annotate_overlay(
+    cmd: &Value,
+    state: &mut DaemonState,
+) -> Result<Value, String> {
+    let on = cmd.get("on").and_then(|v| v.as_bool()).unwrap_or(true);
+
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    if on {
+        // Refresh ref_map so the overlay numbers match the current DOM.
+        state.ref_map.clear();
+        let options = SnapshotOptions {
+            selector: None,
+            interactive: true,
+            compact: false,
+            depth: None,
+            urls: false,
+        };
+        snapshot::take_snapshot(
+            &mgr.client,
+            &session_id,
+            &options,
+            &mut state.ref_map,
+            state.active_frame_id.as_deref(),
+            &state.iframe_sessions,
+        )
+        .await?;
+    }
+
+    let count =
+        screenshot::set_live_annotation(&mgr.client, &session_id, &state.ref_map, on).await?;
+
+    Ok(json!({ "on": on, "count": count }))
+}
 
 async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -597,6 +597,32 @@ fn get_screenshot_dir() -> PathBuf {
     }
 }
 
+/// Inject or remove the live-annotation overlay (the same red box + number
+/// labels used for `screenshot --annotate`) on the current page. Used by the
+/// dashboard toggle to show element refs in the live streaming viewport.
+///
+/// Caller is responsible for ensuring `ref_map` is current (typically by
+/// calling `snapshot::take_snapshot` immediately before turning on).
+pub async fn set_live_annotation(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    on: bool,
+) -> Result<usize, String> {
+    if !on {
+        remove_annotation_overlay(client, session_id).await?;
+        return Ok(0);
+    }
+    let raw = collect_annotations(client, session_id, ref_map).await?;
+    let items = filter_annotations(raw, None);
+    if items.is_empty() {
+        let _ = remove_annotation_overlay(client, session_id).await;
+        return Ok(0);
+    }
+    inject_annotation_overlay(client, session_id, &items).await?;
+    Ok(items.len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -191,7 +191,13 @@ export function Viewport() {
 
   // Live element-annotation toggle: when ON, the daemon injects numbered
   // boxes onto the active page so refs are visible in the streaming viewport.
+  // State is session-scoped — switching sessions resets the toggle to OFF so
+  // the UI doesn't claim "on" for a session whose overlay was never injected.
   const [annotateOn, setAnnotateOn] = useState(false);
+  useEffect(() => {
+    setAnnotateOn(false);
+  }, [sessionName]);
+
   const toggleAnnotate = useCallback(async () => {
     const next = !annotateOn;
     setAnnotateOn(next);

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai/react";
-import { ArrowLeft, ArrowRight, Camera, Circle, FileCode, Maximize, Moon, RotateCw, Smartphone, Square, Sun, Wifi, WifiOff } from "lucide-react";
+import { ArrowLeft, ArrowRight, Camera, Circle, FileCode, Hash, Maximize, Moon, RotateCw, Smartphone, Square, Sun, Wifi, WifiOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { execCommand, sessionArgs } from "@/lib/exec";
 import { getSessionStreamUrl } from "@/lib/dashboard-routes";
@@ -188,6 +188,24 @@ export function Viewport() {
     (...args: string[]) => execCommand(sessionArgs(sessionName, ...args)),
     [sessionName],
   );
+
+  // Live element-annotation toggle: when ON, the daemon injects numbered
+  // boxes onto the active page so refs are visible in the streaming viewport.
+  const [annotateOn, setAnnotateOn] = useState(false);
+  const toggleAnnotate = useCallback(async () => {
+    const next = !annotateOn;
+    setAnnotateOn(next);
+    await runCmd("annotate-overlay", next ? "on" : "off");
+  }, [annotateOn, runCmd]);
+
+  // Re-apply overlay after navigation so labels match the new DOM.
+  useEffect(() => {
+    if (!annotateOn) return;
+    const t = setTimeout(() => {
+      runCmd("annotate-overlay", "on");
+    }, 300);
+    return () => clearTimeout(t);
+  }, [url, annotateOn, runCmd]);
 
   const handleNavigate = useCallback(async () => {
     if (!addressValue.trim() || navigating) return;
@@ -461,6 +479,26 @@ export function Viewport() {
               />
             </div>
             <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={toggleAnnotate}
+                    aria-pressed={annotateOn}
+                    className={cn(
+                      "shrink-0 rounded p-1 transition-colors hover:bg-muted",
+                      annotateOn
+                        ? "bg-muted text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <Hash className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p>{annotateOn ? "Hide element labels" : "Show element labels"}</p>
+                </TooltipContent>
+              </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button


### PR DESCRIPTION
## Summary

Adds a `#` toggle in the dashboard viewport toolbar (left of the snapshot icon) that injects the same numbered red boxes used by `screenshot --annotate` onto the **live page**, so element refs are visible in the streaming viewport without taking a screenshot.

Motivation: when picking elements interactively from the dashboard, `--annotate` only labels stills. The labels disappear the moment streaming continues, which is awkward for human-in-the-loop selection. This toggle reuses the existing overlay injector so labels stay on screen while the user identifies the target, then can be removed in one click.

CLI equivalent (also new):
```
agent-browser --session <name> annotate-overlay on
agent-browser --session <name> annotate-overlay off
```

The numbers shown on the live overlay match `@eN` from `snapshot -i` — the action takes a fresh snapshot on enable so the ref map is current.

## Changes

**Rust (`cli/`)**
- `native/screenshot.rs`: extract a public `set_live_annotation(client, session_id, ref_map, on)` that reuses the existing `inject_annotation_overlay` / `remove_annotation_overlay` helpers (no new injection code).
- `native/actions.rs`: new `annotate_overlay` action. On enable, clears + refills the ref map via `snapshot::take_snapshot` so overlay numbers match the current DOM.
- `commands.rs`: new `annotate-overlay on|off` CLI verb.

**Dashboard (`packages/dashboard/`)**
- `components/viewport.tsx`: new `Hash` icon toggle button placed left of the snapshot button; local `annotateOn` state; calls `runCmd(\"annotate-overlay\", on?\"on\":\"off\")`. A 300ms-debounced `useEffect` on `url` re-applies the overlay after navigation so labels track the new DOM.

## Test plan

- [x] `cargo build --release --manifest-path cli/Cargo.toml` — clean build.
- [x] `pnpm --filter dashboard build` — clean build.
- [x] Smoke: `agent-browser open https://example.com` → `annotate-overlay on` → DOM contains `#__agent_browser_annotations__` overlay; viewer shows numbered boxes. `off` removes them. Verified via `agent-browser eval` post-toggle.
- [x] Dashboard button reflects state (background tint when active) and tooltip flips between \"Show/Hide element labels\".
- [ ] Multi-tab / iframe sanity (not exercised).
- [ ] WebDriver backend (current implementation is Chrome-CDP only, matches `screenshot --annotate`).

## Notes / Open questions

- Auto-refresh after navigation is heuristic (300ms `setTimeout` on `url` change). SPA route changes that don't update `activeUrlAtom` won't trigger it; users re-click the toggle. A CDP `Page.frameNavigated` hook on the server side would be more robust — happy to follow up if preferred.
- Icon choice (`Hash` from `lucide-react`) is a guess; open to alternatives.