### PR TITLE
fix: retry click with force:true when element has infinite CSS animation

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -36,4 +36,31 @@ describe('toAIFriendlyError', () => {
       expect(result.message).toContain('cookie banners');
     });
   });
+
+  describe('element is not stable (infinite CSS animation)', () => {
+    // Playwright's stability check times out when a button has an infinite CSS
+    // animation (e.g. a pulsing "call to action" effect in a game UI).
+    // handleClick catches this specific error and retries with force:true rather
+    // than surfacing a generic timeout to the user.
+    //
+    // If the force retry itself fails, the error reaches toAIFriendlyError.
+    // Verify it is treated as a generic action timeout (not "not found").
+    it('not-stable timeout falls back to generic timed-out message', () => {
+      const error = new Error(
+        'locator.click: Timeout 25000ms exceeded.\nCall log:\n' +
+          "  - waiting for getByRole('button', { name: 'Gæt', exact: true })\n" +
+          "  - locator resolved to <button class='_enter _q'>Gæt</button>\n" +
+          '  - attempting click action\n' +
+          '    - waiting for element to be visible, enabled and stable\n' +
+          '    - element is not stable\n' +
+          '    - retrying click action'
+      );
+
+      const result = toAIFriendlyError(error, '@e34');
+
+      expect(result.message).toContain('timed out');
+      expect(result.message).not.toContain('not found');
+      expect(result.message).not.toContain('not visible');
+    });
+  });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -669,6 +669,35 @@ async function handleClick(command: ClickCommand, browser: BrowserManager): Prom
       delay: command.delay,
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Playwright's stability check refuses to click elements that have an active
+    // CSS animation (it waits for the element to be "stable"). Some apps — e.g.
+    // game UIs — apply infinite pulse/glow animations to call-to-action buttons
+    // to draw the user's attention.  When the stability check repeatedly finds
+    // the element "not stable" it eventually times out (25 s default).
+    //
+    // Detection: the Playwright call-log includes "element is not stable" when
+    // this is the actual blocking reason inside a generic Timeout error.
+    //
+    // Fix: retry once with `force: true` which bypasses the stability check
+    // while preserving all other actionability checks (visibility, enabled state,
+    // not covered by another element).  This is safe because we already verified
+    // the element is attached and visible before the first attempt.
+    if (message.includes('element is not stable')) {
+      try {
+        await locator.click({
+          button: command.button,
+          clickCount: command.clickCount,
+          delay: command.delay,
+          force: true,
+        });
+        return successResponse(command.id, { clicked: true });
+      } catch (forceError) {
+        throw toAIFriendlyError(forceError, command.selector);
+      }
+    }
+
     throw toAIFriendlyError(error, command.selector);
   }
 


### PR DESCRIPTION
## Root Cause

Playwright's `locator.click()` waits for the target element to be **stable** (no active CSS animations/transitions) before dispatching the click. Some apps — game UIs in particular — apply **infinite** pulse/glow animations to call-to-action buttons to draw the user's attention. When this happens Playwright retries every 500 ms for the full 25-second timeout and then gives up.

### Confirmed via Playwright trace

After clicking a letter key in a word-game UI, the submit button receives a CSS class that starts a **continuous glowing animation**. The trace shows:

```
locator resolved to <button class="_key ... _enter _q">Gæt</button>
attempting click action
  waiting for element to be visible, enabled and stable
  element is not stable         ← repeated 50+ times
retrying click action
  waiting 500ms
  ...
locator.click: Timeout 25000ms exceeded.
```

The button is completely visible and enabled — only the stability check blocks it.

## Fix

When `locator.click()` times out and the call-log contains **"element is not stable"**, immediately retry once with `{ force: true }`. This bypasses only the stability check while keeping all other actionability checks (visibility, enabled state, pointer-events coverage) intact on the first attempt. Using `force` as a fallback means genuinely uninteractable elements still produce a meaningful error.

```diff
  } catch (error) {
+   const message = error instanceof Error ? error.message : String(error);
+   if (message.includes('element is not stable')) {
+     // Retry once with force:true to bypass the stability check for
+     // elements with infinite CSS animations (e.g. pulsing game buttons).
+     try {
+       await locator.click({ button, clickCount, delay, force: true });
+       return successResponse(command.id, { clicked: true });
+     } catch (forceError) {
+       throw toAIFriendlyError(forceError, command.selector);
+     }
+   }
    throw toAIFriendlyError(error, command.selector);
  }
```

The detection string `"element is not stable"` is specific to Playwright's stability check and does not overlap with the existing "intercepts pointer events" (overlay) or "not visible" checks, so there is no risk of masking other failure modes.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] New regression test documents the expected fallback behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)