### PR TITLE
fix: parse boolean flag values case-insensitively

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -191,10 +191,12 @@ fn env_var_is_truthy(name: &str) -> bool {
 /// Recognizes "true" as true, "false" as false. Bare flag defaults to true.
 fn parse_bool_arg(args: &[String], i: usize) -> (bool, bool) {
     if let Some(v) = args.get(i + 1) {
-        match v.as_str() {
-            "true" => (true, true),
-            "false" => (false, true),
-            _ => (true, false),
+        if v.eq_ignore_ascii_case("true") {
+            (true, true)
+        } else if v.eq_ignore_ascii_case("false") {
+            (false, true)
+        } else {
+            (true, false)
         }
     } else {
         (true, false)
@@ -904,7 +906,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         }
         if GLOBAL_BOOL_FLAGS.contains(&arg.as_str()) {
             if let Some(v) = args.get(i + 1) {
-                if matches!(v.as_str(), "true" | "false") {
+                if v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("false") {
                     i += 1;
                 }
             }
@@ -1411,6 +1413,13 @@ mod tests {
     }
 
     #[test]
+    fn test_bool_flag_values_are_case_insensitive() {
+        let flags = parse_flags(&args("--headed FALSE --json TRUE open example.com"));
+        assert!(!flags.headed);
+        assert!(flags.json);
+    }
+
+    #[test]
     fn test_headed_bare_defaults_true() {
         let flags = parse_flags(&args("--headed open example.com"));
         assert!(flags.headed);
@@ -1450,6 +1459,12 @@ mod tests {
     #[test]
     fn test_clean_args_removes_bool_flag_with_value() {
         let cleaned = clean_args(&args("--headed false --debug true open example.com"));
+        assert_eq!(cleaned, vec!["open", "example.com"]);
+    }
+
+    #[test]
+    fn test_clean_args_removes_case_insensitive_bool_value() {
+        let cleaned = clean_args(&args("--headed FALSE --debug TRUE open example.com"));
         assert_eq!(cleaned, vec!["open", "example.com"]);
     }
 


### PR DESCRIPTION
## Summary
- Parse optional boolean flag values case-insensitively so `FALSE` and `TRUE` behave like `false` and `true`.
- Consume case-insensitive boolean values in `clean_args` so they do not leak into command arguments.
- Add unit coverage for parsing and argument cleanup.

## Validation
- `git diff --check`
- Not run: `cargo test --manifest-path cli/Cargo.toml flags` because `cargo`/`rustc` are not installed in this environment.