### PR TITLE
fix(dashboard): guard Enter handlers against active IME composition

### DIFF
--- a/packages/dashboard/src/components/chat-panel.tsx
+++ b/packages/dashboard/src/components/chat-panel.tsx
@@ -745,7 +745,12 @@ export function ChatPanel() {
               rows={1}
               placeholder="Ask something..."
               onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
+                if (
+                  e.key === "Enter" &&
+                  !e.shiftKey &&
+                  !e.nativeEvent.isComposing &&
+                  e.keyCode !== 229
+                ) {
                   e.preventDefault();
                   handleSubmit(e);
                 }

--- a/packages/dashboard/src/components/console-panel.tsx
+++ b/packages/dashboard/src/components/console-panel.tsx
@@ -137,7 +137,12 @@ export function ConsolePanel() {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (
+        e.key === "Enter" &&
+        !e.shiftKey &&
+        !e.nativeEvent.isComposing &&
+        e.keyCode !== 229
+      ) {
         e.preventDefault();
         handleEval();
       }

--- a/packages/dashboard/src/components/network-panel.tsx
+++ b/packages/dashboard/src/components/network-panel.tsx
@@ -328,7 +328,11 @@ export function NetworkPanel() {
             value={harPath}
             onChange={(e) => setHarPath(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (
+                e.key === "Enter" &&
+                !e.nativeEvent.isComposing &&
+                e.keyCode !== 229
+              ) {
                 e.preventDefault();
                 handleHarStop();
               }

--- a/packages/dashboard/src/components/session-tree.tsx
+++ b/packages/dashboard/src/components/session-tree.tsx
@@ -483,7 +483,11 @@ export function SessionTree() {
             value={newSessionName}
             onChange={(e) => setNewSessionName(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (
+                e.key === "Enter" &&
+                !e.nativeEvent.isComposing &&
+                e.keyCode !== 229
+              ) {
                 e.preventDefault();
                 handleCreateSubmit();
               }

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -447,7 +447,11 @@ export function Viewport() {
                 value={addressValue}
                 onChange={(e) => setAddressValue(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
+                  if (
+                    e.key === "Enter" &&
+                    !e.nativeEvent.isComposing &&
+                    e.keyCode !== 229
+                  ) {
                     e.preventDefault();
                     handleNavigate();
                   }
@@ -675,7 +679,11 @@ export function Viewport() {
             value={customValue}
             onChange={(e) => setCustomValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (
+                e.key === "Enter" &&
+                !e.nativeEvent.isComposing &&
+                e.keyCode !== 229
+              ) {
                 e.preventDefault();
                 submitCustomDimensions();
               }
@@ -705,7 +713,11 @@ export function Viewport() {
             value={recordPath}
             onChange={(e) => setRecordPath(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (
+                e.key === "Enter" &&
+                !e.nativeEvent.isComposing &&
+                e.keyCode !== 229
+              ) {
                 e.preventDefault();
                 handleRecordStart();
               }


### PR DESCRIPTION
## Summary

Fixes #1379.

Every dashboard `Enter`-on-submit input intercepts the key without checking for active IME composition. CJK (Korean / Japanese / Chinese) users -- and anyone using a Compose-key or dead-key IME that uses `Enter` to commit -- cannot type composed characters into the dashboard: pressing `Enter` to commit the composition is treated as "submit", tearing down the composition mid-flight and submitting raw, uncommitted keystrokes.

The fix guards every handler with both the modern `e.nativeEvent.isComposing` check and the legacy `e.keyCode !== 229` fallback (Safari / older WebKit). This is the canonical React pattern for IME-safe `Enter` handling. During composition the handler now no-ops; the browser's IME stack commits the character into the input, and a separate `Enter` (with empty composition state) submits.

## Changes

All in `packages/dashboard/src/components/`:

- `chat-panel.tsx` -- chat textarea (the most user-visible one; the main interaction surface)
- `console-panel.tsx` -- eval textarea
- `viewport.tsx` -- address bar, custom-dimensions dialog, record-path dialog
- `session-tree.tsx` -- new-session name dialog
- `network-panel.tsx` -- HAR-path dialog

The pattern applied everywhere:

```tsx
onKeyDown={(e) => {
  if (
    e.key === "Enter" &&
    !e.shiftKey && // chat / eval textareas only
    !e.nativeEvent.isComposing &&
    e.keyCode !== 229
  ) {
    e.preventDefault();
    handleSubmit(e);
  }
}}
```

## Test plan

- [x] `pnpm --filter dashboard exec tsc --noEmit` -- clean.
- [x] `pnpm --filter dashboard build` -- clean (`next build` includes its own TypeScript pass).
- [x] Reviewed every `e.key === "Enter"` site in `packages/dashboard/src/` -- all 7 sites now guarded (confirmed via `rg`).
- [ ] Manual repro on macOS with Korean 2-Beolsik IME: typing `ㅇㅏㄴ` + `Enter` commits `안` into the chat textarea instead of submitting a partial message. (Listed but not exercised in this turn -- repro steps are in the issue.)

## Notes

- The guard is intentionally redundant (`isComposing` + `keyCode === 229`) per the React community's canonical IME-safe pattern. `isComposing` is the modern signal; `keyCode === 229` covers older Safari/WebKit where `isComposing` may not be reliable during the synthetic Enter-on-commit `keydown`. cmdk's internal IME guard does not help here because the affected `<textarea>` / `<input>` elements are host React inputs, not cmdk primitives.
- No behavior change for non-IME users: composition state is only ever true while an IME is actively composing.
