### PR TITLE
feat: add -F/--frames flag to snapshot for transparent iframe element discovery

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -717,6 +717,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     "-C" | "--cursor" => {
                         obj.insert("cursor".to_string(), json!(true));
                     }
+                    "-F" | "--frames" => {
+                        obj.insert("frames".to_string(), json!(true));
+                    }
                     "-u" | "--urls" => {
                         obj.insert("urls".to_string(), json!(true));
                     }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2485,6 +2485,10 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
             .and_then(|v| v.as_u64())
             .map(|d| d as usize),
         urls: cmd.get("urls").and_then(|v| v.as_bool()).unwrap_or(false),
+        frames: cmd
+            .get("frames")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
     };
 
     state.ref_map.clear();

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -1583,4 +1583,46 @@ mod tests {
 
         assert_eq!(nodes[0].role, "LabelText"); // unchanged
     }
+
+    // -----------------------------------------------------------------------
+    // render_tree: value_text handling
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_render_tree_keeps_button_value_text_in_interactive_mode() {
+        // A button whose value_text differs from its name should render
+        // "role \"name\" [ref=eN]: value_text" — the value suffix must not be
+        // dropped when interactive mode is on.
+        let nodes = vec![TreeNode {
+            role: "button".to_string(),
+            name: "Agree and close: Agree to our data processing and close".to_string(),
+            level: None,
+            checked: None,
+            expanded: None,
+            selected: None,
+            disabled: None,
+            required: None,
+            value_text: Some("Agree and close".to_string()),
+            backend_node_id: None,
+            children: Vec::new(),
+            parent_idx: None,
+            has_ref: true,
+            ref_id: Some("e1".to_string()),
+            depth: 0,
+            cursor_info: None,
+            url: None,
+        }];
+        let options = SnapshotOptions {
+            interactive: true,
+            ..SnapshotOptions::default()
+        };
+        let mut output = String::new();
+
+        render_tree(&nodes, 0, 0, &mut output, &options);
+
+        assert_eq!(
+            output.trim(),
+            "- button \"Agree and close: Agree to our data processing and close\" [ref=e1]: Agree and close"
+        );
+    }
 }

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -81,6 +81,10 @@ pub struct SnapshotOptions {
     pub compact: bool,
     pub depth: Option<usize>,
     pub urls: bool,
+    /// When true, recurse into child iframes and inline their content.
+    /// Element refs from iframes carry frame context, so interactions
+    /// (click/fill/type) work without manually switching frames.
+    pub frames: bool,
 }
 
 struct TreeNode {
@@ -491,7 +495,8 @@ pub async fn take_snapshot(
     // resolve the child frame ID and take a snapshot of its content.
     // We only recurse from the main frame (frame_id == None) to avoid
     // unbounded depth; nested iframes within iframes are not expanded.
-    if frame_id.is_none() {
+    // Recursion is opt-in: requires options.frames == true (-F / --frames).
+    if options.frames && frame_id.is_none() {
         let mut iframe_snapshots: Vec<(String, String)> = Vec::new(); // (ref_id, child_snapshot)
         for node in tree_nodes.iter() {
             if node.role != "Iframe" || !node.has_ref {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1745,14 +1745,15 @@ Returns an accessibility tree representation of the page with element
 references (like @e1, @e2) that can be used in subsequent commands.
 Designed for AI agents to understand page structure.
 
-Iframes are automatically detected and inlined. When the main-frame
-snapshot runs, each Iframe node is resolved and its child accessibility
-tree is appended beneath it in the output. Element refs inside iframes
-carry frame context, so click/fill/type work without manually switching
-frames. Use 'frame <sel|@ref>' then 'snapshot -i' to scope to one iframe.
+Use -F to include iframe content. When the main-frame snapshot runs with
+-F, each Iframe node is resolved and its child accessibility tree is
+appended beneath it in the output. Element refs inside iframes carry frame
+context, so click/fill/type work without manually switching frames.
+Use 'frame <sel|@ref>' then 'snapshot -i' to scope to one iframe.
 
 Options:
   -i, --interactive    Only include interactive elements
+  -F, --frames         Include elements from all iframes (refs work transparently)
   -u, --urls           Include href URLs for link elements
   -c, --compact        Remove empty structural elements
   -d, --depth <n>      Limit tree depth
@@ -3175,6 +3176,7 @@ Setup:
 
 Snapshot Options:
   -i, --interactive          Only interactive elements
+  -F, --frames               Include elements from all iframes (refs work transparently)
   -c, --compact              Remove empty structural elements
   -d, --depth <n>            Limit tree depth
   -s, --selector <sel>       Scope to CSS selector

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1745,6 +1745,12 @@ Returns an accessibility tree representation of the page with element
 references (like @e1, @e2) that can be used in subsequent commands.
 Designed for AI agents to understand page structure.
 
+Iframes are automatically detected and inlined. When the main-frame
+snapshot runs, each Iframe node is resolved and its child accessibility
+tree is appended beneath it in the output. Element refs inside iframes
+carry frame context, so click/fill/type work without manually switching
+frames. Use 'frame <sel|@ref>' then 'snapshot -i' to scope to one iframe.
+
 Options:
   -i, --interactive    Only include interactive elements
   -u, --urls           Include href URLs for link elements
@@ -3054,6 +3060,7 @@ Navigation:
   back                       Go back
   forward                    Go forward
   reload                     Reload page
+  frame <sel|main>           Switch into an iframe (or 'main' to return)
 
 Get Info:  agent-browser get <what> [selector]
   text, html, value, attr <name>, title, url, count, box, styles, cdp-url


### PR DESCRIPTION
## Summary

- **New `-F` / `--frames` flag** on `snapshot`: opt-in to inlining iframe content alongside the main frame. Without it, snapshot shows only the main-frame tree (fast, no noise from ad/tracker iframes). With it, each Iframe node's child accessibility tree is appended beneath it in the output and element refs carry frame context.
- **`frame <sel|main>` added to the Navigation section** of `--help` so the command is discoverable alongside back/forward/reload.
- **`agent-browser help snapshot`** documents the new flag and explains transparent ref behaviour.
- **Regression test** for value_text rendering on buttons in interactive mode.

## Usage

```bash
# Snapshot + iframe content in one shot
agent-browser snapshot -i -F

# Example output
# - Iframe "game" [ref=e3]
#   - button "A" [ref=e4]   ← cross-origin iframe button
#   - button "B" [ref=e5]

# Refs inside iframes work transparently — no frame-switching required
agent-browser click @e4

# Or scope to a single iframe for a focused snapshot
agent-browser frame @e3
agent-browser snapshot -i
agent-browser frame main
```

## Changes

| File | Change |
|---|---|
| `cli/src/native/snapshot.rs` | Add `frames: bool` to `SnapshotOptions`; gate iframe recursion behind `options.frames` |
| `cli/src/native/actions.rs` | Wire `frames` field through `handle_snapshot` |
| `cli/src/commands.rs` | Parse `-F` / `--frames` snapshot flag |
| `cli/src/output.rs` | Document `-F` in `help snapshot` and Snapshot Options; add `frame` to Navigation |

## Test plan

- [x] `cargo test` — 741 tests pass (one pre-existing flaky env-var test only fails under parallel execution, not in isolation)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `agent-browser --help` shows `frame <sel|main>` under Navigation and `-F` under Snapshot Options
- [x] `agent-browser help snapshot` shows iframe paragraph with `-F` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)