### PR TITLE
Add Obscura browser engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,8 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--action-policy <path>` | Path to action policy JSON file (or `AGENT_BROWSER_ACTION_POLICY` env) |
 | `--confirm-actions <list>` | Action categories requiring confirmation (or `AGENT_BROWSER_CONFIRM_ACTIONS` env) |
 | `--confirm-interactive` | Interactive confirmation prompts; auto-denies if stdin is not a TTY (or `AGENT_BROWSER_CONFIRM_INTERACTIVE` env) |
-| `--engine <name>` | Browser engine: `chrome` (default), `lightpanda` (or `AGENT_BROWSER_ENGINE` env) |
+| `--engine <name>` | Browser engine: `chrome` (default), `lightpanda`, `obscura` (or `AGENT_BROWSER_ENGINE` env) |
+| `AGENT_BROWSER_OBSCURA_STEALTH` env | Run the Obscura engine (`--engine obscura`) in stealth mode: consistent fingerprint, tracker blocking |
 | `--no-auto-dialog` | Disable automatic dismissal of `alert`/`beforeunload` dialogs (or `AGENT_BROWSER_NO_AUTO_DIALOG` env) |
 | `--model <name>` | AI model for chat command (or `AI_GATEWAY_MODEL` env) |
 | `-v`, `--verbose` | Show tool commands and their raw output (chat) |
@@ -1223,7 +1224,7 @@ agent-browser uses a client-daemon architecture:
 
 The daemon starts automatically on first command and persists between commands for fast subsequent operations. To auto-shutdown the daemon after a period of inactivity, set `AGENT_BROWSER_IDLE_TIMEOUT_MS` (value in milliseconds). When set, the daemon closes the browser and exits after receiving no commands for the specified duration.
 
-**Browser Engine:** Uses Chrome (from Chrome for Testing) by default. The `--engine` flag selects between `chrome` and `lightpanda`. Supported browsers: Chromium/Chrome (via CDP) and Safari (via WebDriver for iOS).
+**Browser Engine:** Uses Chrome (from Chrome for Testing) by default. The `--engine` flag selects between `chrome`, `lightpanda`, and `obscura`. Supported browsers: Chromium/Chrome (via CDP), Lightpanda and Obscura (via CDP), and Safari (via WebDriver for iOS).
 
 ## Platforms
 

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -130,7 +130,7 @@
     },
     "engine": {
       "type": "string",
-      "enum": ["chrome", "lightpanda"],
+      "enum": ["chrome", "lightpanda", "obscura"],
       "default": "chrome",
       "description": "Browser engine to use."
     },

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -9,6 +9,10 @@ use super::cdp::chrome::{auto_connect_cdp, launch_chrome, ChromeProcess, LaunchO
 use super::cdp::client::CdpClient;
 use super::cdp::discovery::discover_cdp_url;
 use super::cdp::lightpanda::{launch_lightpanda, LightpandaLaunchOptions, LightpandaProcess};
+use super::cdp::obscura::{
+    launch_obscura, stealth_from_env as obscura_stealth_from_env, ObscuraLaunchOptions,
+    ObscuraProcess,
+};
 use super::cdp::types::*;
 use super::element::{resolve_element_object_id, RefMap};
 
@@ -84,6 +88,34 @@ fn validate_lightpanda_options(options: &LaunchOptions) -> Result<(), String> {
         return Err(
             "Custom Chrome arguments (--args) are not supported with Lightpanda".to_string(),
         );
+    }
+    Ok(())
+}
+
+/// Validates that Chrome-only options are not used with Obscura.
+fn validate_obscura_options(options: &LaunchOptions) -> Result<(), String> {
+    if options
+        .extensions
+        .as_ref()
+        .map(|e| !e.is_empty())
+        .unwrap_or(false)
+    {
+        return Err("Extensions are not supported with Obscura".to_string());
+    }
+    if options.profile.is_some() {
+        return Err("Profiles are not supported with Obscura".to_string());
+    }
+    if options.storage_state.is_some() {
+        return Err("Storage state is not supported with Obscura".to_string());
+    }
+    if options.allow_file_access {
+        return Err("File access is not supported with Obscura".to_string());
+    }
+    if !options.headless {
+        return Err("Headed mode is not supported with Obscura (headless only)".to_string());
+    }
+    if !options.args.is_empty() {
+        return Err("Custom Chrome arguments (--args) are not supported with Obscura".to_string());
     }
     Ok(())
 }
@@ -265,6 +297,7 @@ impl WaitUntil {
 pub enum BrowserProcess {
     Chrome(ChromeProcess),
     Lightpanda(LightpandaProcess),
+    Obscura(ObscuraProcess),
 }
 
 impl BrowserProcess {
@@ -272,6 +305,7 @@ impl BrowserProcess {
         match self {
             BrowserProcess::Chrome(p) => p.kill(),
             BrowserProcess::Lightpanda(p) => p.kill(),
+            BrowserProcess::Obscura(p) => p.kill(),
         }
     }
 
@@ -279,6 +313,7 @@ impl BrowserProcess {
         match self {
             BrowserProcess::Chrome(p) => p.wait_or_kill(timeout),
             BrowserProcess::Lightpanda(p) => p.kill(),
+            BrowserProcess::Obscura(p) => p.kill(),
         }
     }
 
@@ -287,6 +322,7 @@ impl BrowserProcess {
         match self {
             BrowserProcess::Chrome(p) => p.has_exited(),
             BrowserProcess::Lightpanda(_) => false,
+            BrowserProcess::Obscura(_) => false,
         }
     }
 }
@@ -311,6 +347,10 @@ const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const LIGHTPANDA_CDP_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(10);
 
+const OBSCURA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const OBSCURA_CDP_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const OBSCURA_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(10);
+
 impl BrowserManager {
     pub async fn launch(options: LaunchOptions, engine: Option<&str>) -> Result<Self, String> {
         let engine = engine.unwrap_or("chrome");
@@ -329,9 +369,12 @@ impl BrowserManager {
             "lightpanda" => {
                 validate_lightpanda_options(&options)?;
             }
+            "obscura" => {
+                validate_obscura_options(&options)?;
+            }
             _ => {
                 return Err(format!(
-                    "Unknown engine '{}'. Supported engines: chrome, lightpanda",
+                    "Unknown engine '{}'. Supported engines: chrome, lightpanda, obscura",
                     engine
                 ));
             }
@@ -353,6 +396,17 @@ impl BrowserManager {
                 let url = lp.ws_url.clone();
                 (url, BrowserProcess::Lightpanda(lp))
             }
+            "obscura" => {
+                let obscura_options = ObscuraLaunchOptions {
+                    executable_path: options.executable_path.clone(),
+                    proxy: options.proxy.clone(),
+                    port: None,
+                    stealth: obscura_stealth_from_env(),
+                };
+                let ob = launch_obscura(&obscura_options).await?;
+                let url = ob.ws_url.clone();
+                (url, BrowserProcess::Obscura(ob))
+            }
             _ => {
                 let chrome = tokio::task::spawn_blocking(move || launch_chrome(&options))
                     .await
@@ -364,6 +418,8 @@ impl BrowserManager {
 
         let manager = if engine == "lightpanda" {
             initialize_lightpanda_manager(ws_url, process).await?
+        } else if engine == "obscura" {
+            initialize_obscura_manager(ws_url, process).await?
         } else {
             let client = Arc::new(CdpClient::connect(&ws_url).await?);
             let mut manager = Self {
@@ -1671,6 +1727,84 @@ fn lightpanda_target_init_timeout(last_error: Option<&str>) -> String {
     let mut message = format!(
         "Timed out after {}ms waiting for Lightpanda Target domain to initialize",
         LIGHTPANDA_TARGET_INIT_TIMEOUT.as_millis(),
+    );
+    if let Some(last_error) = last_error {
+        message.push_str(&format!("\nLast error: {}", last_error));
+    }
+    message
+}
+
+async fn initialize_obscura_manager(
+    ws_url: String,
+    process: BrowserProcess,
+) -> Result<BrowserManager, String> {
+    let deadline = Instant::now() + OBSCURA_TARGET_INIT_TIMEOUT;
+    let mut process = Some(process);
+
+    loop {
+        let client = match connect_cdp_with_retry(
+            &ws_url,
+            OBSCURA_CDP_CONNECT_TIMEOUT,
+            OBSCURA_CDP_CONNECT_POLL_INTERVAL,
+        )
+        .await
+        {
+            Ok(client) => client,
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    return Err(obscura_target_init_timeout(Some(&err)));
+                }
+                tokio::time::sleep(OBSCURA_CDP_CONNECT_POLL_INTERVAL).await;
+                continue;
+            }
+        };
+
+        let mut manager = BrowserManager {
+            client: Arc::new(client),
+            browser_process: None,
+            ws_url: ws_url.clone(),
+            pages: Vec::new(),
+            active_page_index: 0,
+            default_timeout_ms: 25_000,
+            download_path: None,
+            ignore_https_errors: false,
+            visited_origins: HashSet::new(),
+            next_tab_id: 1,
+        };
+
+        let remaining = match remaining_until(deadline) {
+            Some(remaining) => remaining,
+            None => {
+                return Err(obscura_target_init_timeout(Some(
+                    "deadline expired before retry",
+                )))
+            }
+        };
+
+        match tokio::time::timeout(remaining, manager.discover_and_attach_targets()).await {
+            Ok(Ok(())) => {
+                manager.browser_process = process.take();
+                return Ok(manager);
+            }
+            Ok(Err(err)) => {
+                if Instant::now() >= deadline {
+                    return Err(obscura_target_init_timeout(Some(&err)));
+                }
+                tokio::time::sleep(OBSCURA_CDP_CONNECT_POLL_INTERVAL).await;
+            }
+            Err(_) => {
+                return Err(obscura_target_init_timeout(Some(
+                    "Target domain initialization attempt exceeded the remaining startup deadline",
+                )));
+            }
+        }
+    }
+}
+
+fn obscura_target_init_timeout(last_error: Option<&str>) -> String {
+    let mut message = format!(
+        "Timed out after {}ms waiting for Obscura Target domain to initialize",
+        OBSCURA_TARGET_INIT_TIMEOUT.as_millis(),
     );
     if let Some(last_error) = last_error {
         message.push_str(&format!("\nLast error: {}", last_error));

--- a/cli/src/native/cdp/mod.rs
+++ b/cli/src/native/cdp/mod.rs
@@ -2,4 +2,5 @@ pub mod chrome;
 pub mod client;
 pub mod discovery;
 pub mod lightpanda;
+pub mod obscura;
 pub mod types;

--- a/cli/src/native/cdp/obscura.rs
+++ b/cli/src/native/cdp/obscura.rs
@@ -1,0 +1,541 @@
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::discovery::discover_cdp_url_with_timeout;
+
+const OBSCURA_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const OBSCURA_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const OBSCURA_DISCOVERY_TIMEOUT: Duration = Duration::from_millis(500);
+const MAX_LOG_LINES: usize = 40;
+
+pub struct ObscuraProcess {
+    child: Child,
+    pub ws_url: String,
+    _log_drainers: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl ObscuraProcess {
+    pub fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for ObscuraProcess {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+#[derive(Default)]
+pub struct ObscuraLaunchOptions {
+    pub executable_path: Option<String>,
+    pub proxy: Option<String>,
+    pub port: Option<u16>,
+    /// Run Obscura with `--stealth` (privacy-first consistent browser
+    /// fingerprint and tracker blocking). Off by default for Chrome parity.
+    pub stealth: bool,
+}
+
+/// Obscura's stealth mode is opt-in via the `AGENT_BROWSER_OBSCURA_STEALTH`
+/// environment variable. Accepts `1`, `true`, `yes`, or `on`.
+pub fn stealth_from_env() -> bool {
+    std::env::var("AGENT_BROWSER_OBSCURA_STEALTH")
+        .map(|v| stealth_flag_enabled(&v))
+        .unwrap_or(false)
+}
+
+fn stealth_flag_enabled(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn build_obscura_serve_args(port: u16, proxy: Option<&str>, stealth: bool) -> Vec<String> {
+    let mut args = vec![
+        "serve".to_string(),
+        "--host".to_string(),
+        "127.0.0.1".to_string(),
+        "--port".to_string(),
+        port.to_string(),
+    ];
+
+    if let Some(proxy) = proxy {
+        args.push("--proxy".to_string());
+        args.push(proxy.to_string());
+    }
+
+    if stealth {
+        args.push("--stealth".to_string());
+    }
+
+    args
+}
+
+#[derive(Clone, Default)]
+struct LaunchLogBuffer {
+    stdout: Arc<Mutex<VecDeque<String>>>,
+    stderr: Arc<Mutex<VecDeque<String>>>,
+}
+
+impl LaunchLogBuffer {
+    fn push_stdout(&self, line: String) {
+        push_bounded(&self.stdout, line);
+    }
+
+    fn push_stderr(&self, line: String) {
+        push_bounded(&self.stderr, line);
+    }
+
+    fn snapshot_stdout(&self) -> Vec<String> {
+        self.stdout
+            .lock()
+            .expect("stdout log buffer poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    fn snapshot_stderr(&self) -> Vec<String> {
+        self.stderr
+            .lock()
+            .expect("stderr log buffer poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
+fn push_bounded(buffer: &Mutex<VecDeque<String>>, line: String) {
+    let mut guard = buffer.lock().expect("log buffer poisoned");
+    if guard.len() >= MAX_LOG_LINES {
+        guard.pop_front();
+    }
+    guard.push_back(line);
+}
+
+pub fn find_obscura() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        if let Ok(output) = Command::new("which").arg("obscura").output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Some(PathBuf::from(path));
+                }
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        if let Ok(output) = Command::new("where").arg("obscura").output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Some(PathBuf::from(path));
+                }
+            }
+        }
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        let candidates = [
+            home.join(".obscura/obscura"),
+            home.join(".local/bin/obscura"),
+            home.join(".cargo/bin/obscura"),
+        ];
+        for c in &candidates {
+            if c.exists() {
+                return Some(c.clone());
+            }
+        }
+    }
+
+    None
+}
+
+pub async fn launch_obscura(options: &ObscuraLaunchOptions) -> Result<ObscuraProcess, String> {
+    let binary_path = match &options.executable_path {
+        Some(p) => PathBuf::from(p),
+        None => find_obscura().ok_or(
+            "Obscura not found. Install it from https://github.com/h4ckf0r0day/obscura or use --executable-path.",
+        )?,
+    };
+
+    let port = match options.port {
+        Some(p) => p,
+        None => TcpListener::bind("127.0.0.1:0")
+            .and_then(|l| l.local_addr())
+            .map(|a| a.port())
+            .map_err(|e| format!("Failed to find an available port for Obscura: {}", e))?,
+    };
+    let args = build_obscura_serve_args(port, options.proxy.as_deref(), options.stealth);
+
+    let mut child = Command::new(&binary_path)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to launch Obscura at {:?}: {}", binary_path, e))?;
+
+    let (log_buffer, log_drainers) = start_log_drainers(&mut child)?;
+
+    let ws_url = match wait_for_obscura_ready(
+        &mut child,
+        port,
+        &log_buffer,
+        OBSCURA_STARTUP_TIMEOUT,
+    )
+    .await
+    {
+        Ok(url) => url,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
+    };
+
+    Ok(ObscuraProcess {
+        child,
+        ws_url,
+        _log_drainers: log_drainers,
+    })
+}
+
+fn start_log_drainers(
+    child: &mut Child,
+) -> Result<(LaunchLogBuffer, Vec<std::thread::JoinHandle<()>>), String> {
+    let stdout = child.stdout.take().ok_or_else(|| {
+        let _ = child.kill();
+        "Failed to capture Obscura stdout".to_string()
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        let _ = child.kill();
+        "Failed to capture Obscura stderr".to_string()
+    })?;
+
+    let logs = LaunchLogBuffer::default();
+    let stdout_logs = logs.clone();
+    let stderr_logs = logs.clone();
+
+    let stdout_handle =
+        std::thread::spawn(move || drain_reader(stdout, move |line| stdout_logs.push_stdout(line)));
+    let stderr_handle =
+        std::thread::spawn(move || drain_reader(stderr, move |line| stderr_logs.push_stderr(line)));
+
+    Ok((logs, vec![stdout_handle, stderr_handle]))
+}
+
+fn drain_reader<R, F>(reader: R, mut push: F)
+where
+    R: std::io::Read,
+    F: FnMut(String),
+{
+    for line in BufReader::new(reader).lines() {
+        match line {
+            Ok(line) => push(line),
+            Err(_) => break,
+        }
+    }
+}
+
+async fn wait_for_obscura_ready(
+    child: &mut Child,
+    port: u16,
+    logs: &LaunchLogBuffer,
+    startup_timeout: Duration,
+) -> Result<String, String> {
+    let deadline = std::time::Instant::now() + startup_timeout;
+    let mut last_probe_error = None;
+
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            // Give the drainer threads a brief window to flush the last log lines
+            // before we snapshot them.  This is best-effort: lines written just
+            // before exit may still be missing, but the most useful output (early
+            // startup errors) will already be in the buffer.
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            return Err(obscura_launch_error(
+                &format!(
+                    "Obscura exited before CDP became ready (status: {})",
+                    status
+                ),
+                logs,
+                last_probe_error.as_deref(),
+            ));
+        }
+
+        match discover_cdp_url_with_timeout("127.0.0.1", port, None, OBSCURA_DISCOVERY_TIMEOUT)
+            .await
+        {
+            Ok(ws_url) => return Ok(ws_url),
+            Err(err) => last_probe_error = Some(err),
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Err(obscura_launch_error(
+                &format!(
+                    "Timed out after {}ms waiting for Obscura CDP endpoint on port {}",
+                    startup_timeout.as_millis(),
+                    port
+                ),
+                logs,
+                last_probe_error.as_deref(),
+            ));
+        }
+
+        tokio::time::sleep(OBSCURA_POLL_INTERVAL).await;
+    }
+}
+
+fn obscura_launch_error(
+    message: &str,
+    logs: &LaunchLogBuffer,
+    last_probe_error: Option<&str>,
+) -> String {
+    let stdout_lines = logs.snapshot_stdout();
+    let stderr_lines = logs.snapshot_stderr();
+    let mut details = Vec::new();
+
+    if let Some(err) = last_probe_error {
+        details.push(format!("Last probe error: {}", err));
+    }
+
+    if !stderr_lines.is_empty() {
+        details.push(format!(
+            "Obscura stderr (last {} lines):\n  {}",
+            stderr_lines.len(),
+            stderr_lines.join("\n  ")
+        ));
+    }
+
+    if !stdout_lines.is_empty() {
+        details.push(format!(
+            "Obscura stdout (last {} lines):\n  {}",
+            stdout_lines.len(),
+            stdout_lines.join("\n  ")
+        ));
+    }
+
+    if details.is_empty() {
+        format!("{} (no stdout/stderr output from Obscura)", message)
+    } else {
+        format!("{}\n{}", message, details.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener as TokioTcpListener;
+
+    fn unused_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    async fn serve_json_version_once_after_delay(port: u16, delay_ms: u64, body: &'static str) {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        let listener = TokioTcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        let _ = socket.read(&mut buf).await;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn waits_for_ready_without_logs() {
+        let port = unused_port();
+        tokio::spawn(serve_json_version_once_after_delay(
+            port,
+            150,
+            r#"{"webSocketDebuggerUrl":"ws://127.0.0.1:9222/"}"#,
+        ));
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 5"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let (logs, _drainers) = start_log_drainers(&mut child).unwrap();
+        let ws_url = wait_for_obscura_ready(&mut child, port, &logs, OBSCURA_STARTUP_TIMEOUT)
+            .await
+            .unwrap();
+
+        assert_eq!(ws_url, format!("ws://127.0.0.1:{}/", port));
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn child_exit_surfaces_logs() {
+        let port = unused_port();
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "echo boom >&2; sleep 0.1; exit 23"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let (logs, _drainers) = start_log_drainers(&mut child).unwrap();
+        let err = wait_for_obscura_ready(&mut child, port, &logs, OBSCURA_STARTUP_TIMEOUT)
+            .await
+            .unwrap_err();
+
+        assert!(err.contains("Obscura exited before CDP became ready"));
+        assert!(err.contains("boom"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timeout_reports_last_probe_error() {
+        let port = unused_port();
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let timeout = Duration::from_millis(300);
+        let (logs, _drainers) = start_log_drainers(&mut child).unwrap();
+        let err = tokio::time::timeout(
+            Duration::from_secs(2),
+            wait_for_obscura_ready(&mut child, port, &logs, timeout),
+        )
+        .await
+        .expect("ready wait should return before outer timeout")
+        .unwrap_err();
+
+        assert!(err.contains("Timed out after 300ms waiting for Obscura CDP endpoint"));
+        assert!(
+            err.contains("Failed to connect to CDP") || err.contains("Timeout connecting to CDP")
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn test_find_obscura_returns_none_when_missing() {
+        let _ = find_obscura();
+    }
+
+    #[test]
+    fn test_obscura_launch_error_no_logs() {
+        let logs = LaunchLogBuffer::default();
+        let msg = obscura_launch_error("Obscura exited", &logs, None);
+        assert!(msg.contains("no stdout/stderr output"));
+    }
+
+    #[test]
+    fn test_obscura_launch_error_with_lines() {
+        let logs = LaunchLogBuffer::default();
+        logs.push_stdout("stdout line".to_string());
+        logs.push_stderr("stderr line".to_string());
+        let msg = obscura_launch_error("Obscura exited", &logs, Some("connect failed"));
+        assert!(msg.contains("stdout line"));
+        assert!(msg.contains("stderr line"));
+        assert!(msg.contains("Last probe error: connect failed"));
+    }
+
+    #[test]
+    fn test_default_options() {
+        let opts = ObscuraLaunchOptions::default();
+        assert!(opts.executable_path.is_none());
+        assert!(opts.proxy.is_none());
+        assert!(opts.port.is_none());
+        assert!(!opts.stealth);
+    }
+
+    #[test]
+    fn test_build_obscura_serve_args_minimal() {
+        let args = build_obscura_serve_args(9222, None, false);
+
+        assert_eq!(
+            args,
+            vec![
+                "serve".to_string(),
+                "--host".to_string(),
+                "127.0.0.1".to_string(),
+                "--port".to_string(),
+                "9222".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_obscura_serve_args_with_proxy() {
+        let args = build_obscura_serve_args(9333, Some("http://127.0.0.1:8080"), false);
+
+        assert_eq!(
+            args,
+            vec![
+                "serve".to_string(),
+                "--host".to_string(),
+                "127.0.0.1".to_string(),
+                "--port".to_string(),
+                "9333".to_string(),
+                "--proxy".to_string(),
+                "http://127.0.0.1:8080".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_obscura_serve_args_with_stealth() {
+        let args = build_obscura_serve_args(9222, None, true);
+
+        assert_eq!(
+            args,
+            vec![
+                "serve".to_string(),
+                "--host".to_string(),
+                "127.0.0.1".to_string(),
+                "--port".to_string(),
+                "9222".to_string(),
+                "--stealth".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_stealth_flag_enabled_parsing() {
+        for v in ["1", "true", "TRUE", "yes", "on", " on "] {
+            assert!(stealth_flag_enabled(v), "{v:?} should enable stealth");
+        }
+        for v in ["0", "false", "no", "off", ""] {
+            assert!(!stealth_flag_enabled(v), "{v:?} should not enable stealth");
+        }
+    }
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -297,6 +297,92 @@ async fn e2e_lightpanda_auto_launch_can_open_page() {
     assert_eq!(get_data(&resp)["closed"], true);
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_obscura_launch_can_open_page() {
+    let obscura_bin = match std::env::var("OBSCURA_BIN") {
+        Ok(path) if !path.is_empty() => path,
+        _ => return,
+    };
+
+    let mut state = DaemonState::new();
+
+    let resp = tokio::time::timeout(
+        tokio::time::Duration::from_secs(20),
+        execute_command(
+            &json!({
+                "id": "1",
+                "action": "launch",
+                "headless": true,
+                "engine": "obscura",
+                "executablePath": obscura_bin,
+            }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("Obscura launch should not hang");
+
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["launched"], true);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], "https://example.com/");
+    assert_eq!(get_data(&resp)["title"], "Example Domain");
+
+    let resp = execute_command(&json!({ "id": "3", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["closed"], true);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_obscura_auto_launch_can_open_page() {
+    let obscura_bin = match std::env::var("OBSCURA_BIN") {
+        Ok(path) if !path.is_empty() => path,
+        _ => return,
+    };
+
+    let prev_engine = std::env::var("AGENT_BROWSER_ENGINE").ok();
+    let prev_path = std::env::var("AGENT_BROWSER_EXECUTABLE_PATH").ok();
+    std::env::set_var("AGENT_BROWSER_ENGINE", "obscura");
+    std::env::set_var("AGENT_BROWSER_EXECUTABLE_PATH", &obscura_bin);
+
+    let mut state = DaemonState::new();
+
+    let resp = tokio::time::timeout(
+        tokio::time::Duration::from_secs(20),
+        execute_command(
+            &json!({ "id": "1", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("Obscura auto-launch should not hang");
+
+    match prev_engine {
+        Some(value) => std::env::set_var("AGENT_BROWSER_ENGINE", value),
+        None => std::env::remove_var("AGENT_BROWSER_ENGINE"),
+    }
+    match prev_path {
+        Some(value) => std::env::set_var("AGENT_BROWSER_EXECUTABLE_PATH", value),
+        None => std::env::remove_var("AGENT_BROWSER_EXECUTABLE_PATH"),
+    }
+
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], "https://example.com/");
+    assert_eq!(get_data(&resp)["title"], "Example Domain");
+
+    let resp = execute_command(&json!({ "id": "2", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["closed"], true);
+}
+
 // ---------------------------------------------------------------------------
 // Runtime stream lifecycle
 // ---------------------------------------------------------------------------

--- a/cli/src/native/stream/chat.rs
+++ b/cli/src/native/stream/chat.rs
@@ -145,7 +145,7 @@ RULES:
 - Keep responses concise.
 - For screenshots, omit the path argument so they save to the default location (which will be displayed inline). Screenshots from tool calls are ALREADY shown to the user. Do NOT re-display them with markdown image syntax in your text response. Never use `![...]()` to reference screenshots.
 - To create a new session: add `--session <name>` to any command (e.g. `agent-browser --session my-session open https://example.com`). If the session does not exist, it will be created automatically.
-- To use a different browser engine: add `--engine <engine>` (e.g. `agent-browser --session lp-session --engine lightpanda open https://example.com`). Supported engines: chrome (default), lightpanda.
+- To use a different browser engine: add `--engine <engine>` (e.g. `agent-browser --session lp-session --engine lightpanda open https://example.com`). Supported engines: chrome (default), lightpanda, obscura.
 
 The following skill references describe agent-browser capabilities in detail. Use them when deciding which commands to run and how to approach tasks.
 {sections}"#,

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3220,7 +3220,7 @@ Options:
   --action-policy <path>     Action policy JSON file (or AGENT_BROWSER_ACTION_POLICY)
   --confirm-actions <list>   Categories requiring confirmation (or AGENT_BROWSER_CONFIRM_ACTIONS)
   --confirm-interactive      Interactive confirmation prompts; auto-denies if stdin is not a TTY (or AGENT_BROWSER_CONFIRM_INTERACTIVE)
-  --engine <name>            Browser engine: chrome (default), lightpanda (or AGENT_BROWSER_ENGINE)
+  --engine <name>            Browser engine: chrome (default), lightpanda, obscura (or AGENT_BROWSER_ENGINE)
   --no-auto-dialog           Disable automatic dismissal of alert/beforeunload dialogs (or AGENT_BROWSER_NO_AUTO_DIALOG)
   --model <name>             AI model for chat (or AI_GATEWAY_MODEL env)
   -v, --verbose              Show tool commands and their raw output
@@ -3285,7 +3285,8 @@ Environment:
   AGENT_BROWSER_CONFIRM_ACTIONS  Action categories requiring confirmation
   AGENT_BROWSER_CONFIRM_INTERACTIVE Enable interactive confirmation prompts
   AGENT_BROWSER_NO_AUTO_DIALOG   Disable automatic dismissal of alert/beforeunload dialogs
-  AGENT_BROWSER_ENGINE           Browser engine: chrome (default), lightpanda
+  AGENT_BROWSER_ENGINE           Browser engine: chrome (default), lightpanda, obscura
+  AGENT_BROWSER_OBSCURA_STEALTH  Run the Obscura engine in stealth mode (consistent fingerprint, tracker blocking)
   HTTP_PROXY / HTTPS_PROXY       Standard proxy env vars (fallback if AGENT_BROWSER_PROXY not set)
   ALL_PROXY                      SOCKS proxy (fallback for proxy)
   NO_PROXY                       Bypass proxy for hosts (fallback for proxy-bypass)

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -130,7 +130,7 @@
     },
     "engine": {
       "type": "string",
-      "enum": ["chrome", "lightpanda"],
+      "enum": ["chrome", "lightpanda", "obscura"],
       "default": "chrome",
       "description": "Browser engine to use."
     },

--- a/docs/src/app/engines/obscura/layout.tsx
+++ b/docs/src/app/engines/obscura/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("engines/obscura");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/engines/obscura/page.mdx
+++ b/docs/src/app/engines/obscura/page.mdx
@@ -1,0 +1,102 @@
+# Obscura
+
+[Obscura](https://github.com/h4ckf0r0day/obscura) is a headless browser engine written in Rust. It runs real JavaScript through V8, speaks the Chrome DevTools Protocol, and is built as a drop-in replacement for headless Chrome for web scraping and AI agent automation.
+
+agent-browser manages Obscura the same way it manages Chrome. It spawns the `obscura serve` process, connects over CDP, and shuts it down when done. All downstream commands (snapshot, click, fill, screenshot, and so on) run through the same CDP path.
+
+## Installation
+
+Install the Obscura binary before using it with agent-browser:
+
+<table>
+  <thead>
+    <tr><th>Platform</th><th>Command</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Linux (x86_64)</td>
+      <td><code>curl -LO https://github.com/h4ckf0r0day/obscura/releases/latest/download/obscura-x86_64-linux.tar.gz && tar xzf obscura-x86_64-linux.tar.gz</code></td>
+    </tr>
+    <tr>
+      <td>macOS (Apple Silicon)</td>
+      <td><code>curl -LO https://github.com/h4ckf0r0day/obscura/releases/latest/download/obscura-aarch64-macos.tar.gz && tar xzf obscura-aarch64-macos.tar.gz</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Move the binary somewhere in your `PATH` (e.g. `/usr/local/bin/obscura` or `~/.local/bin/obscura`).
+
+See the [Obscura README](https://github.com/h4ckf0r0day/obscura) for more install options, including Docker and building from source.
+
+## Usage
+
+Use the `--engine` flag to select Obscura:
+
+```bash
+agent-browser --engine obscura open example.com
+agent-browser --engine obscura snapshot
+agent-browser --engine obscura screenshot
+```
+
+Or set it as the default via environment variable:
+
+```bash
+export AGENT_BROWSER_ENGINE=obscura
+agent-browser open example.com
+```
+
+Or in your `agent-browser.json` config:
+
+```json
+{
+  "engine": "obscura"
+}
+```
+
+## Custom Binary Path
+
+If the `obscura` binary is not in your `PATH`, use `--executable-path`:
+
+```bash
+agent-browser --engine obscura --executable-path /path/to/obscura open example.com
+```
+
+## Stealth mode
+
+Obscura ships an optional stealth mode that presents a privacy-first, consistent browser fingerprint and blocks known trackers. Enable it for the Obscura engine by setting `AGENT_BROWSER_OBSCURA_STEALTH`:
+
+```bash
+AGENT_BROWSER_OBSCURA_STEALTH=1 agent-browser --engine obscura open example.com
+```
+
+When set, agent-browser launches `obscura serve` with `--stealth`. Accepted values are `1`, `true`, `yes`, and `on`. Stealth is off by default so the engine behaves like a standard browser.
+
+## Differences from Chrome
+
+Obscura is a purpose-built headless engine. Some Chrome-specific features are not available:
+
+<table>
+  <thead>
+    <tr><th>Feature</th><th>Status</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Extensions (<code>--extension</code>)</td><td>Not supported</td></tr>
+    <tr><td>Persistent profiles (<code>--profile</code>)</td><td>Not supported</td></tr>
+    <tr><td>Storage state (<code>--state</code>)</td><td>Not supported</td></tr>
+    <tr><td>File access (<code>--allow-file-access</code>)</td><td>Not supported</td></tr>
+    <tr><td>Headed mode (<code>--headed</code>)</td><td>Not applicable (headless only)</td></tr>
+  </tbody>
+</table>
+
+agent-browser returns a clear error if you combine `--engine obscura` with unsupported flags.
+
+## When to Use Obscura
+
+Obscura is a good fit for:
+
+- Web scraping and data extraction with real JavaScript execution
+- AI agent workflows that want a lightweight CDP target
+- CI/CD environments where you prefer a single self-contained binary
+- Setups that want a privacy-first, consistent browser fingerprint (Obscura ships an optional stealth mode)
+
+Use Chrome when you need full browser fidelity, extensions, or persistent profiles.

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -64,6 +64,7 @@ export const navigation: NavSection[] = [
     items: [
       { name: "Chrome", href: "/engines/chrome" },
       { name: "Lightpanda", href: "/engines/lightpanda" },
+      { name: "Obscura", href: "/engines/obscura" },
     ],
   },
   {

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -24,6 +24,7 @@ export const PAGE_TITLES: Record<string, string> = {
   security: "Security",
   "engines/chrome": "Chrome",
   "engines/lightpanda": "Lightpanda",
+  "engines/obscura": "Obscura",
   next: "Next.js + Vercel",
   "native-mode": "Native Mode",
   "providers/agentcore": "AgentCore",


### PR DESCRIPTION

  Add Obscura browser engine support

  Summary

  Adds Obscura (https://github.com/h4ckf0r0day/obscura) as a third local browser engine, selectable with --engine obscura (or AGENT_BROWSER_ENGINE=obscura), alongside Chrome and Lightpanda.

  Obscura is a headless browser written in Rust that runs real JavaScript through V8 and speaks the Chrome DevTools Protocol. agent-browser manages it the same way it manages Lightpanda: it spawns obscura serve, discovers
  the CDP endpoint from /json/version, connects, and runs every downstream command (snapshot, click, fill, screenshot, and so on) over the same CDP path. No changes to the shared CDP client or discovery logic were needed,
  since Obscura already serves /json/version with a webSocketDebuggerUrl.

  What is included

  Engine launcher
  - cli/src/native/cdp/obscura.rs (new): spawns obscura serve --host 127.0.0.1 --port <port>, drains stdout and stderr into a bounded buffer, waits for the CDP endpoint via the existing discovery probe. Mirrors
  lightpanda.rs, including binary lookup (which obscura, then ~/.obscura, ~/.local/bin, ~/.cargo/bin) and startup error reporting.
  - cli/src/native/cdp/mod.rs: registers the module.
  
  Engine wiring (cli/src/native/browser.rs)
  - --engine obscura validation (rejects Chrome-only options: extensions, profiles, storage state, file access, headed mode, custom args, matching Lightpanda).
  - BrowserProcess::Obscura variant and process lifecycle.
  - initialize_obscura_manager: connect-with-retry plus target-domain init bounded by a startup deadline.

  Stealth mode
  - Opt-in via AGENT_BROWSER_OBSCURA_STEALTH (1, true, yes, on). When set, the launcher adds --stealth to obscura serve. Off by default for Chrome parity.

  Help and documentation
  - cli/src/output.rs: --engine line plus a new AGENT_BROWSER_OBSCURA_STEALTH entry in the environment-variable section.
  - cli/src/native/stream/chat.rs: engine list in the agent system prompt.
  - README.md: options table (engine values and the stealth env var) and the browser-engine architecture note.
  - docs/src/app/engines/obscura/: new engine page (installation, usage, custom binary path, stealth mode, differences from Chrome, when to use) and its layout.
  - docs/src/lib/docs-navigation.ts, docs/src/lib/page-titles.ts: sidebar entry and page title.
  - agent-browser.schema.json, docs/public/schema.json: engine enum now includes obscura.

  Tests
  - cdp/obscura.rs: unit tests for argument building (with and without proxy and stealth), stealth env parsing, startup readiness, child-exit and timeout error reporting.
  - e2e_tests.rs: two #[ignore]'d e2e tests gated on OBSCURA_BIN (explicit launch and AGENT_BROWSER_ENGINE auto-launch), matching the Lightpanda e2e pattern.

  Usage

  agent-browser --engine obscura open example.com
  export AGENT_BROWSER_ENGINE=obscura && agent-browser open example.com
  AGENT_BROWSER_OBSCURA_STEALTH=1 agent-browser --engine obscura open example.com
  agent-browser --engine obscura --executable-path /path/to/obscura open example.com

  Validation

  - cargo fmt --check and cargo clippy -- -D warnings: clean.
  - cargo test --profile ci: full unit suite passes, including the new Obscura tests.
  - e2e against a real Obscura binary: both pass (navigate to example.com returns the expected url and title, then close).
  - Manual CLI: open, snapshot, close all work; with the stealth env var the spawned process is obscura serve --host 127.0.0.1 --port <port> --stealth.

  Notes

  - skill-data/ is untouched. Engine selection is not documented there for any engine today, so I matched that footprint. Can add an engines section to skill-data/core/SKILL.md if you want it covered for all engines.
  - No CHANGELOG.md or package.json changes, per the release process in AGENTS.md.

