### PR TITLE
Shrink npm package binary distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,14 @@ jobs:
         with:
           node-version-file: .node-version
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Check version sync
         run: node scripts/check-version-sync.js
+
+      - name: Check npm package contents
+        run: pnpm run pack:check
 
   rust:
     name: Rust
@@ -236,11 +242,29 @@ jobs:
         run: Copy-Item cli/target/${{ matrix.target }}/release/agent-browser.exe bin/${{ matrix.binary }}
 
       - name: Test npm global install
+        if: runner.os != 'Windows'
         run: |
           npm pack
-          npm install -g agent-browser-*.tgz
+          npm install -g agent-browser-*.tgz --ignore-scripts
+          PACKAGE_DIR="$(npm root -g)/agent-browser"
+          mkdir -p "$PACKAGE_DIR/bin"
+          cp "bin/${{ matrix.binary }}" "$PACKAGE_DIR/bin/${{ matrix.binary }}"
+          node "$PACKAGE_DIR/scripts/postinstall.js"
           agent-browser --version
         shell: bash
+
+      - name: Test npm global install
+        if: runner.os == 'Windows'
+        run: |
+          npm pack
+          $tarball = (Get-ChildItem agent-browser-*.tgz | Select-Object -First 1).FullName
+          npm install -g $tarball --ignore-scripts
+          $packageDir = "$(npm root -g)\agent-browser"
+          New-Item -ItemType Directory -Force "$packageDir\bin" | Out-Null
+          Copy-Item "bin\${{ matrix.binary }}" "$packageDir\bin\${{ matrix.binary }}"
+          node "$packageDir\scripts\postinstall.js"
+          agent-browser --version
+        shell: pwsh
 
       - name: Verify symlink points to native binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
 
   publish:
     name: Publish to npm
-    needs: [check-release, build-binaries]
+    needs: [check-release, build-binaries, github-release]
     if: needs.check-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -216,7 +216,31 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download all binary artifacts
+      - name: Verify npm package contents
+        run: pnpm run pack:check
+
+      - name: Test install from npm package tarball
+        run: |
+          npm pack
+          npm install -g agent-browser-*.tgz
+          agent-browser --version
+
+      - name: Publish to npm
+        run: npm publish --provenance
+
+  github-release:
+    name: Create GitHub Release
+    needs: [check-release, build-binaries]
+    if: always() && needs.build-binaries.result == 'success' && needs.check-release.outputs.needs_github_release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts/
@@ -227,10 +251,9 @@ jobs:
           find artifacts -type f -name 'agent-browser-*' -exec mv {} bin/ \;
           rm -rf artifacts
           chmod +x bin/agent-browser-* 2>/dev/null || true
-          echo "Binaries in bin/:"
           ls -la bin/
 
-      - name: Verify all binaries exist
+      - name: Verify binaries exist
         run: |
           EXPECTED_BINARIES=(
             "agent-browser-linux-x64"
@@ -262,44 +285,6 @@ jobs:
             exit 1
           fi
           echo "All 7 platform binaries present and valid"
-
-      - name: Publish to npm
-        run: npm publish --provenance
-
-  github-release:
-    name: Create GitHub Release
-    needs: [check-release, build-binaries, publish]
-    if: always() && needs.build-binaries.result == 'success' && needs.check-release.outputs.needs_github_release == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts/
-
-      - name: Move binaries to bin directory
-        run: |
-          mkdir -p bin
-          find artifacts -type f -name 'agent-browser-*' -exec mv {} bin/ \;
-          rm -rf artifacts
-          chmod +x bin/agent-browser-* 2>/dev/null || true
-          ls -la bin/
-
-      - name: Verify binaries exist
-        run: |
-          BINARY_COUNT=$(ls bin/agent-browser-* 2>/dev/null | wc -l)
-          if [ "$BINARY_COUNT" -lt 7 ]; then
-            echo "Error: Expected 7 binaries, found $BINARY_COUNT"
-            ls -la bin/
-            exit 1
-          fi
-          echo "Found $BINARY_COUNT binaries"
 
       - name: Extract changelog entry
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Generate native binary checksum manifest
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f -name 'agent-browser-*' -exec cp {} release-assets/ \;
+          node scripts/generate-native-manifest.js release-assets
+
       - name: Verify npm package contents
         run: pnpm run pack:check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ To prepare a release:
 5. Add a matching entry to `docs/src/app/changelog/page.mdx` at the top (below the `# Changelog` heading)
 6. Open a PR and merge to `main`
 
-When the PR merges, CI compares `package.json` version to what's on npm. If it differs, it builds all 7 platform binaries, publishes to npm, and creates the GitHub release automatically. The GitHub release body is extracted from the content between the `<!-- release:start -->` and `<!-- release:end -->` markers in `CHANGELOG.md`.
+When the PR merges, CI compares `package.json` version to what's on npm. If it differs, it builds all 7 platform binaries, creates or updates the GitHub release with those binary assets, then publishes to npm. The GitHub release body is extracted from the content between the `<!-- release:start -->` and `<!-- release:end -->` markers in `CHANGELOG.md`.
 
 ### Writing the changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ To prepare a release:
 5. Add a matching entry to `docs/src/app/changelog/page.mdx` at the top (below the `# Changelog` heading)
 6. Open a PR and merge to `main`
 
-When the PR merges, CI compares `package.json` version to what's on npm. If it differs, it builds all 7 platform binaries, creates or updates the GitHub release with those binary assets, then publishes to npm. The GitHub release body is extracted from the content between the `<!-- release:start -->` and `<!-- release:end -->` markers in `CHANGELOG.md`.
+When the PR merges, CI compares `package.json` version to what's on npm. If it differs, it builds all 7 platform binaries, creates or updates the GitHub release with those binary assets, generates the npm checksum manifest from those assets, then publishes to npm. The GitHub release body is extracted from the content between the `<!-- release:start -->` and `<!-- release:end -->` markers in `CHANGELOG.md`.
 
 ### Writing the changelog
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Browser automation CLI for AI agents. Fast native Rust CLI.
 
 ### Global Installation (recommended)
 
-Installs the native Rust binary:
+Installs a small launcher, then downloads the native Rust binary for your platform from the GitHub release:
 
 ```bash
 npm install -g agent-browser
@@ -25,6 +25,7 @@ agent-browser install
 ```
 
 Then use via `package.json` scripts or by invoking `agent-browser` directly.
+The npm install downloads only the native binary for the current platform. Chrome is still downloaded separately with `agent-browser install`.
 
 ### Homebrew (macOS)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Browser automation CLI for AI agents. Fast native Rust CLI.
 
 ### Global Installation (recommended)
 
-Installs a small launcher, then downloads the native Rust binary for your platform from the GitHub release:
+Installs a small launcher, then downloads and verifies the native Rust binary for your platform from the GitHub release:
 
 ```bash
 npm install -g agent-browser
@@ -25,7 +25,7 @@ agent-browser install
 ```
 
 Then use via `package.json` scripts or by invoking `agent-browser` directly.
-The npm install downloads only the native binary for the current platform. Chrome is still downloaded separately with `agent-browser install`.
+The npm install downloads only the native binary for the current platform. If install scripts are disabled, the first `agent-browser` run retries the verified download and repairs the command to use the native binary directly. Chrome is still downloaded separately with `agent-browser install`.
 
 ### Homebrew (macOS)
 

--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -9,12 +9,21 @@
  */
 
 import { spawn, execSync } from 'child_process';
-import { existsSync, accessSync, chmodSync, constants } from 'fs';
+import { existsSync, accessSync, chmodSync, constants, readFileSync, statSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { platform, arch } from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+
+function hasUsableBinary(path) {
+  try {
+    return statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
 
 // Detect if the system uses musl libc (e.g. Alpine Linux)
 function isMusl() {
@@ -75,12 +84,29 @@ function main() {
 
   const binaryPath = join(__dirname, binaryName);
 
-  if (!existsSync(binaryPath)) {
+  if (!hasUsableBinary(binaryPath)) {
+    let releaseUrl = null;
+    try {
+      const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
+      releaseUrl = `https://github.com/vercel-labs/agent-browser/releases/download/v${packageJson.version}/${binaryName}`;
+    } catch {
+      // Best effort only
+    }
+
     console.error(`Error: No binary found for ${platform()}-${arch()}`);
     console.error(`Expected: ${binaryPath}`);
     console.error('');
-    console.error('Run "npm run build:native" to build for your platform,');
-    console.error('or reinstall the package to trigger the postinstall download.');
+    console.error('The native binary is downloaded during npm postinstall.');
+    console.error('Reinstall this package to retry the download.');
+    if (releaseUrl) {
+      console.error('');
+      console.error('Manual download:');
+      console.error(`  ${releaseUrl}`);
+    }
+    if (existsSync(join(projectRoot, 'cli', 'Cargo.toml'))) {
+      console.error('');
+      console.error('For a source checkout, run "pnpm run build:native".');
+    }
     process.exit(1);
   }
 

--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -1,80 +1,29 @@
 #!/usr/bin/env node
 
 /**
- * Cross-platform CLI wrapper for agent-browser
- * 
- * This wrapper enables npx support on Windows where shell scripts don't work.
- * For global installs, postinstall.js patches the shims to invoke the native
- * binary directly (zero overhead).
+ * Cross-platform CLI bootstrap for agent-browser.
+ *
+ * Normal installs patch the agent-browser command to point directly at the
+ * native binary during postinstall. If lifecycle scripts were disabled, this
+ * launcher downloads and verifies the native binary on first run, patches the
+ * command link or shim, then delegates to the native binary for the current
+ * command.
  */
 
-import { spawn, execSync } from 'child_process';
-import { existsSync, accessSync, chmodSync, constants, readFileSync, statSync } from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
-import { platform, arch } from 'os';
+import { spawn } from 'child_process';
+import { arch, platform } from 'os';
+import {
+  ensureNativeBinary,
+  getBinaryName,
+  getBinaryPath,
+  getDownloadUrl,
+  isSourceCheckout,
+  optimizeCommandLinks,
+  packageVersion,
+  projectRoot,
+} from '../scripts/native-binary.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const projectRoot = join(__dirname, '..');
-
-function hasUsableBinary(path) {
-  try {
-    return statSync(path).size > 0;
-  } catch {
-    return false;
-  }
-}
-
-// Detect if the system uses musl libc (e.g. Alpine Linux)
-function isMusl() {
-  if (platform() !== 'linux') return false;
-  try {
-    const result = execSync('ldd --version 2>&1 || true', { encoding: 'utf8' });
-    return result.toLowerCase().includes('musl');
-  } catch {
-    return existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1');
-  }
-}
-
-// Map Node.js platform/arch to binary naming convention
-function getBinaryName() {
-  const os = platform();
-  const cpuArch = arch();
-
-  let osKey;
-  switch (os) {
-    case 'darwin':
-      osKey = 'darwin';
-      break;
-    case 'linux':
-      osKey = isMusl() ? 'linux-musl' : 'linux';
-      break;
-    case 'win32':
-      osKey = 'win32';
-      break;
-    default:
-      return null;
-  }
-
-  let archKey;
-  switch (cpuArch) {
-    case 'x64':
-    case 'x86_64':
-      archKey = 'x64';
-      break;
-    case 'arm64':
-    case 'aarch64':
-      archKey = 'arm64';
-      break;
-    default:
-      return null;
-  }
-
-  const ext = os === 'win32' ? '.exe' : '';
-  return `agent-browser-${osKey}-${archKey}${ext}`;
-}
-
-function main() {
+async function main() {
   const binaryName = getBinaryName();
 
   if (!binaryName) {
@@ -82,52 +31,41 @@ function main() {
     process.exit(1);
   }
 
-  const binaryPath = join(__dirname, binaryName);
-
-  if (!hasUsableBinary(binaryPath)) {
-    let releaseUrl = null;
-    try {
-      const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
-      releaseUrl = `https://github.com/vercel-labs/agent-browser/releases/download/v${packageJson.version}/${binaryName}`;
-    } catch {
-      // Best effort only
-    }
-
-    console.error(`Error: No binary found for ${platform()}-${arch()}`);
+  let binaryPath = getBinaryPath(projectRoot, binaryName);
+  try {
+    const result = await ensureNativeBinary({
+      binaryName,
+      log: message => console.error(message),
+      quietExisting: true,
+    });
+    binaryPath = result.binaryPath;
+    optimizeCommandLinks({
+      binaryPath,
+      invokedPath: process.argv[1],
+      log: message => console.error(message),
+    });
+  } catch (err) {
+    console.error(`Error: No native binary available for ${platform()}-${arch()}`);
     console.error(`Expected: ${binaryPath}`);
     console.error('');
-    console.error('The native binary is downloaded during npm postinstall.');
-    console.error('Reinstall this package to retry the download.');
-    if (releaseUrl) {
+    console.error(`Reason: ${err.message}`);
+    console.error('');
+    console.error('The native binary is downloaded during npm postinstall or first run.');
+    console.error('Reinstall this package to retry the install-time download.');
+    try {
       console.error('');
       console.error('Manual download:');
-      console.error(`  ${releaseUrl}`);
+      console.error(`  ${getDownloadUrl(binaryName, packageVersion(projectRoot))}`);
+    } catch {
+      // Best effort only.
     }
-    if (existsSync(join(projectRoot, 'cli', 'Cargo.toml'))) {
+    if (isSourceCheckout()) {
       console.error('');
       console.error('For a source checkout, run "pnpm run build:native".');
     }
     process.exit(1);
   }
 
-  // Ensure binary is executable (fixes EACCES on macOS/Linux when postinstall didn't run,
-  // e.g., when using bun which blocks lifecycle scripts by default)
-  if (platform() !== 'win32') {
-    try {
-      accessSync(binaryPath, constants.X_OK);
-    } catch {
-      // Binary exists but isn't executable - fix it
-      try {
-        chmodSync(binaryPath, 0o755);
-      } catch (chmodErr) {
-        console.error(`Error: Cannot make binary executable: ${chmodErr.message}`);
-        console.error('Try running: chmod +x ' + binaryPath);
-        process.exit(1);
-      }
-    }
-  }
-
-  // Spawn the native binary with inherited stdio
   const child = spawn(binaryPath, process.argv.slice(2), {
     stdio: 'inherit',
     windowsHide: false,
@@ -143,4 +81,7 @@ function main() {
   });
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -2,14 +2,14 @@
 
 ## Global installation (recommended)
 
-Installs the native Rust binary for maximum performance:
+Installs a small launcher, then downloads the native Rust binary for your platform from the GitHub release:
 
 ```bash
 npm install -g agent-browser
 agent-browser install  # Download Chrome from Chrome for Testing (first time)
 ```
 
-This is the fastest option -- commands run through the native Rust CLI directly with sub-millisecond parsing overhead.
+This is the fastest option — commands run through the native Rust CLI directly with sub-millisecond parsing overhead. Chrome is still downloaded separately with `agent-browser install`.
 
 ## Quick start (no install)
 
@@ -28,6 +28,7 @@ npx agent-browser install  # Download Chrome (first time)
 ```
 
 Then use via `npx` or `package.json` scripts.
+The npm install downloads only the native binary for the current platform.
 
 ## Homebrew (macOS)
 

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -2,7 +2,7 @@
 
 ## Global installation (recommended)
 
-Installs a small launcher, then downloads the native Rust binary for your platform from the GitHub release:
+Installs a small launcher, then downloads and verifies the native Rust binary for your platform from the GitHub release:
 
 ```bash
 npm install -g agent-browser
@@ -28,7 +28,7 @@ npx agent-browser install  # Download Chrome (first time)
 ```
 
 Then use via `npx` or `package.json` scripts.
-The npm install downloads only the native binary for the current platform.
+The npm install downloads only the native binary for the current platform. If install scripts are disabled, the first `agent-browser` run retries the verified download and repairs the command to use the native binary directly.
 
 ## Homebrew (macOS)
 

--- a/docs/src/app/page.mdx
+++ b/docs/src/app/page.mdx
@@ -62,4 +62,4 @@ Daemon starts automatically and persists between commands.
 
 ## Platforms
 
-Native Rust binaries for macOS (ARM64, x64), Linux (ARM64, x64), and Windows (x64).
+Native Rust binaries for macOS (ARM64, x64), Linux (ARM64, x64), and Windows (x64). npm installs download only the binary for the current platform from GitHub Releases.

--- a/docs/src/app/page.mdx
+++ b/docs/src/app/page.mdx
@@ -62,4 +62,4 @@ Daemon starts automatically and persists between commands.
 
 ## Platforms
 
-Native Rust binaries for macOS (ARM64, x64), Linux (ARM64, x64), and Windows (x64). npm installs download only the binary for the current platform from GitHub Releases.
+Native Rust binaries for macOS (ARM64, x64), Linux (ARM64, x64), and Windows (x64). npm installs download and verify only the binary for the current platform from GitHub Releases.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "pnpm": ">=11.0.0"
   },
   "files": [
-    "bin",
-    "scripts",
+    "bin/agent-browser.js",
+    "scripts/postinstall.js",
     "skill-data",
     "skills"
   ],
@@ -20,6 +20,7 @@
   "scripts": {
     "version:sync": "node scripts/sync-version.js",
     "version": "npm run version:sync && git add cli/Cargo.toml",
+    "pack:check": "node scripts/check-npm-package.js",
     "build:native": "npm run version:sync && cargo build --release --manifest-path cli/Cargo.toml && node scripts/copy-native.js",
     "build:linux": "npm run version:sync && docker compose -f docker/docker-compose.yml run --rm build-linux",
     "build:macos": "npm run version:sync && (cargo build --release --manifest-path cli/Cargo.toml --target aarch64-apple-darwin & cargo build --release --manifest-path cli/Cargo.toml --target x86_64-apple-darwin & wait) && cp cli/target/aarch64-apple-darwin/release/agent-browser bin/agent-browser-darwin-arm64 && cp cli/target/x86_64-apple-darwin/release/agent-browser bin/agent-browser-darwin-x64",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "files": [
     "bin/agent-browser.js",
     "scripts/postinstall.js",
+    "scripts/native-binary.js",
+    "scripts/native-binaries.json",
     "skill-data",
     "skills"
   ],
@@ -21,13 +23,14 @@
     "version:sync": "node scripts/sync-version.js",
     "version": "npm run version:sync && git add cli/Cargo.toml",
     "pack:check": "node scripts/check-npm-package.js",
+    "native:manifest": "node scripts/generate-native-manifest.js",
     "build:native": "npm run version:sync && cargo build --release --manifest-path cli/Cargo.toml && node scripts/copy-native.js",
     "build:linux": "npm run version:sync && docker compose -f docker/docker-compose.yml run --rm build-linux",
     "build:macos": "npm run version:sync && (cargo build --release --manifest-path cli/Cargo.toml --target aarch64-apple-darwin & cargo build --release --manifest-path cli/Cargo.toml --target x86_64-apple-darwin & wait) && cp cli/target/aarch64-apple-darwin/release/agent-browser bin/agent-browser-darwin-arm64 && cp cli/target/x86_64-apple-darwin/release/agent-browser bin/agent-browser-darwin-x64",
     "build:windows": "npm run version:sync && docker compose -f docker/docker-compose.yml run --rm build-windows",
     "build:all-platforms": "npm run version:sync && (npm run build:linux & npm run build:windows & wait) && npm run build:macos",
     "build:docker": "docker build -t agent-browser-builder -f docker/Dockerfile.build .",
-    "release": "npm run version:sync && npm run build:all-platforms && npm publish",
+    "release": "npm run version:sync && npm run build:all-platforms && node scripts/generate-native-manifest.js bin && npm publish",
     "postinstall": "node scripts/postinstall.js",
     "build:dashboard": "cd packages/dashboard && pnpm build"
   },

--- a/scripts/check-npm-package.js
+++ b/scripts/check-npm-package.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that the npm package ships the JS launcher and install scripts, but
+ * not the platform-specific native binaries. Those binaries are release assets
+ * and are downloaded by scripts/postinstall.js for the current platform.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const npmCache = mkdtempSync(join(tmpdir(), 'agent-browser-npm-cache-'));
+let output;
+try {
+  output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NPM_CONFIG_CACHE: npmCache,
+      npm_config_cache: npmCache,
+    },
+  });
+} finally {
+  rmSync(npmCache, { recursive: true, force: true });
+}
+const packs = JSON.parse(output);
+const pack = packs[0];
+
+if (!pack || !Array.isArray(pack.files)) {
+  console.error('Could not inspect npm package contents');
+  process.exit(1);
+}
+
+const files = pack.files.map(file => file.path);
+const fileSet = new Set(files);
+const requiredFiles = [
+  'bin/agent-browser.js',
+  'scripts/postinstall.js',
+  'package.json',
+  'README.md',
+];
+const missing = requiredFiles.filter(file => !fileSet.has(file));
+const forbidden = files.filter(file =>
+  /^bin\/agent-browser-(?:darwin|linux|linux-musl|win32)/.test(file)
+);
+const maxUnpackedSize = 1_000_000;
+
+if (missing.length > 0) {
+  console.error('npm package is missing required files:');
+  for (const file of missing) {
+    console.error(`  ${file}`);
+  }
+  process.exit(1);
+}
+
+if (forbidden.length > 0) {
+  console.error('npm package includes native binaries that should stay on GitHub Releases:');
+  for (const file of forbidden) {
+    console.error(`  ${file}`);
+  }
+  process.exit(1);
+}
+
+if (pack.unpackedSize > maxUnpackedSize) {
+  console.error(
+    `npm package is too large: ${pack.unpackedSize} bytes, expected <= ${maxUnpackedSize}`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `npm package contents OK: ${files.length} files, ${pack.unpackedSize} bytes unpacked`
+);

--- a/scripts/check-npm-package.js
+++ b/scripts/check-npm-package.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 
 /**
- * Verifies that the npm package ships the JS launcher and install scripts, but
- * not the platform-specific native binaries. Those binaries are release assets
- * and are downloaded by scripts/postinstall.js for the current platform.
+ * Verifies that the npm package ships the JS launcher, install scripts, and
+ * checksum manifest, but not the platform-specific native binaries. Those
+ * binaries are release assets and are downloaded for the current platform.
  */
 
 import { execFileSync } from 'child_process';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { BINARY_MANIFEST_PATH, EXPECTED_BINARY_NAMES } from './native-binary.js';
 
 const npmCache = mkdtempSync(join(tmpdir(), 'agent-browser-npm-cache-'));
 let output;
@@ -38,6 +39,8 @@ const fileSet = new Set(files);
 const requiredFiles = [
   'bin/agent-browser.js',
   'scripts/postinstall.js',
+  'scripts/native-binary.js',
+  'scripts/native-binaries.json',
   'package.json',
   'README.md',
 ];
@@ -67,6 +70,26 @@ if (pack.unpackedSize > maxUnpackedSize) {
   console.error(
     `npm package is too large: ${pack.unpackedSize} bytes, expected <= ${maxUnpackedSize}`
   );
+  process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync(BINARY_MANIFEST_PATH, 'utf8'));
+const invalidManifestEntries = EXPECTED_BINARY_NAMES.filter((name) => {
+  const entry = manifest.binaries?.[name];
+  return (
+    !entry ||
+    typeof entry.sha256 !== 'string' ||
+    !/^[a-f0-9]{64}$/.test(entry.sha256) ||
+    !Number.isInteger(entry.size) ||
+    entry.size <= 100000
+  );
+});
+
+if (invalidManifestEntries.length > 0) {
+  console.error('native binary checksum manifest is missing valid entries:');
+  for (const file of invalidManifestEntries) {
+    console.error(`  ${file}`);
+  }
   process.exit(1);
 }
 

--- a/scripts/generate-native-manifest.js
+++ b/scripts/generate-native-manifest.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+/**
+ * Generates the checksum manifest used to verify native binary downloads.
+ *
+ * Usage:
+ *   node scripts/generate-native-manifest.js <directory-with-release-assets>
+ */
+
+import { createHash } from 'crypto';
+import { readFileSync, statSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { BINARY_MANIFEST_PATH, EXPECTED_BINARY_NAMES, GITHUB_REPO } from './native-binary.js';
+
+const assetDir = process.argv[2] || 'bin';
+const binaries = {};
+const missing = [];
+
+for (const name of EXPECTED_BINARY_NAMES) {
+  const path = join(assetDir, name);
+  try {
+    const contents = readFileSync(path);
+    binaries[name] = {
+      sha256: createHash('sha256').update(contents).digest('hex'),
+      size: statSync(path).size,
+    };
+  } catch {
+    missing.push(name);
+  }
+}
+
+if (missing.length > 0) {
+  console.error('Missing release assets for checksum manifest:');
+  for (const name of missing) {
+    console.error(`  ${name}`);
+  }
+  process.exit(1);
+}
+
+const manifest = {
+  version: 1,
+  repo: GITHUB_REPO,
+  binaries,
+};
+
+writeFileSync(BINARY_MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`Wrote native binary checksum manifest: ${BINARY_MANIFEST_PATH}`);

--- a/scripts/native-binaries.json
+++ b/scripts/native-binaries.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "repo": "vercel-labs/agent-browser",
+  "binaries": {
+    "agent-browser-linux-x64": {
+      "sha256": "c249a948cb6a60df94320e319c372a5e679466ca8ea2cc4e69bac4fcc7c270f3",
+      "size": 11547624
+    },
+    "agent-browser-linux-arm64": {
+      "sha256": "622d5cb27388a8efbf6a6d7434b20bcac497ed6d55765ec8e37eaa27dc0db963",
+      "size": 10119224
+    },
+    "agent-browser-linux-musl-x64": {
+      "sha256": "94725da72c38ce931118a0fa3be314dec5350100af645341af1e97277be88a0b",
+      "size": 11420912
+    },
+    "agent-browser-linux-musl-arm64": {
+      "sha256": "1381110e54c0d9e6c6dc4a0a7e97a64de4a7bb4d6bc067de2e091c940700e741",
+      "size": 9983368
+    },
+    "agent-browser-win32-x64.exe": {
+      "sha256": "cbd20c16d1909d63d9e4b8f14959bf20df2134ebf86a5e87efe6eb0f2a1577be",
+      "size": 11220480
+    },
+    "agent-browser-darwin-x64": {
+      "sha256": "7482cfca7f55bb874a649247d5d9c220c404be527e6f0e01c36861949a9e9969",
+      "size": 10995088
+    },
+    "agent-browser-darwin-arm64": {
+      "sha256": "a703fd9b74836d2849cfd6deb279e5d8ddcb768aa7b3d9c00352166cb930757a",
+      "size": 10081664
+    }
+  }
+}

--- a/scripts/native-binary.js
+++ b/scripts/native-binary.js
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+
+/**
+ * Shared native binary bootstrap utilities.
+ *
+ * The npm package ships a small JavaScript launcher and downloads exactly one
+ * platform binary from GitHub Releases. Both postinstall and first-run fallback
+ * use this module so lifecycle-disabled installs can recover without keeping all
+ * platform binaries in the npm tarball.
+ */
+
+import { execSync } from 'child_process';
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  createWriteStream,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { createHash } from 'crypto';
+import { get } from 'https';
+import { Transform } from 'stream';
+import { pipeline } from 'stream/promises';
+import { arch, platform } from 'os';
+import { basename, dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const projectRoot = join(__dirname, '..');
+export const binDir = join(projectRoot, 'bin');
+export const GITHUB_REPO = 'vercel-labs/agent-browser';
+export const BINARY_MANIFEST_PATH = join(projectRoot, 'scripts', 'native-binaries.json');
+export const EXPECTED_BINARY_NAMES = [
+  'agent-browser-linux-x64',
+  'agent-browser-linux-arm64',
+  'agent-browser-linux-musl-x64',
+  'agent-browser-linux-musl-arm64',
+  'agent-browser-win32-x64.exe',
+  'agent-browser-darwin-x64',
+  'agent-browser-darwin-arm64',
+];
+
+export function hasUsableBinary(path) {
+  try {
+    return statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function isSourceCheckout(root = projectRoot) {
+  return existsSync(join(root, 'cli', 'Cargo.toml'));
+}
+
+export function packageVersion(root = projectRoot) {
+  const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  return packageJson.version;
+}
+
+export function isMusl() {
+  if (platform() !== 'linux') return false;
+  try {
+    const result = execSync('ldd --version 2>&1 || true', { encoding: 'utf8' });
+    return result.toLowerCase().includes('musl');
+  } catch {
+    return existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1');
+  }
+}
+
+export function getBinaryName() {
+  const os = platform();
+  const cpuArch = arch();
+
+  let osKey;
+  switch (os) {
+    case 'darwin':
+      osKey = 'darwin';
+      break;
+    case 'linux':
+      osKey = isMusl() ? 'linux-musl' : 'linux';
+      break;
+    case 'win32':
+      osKey = 'win32';
+      break;
+    default:
+      return null;
+  }
+
+  let archKey;
+  switch (cpuArch) {
+    case 'x64':
+    case 'x86_64':
+      archKey = 'x64';
+      break;
+    case 'arm64':
+    case 'aarch64':
+      archKey = 'arm64';
+      break;
+    default:
+      return null;
+  }
+
+  const ext = os === 'win32' ? '.exe' : '';
+  return `agent-browser-${osKey}-${archKey}${ext}`;
+}
+
+export function getBinaryPath(root = projectRoot, binaryName = getBinaryName()) {
+  return binaryName ? join(root, 'bin', binaryName) : null;
+}
+
+export function getDownloadUrl(binaryName, version = packageVersion()) {
+  return `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${binaryName}`;
+}
+
+export function loadBinaryManifest(root = projectRoot) {
+  const manifestPath = join(root, 'scripts', 'native-binaries.json');
+  return JSON.parse(readFileSync(manifestPath, 'utf8'));
+}
+
+export function getManifestEntry(binaryName, root = projectRoot) {
+  const manifest = loadBinaryManifest(root);
+  return manifest.binaries?.[binaryName] ?? null;
+}
+
+function cleanupFile(path) {
+  try {
+    unlinkSync(path);
+  } catch {
+    // Best effort cleanup only.
+  }
+}
+
+async function getResponse(url, redirects = 0) {
+  return new Promise((resolveResponse, rejectResponse) => {
+    get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        response.resume();
+        if (redirects >= 5 || !response.headers.location) {
+          rejectResponse(new Error('Too many redirects while downloading native binary'));
+          return;
+        }
+        const nextUrl = new URL(response.headers.location, url).toString();
+        resolveResponse(getResponse(nextUrl, redirects + 1));
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        rejectResponse(new Error(`Failed to download: HTTP ${response.statusCode}`));
+        return;
+      }
+
+      resolveResponse(response);
+    }).on('error', rejectResponse);
+  });
+}
+
+async function downloadFile(url, dest, expected) {
+  const tmpDest = `${dest}.download-${process.pid}-${Date.now()}`;
+
+  try {
+    const response = await getResponse(url);
+    const hash = createHash('sha256');
+    const hashStream = new Transform({
+      transform(chunk, _encoding, callback) {
+        hash.update(chunk);
+        callback(null, chunk);
+      },
+    });
+
+    await pipeline(response, hashStream, createWriteStream(tmpDest, { flags: 'wx' }));
+
+    const actualSha256 = hash.digest('hex');
+    const actualSize = statSync(tmpDest).size;
+    if (expected.size != null && actualSize !== expected.size) {
+      throw new Error(
+        `Downloaded binary size mismatch: got ${actualSize} bytes, expected ${expected.size}`
+      );
+    }
+    if (actualSha256 !== expected.sha256) {
+      throw new Error(
+        `Downloaded binary checksum mismatch: got ${actualSha256}, expected ${expected.sha256}`
+      );
+    }
+
+    renameSync(tmpDest, dest);
+  } catch (err) {
+    cleanupFile(tmpDest);
+    cleanupFile(dest);
+    throw err;
+  }
+}
+
+export function ensureExecutable(binaryPath) {
+  if (platform() === 'win32') return;
+  try {
+    accessSync(binaryPath, constants.X_OK);
+  } catch {
+    chmodSync(binaryPath, 0o755);
+  }
+}
+
+export async function ensureNativeBinary(options = {}) {
+  const {
+    root = projectRoot,
+    log = console.log,
+    quietExisting = false,
+    binaryName = getBinaryName(),
+  } = options;
+
+  if (!binaryName) {
+    throw new Error(`Unsupported platform: ${platform()}-${arch()}`);
+  }
+
+  const binaryPath = getBinaryPath(root, binaryName);
+  if (hasUsableBinary(binaryPath)) {
+    ensureExecutable(binaryPath);
+    if (!quietExisting) {
+      log(`✓ Native binary ready: ${binaryName}`);
+    }
+    return { binaryName, binaryPath, downloaded: false };
+  }
+
+  const version = packageVersion(root);
+  const downloadUrl = getDownloadUrl(binaryName, version);
+  let manifestEntry;
+  try {
+    manifestEntry = getManifestEntry(binaryName, root);
+  } catch (err) {
+    throw new Error(`Could not read native binary checksum manifest: ${err.message}`);
+  }
+  if (!manifestEntry?.sha256) {
+    throw new Error(`No checksum manifest entry for ${binaryName}`);
+  }
+
+  mkdirSync(dirname(binaryPath), { recursive: true });
+  log(`Downloading native binary for ${platform()}-${arch()}...`);
+  log(`URL: ${downloadUrl}`);
+
+  await downloadFile(downloadUrl, binaryPath, manifestEntry);
+  ensureExecutable(binaryPath);
+  log(`✓ Downloaded and verified native binary: ${binaryName}`);
+
+  return { binaryName, binaryPath, downloaded: true };
+}
+
+export function writeInstallMethod(root = projectRoot) {
+  const ua = process.env.npm_config_user_agent || '';
+  let method = '';
+  if (ua.startsWith('pnpm/')) method = 'pnpm';
+  else if (ua.startsWith('yarn/')) method = 'yarn';
+  else if (ua.startsWith('bun/')) method = 'bun';
+  else if (ua.startsWith('npm/')) method = 'npm';
+
+  if (method) {
+    try {
+      writeFileSync(join(root, 'bin', '.install-method'), method);
+    } catch {
+      // Non-critical. The Rust upgrade command falls back to heuristics.
+    }
+  }
+}
+
+function addCandidate(set, candidate) {
+  if (candidate) set.add(resolve(candidate));
+}
+
+function unixBinLinkCandidates(root, invokedPath) {
+  const candidates = new Set();
+  if (invokedPath && basename(invokedPath) === 'agent-browser') {
+    addCandidate(candidates, invokedPath);
+  }
+
+  try {
+    const prefix = execSync('npm prefix -g', { encoding: 'utf8' }).trim();
+    addCandidate(candidates, join(prefix, 'bin', 'agent-browser'));
+  } catch {
+    // npm may not be available.
+  }
+
+  addCandidate(candidates, join(root, '..', '.bin', 'agent-browser'));
+  if (process.env.INIT_CWD) {
+    addCandidate(candidates, join(process.env.INIT_CWD, 'node_modules', '.bin', 'agent-browser'));
+  }
+
+  return [...candidates];
+}
+
+function replaceUnixSymlink(linkPath, binaryPath) {
+  let stat;
+  try {
+    stat = lstatSync(linkPath);
+  } catch {
+    return false;
+  }
+  if (!stat.isSymbolicLink()) {
+    return false;
+  }
+
+  const currentTarget = readlinkSync(linkPath);
+  const resolvedTarget = resolve(dirname(linkPath), currentTarget);
+  if (basename(resolvedTarget) !== 'agent-browser.js') {
+    return false;
+  }
+
+  unlinkSync(linkPath);
+  symlinkSync(binaryPath, linkPath);
+  return true;
+}
+
+function windowsBinDirs(root) {
+  const dirs = new Set();
+  try {
+    addCandidate(dirs, execSync('npm prefix -g', { encoding: 'utf8' }).trim());
+  } catch {
+    // npm may not be available.
+  }
+
+  addCandidate(dirs, join(root, '..', '.bin'));
+  if (process.env.INIT_CWD) {
+    addCandidate(dirs, join(process.env.INIT_CWD, 'node_modules', '.bin'));
+  }
+  return [...dirs];
+}
+
+function replaceWindowsShims(binDirPath, binaryPath) {
+  const cmdShim = join(binDirPath, 'agent-browser.cmd');
+  const ps1Shim = join(binDirPath, 'agent-browser.ps1');
+
+  if (!existsSync(cmdShim)) {
+    return false;
+  }
+
+  const cmdContent = `@ECHO off\r\n"${binaryPath}" %*\r\n`;
+  const ps1Content = `#!/usr/bin/env pwsh\r\n& "${binaryPath}" $args\r\nexit $LASTEXITCODE\r\n`;
+  writeFileSync(cmdShim, cmdContent);
+  if (existsSync(ps1Shim)) {
+    writeFileSync(ps1Shim, ps1Content);
+  }
+  return true;
+}
+
+export function optimizeCommandLinks(options = {}) {
+  const {
+    root = projectRoot,
+    binaryPath = getBinaryPath(root),
+    invokedPath = process.argv[1],
+    log = console.log,
+  } = options;
+
+  if (!hasUsableBinary(binaryPath)) {
+    return false;
+  }
+
+  const optimized = [];
+  try {
+    if (platform() === 'win32') {
+      for (const binDirPath of windowsBinDirs(root)) {
+        if (replaceWindowsShims(binDirPath, binaryPath)) {
+          optimized.push(binDirPath);
+        }
+      }
+    } else {
+      for (const linkPath of unixBinLinkCandidates(root, invokedPath)) {
+        if (replaceUnixSymlink(linkPath, binaryPath)) {
+          optimized.push(linkPath);
+        }
+      }
+    }
+  } catch (err) {
+    log(`⚠ Could not optimize command shim: ${err.message}`);
+    log('  CLI will work via Node.js wrapper until the shim is repaired.');
+    return false;
+  }
+
+  if (optimized.length > 0) {
+    log('✓ Optimized: agent-browser command points to native binary');
+    return true;
+  }
+
+  return false;
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,14 +2,28 @@
 
 /**
  * Postinstall script for agent-browser
- * 
- * Downloads the platform-specific native binary if not present.
+ *
+ * Downloads the platform-specific native binary from the matching GitHub
+ * release. The npm package intentionally ships only the JS launcher plus
+ * install scripts so installs do not download binaries for other platforms.
  * On global installs, patches npm's bin entry to use the native binary directly:
  * - Windows: Overwrites .cmd/.ps1 shims
  * - Mac/Linux: Replaces symlink to point to native binary
  */
 
-import { existsSync, mkdirSync, chmodSync, createWriteStream, unlinkSync, writeFileSync, symlinkSync, lstatSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  createWriteStream,
+  unlinkSync,
+  writeFileSync,
+  symlinkSync,
+  lstatSync,
+  readFileSync,
+  renameSync,
+  statSync,
+} from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { platform, arch } from 'os';
@@ -37,45 +51,93 @@ const platformKey = `${osKey}-${arch()}`;
 const ext = platform() === 'win32' ? '.exe' : '';
 const binaryName = `agent-browser-${platformKey}${ext}`;
 const binaryPath = join(binDir, binaryName);
+const sourceCheckoutMarker = join(projectRoot, 'cli', 'Cargo.toml');
 
 // Package info
-const packageJson = JSON.parse(
-  (await import('fs')).readFileSync(join(projectRoot, 'package.json'), 'utf8')
-);
+const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
 const version = packageJson.version;
 
 // GitHub release URL
 const GITHUB_REPO = 'vercel-labs/agent-browser';
 const DOWNLOAD_URL = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${binaryName}`;
 
+function hasUsableBinary(path) {
+  try {
+    return statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function cleanupFile(path) {
+  try {
+    unlinkSync(path);
+  } catch {
+    // Best effort cleanup only
+  }
+}
+
 async function downloadFile(url, dest) {
+  const tmpDest = `${dest}.download-${process.pid}-${Date.now()}`;
+
   return new Promise((resolve, reject) => {
-    const file = createWriteStream(dest);
-    
-    const request = (url) => {
-      get(url, (response) => {
+    const file = createWriteStream(tmpDest, { flags: 'wx' });
+    let settled = false;
+
+    const fail = (err) => {
+      if (settled) return;
+      settled = true;
+      file.destroy();
+      cleanupFile(tmpDest);
+      cleanupFile(dest);
+      reject(err);
+    };
+
+    const succeed = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        renameSync(tmpDest, dest);
+        resolve();
+      } catch (err) {
+        cleanupFile(tmpDest);
+        reject(err);
+      }
+    };
+
+    const request = (currentUrl, redirects = 0) => {
+      get(currentUrl, (response) => {
         // Handle redirects
-        if (response.statusCode === 301 || response.statusCode === 302) {
-          request(response.headers.location);
+        if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+          response.resume();
+          if (redirects >= 5 || !response.headers.location) {
+            fail(new Error('Too many redirects while downloading native binary'));
+            return;
+          }
+          request(new URL(response.headers.location, currentUrl).toString(), redirects + 1);
           return;
         }
-        
+
         if (response.statusCode !== 200) {
-          reject(new Error(`Failed to download: HTTP ${response.statusCode}`));
+          response.resume();
+          fail(new Error(`Failed to download: HTTP ${response.statusCode}`));
           return;
         }
-        
+
         response.pipe(file);
         file.on('finish', () => {
-          file.close();
-          resolve();
+          file.close((err) => {
+            if (err) {
+              fail(err);
+              return;
+            }
+            succeed();
+          });
         });
-      }).on('error', (err) => {
-        unlinkSync(dest);
-        reject(err);
-      });
+      }).on('error', fail);
     };
-    
+
+    file.on('error', fail);
     request(url);
   });
 }
@@ -107,7 +169,7 @@ function writeInstallMethod() {
 
 async function main() {
   // Check if binary already exists
-  if (existsSync(binaryPath)) {
+  if (hasUsableBinary(binaryPath)) {
     // Ensure binary is executable (npm doesn't preserve execute bit)
     if (platform() !== 'win32') {
       chmodSync(binaryPath, 0o755);
@@ -143,9 +205,21 @@ async function main() {
   } catch (err) {
     console.log(`Could not download native binary: ${err.message}`);
     console.log('');
-    console.log('To build the native binary locally:');
-    console.log('  1. Install Rust: https://rustup.rs');
-    console.log('  2. Run: npm run build:native');
+    console.log('The npm package downloads the native binary from GitHub Releases during install.');
+    console.log('Reinstall the package to retry, or download the matching release asset manually:');
+    console.log(`  ${DOWNLOAD_URL}`);
+    console.log(`  Place it at: ${binaryPath}`);
+    if (existsSync(sourceCheckoutMarker)) {
+      console.log('');
+      console.log('For a source checkout, you can also build the native binary locally:');
+      console.log('  1. Install Rust: https://rustup.rs');
+      console.log('  2. Run: pnpm run build:native');
+      console.log('');
+      console.log('Continuing because this looks like a source checkout.');
+    } else {
+      process.exitCode = 1;
+      return;
+    }
   }
 
   writeInstallMethod();
@@ -231,6 +305,10 @@ async function fixGlobalInstallBin() {
  * Replace the symlink to the JS wrapper with a symlink to the native binary.
  */
 async function fixUnixSymlink() {
+  if (!hasUsableBinary(binaryPath)) {
+    return;
+  }
+
   // Get npm's global bin directory (npm prefix -g + /bin)
   let npmBinDir;
   try {
@@ -293,7 +371,7 @@ async function fixWindowsShims() {
   const absoluteBinaryPath = join(npmBinDir, relativeBinaryPath);
 
   // Only rewrite shims if the native binary actually exists
-  if (!existsSync(absoluteBinaryPath)) {
+  if (!hasUsableBinary(absoluteBinaryPath)) {
     return;
   }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,215 +1,40 @@
 #!/usr/bin/env node
 
 /**
- * Postinstall script for agent-browser
+ * Postinstall script for agent-browser.
  *
- * Downloads the platform-specific native binary from the matching GitHub
- * release. The npm package intentionally ships only the JS launcher plus
- * install scripts so installs do not download binaries for other platforms.
- * On global installs, patches npm's bin entry to use the native binary directly:
- * - Windows: Overwrites .cmd/.ps1 shims
- * - Mac/Linux: Replaces symlink to point to native binary
+ * Downloads and verifies the platform-specific native binary from the matching
+ * GitHub release. The npm package intentionally ships only the JS launcher,
+ * checksum manifest, and install scripts so installs do not download binaries
+ * for other platforms.
+ *
+ * On global installs, and on local installs when the package manager has already
+ * created a .bin link, patches the command entry to use the native binary
+ * directly for zero-overhead startup.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  chmodSync,
-  createWriteStream,
-  unlinkSync,
-  writeFileSync,
-  symlinkSync,
-  lstatSync,
-  readFileSync,
-  renameSync,
-  statSync,
-} from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
-import { platform, arch } from 'os';
-import { get } from 'https';
 import { execSync } from 'child_process';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const projectRoot = join(__dirname, '..');
-const binDir = join(projectRoot, 'bin');
-
-// Detect if the system uses musl libc (e.g. Alpine Linux)
-function isMusl() {
-  if (platform() !== 'linux') return false;
-  try {
-    const result = execSync('ldd --version 2>&1 || true', { encoding: 'utf8' });
-    return result.toLowerCase().includes('musl');
-  } catch {
-    return existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1');
-  }
-}
-
-// Platform detection
-const osKey = platform() === 'linux' && isMusl() ? 'linux-musl' : platform();
-const platformKey = `${osKey}-${arch()}`;
-const ext = platform() === 'win32' ? '.exe' : '';
-const binaryName = `agent-browser-${platformKey}${ext}`;
-const binaryPath = join(binDir, binaryName);
-const sourceCheckoutMarker = join(projectRoot, 'cli', 'Cargo.toml');
-
-// Package info
-const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
-const version = packageJson.version;
-
-// GitHub release URL
-const GITHUB_REPO = 'vercel-labs/agent-browser';
-const DOWNLOAD_URL = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${binaryName}`;
-
-function hasUsableBinary(path) {
-  try {
-    return statSync(path).size > 0;
-  } catch {
-    return false;
-  }
-}
-
-function cleanupFile(path) {
-  try {
-    unlinkSync(path);
-  } catch {
-    // Best effort cleanup only
-  }
-}
-
-async function downloadFile(url, dest) {
-  const tmpDest = `${dest}.download-${process.pid}-${Date.now()}`;
-
-  return new Promise((resolve, reject) => {
-    const file = createWriteStream(tmpDest, { flags: 'wx' });
-    let settled = false;
-
-    const fail = (err) => {
-      if (settled) return;
-      settled = true;
-      file.destroy();
-      cleanupFile(tmpDest);
-      cleanupFile(dest);
-      reject(err);
-    };
-
-    const succeed = () => {
-      if (settled) return;
-      settled = true;
-      try {
-        renameSync(tmpDest, dest);
-        resolve();
-      } catch (err) {
-        cleanupFile(tmpDest);
-        reject(err);
-      }
-    };
-
-    const request = (currentUrl, redirects = 0) => {
-      get(currentUrl, (response) => {
-        // Handle redirects
-        if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
-          response.resume();
-          if (redirects >= 5 || !response.headers.location) {
-            fail(new Error('Too many redirects while downloading native binary'));
-            return;
-          }
-          request(new URL(response.headers.location, currentUrl).toString(), redirects + 1);
-          return;
-        }
-
-        if (response.statusCode !== 200) {
-          response.resume();
-          fail(new Error(`Failed to download: HTTP ${response.statusCode}`));
-          return;
-        }
-
-        response.pipe(file);
-        file.on('finish', () => {
-          file.close((err) => {
-            if (err) {
-              fail(err);
-              return;
-            }
-            succeed();
-          });
-        });
-      }).on('error', fail);
-    };
-
-    file.on('error', fail);
-    request(url);
-  });
-}
-
-/**
- * Detect which package manager ran this postinstall and write a marker file
- * next to the binary so `agent-browser upgrade` can use the correct one
- * without fragile path heuristics or slow subprocess probing.
- *
- * npm_config_user_agent is set by npm/pnpm/yarn/bun during lifecycle scripts,
- * e.g. "pnpm/8.10.0 node/v20.10.0 linux x64"
- */
-function writeInstallMethod() {
-  const ua = process.env.npm_config_user_agent || '';
-  let method = '';
-  if (ua.startsWith('pnpm/')) method = 'pnpm';
-  else if (ua.startsWith('yarn/')) method = 'yarn';
-  else if (ua.startsWith('bun/')) method = 'bun';
-  else if (ua.startsWith('npm/')) method = 'npm';
-
-  if (method) {
-    try {
-      writeFileSync(join(binDir, '.install-method'), method);
-    } catch {
-      // Non-critical — upgrade will fall back to heuristics
-    }
-  }
-}
+import { existsSync } from 'fs';
+import { platform } from 'os';
+import {
+  ensureNativeBinary,
+  hasUsableBinary,
+  isSourceCheckout,
+  optimizeCommandLinks,
+  writeInstallMethod,
+} from './native-binary.js';
 
 async function main() {
-  // Check if binary already exists
-  if (hasUsableBinary(binaryPath)) {
-    // Ensure binary is executable (npm doesn't preserve execute bit)
-    if (platform() !== 'win32') {
-      chmodSync(binaryPath, 0o755);
-    }
-    console.log(`✓ Native binary ready: ${binaryName}`);
-
-    writeInstallMethod();
-
-    // On global installs, fix npm's bin entry to use native binary directly
-    await fixGlobalInstallBin();
-
-    showInstallReminder();
-    return;
-  }
-
-  // Ensure bin directory exists
-  if (!existsSync(binDir)) {
-    mkdirSync(binDir, { recursive: true });
-  }
-
-  console.log(`Downloading native binary for ${platformKey}...`);
-  console.log(`URL: ${DOWNLOAD_URL}`);
-
+  let result;
   try {
-    await downloadFile(DOWNLOAD_URL, binaryPath);
-
-    // Make executable on Unix
-    if (platform() !== 'win32') {
-      chmodSync(binaryPath, 0o755);
-    }
-
-    console.log(`✓ Downloaded native binary: ${binaryName}`);
+    result = await ensureNativeBinary();
   } catch (err) {
-    console.log(`Could not download native binary: ${err.message}`);
+    console.log(`Could not prepare native binary: ${err.message}`);
     console.log('');
     console.log('The npm package downloads the native binary from GitHub Releases during install.');
-    console.log('Reinstall the package to retry, or download the matching release asset manually:');
-    console.log(`  ${DOWNLOAD_URL}`);
-    console.log(`  Place it at: ${binaryPath}`);
-    if (existsSync(sourceCheckoutMarker)) {
+    console.log('Reinstall the package to retry the download.');
+
+    if (isSourceCheckout()) {
       console.log('');
       console.log('For a source checkout, you can also build the native binary locally:');
       console.log('  1. Install Rust: https://rustup.rs');
@@ -224,9 +49,9 @@ async function main() {
 
   writeInstallMethod();
 
-  // On global installs, fix npm's bin entry to use native binary directly
-  // This avoids the /bin/sh error on Windows and provides zero-overhead execution
-  await fixGlobalInstallBin();
+  if (result && hasUsableBinary(result.binaryPath)) {
+    optimizeCommandLinks({ binaryPath: result.binaryPath });
+  }
 
   showInstallReminder();
 }
@@ -245,8 +70,8 @@ function findSystemChrome() {
     const names = ['google-chrome', 'google-chrome-stable', 'chromium-browser', 'chromium'];
     for (const name of names) {
       try {
-        const result = execSync(`which ${name} 2>/dev/null`, { encoding: 'utf8' }).trim();
-        if (result) return result;
+        const foundPath = execSync(`which ${name} 2>/dev/null`, { encoding: 'utf8' }).trim();
+        if (foundPath) return foundPath;
       } catch {}
     }
     return null;
@@ -288,105 +113,7 @@ function showInstallReminder() {
   console.log('');
 }
 
-/**
- * Fix npm's bin entry on global installs to use the native binary directly.
- * This provides zero-overhead CLI execution for global installs.
- */
-async function fixGlobalInstallBin() {
-  if (platform() === 'win32') {
-    await fixWindowsShims();
-  } else {
-    await fixUnixSymlink();
-  }
-}
-
-/**
- * Fix npm symlink on Mac/Linux global installs.
- * Replace the symlink to the JS wrapper with a symlink to the native binary.
- */
-async function fixUnixSymlink() {
-  if (!hasUsableBinary(binaryPath)) {
-    return;
-  }
-
-  // Get npm's global bin directory (npm prefix -g + /bin)
-  let npmBinDir;
-  try {
-    const prefix = execSync('npm prefix -g', { encoding: 'utf8' }).trim();
-    npmBinDir = join(prefix, 'bin');
-  } catch {
-    return; // npm not available
-  }
-
-  const symlinkPath = join(npmBinDir, 'agent-browser');
-
-  // Check if symlink exists (indicates global install)
-  try {
-    const stat = lstatSync(symlinkPath);
-    if (!stat.isSymbolicLink()) {
-      return; // Not a symlink, don't touch it
-    }
-  } catch {
-    return; // Symlink doesn't exist, not a global install
-  }
-
-  // Replace symlink to point directly to native binary
-  try {
-    unlinkSync(symlinkPath);
-    symlinkSync(binaryPath, symlinkPath);
-    console.log('✓ Optimized: symlink points to native binary (zero overhead)');
-  } catch (err) {
-    // Permission error or other issue - not critical, JS wrapper still works
-    console.log(`⚠ Could not optimize symlink: ${err.message}`);
-    console.log('  CLI will work via Node.js wrapper (slightly slower startup)');
-  }
-}
-
-/**
- * Fix npm-generated shims on Windows global installs.
- * npm generates shims that try to run /bin/sh, which doesn't exist on Windows.
- * We overwrite them to invoke the native .exe directly.
- */
-async function fixWindowsShims() {
-  let npmBinDir;
-  try {
-    npmBinDir = execSync('npm prefix -g', { encoding: 'utf8' }).trim();
-  } catch {
-    return;
-  }
-
-  const cmdShim = join(npmBinDir, 'agent-browser.cmd');
-  const ps1Shim = join(npmBinDir, 'agent-browser.ps1');
-
-  // Shims may not exist yet during postinstall (npm creates them after
-  // lifecycle scripts). If missing, fall back: the JS wrapper at
-  // bin/agent-browser.js handles Windows correctly via child_process.spawn.
-  if (!existsSync(cmdShim)) {
-    return;
-  }
-
-  // Detect architecture so ARM64 Windows is handled correctly
-  const cpuArch = arch() === 'arm64' ? 'arm64' : 'x64';
-  const relativeBinaryPath = `node_modules\\agent-browser\\bin\\agent-browser-win32-${cpuArch}.exe`;
-  const absoluteBinaryPath = join(npmBinDir, relativeBinaryPath);
-
-  // Only rewrite shims if the native binary actually exists
-  if (!hasUsableBinary(absoluteBinaryPath)) {
-    return;
-  }
-
-  try {
-    const cmdContent = `@ECHO off\r\n"%~dp0${relativeBinaryPath}" %*\r\n`;
-    writeFileSync(cmdShim, cmdContent);
-
-    const ps1Content = `#!/usr/bin/env pwsh\r\n$basedir = Split-Path $MyInvocation.MyCommand.Definition -Parent\r\n& "$basedir\\${relativeBinaryPath}" $args\r\nexit $LASTEXITCODE\r\n`;
-    writeFileSync(ps1Shim, ps1Content);
-
-    console.log('✓ Optimized: shims point to native binary (zero overhead)');
-  } catch (err) {
-    console.log(`⚠ Could not optimize shims: ${err.message}`);
-    console.log('  CLI will work via Node.js wrapper (slightly slower startup)');
-  }
-}
-
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -32,7 +32,7 @@ next ref interaction.
 ## Quickstart
 
 ```bash
-# Install once
+# Install once. npm downloads the matching native binary; install downloads Chrome.
 npm i -g agent-browser && agent-browser install
 
 # Take a screenshot of a page

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -32,7 +32,7 @@ next ref interaction.
 ## Quickstart
 
 ```bash
-# Install once. npm downloads the matching native binary; install downloads Chrome.
+# Install once. npm downloads and verifies the matching native binary; install downloads Chrome.
 npm i -g agent-browser && agent-browser install
 
 # Take a screenshot of a page


### PR DESCRIPTION
- Exclude platform binaries from the npm tarball and add a package contents guard.
- Download the matching native binary from GitHub Releases during postinstall.
- Publish GitHub release assets before npm so fresh installs can fetch binaries.