### PR TITLE
[CLI] Fix --session-name auto-restore, --state precedence, and --init-script ordering on launch

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1945,6 +1945,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
+        try_auto_restore_state(state).await;
         load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
         return Ok(json!({ "launched": true }));
@@ -1957,6 +1958,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
+        try_auto_restore_state(state).await;
         load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
         return Ok(json!({ "launched": true }));
@@ -1969,6 +1971,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
+        try_auto_restore_state(state).await;
         load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
         return Ok(json!({ "launched": true }));
@@ -2007,6 +2010,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.start_dialog_handler();
                         state.update_stream_client().await;
                         write_provider_file(&state.session_id, provider);
+                        try_auto_restore_state(state).await;
                         load_storage_state_or_rollback(state, &storage_state_owned).await?;
                         apply_launch_init_scripts(state).await;
 
@@ -2104,6 +2108,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     // Load storage state only after Fetch interception is active so replayed
     // origin navigations go through the same domain and proxy handling as
     // normal browser traffic.
+    try_auto_restore_state(state).await;
     load_storage_state_or_rollback(state, &storage_state_owned).await?;
 
     apply_launch_init_scripts(state).await;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1548,7 +1548,9 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
         state.start_dialog_handler();
         state.update_stream_client().await;
         apply_launch_init_scripts(state).await;
-        try_auto_restore_state(state).await;
+        if storage_state_path.is_none() {
+            try_auto_restore_state(state).await;
+        }
         try_load_storage_state(state, &storage_state_path).await;
         return Ok(());
     }
@@ -1561,7 +1563,9 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
         state.start_dialog_handler();
         state.update_stream_client().await;
         apply_launch_init_scripts(state).await;
-        try_auto_restore_state(state).await;
+        if storage_state_path.is_none() {
+            try_auto_restore_state(state).await;
+        }
         try_load_storage_state(state, &storage_state_path).await;
         return Ok(());
     }
@@ -1597,7 +1601,9 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
                     state.update_stream_client().await;
                     write_provider_file(&state.session_id, &p);
                     apply_launch_init_scripts(state).await;
-                    try_auto_restore_state(state).await;
+                    if storage_state_path.is_none() {
+                        try_auto_restore_state(state).await;
+                    }
                     try_load_storage_state(state, &storage_state_path).await;
                     return Ok(());
                 }
@@ -1631,7 +1637,9 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
     }
 
     apply_launch_init_scripts(state).await;
-    try_auto_restore_state(state).await;
+    if storage_state_path.is_none() {
+        try_auto_restore_state(state).await;
+    }
     try_load_storage_state(state, &storage_state_path).await;
     Ok(())
 }
@@ -1945,9 +1953,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
-        try_auto_restore_state(state).await;
-        load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
+        if storage_state_owned.is_none() {
+            try_auto_restore_state(state).await;
+        }
+        load_storage_state_or_rollback(state, &storage_state_owned).await?;
         return Ok(json!({ "launched": true }));
     }
 
@@ -1958,9 +1968,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
-        try_auto_restore_state(state).await;
-        load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
+        if storage_state_owned.is_none() {
+            try_auto_restore_state(state).await;
+        }
+        load_storage_state_or_rollback(state, &storage_state_owned).await?;
         return Ok(json!({ "launched": true }));
     }
 
@@ -1971,9 +1983,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
-        try_auto_restore_state(state).await;
-        load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
+        if storage_state_owned.is_none() {
+            try_auto_restore_state(state).await;
+        }
+        load_storage_state_or_rollback(state, &storage_state_owned).await?;
         return Ok(json!({ "launched": true }));
     }
 
@@ -2010,9 +2024,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.start_dialog_handler();
                         state.update_stream_client().await;
                         write_provider_file(&state.session_id, provider);
-                        try_auto_restore_state(state).await;
-                        load_storage_state_or_rollback(state, &storage_state_owned).await?;
                         apply_launch_init_scripts(state).await;
+                        if storage_state_owned.is_none() {
+                            try_auto_restore_state(state).await;
+                        }
+                        load_storage_state_or_rollback(state, &storage_state_owned).await?;
 
                         if let Some(info) = providers::get_agentcore_info() {
                             return Ok(json!({
@@ -2105,13 +2121,17 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         }
     }
 
+    // Register init scripts before any restore-driven navigation so they apply
+    // to those navigations too.
+    apply_launch_init_scripts(state).await;
+
     // Load storage state only after Fetch interception is active so replayed
     // origin navigations go through the same domain and proxy handling as
     // normal browser traffic.
-    try_auto_restore_state(state).await;
+    if storage_state_owned.is_none() {
+        try_auto_restore_state(state).await;
+    }
     load_storage_state_or_rollback(state, &storage_state_owned).await?;
-
-    apply_launch_init_scripts(state).await;
 
     Ok(json!({ "launched": true }))
 }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5102,10 +5102,8 @@ async fn e2e_session_name_auto_restores_cookies() {
 
     // Session 2: fresh DaemonState with same session_name. Navigate without
     // explicit launch — this triggers auto_launch which calls
-    // try_auto_restore_state.
-    //
-    // NOTE: an explicit `launch` command skips auto_launch entirely, so
-    // session-name auto-restore only fires via the auto_launch path.
+    // try_auto_restore_state. See e2e_session_name_auto_restores_cookies_via_explicit_launch
+    // below for the explicit-launch (handle_launch) variant.
     {
         let mut state = DaemonState::new();
 
@@ -5127,6 +5125,119 @@ async fn e2e_session_name_auto_restores_cookies() {
         assert!(
             found,
             "Cookie should be auto-restored via --session-name. Cookies found: {:?}",
+            cookies
+                .iter()
+                .map(|c| c["name"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+
+        let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    // Clean up auto-saved state files
+    let sessions_dir = dirs::home_dir()
+        .unwrap()
+        .join(".agent-browser")
+        .join("sessions");
+    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
+        for entry in entries.flatten() {
+            let fname = entry.file_name().to_string_lossy().to_string();
+            if fname.starts_with(&format!("{}-", session_name)) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
+/// Regression test for the `--headed` / `--executable-path` auto-restore gap.
+///
+/// Flags like `--headed` and `--executable-path` cause the CLI to dispatch an
+/// explicit `launch` command before the first action, which routes through
+/// `handle_launch` rather than `auto_launch`. Prior to the fix, only
+/// `auto_launch` invoked `try_auto_restore_state`, so `--session-name` silently
+/// failed to restore for any flag combination that triggered an explicit
+/// launch.
+#[tokio::test]
+#[ignore]
+async fn e2e_session_name_auto_restores_cookies_via_explicit_launch() {
+    let session_name = format!(
+        "e2e-session-name-explicit-{}",
+        &uuid::Uuid::new_v4().to_string()[..8]
+    );
+
+    let env = EnvGuard::new(&["AGENT_BROWSER_SESSION_NAME"]);
+    env.set("AGENT_BROWSER_SESSION_NAME", &session_name);
+
+    // Session 1: launch, set a cookie, close (auto-saves state).
+    {
+        let mut state = DaemonState::new();
+
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({
+                "id": "3",
+                "action": "cookies_set",
+                "name": "session_name_explicit_test",
+                "value": "auto_restored_via_handle_launch",
+                "domain": ".example.com",
+                "path": "/",
+                "expires": 2000000000
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(&json!({ "id": "5", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    // Session 2: fresh DaemonState, send an EXPLICIT `launch` command (as the
+    // CLI does whenever --headed, --executable-path, --proxy, etc. is set).
+    // This routes through handle_launch — exactly the path that was broken.
+    {
+        let mut state = DaemonState::new();
+
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp =
+            execute_command(&json!({ "id": "3", "action": "cookies_get" }), &mut state).await;
+        assert_success(&resp);
+        let cookies = get_data(&resp)["cookies"].as_array().unwrap();
+        let found = cookies.iter().any(|c| {
+            c["name"] == "session_name_explicit_test"
+                && c["value"] == "auto_restored_via_handle_launch"
+        });
+        assert!(
+            found,
+            "Cookie should be auto-restored via --session-name through handle_launch. \
+             Cookies found: {:?}",
             cookies
                 .iter()
                 .map(|c| c["name"].as_str().unwrap_or("?"))

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5263,6 +5263,271 @@ async fn e2e_session_name_auto_restores_cookies_via_explicit_launch() {
     }
 }
 
+/// Regression test: explicit `--state` must win over `--session-name`
+/// auto-restore. When both are set, auto-restore is skipped so the explicit
+/// file is the sole source of state — no silent merge of stale session data.
+#[tokio::test]
+#[ignore]
+async fn e2e_explicit_state_skips_session_name_auto_restore() {
+    let session_name = format!(
+        "e2e-session-name-vs-state-{}",
+        &uuid::Uuid::new_v4().to_string()[..8]
+    );
+
+    let env = EnvGuard::new(&["AGENT_BROWSER_SESSION_NAME"]);
+    env.set("AGENT_BROWSER_SESSION_NAME", &session_name);
+
+    // Pre-populate the session-name auto-state with a marker cookie.
+    {
+        let mut state = DaemonState::new();
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let resp = execute_command(
+            &json!({
+                "id": "3",
+                "action": "cookies_set",
+                "name": "from_session_name",
+                "value": "stale",
+                "domain": ".example.com",
+                "path": "/",
+                "expires": 2000000000
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let resp = execute_command(&json!({ "id": "4", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    // Build an explicit --state file with a *different* cookie. Write the
+    // JSON directly to avoid the auto-save side effect from close().
+    let explicit_state_path = std::env::temp_dir()
+        .join(format!(
+            "agent-browser-e2e-explicit-state-{}.json",
+            uuid::Uuid::new_v4()
+        ))
+        .to_string_lossy()
+        .to_string();
+    let explicit_state_json = json!({
+        "cookies": [{
+            "name": "from_explicit_state",
+            "value": "winner",
+            "domain": ".example.com",
+            "path": "/",
+            "expires": 2000000000.0_f64,
+            "size": 0,
+            "httpOnly": false,
+            "secure": false,
+            "session": false
+        }],
+        "origins": []
+    });
+    std::fs::write(
+        &explicit_state_path,
+        serde_json::to_string(&explicit_state_json).unwrap(),
+    )
+    .expect("explicit state file should be writable");
+
+    // Launch with both --session-name (env) and explicit --state (command
+    // payload). Auto-restore must be skipped.
+    {
+        let mut state = DaemonState::new();
+        let resp = execute_command(
+            &json!({
+                "id": "1",
+                "action": "launch",
+                "headless": true,
+                "storageState": &explicit_state_path
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let resp =
+            execute_command(&json!({ "id": "3", "action": "cookies_get" }), &mut state).await;
+        assert_success(&resp);
+        let cookies = get_data(&resp)["cookies"].as_array().unwrap();
+        let from_explicit = cookies
+            .iter()
+            .any(|c| c["name"] == "from_explicit_state" && c["value"] == "winner");
+        let from_session_name = cookies.iter().any(|c| c["name"] == "from_session_name");
+        assert!(
+            from_explicit,
+            "explicit --state cookie should be loaded. cookies: {:?}",
+            cookies
+                .iter()
+                .map(|c| c["name"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !from_session_name,
+            "session-name auto-restore must be skipped when --state is explicit; \
+             unexpected stale cookie. cookies: {:?}",
+            cookies
+                .iter()
+                .map(|c| c["name"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+        let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    let _ = std::fs::remove_file(&explicit_state_path);
+    let sessions_dir = dirs::home_dir()
+        .unwrap()
+        .join(".agent-browser")
+        .join("sessions");
+    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
+        for entry in entries.flatten() {
+            let fname = entry.file_name().to_string_lossy().to_string();
+            if fname.starts_with(&format!("{}-", session_name)) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
+/// Regression test: `--init-script` must be registered before any
+/// restore-driven navigation, so the script fires on those navigations.
+/// `state::load_state` navigates to each origin to replay localStorage —
+/// if the init script were registered afterwards, it would miss that page.
+#[tokio::test]
+#[ignore]
+async fn e2e_init_script_applies_to_restore_navigation() {
+    let session_name = format!(
+        "e2e-init-before-restore-{}",
+        &uuid::Uuid::new_v4().to_string()[..8]
+    );
+
+    // Pre-seed the session-name auto-state file with a localStorage origin
+    // for example.com so restore performs a navigation we can observe.
+    let sessions_dir = dirs::home_dir()
+        .unwrap()
+        .join(".agent-browser")
+        .join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir should exist");
+    let auto_state_path = sessions_dir.join(format!("{}-seed.json", session_name));
+    let auto_state_json = json!({
+        "cookies": [{
+            "name": "restore_probe",
+            "value": "1",
+            "domain": ".example.com",
+            "path": "/",
+            "expires": 2000000000.0_f64,
+            "size": 0,
+            "httpOnly": false,
+            "secure": false,
+            "session": false
+        }],
+        "origins": [{
+            "origin": "https://example.com",
+            "localStorage": [{ "name": "probe_key", "value": "probe_value" }],
+            "sessionStorage": []
+        }]
+    });
+    std::fs::write(
+        &auto_state_path,
+        serde_json::to_string(&auto_state_json).unwrap(),
+    )
+    .expect("seed auto-state file should be writable");
+
+    // Init script that flips a window marker on every new document load.
+    let init_script_path = std::env::temp_dir().join(format!(
+        "agent-browser-e2e-init-script-{}.js",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::write(
+        &init_script_path,
+        "window.__init_marker__ = 'fired';",
+    )
+    .expect("init script file should be writable");
+
+    let env = EnvGuard::new(&[
+        "AGENT_BROWSER_SESSION_NAME",
+        "AGENT_BROWSER_INIT_SCRIPTS",
+    ]);
+    env.set("AGENT_BROWSER_SESSION_NAME", &session_name);
+    env.set(
+        "AGENT_BROWSER_INIT_SCRIPTS",
+        init_script_path.to_str().unwrap(),
+    );
+
+    {
+        let mut state = DaemonState::new();
+
+        // Explicit `launch` (the path that was broken) — auto-restore
+        // navigates to https://example.com to replay localStorage. The init
+        // script must already be registered before that navigation.
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        // Do NOT navigate explicitly — that would trigger the init script
+        // independently and mask the bug. Evaluate on the page that the
+        // restore navigation left us on.
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "evaluate", "script": "window.__init_marker__" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        assert_eq!(
+            get_data(&resp)["result"], "fired",
+            "init script must run on the restore-driven navigation. \
+             If undefined, the script was registered after restore."
+        );
+
+        // Sanity-check that the restore itself actually fired.
+        let resp =
+            execute_command(&json!({ "id": "3", "action": "cookies_get" }), &mut state).await;
+        assert_success(&resp);
+        let cookies = get_data(&resp)["cookies"].as_array().unwrap();
+        assert!(
+            cookies
+                .iter()
+                .any(|c| c["name"] == "restore_probe" && c["value"] == "1"),
+            "seeded cookie should be restored — restore-path precondition. cookies: {:?}",
+            cookies
+                .iter()
+                .map(|c| c["name"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+
+        let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    let _ = std::fs::remove_file(&init_script_path);
+    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
+        for entry in entries.flatten() {
+            let fname = entry.file_name().to_string_lossy().to_string();
+            if fname.starts_with(&format!("{}-", session_name)) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
 /// Verify that explicit `state_load` restores cookies into an existing
 /// session (baseline sanity check — this path is known to work).
 #[tokio::test]


### PR DESCRIPTION
`--session-name <slug>` silently failed to auto-restore cookies and localStorage whenever the CLI dispatched an explicit `launch` command — any of `--headed`, `--executable-path`, `--proxy`, `--user-agent`, `--args`, `--profile`, `--state`, `--allow-file-access`, `--color-scheme`, `--download-path`, `--engine`, or `--extensions`. `try_auto_restore_state` was wired into the four branches of `auto_launch` but none of the five parallel branches of `handle_launch`. Now mirrored in each (`cdp_url`, `cdp_port`, `auto_connect`, `provider`, local).

Two adjacent ordering bugs surfaced while testing. `--session-name` and explicit `--state` both loaded, merging stale auto-state into the explicit file — `try_auto_restore_state` is now gated on `storage_state.is_none()` so explicit `--state` is the sole source. `--init-script` registered via `Page.addScriptToEvaluateOnNewDocument` ran *after* restore, missing the per-origin navigations `state::load_state` performs to replay localStorage — `apply_launch_init_scripts` now runs before restore in `handle_launch`, matching `auto_launch`'s existing order. Adds `e2e_session_name_auto_restores_cookies_via_explicit_launch`, `e2e_explicit_state_skips_session_name_auto_restore`, and `e2e_init_script_applies_to_restore_navigation`; the two new tests fail on the prior code.