### PR TITLE
Fix iframe-blind snapshot/click; add snapshot --frames for transparent iframe discovery

### DIFF
--- a/.agents/skills/agent-browser/references/commands.md
+++ b/.agents/skills/agent-browser/references/commands.md
@@ -21,11 +21,15 @@ agent-browser connect 9222    # Connect to browser via CDP port
 agent-browser snapshot            # Full accessibility tree
 agent-browser snapshot -i         # Interactive elements only (recommended)
 agent-browser snapshot -C         # Also include cursor:pointer / onclick elements
-agent-browser snapshot -i -C      # Interactive + cursor-interactive (widest net)
+agent-browser snapshot -F         # Include elements from all iframes automatically
+agent-browser snapshot -i -F      # Interactive elements from page + all iframes
+agent-browser snapshot -i -C -F   # Widest net: interactive + cursor + iframes
 agent-browser snapshot -c         # Compact output
 agent-browser snapshot -d 3       # Limit depth to 3
 agent-browser snapshot -s "#main" # Scope to CSS selector
 ```
+
+`-F / --frames` discovers all iframes automatically and merges their elements into the output. Refs from iframes work transparently with `click`, `fill`, `get`, etc. — no manual `frame` switching required. Use the `frame` command when you want to work exclusively inside one iframe.
 
 When inside an iframe (after `agent-browser frame <sel>`), snapshot and all interactions target the iframe's document — use `frame main` to return to the main page.
 

--- a/.agents/skills/agent-browser/references/commands.md
+++ b/.agents/skills/agent-browser/references/commands.md
@@ -1,0 +1,278 @@
+# Command Reference
+
+Complete reference for all agent-browser commands. For quick start and common patterns, see SKILL.md.
+
+## Navigation
+
+```bash
+agent-browser open <url>      # Navigate to URL (aliases: goto, navigate)
+                              # Supports: https://, http://, file://, about:, data://
+                              # Auto-prepends https:// if no protocol given
+agent-browser back            # Go back
+agent-browser forward         # Go forward
+agent-browser reload          # Reload page
+agent-browser close           # Close browser (aliases: quit, exit)
+agent-browser connect 9222    # Connect to browser via CDP port
+```
+
+## Snapshot (page analysis)
+
+```bash
+agent-browser snapshot            # Full accessibility tree
+agent-browser snapshot -i         # Interactive elements only (recommended)
+agent-browser snapshot -C         # Also include cursor:pointer / onclick elements
+agent-browser snapshot -i -C      # Interactive + cursor-interactive (widest net)
+agent-browser snapshot -c         # Compact output
+agent-browser snapshot -d 3       # Limit depth to 3
+agent-browser snapshot -s "#main" # Scope to CSS selector
+```
+
+When inside an iframe (after `agent-browser frame <sel>`), snapshot and all interactions target the iframe's document — use `frame main` to return to the main page.
+
+## Interactions (use @refs from snapshot)
+
+```bash
+agent-browser click @e1           # Click
+agent-browser click @e1 --new-tab # Click and open in new tab
+agent-browser dblclick @e1        # Double-click
+agent-browser focus @e1           # Focus element
+agent-browser fill @e2 "text"     # Clear and type
+agent-browser type @e2 "text"     # Type without clearing
+agent-browser press Enter         # Press key (alias: key)
+agent-browser press Control+a     # Key combination
+agent-browser keydown Shift       # Hold key down
+agent-browser keyup Shift         # Release key
+agent-browser hover @e1           # Hover
+agent-browser check @e1           # Check checkbox
+agent-browser uncheck @e1         # Uncheck checkbox
+agent-browser select @e1 "value"  # Select dropdown option
+agent-browser select @e1 "a" "b"  # Select multiple options
+agent-browser scroll down 500     # Scroll page (default: down 300px)
+agent-browser scrollintoview @e1  # Scroll element into view (alias: scrollinto)
+agent-browser drag @e1 @e2        # Drag and drop
+agent-browser upload @e1 file.pdf # Upload files
+```
+
+## Get Information
+
+```bash
+agent-browser get text @e1        # Get element text
+agent-browser get html @e1        # Get innerHTML
+agent-browser get value @e1       # Get input value
+agent-browser get attr @e1 href   # Get attribute
+agent-browser get title           # Get page title
+agent-browser get url             # Get current URL
+agent-browser get count ".item"   # Count matching elements
+agent-browser get box @e1         # Get bounding box
+agent-browser get styles @e1      # Get computed styles (font, color, bg, etc.)
+```
+
+## Check State
+
+```bash
+agent-browser is visible @e1      # Check if visible
+agent-browser is enabled @e1      # Check if enabled
+agent-browser is checked @e1      # Check if checked
+```
+
+## Screenshots and PDF
+
+```bash
+agent-browser screenshot          # Save to temporary directory
+agent-browser screenshot path.png # Save to specific path
+agent-browser screenshot --full   # Full page
+agent-browser pdf output.pdf      # Save as PDF
+```
+
+## Video Recording
+
+```bash
+agent-browser record start ./demo.webm    # Start recording
+agent-browser click @e1                   # Perform actions
+agent-browser record stop                 # Stop and save video
+agent-browser record restart ./take2.webm # Stop current + start new
+```
+
+## Wait
+
+```bash
+agent-browser wait @e1                     # Wait for element
+agent-browser wait 2000                    # Wait milliseconds
+agent-browser wait --text "Success"        # Wait for text (or -t)
+agent-browser wait --url "**/dashboard"    # Wait for URL pattern (or -u)
+agent-browser wait --load networkidle      # Wait for network idle (or -l)
+agent-browser wait --fn "window.ready"     # Wait for JS condition (or -f)
+```
+
+## Mouse Control
+
+```bash
+agent-browser mouse move 100 200      # Move mouse
+agent-browser mouse down left         # Press button
+agent-browser mouse up left           # Release button
+agent-browser mouse wheel 100         # Scroll wheel
+```
+
+## Semantic Locators (alternative to refs)
+
+```bash
+agent-browser find role button click --name "Submit"
+agent-browser find text "Sign In" click
+agent-browser find text "Sign In" click --exact      # Exact match only
+agent-browser find label "Email" fill "user@test.com"
+agent-browser find placeholder "Search" type "query"
+agent-browser find alt "Logo" click
+agent-browser find title "Close" click
+agent-browser find testid "submit-btn" click
+agent-browser find first ".item" click
+agent-browser find last ".item" click
+agent-browser find nth 2 "a" hover
+```
+
+## Browser Settings
+
+```bash
+agent-browser set viewport 1920 1080          # Set viewport size
+agent-browser set device "iPhone 14"          # Emulate device
+agent-browser set geo 37.7749 -122.4194       # Set geolocation (alias: geolocation)
+agent-browser set offline on                  # Toggle offline mode
+agent-browser set headers '{"X-Key":"v"}'     # Extra HTTP headers
+agent-browser set credentials user pass       # HTTP basic auth (alias: auth)
+agent-browser set media dark                  # Emulate color scheme
+agent-browser set media light reduced-motion  # Light mode + reduced motion
+```
+
+## Cookies and Storage
+
+```bash
+agent-browser cookies                     # Get all cookies
+agent-browser cookies set name value      # Set cookie
+agent-browser cookies clear               # Clear cookies
+agent-browser storage local               # Get all localStorage
+agent-browser storage local key           # Get specific key
+agent-browser storage local set k v       # Set value
+agent-browser storage local clear         # Clear all
+```
+
+## Network
+
+```bash
+agent-browser network route <url>              # Intercept requests
+agent-browser network route <url> --abort      # Block requests
+agent-browser network route <url> --body '{}'  # Mock response
+agent-browser network unroute [url]            # Remove routes
+agent-browser network requests                 # View tracked requests
+agent-browser network requests --filter api    # Filter requests
+```
+
+## Tabs and Windows
+
+```bash
+agent-browser tab                 # List tabs
+agent-browser tab new [url]       # New tab
+agent-browser tab 2               # Switch to tab by index
+agent-browser tab close           # Close current tab
+agent-browser tab close 2         # Close tab by index
+agent-browser window new          # New window
+```
+
+## Frames
+
+```bash
+agent-browser frame "#iframe"             # Switch into iframe by CSS selector
+agent-browser frame ".kl-game__iframe"    # Class selector also works
+agent-browser frame main                  # Return to main page frame
+```
+
+After `frame <sel>`, all subsequent commands (`snapshot`, `click`, `get`, `eval`, etc.) operate inside the iframe — including cross-origin iframes. The frame context persists for the life of the daemon session; use `frame main` to reset.
+
+```bash
+# Typical iframe workflow
+agent-browser frame "iframe.game"   # enter iframe
+agent-browser snapshot -i           # see buttons/links inside it
+agent-browser click @e5             # click ref from that snapshot
+agent-browser frame main            # return to parent page
+```
+
+## Dialogs
+
+```bash
+agent-browser dialog accept [text]  # Accept dialog
+agent-browser dialog dismiss        # Dismiss dialog
+```
+
+## JavaScript
+
+```bash
+agent-browser eval "document.title"          # Simple expressions only
+agent-browser eval -b "<base64>"             # Any JavaScript (base64 encoded)
+agent-browser eval --stdin                   # Read script from stdin
+```
+
+Use `-b`/`--base64` or `--stdin` for reliable execution. Shell escaping with nested quotes and special characters is error-prone.
+
+```bash
+# Base64 encode your script, then:
+agent-browser eval -b "ZG9jdW1lbnQucXVlcnlTZWxlY3RvcignW3NyYyo9Il9uZXh0Il0nKQ=="
+
+# Or use stdin with heredoc for multiline scripts:
+cat <<'EOF' | agent-browser eval --stdin
+const links = document.querySelectorAll('a');
+Array.from(links).map(a => a.href);
+EOF
+```
+
+## State Management
+
+```bash
+agent-browser state save auth.json    # Save cookies, storage, auth state
+agent-browser state load auth.json    # Restore saved state
+```
+
+## Global Options
+
+```bash
+agent-browser --session <name> ...    # Isolated browser session
+agent-browser --json ...              # JSON output for parsing
+agent-browser --headed ...            # Show browser window (not headless)
+agent-browser --full ...              # Full page screenshot (-f)
+agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
+agent-browser -p <provider> ...       # Cloud browser provider (--provider)
+agent-browser --proxy <url> ...       # Use proxy server
+agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy
+agent-browser --headers <json> ...    # HTTP headers scoped to URL's origin
+agent-browser --executable-path <p>   # Custom browser executable
+agent-browser --extension <path> ...  # Load browser extension (repeatable)
+agent-browser --ignore-https-errors   # Ignore SSL certificate errors
+agent-browser --help                  # Show help (-h)
+agent-browser --version               # Show version (-V)
+agent-browser <command> --help        # Show detailed help for a command
+```
+
+## Debugging
+
+```bash
+agent-browser --headed open example.com   # Show browser window
+agent-browser --cdp 9222 snapshot         # Connect via CDP port
+agent-browser connect 9222                # Alternative: connect command
+agent-browser console                     # View console messages
+agent-browser console --clear             # Clear console
+agent-browser errors                      # View page errors
+agent-browser errors --clear              # Clear errors
+agent-browser highlight @e1               # Highlight element
+agent-browser trace start                 # Start recording trace
+agent-browser trace stop trace.zip        # Stop and save trace
+agent-browser profiler start              # Start Chrome DevTools profiling
+agent-browser profiler stop trace.json    # Stop and save profile
+```
+
+## Environment Variables
+
+```bash
+AGENT_BROWSER_SESSION="mysession"            # Default session name
+AGENT_BROWSER_EXECUTABLE_PATH="/path/chrome" # Custom browser path
+AGENT_BROWSER_EXTENSIONS="/ext1,/ext2"       # Comma-separated extension paths
+AGENT_BROWSER_PROVIDER="browserbase"         # Cloud browser provider
+AGENT_BROWSER_STREAM_PORT="9223"             # WebSocket streaming port
+AGENT_BROWSER_HOME="/path/to/agent-browser"  # Custom install location
+```

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -502,6 +502,9 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                     "-C" | "--cursor" => {
                         obj.insert("cursor".to_string(), json!(true));
                     }
+                    "-F" | "--frames" => {
+                        obj.insert("frames".to_string(), json!(true));
+                    }
                     "-d" | "--depth" => {
                         if let Some(d) = rest.get(i + 1) {
                             if let Ok(n) = d.parse::<i32>() {

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -721,4 +721,36 @@ mod tests {
         assert!(dups.contains_key("button:Submit"));
         assert!(!dups.contains_key("button:Cancel"));
     }
+
+    #[test]
+    fn test_render_tree_keeps_button_value_text_in_interactive_mode() {
+        let nodes = vec![TreeNode {
+            role: "button".to_string(),
+            name: "Agree and close: Agree to our data processing and close".to_string(),
+            level: None,
+            checked: None,
+            expanded: None,
+            selected: None,
+            disabled: None,
+            required: None,
+            value_text: Some("Agree and close".to_string()),
+            backend_node_id: None,
+            children: Vec::new(),
+            has_ref: true,
+            ref_id: Some("e1".to_string()),
+            depth: 0,
+        }];
+        let options = SnapshotOptions {
+            interactive: true,
+            ..SnapshotOptions::default()
+        };
+        let mut output = String::new();
+
+        render_tree(&nodes, 0, 0, &mut output, &options);
+
+        assert_eq!(
+            output.trim(),
+            "- button \"Agree and close: Agree to our data processing and close\" [ref=e1]: Agree and close"
+        );
+    }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2413,6 +2413,7 @@ Setup:
 Snapshot Options:
   -i, --interactive          Only interactive elements
   -C, --cursor               Also include cursor:pointer / onclick elements
+  -F, --frames               Include elements from all iframes (refs work transparently)
   -c, --compact              Remove empty structural elements
   -d, --depth <n>            Limit tree depth
   -s, --selector <sel>       Scope to CSS selector

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2346,6 +2346,7 @@ Navigation:
   back                       Go back
   forward                    Go forward
   reload                     Reload page
+  frame <sel|main>           Switch into an iframe (or 'main' to return)
 
 Get Info:  agent-browser get <what> [selector]
   text, html, value, attr <name>, title, url, count, box, styles
@@ -2411,6 +2412,7 @@ Setup:
 
 Snapshot Options:
   -i, --interactive          Only interactive elements
+  -C, --cursor               Also include cursor:pointer / onclick elements
   -c, --compact              Remove empty structural elements
   -d, --depth <n>            Limit tree depth
   -s, --selector <sel>       Scope to CSS selector

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -919,6 +919,7 @@ async function handleSnapshot(
     maxDepth?: number;
     compact?: boolean;
     selector?: string;
+    frames?: boolean;
   },
   browser: BrowserManager
 ): Promise<Response<SnapshotData>> {
@@ -929,6 +930,7 @@ async function handleSnapshot(
     maxDepth: command.maxDepth,
     compact: command.compact,
     selector: command.selector,
+    frames: command.frames,
   });
 
   // Simplify refs for output (just role and name)

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -19,7 +19,13 @@ import os from 'node:os';
 import { existsSync, mkdirSync, rmSync, readFileSync, statSync } from 'node:fs';
 import { writeFile, mkdir } from 'node:fs/promises';
 import type { LaunchCommand, TraceEvent } from './types.js';
-import { type RefMap, type EnhancedSnapshot, getEnhancedSnapshot, parseRef } from './snapshot.js';
+import {
+  type RefMap,
+  type EnhancedSnapshot,
+  getEnhancedSnapshot,
+  getMultiFrameSnapshot,
+  parseRef,
+} from './snapshot.js';
 import { safeHeaderMerge } from './state-utils.js';
 import { isDomainAllowed, installDomainFilter, parseDomainList } from './domain-filter.js';
 import {
@@ -176,8 +182,11 @@ export class BrowserManager {
     maxDepth?: number;
     compact?: boolean;
     selector?: string;
+    frames?: boolean;
   }): Promise<EnhancedSnapshot> {
-    const snapshot = await getEnhancedSnapshot(this.getFrame(), options);
+    const snapshot = options?.frames
+      ? await getMultiFrameSnapshot(this.getPage(), options)
+      : await getEnhancedSnapshot(this.getFrame(), options);
     this.refMap = snapshot.refs;
     this.lastSnapshot = snapshot.tree;
     return snapshot;
@@ -215,12 +224,28 @@ export class BrowserManager {
     const refData = this.refMap[ref];
     if (!refData) return null;
 
+    // Refs from --frames snapshots carry a frameSelector. Use frameLocator() so
+    // the click targets the right iframe without changing the active frame context.
+    if (refData.frameSelector) {
+      const fl = this.getPage().frameLocator(refData.frameSelector);
+      if (refData.role === 'clickable' || refData.role === 'focusable') {
+        return fl.locator(refData.selector);
+      }
+      let locator: Locator = fl.getByRole(refData.role as any, {
+        name: refData.name,
+        exact: true,
+      });
+      if (refData.nth !== undefined) {
+        locator = locator.nth(refData.nth);
+      }
+      return locator;
+    }
+
     const frame = this.getFrame();
 
     // Check if this is a cursor-interactive element (uses CSS selector, not ARIA role)
     // These have pseudo-roles 'clickable' or 'focusable' and a CSS selector
     if (refData.role === 'clickable' || refData.role === 'focusable') {
-      // The selector is a CSS selector, use it directly
       return frame.locator(refData.selector);
     }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -177,8 +177,7 @@ export class BrowserManager {
     compact?: boolean;
     selector?: string;
   }): Promise<EnhancedSnapshot> {
-    const page = this.getPage();
-    const snapshot = await getEnhancedSnapshot(page, options);
+    const snapshot = await getEnhancedSnapshot(this.getFrame(), options);
     this.refMap = snapshot.refs;
     this.lastSnapshot = snapshot.tree;
     return snapshot;
@@ -216,17 +215,17 @@ export class BrowserManager {
     const refData = this.refMap[ref];
     if (!refData) return null;
 
-    const page = this.getPage();
+    const frame = this.getFrame();
 
     // Check if this is a cursor-interactive element (uses CSS selector, not ARIA role)
     // These have pseudo-roles 'clickable' or 'focusable' and a CSS selector
     if (refData.role === 'clickable' || refData.role === 'focusable') {
       // The selector is a CSS selector, use it directly
-      return page.locator(refData.selector);
+      return frame.locator(refData.selector);
     }
 
     // Build locator with exact: true to avoid substring matches
-    let locator: Locator = page.getByRole(refData.role as any, {
+    let locator: Locator = frame.getByRole(refData.role as any, {
       name: refData.name,
       exact: true,
     });
@@ -310,8 +309,7 @@ export class BrowserManager {
     if (locator) return locator;
 
     // Otherwise treat as regular selector
-    const page = this.getPage();
-    return page.locator(selectorOrRef);
+    return this.getFrame().locator(selectorOrRef);
   }
 
   /**

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -226,8 +226,11 @@ export class BrowserManager {
 
     // Refs from --frames snapshots carry a frameSelector. Use frameLocator() so
     // the click targets the right iframe without changing the active frame context.
+    // When frameNth is set, use .nth() (document-wide) rather than CSS :nth-of-type
+    // (parent-scoped) to reach the correct iframe.
     if (refData.frameSelector) {
-      const fl = this.getPage().frameLocator(refData.frameSelector);
+      const baseFl = this.getPage().frameLocator(refData.frameSelector);
+      const fl = refData.frameNth !== undefined ? baseFl.nth(refData.frameNth) : baseFl;
       if (refData.role === 'clickable' || refData.role === 'focusable') {
         return fl.locator(refData.selector);
       }
@@ -388,13 +391,17 @@ export class BrowserManager {
   }
 
   /**
-   * Get the current frame (or page's main frame if no frame is selected)
+   * Get the current frame (or page's main frame if no frame is selected).
+   * Clears activeFrame if it has been detached (e.g. after navigation or tab switch)
+   * so callers never receive a stale frame handle.
    */
   getFrame(): Frame {
     if (this.activeFrame) {
-      return this.activeFrame;
+      if (!this.getPage().frames().includes(this.activeFrame)) {
+        this.activeFrame = null;
+      }
     }
-    return this.getPage().mainFrame();
+    return this.activeFrame ?? this.getPage().mainFrame();
   }
 
   /**

--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as crypto from 'crypto';
+import { existsSync, renameSync } from 'node:fs';
 import {
   encryptData,
   decryptData,
   getEncryptionKey,
+  getKeyFilePath,
   isEncryptedPayload,
   ENCRYPTION_KEY_ENV,
   IV_LENGTH,
@@ -250,8 +252,23 @@ describe('encryption', () => {
 
   describe('getEncryptionKey', () => {
     const originalEnv = process.env[ENCRYPTION_KEY_ENV];
+    const keyPath = getKeyFilePath();
+    const keyBackupPath = keyPath + '.test-backup';
+
+    beforeEach(() => {
+      // auth-vault tests running earlier in the suite may auto-generate the key
+      // file, which causes tests expecting null to fail. Temporarily move it out
+      // of the way so getEncryptionKey() falls through to the env-var-only path.
+      if (existsSync(keyPath)) {
+        renameSync(keyPath, keyBackupPath);
+      }
+    });
 
     afterEach(() => {
+      // Restore the key file if we moved it
+      if (existsSync(keyBackupPath)) {
+        renameSync(keyBackupPath, keyPath);
+      }
       // Restore original env
       if (originalEnv !== undefined) {
         process.env[ENCRYPTION_KEY_ENV] = originalEnv;

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -802,6 +802,7 @@ const snapshotSchema = baseCommandSchema.extend({
   maxDepth: z.number().nonnegative().optional(),
   compact: z.boolean().optional(),
   selector: z.string().optional(),
+  frames: z.boolean().optional(),
 });
 
 const evaluateSchema = baseCommandSchema.extend({

--- a/src/snapshot.test.ts
+++ b/src/snapshot.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getEnhancedSnapshot } from './snapshot.js';
+
+describe('getEnhancedSnapshot', () => {
+  it('keeps quoted ARIA buttons in interactive snapshots', async () => {
+    const ariaTree = `
+- document:
+  - dialog "Welcome to Børsen Consent Management":
+    - document:
+      - paragraph:
+        - button "our 89 partners"
+      - 'button "Agree and close: Agree to our data processing and close"': Agree and close
+      - 'button "Disagree and close: Disagree to our data processing and close"': Disagree and close
+      - 'button "Learn More: Configure your consents"': Learn More →
+`.trim();
+
+    const ariaSnapshot = vi.fn().mockResolvedValue(ariaTree);
+    const locator = vi.fn().mockReturnValue({ ariaSnapshot });
+    const page = { locator } as any;
+
+    const { tree, refs } = await getEnhancedSnapshot(page, { interactive: true });
+
+    expect(tree).toContain(
+      '- button "Agree and close: Agree to our data processing and close" [ref=e2]: Agree and close'
+    );
+    expect(tree).toContain(
+      '- button "Disagree and close: Disagree to our data processing and close" [ref=e3]: Disagree and close'
+    );
+    expect(tree).toContain('- button "Learn More: Configure your consents" [ref=e4]: Learn More →');
+    expect(refs.e2).toMatchObject({
+      role: 'button',
+      name: 'Agree and close: Agree to our data processing and close',
+    });
+    expect(refs.e4).toMatchObject({
+      role: 'button',
+      name: 'Learn More: Configure your consents',
+    });
+  });
+});

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -47,6 +47,13 @@ export interface SnapshotOptions {
   selector?: string;
 }
 
+interface ParsedAriaLine {
+  prefix: string;
+  role: string;
+  name?: string;
+  suffix: string;
+}
+
 // Counter for generating refs
 let refCounter = 0;
 
@@ -62,6 +69,46 @@ export function resetRefs(): void {
  */
 function nextRef(): string {
   return `e${++refCounter}`;
+}
+
+function parseAriaNodeKey(key: string): Omit<ParsedAriaLine, 'prefix'> | null {
+  const match = key.match(/^(\w+)(?:\s+"([^"]*)")?(.*)$/);
+  if (!match) return null;
+
+  const [, role, name, suffix] = match;
+  return {
+    role,
+    name,
+    suffix: suffix ?? '',
+  };
+}
+
+function parseAriaLine(line: string): ParsedAriaLine | null {
+  const standardMatch = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+  if (standardMatch) {
+    const [, prefix, role, name, suffix] = standardMatch;
+    return {
+      prefix,
+      role,
+      name,
+      suffix: suffix ?? '',
+    };
+  }
+
+  const quotedMatch = line.match(/^(\s*-\s*)'((?:[^']|'')+)'(?::\s*(.*))?$/);
+  if (!quotedMatch) return null;
+
+  const [, prefix, rawKey, value] = quotedMatch;
+  const key = rawKey.replace(/''/g, "'");
+  const parsedKey = parseAriaNodeKey(key);
+  if (!parsedKey) return null;
+
+  return {
+    prefix,
+    role: parsedKey.role,
+    name: parsedKey.name,
+    suffix: `${parsedKey.suffix}${value ? `: ${value}` : ''}`,
+  };
 }
 
 /**
@@ -393,10 +440,10 @@ function processAriaTree(ariaTree: string, refs: RefMap, options: SnapshotOption
   // For interactive-only mode, we collect just interactive elements
   if (options.interactive) {
     for (const line of lines) {
-      const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
-      if (!match) continue;
+      const parsed = parseAriaLine(line);
+      if (!parsed) continue;
 
-      const [, , role, name, suffix] = match;
+      const { role, name, suffix } = parsed;
       const roleLower = role.toLowerCase();
 
       if (INTERACTIVE_ROLES.has(roleLower)) {
@@ -416,7 +463,7 @@ function processAriaTree(ariaTree: string, refs: RefMap, options: SnapshotOption
         enhanced += ` [ref=${ref}]`;
         // Only show nth in output if it's > 0 (for readability)
         if (nth > 0) enhanced += ` [nth=${nth}]`;
-        if (suffix && suffix.includes('[')) enhanced += suffix;
+        if (suffix) enhanced += suffix;
 
         result.push(enhanced);
       }
@@ -491,9 +538,9 @@ function processLine(
   //   - button "Submit"
   //   - heading "Title" [level=1]
   //   - link "Click me":
-  const match = line.match(/^(\s*-\s*)(\w+)(?:\s+"([^"]*)")?(.*)$/);
+  const parsed = parseAriaLine(line);
 
-  if (!match) {
+  if (!parsed) {
     // Metadata lines (like /url:) or text content
     if (options.interactive) {
       // In interactive mode, only keep metadata under interactive elements
@@ -502,7 +549,7 @@ function processLine(
     return line;
   }
 
-  const [, prefix, role, name, suffix] = match;
+  const { prefix, role, name, suffix } = parsed;
   const roleLower = role.toLowerCase();
 
   // Skip metadata lines (like /url:)

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -28,6 +28,8 @@ export interface RefMap {
     nth?: number;
     /** CSS selector of the iframe containing this element (absent = main frame) */
     frameSelector?: string;
+    /** 0-based index for FrameLocator.nth() when frameSelector is a generic tag (e.g. 'iframe') */
+    frameNth?: number;
   };
 }
 
@@ -423,23 +425,37 @@ export async function getMultiFrameSnapshot(
 
   // Top-level iframes
   const iframeHandles = await page.$$('iframe');
-  for (const handle of iframeHandles) {
+  for (let iframeIndex = 0; iframeIndex < iframeHandles.length; iframeIndex++) {
+    const handle = iframeHandles[iframeIndex];
     const frame = await handle.contentFrame();
     if (!frame) continue;
 
-    // Build a stable CSS selector for this iframe element.
-    // Uses new Function to keep browser DOM globals out of TS scope.
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval
-    const iframeSelectorFn = new Function(
-      'return (el) => { ' +
-        "if (el.id) return '#' + CSS.escape(el.id); " +
-        'const cls = Array.from(el.classList)[0]; ' +
-        "if (cls) return 'iframe.' + CSS.escape(cls); " +
-        "const all = Array.from(document.querySelectorAll('iframe')); " +
-        "return 'iframe:nth-of-type(' + (all.indexOf(el) + 1) + ')'; " +
-        '}'
-    )() as (el: object) => string;
-    const iframeSelector: string = await handle.evaluate(iframeSelectorFn);
+    // Build the most specific CSS selector available for this iframe.
+    // Prefer id > src attribute > class.
+    // Fallback: store 'iframe' + iframeIndex so getLocatorFromRef can use
+    // FrameLocator.nth(n), which is document-wide (unlike CSS :nth-of-type
+    // which is parent-scoped and would point at the wrong element).
+    let iframeSelector: string;
+    let iframeNth: number | undefined;
+
+    const iframeId = await handle.getAttribute('id');
+    if (iframeId) {
+      iframeSelector = `#${iframeId}`;
+    } else {
+      const srcAttr = await handle.getAttribute('src');
+      if (srcAttr) {
+        iframeSelector = `iframe[src=${JSON.stringify(srcAttr)}]`;
+      } else {
+        const clsAttr = await handle.getAttribute('class');
+        const firstCls = clsAttr?.trim().split(/\s+/)[0];
+        if (firstCls) {
+          iframeSelector = `iframe.${firstCls}`;
+        } else {
+          iframeSelector = 'iframe';
+          iframeNth = iframeIndex;
+        }
+      }
+    }
 
     let frameResult: EnhancedSnapshot;
     try {
@@ -453,10 +469,15 @@ export async function getMultiFrameSnapshot(
 
     // Tag all refs from this iframe so getLocatorFromRef uses frameLocator()
     for (const [ref, data] of Object.entries(frameResult.refs)) {
-      allRefs[ref] = { ...data, frameSelector: iframeSelector };
+      allRefs[ref] = { ...data, frameSelector: iframeSelector, frameNth: iframeNth };
     }
 
-    parts.push(`# [iframe: ${iframeSelector}]\n${frameResult.tree}`);
+    // Human-readable label for the snapshot output
+    const label =
+      iframeId ??
+      (await handle.getAttribute('class'))?.trim().split(/\s+/)[0] ??
+      `iframe[${iframeIndex + 1}]`;
+    parts.push(`# [iframe: ${label}]\n${frameResult.tree}`);
   }
 
   const tree = parts.join('\n\n') || '(no interactive elements)';

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -26,6 +26,8 @@ export interface RefMap {
     name: string;
     /** Index for disambiguation when multiple elements have same role+name */
     nth?: number;
+    /** CSS selector of the iframe containing this element (absent = main frame) */
+    frameSelector?: string;
   };
 }
 
@@ -45,6 +47,8 @@ export interface SnapshotOptions {
   compact?: boolean;
   /** CSS selector to scope the snapshot */
   selector?: string;
+  /** Also snapshot all iframes and merge results (refs carry frameSelector for transparent clicking) */
+  frames?: boolean;
 }
 
 interface ParsedAriaLine {
@@ -308,13 +312,13 @@ async function findCursorInteractiveElements(
 }
 
 /**
- * Get enhanced snapshot with refs and optional filtering
+ * Snapshot a single frame without resetting the ref counter.
+ * Used internally by getEnhancedSnapshot and getMultiFrameSnapshot.
  */
-export async function getEnhancedSnapshot(
+async function snapshotFrame(
   page: Page | Frame,
-  options: SnapshotOptions = {}
+  options: SnapshotOptions
 ): Promise<EnhancedSnapshot> {
-  resetRefs();
   const refs: RefMap = {};
 
   // Get ARIA snapshot from Playwright
@@ -380,6 +384,83 @@ export async function getEnhancedSnapshot(
   }
 
   return { tree: enhancedTree, refs };
+}
+
+/**
+ * Get enhanced snapshot with refs and optional filtering.
+ * Resets the ref counter — use getMultiFrameSnapshot when you need refs
+ * from multiple frames to share a single counter.
+ */
+export async function getEnhancedSnapshot(
+  page: Page | Frame,
+  options: SnapshotOptions = {}
+): Promise<EnhancedSnapshot> {
+  resetRefs();
+  return snapshotFrame(page, options);
+}
+
+/**
+ * Snapshot the main page plus every top-level iframe in a single pass.
+ * All refs share one counter so e.g. e1-e83 are main-frame elements and
+ * e84+ are from iframes. Each iframe ref stores a frameSelector so
+ * getLocatorFromRef can use frameLocator() instead of the active frame.
+ */
+export async function getMultiFrameSnapshot(
+  page: Page,
+  options: SnapshotOptions = {}
+): Promise<EnhancedSnapshot> {
+  resetRefs();
+  const allRefs: RefMap = {};
+  const parts: string[] = [];
+
+  // Main frame
+  const mainResult = await snapshotFrame(page.mainFrame(), options);
+  Object.assign(allRefs, mainResult.refs);
+  const EMPTY = new Set(['(empty)', '(no interactive elements)']);
+  if (mainResult.tree && !EMPTY.has(mainResult.tree)) {
+    parts.push(mainResult.tree);
+  }
+
+  // Top-level iframes
+  const iframeHandles = await page.$$('iframe');
+  for (const handle of iframeHandles) {
+    const frame = await handle.contentFrame();
+    if (!frame) continue;
+
+    // Build a stable CSS selector for this iframe element.
+    // Uses new Function to keep browser DOM globals out of TS scope.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const iframeSelectorFn = new Function(
+      'return (el) => { ' +
+        "if (el.id) return '#' + CSS.escape(el.id); " +
+        'const cls = Array.from(el.classList)[0]; ' +
+        "if (cls) return 'iframe.' + CSS.escape(cls); " +
+        "const all = Array.from(document.querySelectorAll('iframe')); " +
+        "return 'iframe:nth-of-type(' + (all.indexOf(el) + 1) + ')'; " +
+        '}'
+    )() as (el: object) => string;
+    const iframeSelector: string = await handle.evaluate(iframeSelectorFn);
+
+    let frameResult: EnhancedSnapshot;
+    try {
+      frameResult = await snapshotFrame(frame, options);
+    } catch {
+      // iframe may be sandboxed or not yet loaded — skip silently
+      continue;
+    }
+
+    if (!frameResult.tree || EMPTY.has(frameResult.tree)) continue;
+
+    // Tag all refs from this iframe so getLocatorFromRef uses frameLocator()
+    for (const [ref, data] of Object.entries(frameResult.refs)) {
+      allRefs[ref] = { ...data, frameSelector: iframeSelector };
+    }
+
+    parts.push(`# [iframe: ${iframeSelector}]\n${frameResult.tree}`);
+  }
+
+  const tree = parts.join('\n\n') || '(no interactive elements)';
+  return { tree, refs: allRefs };
 }
 
 /**

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -17,7 +17,7 @@
  *   agent-browser click @e2             # Click element by ref
  */
 
-import type { Page, Locator } from 'playwright-core';
+import type { Page, Frame, Locator } from 'playwright-core';
 
 export interface RefMap {
   [ref: string]: {
@@ -187,7 +187,7 @@ function buildSelector(role: string, name: string): string {
  * This finds elements with cursor: pointer or onclick handlers.
  */
 async function findCursorInteractiveElements(
-  page: Page,
+  page: Page | Frame,
   selector?: string
 ): Promise<
   Array<{
@@ -311,7 +311,7 @@ async function findCursorInteractiveElements(
  * Get enhanced snapshot with refs and optional filtering
  */
 export async function getEnhancedSnapshot(
-  page: Page,
+  page: Page | Frame,
   options: SnapshotOptions = {}
 ): Promise<EnhancedSnapshot> {
   resetRefs();


### PR DESCRIPTION
## Problem

Two related iframe issues:

**1. Bug: `frame <sel>` context was silently ignored**
After switching into an iframe with `frame <sel>`, all subsequent commands (`snapshot`, `click`, `fill`, `get`, etc.) still targeted the main page. Three call sites in `BrowserManager` called `getPage()` instead of `getFrame()`, bypassing the active frame state entirely. Cross-origin iframes were completely invisible.

**2. UX: discovering iframe content required prior DOM knowledge**
Even with the bug fixed, you had to know an iframe existed, find its selector, run `frame <sel>`, then `snapshot`. Non-frontend developers had no way to discover that content was inside an iframe without inspecting the DOM manually.

## Solution

### `snapshot --frames` / `-F` — the headline feature

One flag gets you everything: interactive elements from the main page and every iframe, merged into a single ref list, no knowledge of the DOM structure required:

```bash
# Before: had to know the iframe existed, find its selector, switch context manually
agent-browser open "https://danskespil.dk/klublotto/dagens-ordknuden"
agent-browser frame "iframe.kl-game__iframe"   # had to know this
agent-browser snapshot -i                      # only then could you see buttons

# After: one command, everything visible
agent-browser open "https://danskespil.dk/klublotto/dagens-ordknuden"
agent-browser snapshot -i -F
# - button "Log ind" [ref=e10]
# - link "Spil & Quiz" [ref=e6]
# ... (main page elements)
#
# # [iframe: iframe.kl-game__iframe]
# - button "q" [ref=e84]
# - button "w" [ref=e85]
# ...
# - button "Retur" [ref=e114]
# - button "" [ref=e115]    ← backspace

# And clicking just works — no frame switching needed at all
agent-browser click @e85    # types "w" inside the cross-origin iframe
agent-browser click @e114   # submits — refs are fully transparent
```

Refs from iframes carry a `frameSelector` internally. `getLocatorFromRef` uses `page.frameLocator(selector)` for those refs so the caller never needs to know or care that the element is inside an iframe.

### Bug fix: `frame <sel>` now actually works (`src/browser.ts`, `src/snapshot.ts`)

`getSnapshot`, `getLocatorFromRef`, and `getLocator` now call `getFrame()` instead of `getPage()`. `getEnhancedSnapshot` / `findCursorInteractiveElements` widened from `Page` to `Page | Frame`. The `frame` command is still useful when you want to work exclusively inside one iframe across many commands — it's more efficient than re-running `--frames` on every snapshot.

### Internals

`getEnhancedSnapshot` is refactored into a `snapshotFrame` inner function (no counter reset) plus a thin public wrapper, so `getMultiFrameSnapshot` can share one ref counter across all frames and avoid collisions between main and iframe refs.

### Help text fixes (`cli/src/output.rs`)

- `frame <sel|main>` was implemented in the Rust CLI but never added to `--help`
- `-C / --cursor` was parsed but undocumented
- `-F / --frames` added to both parser and help text

## Changed files

| File | Change |
|---|---|
| `src/browser.ts` | `getSnapshot`, `getLocatorFromRef`, `getLocator` use `getFrame()`; route `frames:true` to `getMultiFrameSnapshot`; use `frameLocator()` for iframe refs |
| `src/snapshot.ts` | `Page \| Frame` type; refactor into `snapshotFrame` + wrapper; add `getMultiFrameSnapshot`; add `frameSelector` to `RefMap` |
| `src/protocol.ts` | Add `frames` field to snapshot schema |
| `src/actions.ts` | Pass `frames` through to `browser.getSnapshot` |
| `cli/src/commands.rs` | Parse `-F / --frames` for snapshot command |
| `cli/src/output.rs` | Add `frame` to Navigation; add `-C` and `-F` to Snapshot Options |
| `.agents/…/commands.md` | Document `-C`, `-F`; expand Frames section |

## Test plan

- [ ] `snapshot -i -F` returns elements from main page and all iframes in one output, refs work with `click`/`fill`/`get` without any `frame` command
- [ ] `frame <sel>` + `snapshot -i` still works for single-iframe focus workflow
- [ ] `snapshot -i` without `-F` is unchanged (no regression, no extra latency)
- [ ] `--help` shows `frame` under Navigation, `-C` and `-F` under Snapshot Options
- [ ] Sandboxed/unloaded iframes are skipped silently (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)