### PR TITLE
fix(dashboard): use VK_OEM codes for punctuation in viewport keys

### DIFF
--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -70,6 +70,34 @@ const KEY_INFO: Record<string, { text?: string; keyCode: number }> = {
   PageDown: { keyCode: 34 },
 };
 
+// Windows virtual-key codes for US-layout punctuation. ASCII char codes
+// collide with VK control codes (e.g. '.' = 46 = VK_DELETE), so any
+// printable special character must be mapped to its OEM VK code explicitly.
+// Mirrors `punctuation_key_info()` in cli/src/native/interaction.rs.
+const PUNCTUATION_KEY_INFO: Record<string, number> = {
+  ";": 186, ":": 186, // VK_OEM_1
+  "=": 187, "+": 187, // VK_OEM_PLUS
+  ",": 188, "<": 188, // VK_OEM_COMMA
+  "-": 189, "_": 189, // VK_OEM_MINUS
+  ".": 190, ">": 190, // VK_OEM_PERIOD
+  "/": 191, "?": 191, // VK_OEM_2
+  "`": 192, "~": 192, // VK_OEM_3
+  "[": 219, "{": 219, // VK_OEM_4
+  "\\": 220, "|": 220, // VK_OEM_5
+  "]": 221, "}": 221, // VK_OEM_6
+  "'": 222, '"': 222, // VK_OEM_7
+};
+
+// Returns 0 for unmapped chars (e.g. '!', '@', '你'); CDP still inserts
+// the character via the `text` field on dispatchKeyEvent. Mirrors
+// `char_to_key_info()` in cli/src/native/interaction.rs.
+function charToVirtualKeyCode(ch: string): number {
+  if (ch.length !== 1) return 0;
+  if (/[a-zA-Z]/.test(ch)) return ch.toUpperCase().charCodeAt(0);
+  if (/[0-9]/.test(ch)) return ch.charCodeAt(0);
+  return PUNCTUATION_KEY_INFO[ch] ?? 0;
+}
+
 function cdpButton(btn: number): string {
   switch (btn) {
     case 0: return "left";
@@ -363,7 +391,7 @@ export function Viewport() {
       const text = eventType === "keyDown"
         ? (info?.text ?? (e.key.length === 1 ? e.key : undefined))
         : undefined;
-      const keyCode = info?.keyCode ?? (e.key.length === 1 ? e.key.charCodeAt(0) : 0);
+      const keyCode = info?.keyCode ?? charToVirtualKeyCode(e.key);
       let m = 0;
       if (e.altKey) m |= 1;
       if (e.ctrlKey) m |= 2;


### PR DESCRIPTION
## Summary

Fixes #1380.

The dashboard viewport canvas (`packages/dashboard/src/components/viewport.tsx`) forwards typed keys to the remote browser via the streaming WebSocket. The `windowsVirtualKeyCode` was being filled with `e.key.charCodeAt(0)` for every printable character not in the small hand-mapped control-key table. ASCII char codes and Windows Virtual-Key codes are not the same scheme, so Chrome on the remote side misinterpreted:

- `.` (ASCII 46) -> `VK_DELETE`
- `[` (91) -> `VK_LWIN`
- `!` (33) -> `VK_PRIOR` (PageUp)
- `'` (39) -> `VK_RIGHT`
- `-` (45) -> `VK_INSERT`
- `,` (44) -> `VK_SNAPSHOT` (PrtSc)
- ...and several silently swallowed (`/`, `;`, `=`).

Additionally, lowercase letters (`'a'` = 97) collided with `VK_NUMPAD1`.

This is the same root cause as #833 on the CLI side, which was fixed in #836 by introducing `punctuation_key_info()` with the `VK_OEM_*` table in `cli/src/native/interaction.rs`. The dashboard's TypeScript forwarding was never ported.

## Changes

`packages/dashboard/src/components/viewport.tsx`:

- New `PUNCTUATION_KEY_INFO` table mapping US-layout punctuation (and shifted variants that share a physical key) to `VK_OEM_1..VK_OEM_7` (186-192, 219-222). Mirrors the CLI's `punctuation_key_info()` 1:1.
- New `charToVirtualKeyCode(ch)` helper that:
  - returns the OEM code for mapped punctuation,
  - returns the **uppercased** ASCII for letters (so `'a'` -> 65 = `VK_A`, not 97 = `VK_NUMPAD1`),
  - returns the digit ASCII for digits,
  - returns `0` for unmapped chars (`!@#$%^&*()`, non-ASCII) — Chrome still inserts the character via the `text` field on `Input.dispatchKeyEvent`. This matches the CLI's behavior verbatim (`test_unmapped_chars_return_zero_keycode` in `interaction.rs`).
- `dispatchKey` now calls the helper instead of using `e.key.charCodeAt(0)` directly.

## Deliberate deviation from the issue's suggested patch

The issue suggested mapping `!@#$%^&*()` to digit VK codes (49-57, 48). I followed the **authoritative CLI mapping instead**, which deliberately leaves those at VK=0 (covered by the CLI's `test_unmapped_chars_return_zero_keycode`).

Rationale: sending digit VK codes for shifted top-row symbols would let the remote Chrome trigger native shortcuts that are bound to the digit keys themselves (e.g. `Ctrl+1` would switch tabs even though the user typed `!`). The CLI explicitly rejects this, so I mirrored it. The `text` field still carries the character, so `Input.dispatchKeyEvent` inserts it correctly into focused text fields.

## Test plan

- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean.
- [x] `pnpm --filter dashboard build` (Next.js TypeScript pass) — clean.
- [x] Mapping cross-checked against `cli/src/native/interaction.rs` punctuation table and the existing `test_char_to_key_info_matches_playwright_layout` test cases. Every entry matches Playwright's `USKeyboardLayout`.
- [ ] Manual repro in the dashboard against `https://google.com`: focus the canvas, click into the search box, type `.`, `,`, `!`, `[`, `]`, `;` — characters should now be inserted instead of triggering Delete / PgUp / Win / context-menu. (Reproduction steps in the issue; not exercised in this turn.)

## Related

- #1379 / #1381 — sibling dashboard IME bug, just merged in another PR I'm proposing.
- #833 / #836 — original CLI-side bug and fix; this PR ports #836's table to the dashboard.
- #213 — open PR for Backspace/Delete in the streaming server; touches the same code area but doesn't address punctuation; not in conflict with this change.

## Notes

The fix is intentionally surgical: same shape as #836 on the CLI, no test infrastructure introduced for the dashboard (it has none today). If a unit test is desired for `charToVirtualKeyCode`, happy to add one in a follow-up alongside Vitest setup for the dashboard package.
