### PR TITLE
Support Linux loong64

### DIFF
--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -57,6 +57,9 @@ function getBinaryName() {
     case 'aarch64':
       archKey = 'arm64';
       break;
+    case 'loong64':
+      archKey='loong64';
+      break;
     default:
       return null;
   }


### PR DESCRIPTION
Add support for loong64 on Linux. 
loong64 is about LoongArch architecture.
More information can be found at https://github.com/loongson/LoongArch-Documentation.