### PR TITLE
fix(cli): prevent env-derived flags from triggering implicit re-launch

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1072,24 +1072,41 @@ fn main() {
         }
     }
 
-    // Launch headed browser or configure browser options (without CDP or provider)
-    if (flags.headed
-        || flags.cli_headed  // User explicitly set --headed (even if false)
-        || flags.executable_path.is_some()
-        || flags.profile.is_some()
-        || flags.state.is_some()
-        || flags.proxy.is_some()
-        || flags.args.is_some()
-        || flags.user_agent.is_some()
-        || flags.allow_file_access
-        || should_send_hide_scrollbars_launch_option(
-            flags.cli_hide_scrollbars,
-            flags.hide_scrollbars,
-        )
-        || flags.color_scheme.is_some()
-        || flags.download_path.is_some()
-        || flags.engine.is_some()
-        || !flags.extensions.is_empty())
+    // Launch headed browser or configure browser options (without CDP or provider).
+    // When the daemon is already running, only re-send a launch command if the user
+    // explicitly passed launch-relevant CLI flags (indicating intent to change options).
+    // Environment-variable or config-file derived values alone must NOT trigger a
+    // re-launch — doing so causes hash mismatches that kill the running browser (#1299).
+    let has_explicit_launch_flags = flags.cli_headed
+        || flags.cli_executable_path
+        || flags.cli_profile
+        || flags.cli_state
+        || flags.cli_proxy
+        || flags.cli_args
+        || flags.cli_user_agent
+        || flags.cli_allow_file_access
+        || flags.cli_extensions
+        || flags.cli_download_path
+        || flags.cli_hide_scrollbars;
+
+    if (!daemon_result.already_running || has_explicit_launch_flags)
+        && (flags.headed
+            || flags.cli_headed // User explicitly set --headed (even if false)
+            || flags.executable_path.is_some()
+            || flags.profile.is_some()
+            || flags.state.is_some()
+            || flags.proxy.is_some()
+            || flags.args.is_some()
+            || flags.user_agent.is_some()
+            || flags.allow_file_access
+            || should_send_hide_scrollbars_launch_option(
+                flags.cli_hide_scrollbars,
+                flags.hide_scrollbars,
+            )
+            || flags.color_scheme.is_some()
+            || flags.download_path.is_some()
+            || flags.engine.is_some()
+            || !flags.extensions.is_empty())
         && flags.cdp.is_none()
         && flags.provider.is_none()
         && !flags.auto_connect


### PR DESCRIPTION
## Problem

When `AGENT_BROWSER_EXECUTABLE_PATH` (or other launch-related env vars / config values) is set, every CLI invocation that hits the daemon sends an implicit `launch` command — even when the user only runs a read-only action like `get url`.

Because this second launch omits flags the *original* launch included (e.g. `--proxy`), the computed `launch_hash` differs from the running browser's hash, causing the daemon to **kill and re-launch the browser**. The new browser instance starts at `about:blank`, breaking subsequent commands.

This was introduced in PR #996 (commit `05d86fa`, shipped in v0.24.1) which added hash-based relaunch detection.

## Root Cause

The launch condition in `main.rs` checks `flags.executable_path.is_some()` (among others), which is `true` whenever the env var `AGENT_BROWSER_EXECUTABLE_PATH` is set — regardless of whether the user explicitly passed `--executable-path` on the CLI. This means an env-only configuration silently triggers a launch command on every invocation.

## Fix

Guard the implicit launch with `has_explicit_launch_flags` — a boolean that is `true` only when the user passes launch-relevant flags directly on the CLI (using the `cli_*` tracking fields introduced in PR #996 itself). When the daemon is **already running** and no explicit CLI launch flags are present, the launch command is skipped entirely.

This preserves PR #996's design intent: users can still explicitly change browser options mid-session with `--headed`, `--proxy`, etc., triggering a hash-aware relaunch. But env/config-derived values alone will no longer cause unintended relaunches.

## Reproduction

```bash
# On a machine with AGENT_BROWSER_EXECUTABLE_PATH set:
agent-browser open --proxy http://proxy:port --session test
agent-browser --session test get url   # ← triggers relaunch, returns about:blank
```

## Testing

Verified on Linux (Alibaba Linux, Chrome 140) where `AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome-140`:
- `open --proxy` → `get url` (no explicit flags): browser stays alive, returns correct URL ✓
- `open --proxy` → `get url --proxy` (explicit flag): correctly triggers relaunch ✓
- `open --headed` → `get url`: no spurious relaunch ✓
- Fresh start (no daemon): launch proceeds normally ✓

Closes #1299