### PR TITLE
bin: map ppc64/ppc64le to ppc64 native binary

### DIFF
--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -53,6 +53,10 @@ function getBinaryName() {
     case 'x86_64':
       archKey = 'x64';
       break;
+    case 'ppc64':
+    case 'ppc64le':
+      archKey = 'ppc64';
+      break;
     case 'arm64':
     case 'aarch64':
       archKey = 'arm64';


### PR DESCRIPTION
This fixes only the wrapper-side platform rejection for Linux PowerPC.

It does not claim to solve full `ppc64le` support.

Remaining items are tracked in:
https://github.com/vercel-labs/agent-browser/issues/1391

Specifically, this PR does not address:

- whether a real `agent-browser-linux-ppc64` release artifact should exist
- whether local Chromium provisioning is expected to work on `ppc64le`

The goal here is just to make the wrapper's architecture mapping consistent with the package naming convention.
