### PR TITLE
fix(dashboard): correct click offset by honoring screencast offsetTop

### DIFF
--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -32,6 +32,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   currentFrameAtom,
+  currentFrameMetadataAtom,
   viewportWidthAtom,
   viewportHeightAtom,
   browserConnectedAtom,
@@ -123,6 +124,7 @@ function normalizeUrl(input: string): string {
 
 export function Viewport() {
   const frame = useAtomValue(currentFrameAtom);
+  const frameMetadata = useAtomValue(currentFrameMetadataAtom);
   const viewportWidth = useAtomValue(viewportWidthAtom);
   const viewportHeight = useAtomValue(viewportHeightAtom);
   const browserConnected = useAtomValue(browserConnectedAtom);
@@ -307,18 +309,28 @@ export function Viewport() {
   }, [offline, sessionName]);
 
   const toViewport = useCallback(
-    (e: React.MouseEvent): { x: number; y: number } | null => {
+    (e: React.MouseEvent | React.WheelEvent): { x: number; y: number } | null => {
       const canvas = canvasRef.current;
       if (!canvas) return null;
       const rect = canvas.getBoundingClientRect();
+      // CDP `Page.screencastFrame.metadata.offsetTop` is the gap between the
+      // screenshot's top edge and the page viewport's top edge. Subtract it
+      // before scaling so clicks land on the right row instead of one chrome
+      // bar below.
+      const offsetTop = frameMetadata?.offsetTop ?? 0;
+      const pageScale = frameMetadata?.pageScaleFactor || 1;
+      const offsetTopCss = (offsetTop / viewportHeight) * rect.height;
+      const contentHeight = Math.max(rect.height - offsetTopCss, 1);
       const scaleX = viewportWidth / rect.width;
-      const scaleY = viewportHeight / rect.height;
+      const scaleY = viewportHeight / contentHeight;
+      const xCss = e.clientX - rect.left;
+      const yCss = e.clientY - rect.top - offsetTopCss;
       return {
-        x: Math.round((e.clientX - rect.left) * scaleX),
-        y: Math.round((e.clientY - rect.top) * scaleY),
+        x: Math.round((xCss * scaleX) / pageScale),
+        y: Math.round((yCss * scaleY) / pageScale),
       };
     },
-    [viewportWidth, viewportHeight],
+    [viewportWidth, viewportHeight, frameMetadata],
   );
 
   const handleMouseEvent = useCallback(

--- a/packages/dashboard/src/store/stream.ts
+++ b/packages/dashboard/src/store/stream.ts
@@ -6,6 +6,7 @@ import { useSetAtom } from "jotai/react";
 import type {
   ActivityEvent,
   ConsoleEntry,
+  FrameMetadata,
   StreamMessage,
   TabInfo,
 } from "@/types";
@@ -25,6 +26,7 @@ export const recordingAtom = atom(false);
 export const viewportWidthAtom = atom(1280);
 export const viewportHeightAtom = atom(720);
 export const currentFrameAtom = atom<string | null>(null);
+export const currentFrameMetadataAtom = atom<FrameMetadata | null>(null);
 export const streamEventsAtom = atom<ActivityEvent[]>([]);
 export const consoleLogsAtom = atom<ConsoleEntry[]>([]);
 export const streamTabsAtom = atom<TabInfo[]>([]);
@@ -81,6 +83,7 @@ export function useStreamSync(port: number) {
   const setVpWidth = useSetAtom(viewportWidthAtom);
   const setVpHeight = useSetAtom(viewportHeightAtom);
   const setFrame = useSetAtom(currentFrameAtom);
+  const setFrameMetadata = useSetAtom(currentFrameMetadataAtom);
   const setEvents = useSetAtom(streamEventsAtom);
   const setConsoleLogs = useSetAtom(consoleLogsAtom);
   const setTabs = useSetAtom(streamTabsAtom);
@@ -109,12 +112,13 @@ export function useStreamSync(port: number) {
       setVpWidth(1280);
       setVpHeight(720);
       setFrame(null);
+      setFrameMetadata(null);
       setEvents([]);
       setConsoleLogs([]);
       setTabs([]);
       setEngine("");
     }
-  }, [port, setConnected, setBrowserConnected, setScreencasting, setRecording, setVpWidth, setVpHeight, setFrame, setEvents, setConsoleLogs, setTabs, setEngine]);
+  }, [port, setConnected, setBrowserConnected, setScreencasting, setRecording, setVpWidth, setVpHeight, setFrame, setFrameMetadata, setEvents, setConsoleLogs, setTabs, setEngine]);
 
   const connect = useCallback(() => {
     if (port <= 0) return;
@@ -151,6 +155,7 @@ export function useStreamSync(port: number) {
       switch (msg.type) {
         case "frame":
           setFrame(msg.data);
+          setFrameMetadata(msg.metadata);
           break;
 
         case "status":
@@ -218,7 +223,7 @@ export function useStreamSync(port: number) {
           break;
       }
     };
-  }, [port, setWsRef, setConnected, setBrowserConnected, setScreencasting, setRecording, setVpWidth, setVpHeight, setFrame, setEvents, setConsoleLogs, setTabs, setEngine, setTabCache, setEngineCache]);
+  }, [port, setWsRef, setConnected, setBrowserConnected, setScreencasting, setRecording, setVpWidth, setVpHeight, setFrame, setFrameMetadata, setEvents, setConsoleLogs, setTabs, setEngine, setTabCache, setEngineCache]);
 
   useEffect(() => {
     connect();

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -1,15 +1,17 @@
+export interface FrameMetadata {
+  offsetTop: number;
+  pageScaleFactor: number;
+  deviceWidth: number;
+  deviceHeight: number;
+  scrollOffsetX: number;
+  scrollOffsetY: number;
+  timestamp: number;
+}
+
 export interface FrameMessage {
   type: "frame";
   data: string;
-  metadata: {
-    offsetTop: number;
-    pageScaleFactor: number;
-    deviceWidth: number;
-    deviceHeight: number;
-    scrollOffsetX: number;
-    scrollOffsetY: number;
-    timestamp: number;
-  };
+  metadata: FrameMetadata;
 }
 
 export interface StatusMessage {


### PR DESCRIPTION
## Summary

- The viewport mapped clicks across the full canvas bounding rect, ignoring browser chrome captured at the top of the screencast frame. Because the chrome offset can be 50-100 px, every click landed below the intended target.
- The CDP screencast metadata already reports the chrome height (offsetTop) and zoom factor (pageScaleFactor). The daemon forwards both to the dashboard, but viewport.tsx ignored them.
- `types.ts`: extracts FrameMetadata to a named exported interface (was inline).
- `store/stream.ts`: adds currentFrameMetadataAtom, populated from each incoming frame message and reset on port change.
- `viewport.tsx`: updates toViewport to subtract offsetTop (converted to CSS pixels) and divide by pageScaleFactor before forwarding mouse/wheel coordinates. Also widens the event parameter type to accept WheelEvent alongside MouseEvent.

When offsetTop is 0 and pageScaleFactor is 1, the math reduces to the previous behavior, so frames without chrome are unaffected.

## Verification

- tsc --noEmit passes in packages/dashboard.
- pnpm build passes in packages/dashboard (Next.js production build).