### PR TITLE
Pin Linux release glibc floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
         if: matrix.use_zigbuild
         run: |
           pip3 install ziglang
-          cargo install cargo-zigbuild
+          cargo install cargo-zigbuild --version 0.22.3 --locked
 
       - name: Configure Rust linkers
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,37 +74,44 @@ jobs:
         include:
           - name: Linux x64
             os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            rust_target: x86_64-unknown-linux-gnu
+            build_target: x86_64-unknown-linux-gnu.2.28
             binary: agent-browser-linux-x64
             use_zigbuild: true
           - name: Linux ARM64
             os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            rust_target: aarch64-unknown-linux-gnu
+            build_target: aarch64-unknown-linux-gnu.2.28
             binary: agent-browser-linux-arm64
             use_zigbuild: true
           - name: Linux musl x64
             os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            rust_target: x86_64-unknown-linux-musl
+            build_target: x86_64-unknown-linux-musl
             binary: agent-browser-linux-musl-x64
             use_zigbuild: true
           - name: Linux musl ARM64
             os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
+            rust_target: aarch64-unknown-linux-musl
+            build_target: aarch64-unknown-linux-musl
             binary: agent-browser-linux-musl-arm64
             use_zigbuild: true
           - name: Windows x64
             os: ubuntu-latest
-            target: x86_64-pc-windows-gnu
+            rust_target: x86_64-pc-windows-gnu
+            build_target: x86_64-pc-windows-gnu
             binary: agent-browser-win32-x64.exe
             use_zigbuild: false
           - name: macOS x64
             os: macos-latest
-            target: x86_64-apple-darwin
+            rust_target: x86_64-apple-darwin
+            build_target: x86_64-apple-darwin
             binary: agent-browser-darwin-x64
             use_zigbuild: false
           - name: macOS ARM64
             os: macos-latest
-            target: aarch64-apple-darwin
+            rust_target: aarch64-apple-darwin
+            build_target: aarch64-apple-darwin
             binary: agent-browser-darwin-arm64
             use_zigbuild: false
 
@@ -133,7 +140,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.rust_target }}
 
       - name: Install cross-compilation tools (Linux)
         if: runner.os == 'Linux'
@@ -166,21 +173,31 @@ jobs:
 
       - name: Build with zigbuild
         if: matrix.use_zigbuild
-        run: cargo zigbuild --release --manifest-path cli/Cargo.toml --target ${{ matrix.target }}
+        run: cargo zigbuild --release --manifest-path cli/Cargo.toml --target ${{ matrix.build_target }}
 
       - name: Build with cargo
         if: '!matrix.use_zigbuild'
-        run: cargo build --release --manifest-path cli/Cargo.toml --target ${{ matrix.target }}
+        run: cargo build --release --manifest-path cli/Cargo.toml --target ${{ matrix.rust_target }}
 
       - name: Copy binary
         run: |
           mkdir -p artifacts
-          if [[ "${{ matrix.target }}" == *"windows"* ]]; then
-            cp cli/target/${{ matrix.target }}/release/agent-browser.exe artifacts/${{ matrix.binary }}
+          if [[ "${{ matrix.rust_target }}" == *"windows"* ]]; then
+            cp cli/target/${{ matrix.rust_target }}/release/agent-browser.exe artifacts/${{ matrix.binary }}
           else
-            cp cli/target/${{ matrix.target }}/release/agent-browser artifacts/${{ matrix.binary }}
+            cp cli/target/${{ matrix.rust_target }}/release/agent-browser artifacts/${{ matrix.binary }}
             chmod +x artifacts/${{ matrix.binary }}
           fi
+
+      - name: Verify Linux GNU glibc floor
+        if: matrix.binary == 'agent-browser-linux-x64' || matrix.binary == 'agent-browser-linux-arm64'
+        run: |
+          set -euo pipefail
+          if objdump -p artifacts/${{ matrix.binary }} | grep -E 'GLIBC_2\.([3-9][0-9]|29)'; then
+            echo "ERROR: ${{ matrix.binary }} requires glibc newer than 2.28"
+            exit 1
+          fi
+          objdump -p artifacts/${{ matrix.binary }} | sed -n '/Version References:/,$p'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,5 +1,5 @@
 # Multi-platform Rust cross-compilation image
-FROM rust:1.85-bookworm
+FROM rust:1.88-bookworm
 
 # Install cross-compilation toolchains
 RUN apt-get update && apt-get install -y \
@@ -21,7 +21,7 @@ RUN rustup target add \
 # Install cargo-zigbuild for easier cross-compilation (especially macOS)
 RUN curl -sSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | tar -xJ -C /opt \
     && ln -s /opt/zig-linux-x86_64-0.13.0/zig /usr/local/bin/zig
-RUN cargo install cargo-zigbuild
+RUN cargo install cargo-zigbuild --version 0.22.3 --locked
 
 # Configure linkers for cross-compilation
 RUN mkdir -p /.cargo

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y \
 RUN rustup target add \
     x86_64-unknown-linux-gnu \
     aarch64-unknown-linux-gnu \
+    x86_64-unknown-linux-musl \
+    aarch64-unknown-linux-musl \
     x86_64-apple-darwin \
     aarch64-apple-darwin \
     x86_64-pc-windows-gnu

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,13 +83,36 @@ services:
         rust_target="$${RUST_TARGET:-}"
         build_target="$${BUILD_TARGET:-}"
         legacy_target="$${TARGET:-}"
+        legacy_rust_target=""
+        legacy_build_target=""
 
-        if [ -z "$$rust_target" ] && [ -n "$$legacy_target" ]; then
-          rust_target="$$legacy_target"
+        if [ -n "$$legacy_target" ]; then
+          case "$$legacy_target" in
+            x86_64-unknown-linux-gnu.*)
+              legacy_rust_target="x86_64-unknown-linux-gnu"
+              legacy_build_target="$$legacy_target"
+              ;;
+            aarch64-unknown-linux-gnu.*)
+              legacy_rust_target="aarch64-unknown-linux-gnu"
+              legacy_build_target="$$legacy_target"
+              ;;
+            x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu)
+              legacy_rust_target="$$legacy_target"
+              legacy_build_target="$$legacy_target.2.28"
+              ;;
+            *)
+              legacy_rust_target="$$legacy_target"
+              legacy_build_target="$$legacy_target"
+              ;;
+          esac
         fi
 
-        if [ -z "$$build_target" ] && [ -n "$$legacy_target" ]; then
-          build_target="$$legacy_target"
+        if [ -z "$$rust_target" ] && [ -n "$$legacy_rust_target" ]; then
+          rust_target="$$legacy_rust_target"
+        fi
+
+        if [ -z "$$build_target" ] && [ -n "$$legacy_build_target" ]; then
+          build_target="$$legacy_build_target"
         fi
 
         if [ -z "$$rust_target" ]; then

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,36 +83,55 @@ services:
         rust_target="$${RUST_TARGET:-}"
         build_target="$${BUILD_TARGET:-}"
         legacy_target="$${TARGET:-}"
-        legacy_rust_target=""
-        legacy_build_target=""
 
-        if [ -n "$$legacy_target" ]; then
-          case "$$legacy_target" in
+        normalize_rust_target() {
+          case "$$1" in
             x86_64-unknown-linux-gnu.*)
-              legacy_rust_target="x86_64-unknown-linux-gnu"
-              legacy_build_target="$$legacy_target"
+              printf "%s\n" "x86_64-unknown-linux-gnu"
               ;;
             aarch64-unknown-linux-gnu.*)
-              legacy_rust_target="aarch64-unknown-linux-gnu"
-              legacy_build_target="$$legacy_target"
-              ;;
-            x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu)
-              legacy_rust_target="$$legacy_target"
-              legacy_build_target="$$legacy_target.2.28"
+              printf "%s\n" "aarch64-unknown-linux-gnu"
               ;;
             *)
-              legacy_rust_target="$$legacy_target"
-              legacy_build_target="$$legacy_target"
+              printf "%s\n" "$$1"
               ;;
           esac
+        }
+
+        derive_build_target() {
+          case "$$1" in
+            x86_64-unknown-linux-gnu.*|aarch64-unknown-linux-gnu.*)
+              printf "%s\n" "$$1"
+              ;;
+            x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu)
+              printf "%s.2.28\n" "$$1"
+              ;;
+            *)
+              printf "%s\n" "$$1"
+              ;;
+          esac
+        }
+
+        if [ -n "$$rust_target" ]; then
+          rust_target="$$(normalize_rust_target "$$rust_target")"
         fi
 
-        if [ -z "$$rust_target" ] && [ -n "$$legacy_rust_target" ]; then
-          rust_target="$$legacy_rust_target"
+        if [ -n "$$legacy_target" ]; then
+          if [ -z "$$rust_target" ]; then
+            rust_target="$$(normalize_rust_target "$$legacy_target")"
+          fi
+
+          if [ -z "$$build_target" ]; then
+            build_target="$$(derive_build_target "$$legacy_target")"
+          fi
         fi
 
-        if [ -z "$$build_target" ] && [ -n "$$legacy_build_target" ]; then
-          build_target="$$legacy_build_target"
+        if [ -z "$$rust_target" ] && [ -n "$$build_target" ]; then
+          rust_target="$$(normalize_rust_target "$$build_target")"
+        fi
+
+        if [ -z "$$build_target" ] && [ -n "$$rust_target" ]; then
+          build_target="$$(derive_build_target "$$rust_target")"
         fi
 
         if [ -z "$$rust_target" ]; then
@@ -120,7 +139,13 @@ services:
         fi
 
         if [ -z "$$build_target" ]; then
-          build_target="x86_64-unknown-linux-gnu.2.28"
+          build_target="$$(derive_build_target "$$rust_target")"
+        fi
+
+        expected_rust_target="$$(normalize_rust_target "$$build_target")"
+        if [ "$$expected_rust_target" != "$$rust_target" ]; then
+          echo "ERROR: BUILD_TARGET ($$build_target) maps to $$expected_rust_target, but RUST_TARGET is $$rust_target"
+          exit 1
         fi
 
         rm -f /output/$$OUTPUT_NAME

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@
 services:
   # Build for Linux platforms
   build-linux:
+    platform: linux/amd64
     build:
       context: ..
       dockerfile: docker/Dockerfile.build
@@ -19,14 +20,14 @@ services:
         echo "Building for Linux platforms (parallel)..."
         
         # Build both targets in parallel
-        (echo "→ Linux x64" && cargo zigbuild --release --target x86_64-unknown-linux-gnu && cp /build/target/x86_64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-x64 && chmod +x /output/agent-browser-linux-x64 && echo "✓ Linux x64 done") &
+        (echo "→ Linux x64" && cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28 && cp /build/target/x86_64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-x64 && chmod +x /output/agent-browser-linux-x64 && echo "✓ Linux x64 done") &
         PID1=$!
         
-        (echo "→ Linux ARM64" && cargo zigbuild --release --target aarch64-unknown-linux-gnu && cp /build/target/aarch64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-arm64 && chmod +x /output/agent-browser-linux-arm64 && echo "✓ Linux ARM64 done") &
+        (echo "→ Linux ARM64" && cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.28 && cp /build/target/aarch64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-arm64 && chmod +x /output/agent-browser-linux-arm64 && echo "✓ Linux ARM64 done") &
         PID2=$!
         
         # Wait for both to complete
-        wait $PID1 $PID2
+        wait $$PID1 $$PID2
         
         echo ""
         echo "✓ Linux platforms built successfully!"
@@ -35,6 +36,7 @@ services:
 
   # Build for Windows
   build-windows:
+    platform: linux/amd64
     build:
       context: ..
       dockerfile: docker/Dockerfile.build
@@ -54,8 +56,9 @@ services:
         ls -la /output/agent-browser-win32-*
       '
 
-  # Build for a single target (override with TARGET env var)
+  # Build for a single target
   build-single:
+    platform: linux/amd64
     build:
       context: ..
       dockerfile: docker/Dockerfile.build
@@ -63,12 +66,13 @@ services:
       - ../cli:/build
       - ../bin:/output
     environment:
-      - TARGET=${TARGET:-x86_64-unknown-linux-gnu}
+      - RUST_TARGET=${RUST_TARGET:-x86_64-unknown-linux-gnu}
+      - BUILD_TARGET=${BUILD_TARGET:-x86_64-unknown-linux-gnu.2.28}
       - OUTPUT_NAME=${OUTPUT_NAME:-agent-browser-linux-x64}
     command: |
       -c '
-        cargo zigbuild --release --target $TARGET
-        cp /build/target/$TARGET/release/agent-browser* /output/$OUTPUT_NAME
-        chmod +x /output/$OUTPUT_NAME 2>/dev/null || true
-        echo "✓ Built $OUTPUT_NAME"
+        cargo zigbuild --release --target $$BUILD_TARGET
+        cp /build/target/$$RUST_TARGET/release/agent-browser* /output/$$OUTPUT_NAME
+        chmod +x /output/$$OUTPUT_NAME 2>/dev/null || true
+        echo "✓ Built $$OUTPUT_NAME"
       '

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,18 +72,39 @@ services:
       - ../cli:/build
       - ../bin:/output
     environment:
-      - RUST_TARGET=${RUST_TARGET:-x86_64-unknown-linux-gnu}
-      - BUILD_TARGET=${BUILD_TARGET:-x86_64-unknown-linux-gnu.2.28}
+      - TARGET=${TARGET:-}
+      - RUST_TARGET=${RUST_TARGET:-}
+      - BUILD_TARGET=${BUILD_TARGET:-}
       - OUTPUT_NAME=${OUTPUT_NAME:-agent-browser-linux-x64}
     command: |
       -c '
         set -euo pipefail
 
+        rust_target="$${RUST_TARGET:-}"
+        build_target="$${BUILD_TARGET:-}"
+        legacy_target="$${TARGET:-}"
+
+        if [ -z "$$rust_target" ] && [ -n "$$legacy_target" ]; then
+          rust_target="$$legacy_target"
+        fi
+
+        if [ -z "$$build_target" ] && [ -n "$$legacy_target" ]; then
+          build_target="$$legacy_target"
+        fi
+
+        if [ -z "$$rust_target" ]; then
+          rust_target="x86_64-unknown-linux-gnu"
+        fi
+
+        if [ -z "$$build_target" ]; then
+          build_target="x86_64-unknown-linux-gnu.2.28"
+        fi
+
         rm -f /output/$$OUTPUT_NAME
 
-        cargo zigbuild --release --target $$BUILD_TARGET
+        cargo zigbuild --release --target "$$build_target"
 
-        source_path=/build/target/$$RUST_TARGET/release/agent-browser
+        source_path=/build/target/$$rust_target/release/agent-browser
         if [ -f "$$source_path.exe" ]; then
           source_path="$$source_path.exe"
         fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,19 +16,23 @@ services:
       - ../bin:/output
     command: |
       -c '
-        set -e
-        echo "Building for Linux platforms (parallel)..."
-        
-        # Build both targets in parallel
-        (echo "→ Linux x64" && cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28 && cp /build/target/x86_64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-x64 && chmod +x /output/agent-browser-linux-x64 && echo "✓ Linux x64 done") &
-        PID1=$!
-        
-        (echo "→ Linux ARM64" && cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.28 && cp /build/target/aarch64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-arm64 && chmod +x /output/agent-browser-linux-arm64 && echo "✓ Linux ARM64 done") &
-        PID2=$!
-        
-        # Wait for both to complete
-        wait $$PID1 $$PID2
-        
+        set -euo pipefail
+        echo "Building for Linux platforms..."
+
+        rm -f /output/agent-browser-linux-x64 /output/agent-browser-linux-arm64
+
+        echo "→ Linux x64"
+        cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28
+        cp /build/target/x86_64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-x64
+        chmod +x /output/agent-browser-linux-x64
+        echo "✓ Linux x64 done"
+
+        echo "→ Linux ARM64"
+        cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.28
+        cp /build/target/aarch64-unknown-linux-gnu/release/agent-browser /output/agent-browser-linux-arm64
+        chmod +x /output/agent-browser-linux-arm64
+        echo "✓ Linux ARM64 done"
+
         echo ""
         echo "✓ Linux platforms built successfully!"
         ls -la /output/agent-browser-linux-*
@@ -45,12 +49,14 @@ services:
       - ../bin:/output
     command: |
       -c '
-        set -e
+        set -euo pipefail
         echo "Building for Windows x64..."
-        
+
+        rm -f /output/agent-browser-win32-x64.exe
+
         cargo build --release --target x86_64-pc-windows-gnu
         cp /build/target/x86_64-pc-windows-gnu/release/agent-browser.exe /output/agent-browser-win32-x64.exe
-        
+
         echo ""
         echo "✓ Windows build completed!"
         ls -la /output/agent-browser-win32-*
@@ -71,8 +77,18 @@ services:
       - OUTPUT_NAME=${OUTPUT_NAME:-agent-browser-linux-x64}
     command: |
       -c '
+        set -euo pipefail
+
+        rm -f /output/$$OUTPUT_NAME
+
         cargo zigbuild --release --target $$BUILD_TARGET
-        cp /build/target/$$RUST_TARGET/release/agent-browser* /output/$$OUTPUT_NAME
+
+        source_path=/build/target/$$RUST_TARGET/release/agent-browser
+        if [ -f "$$source_path.exe" ]; then
+          source_path="$$source_path.exe"
+        fi
+
+        cp "$$source_path" /output/$$OUTPUT_NAME
         chmod +x /output/$$OUTPUT_NAME 2>/dev/null || true
         echo "✓ Built $$OUTPUT_NAME"
       '

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:macos": "npm run version:sync && (cargo build --release --manifest-path cli/Cargo.toml --target aarch64-apple-darwin & cargo build --release --manifest-path cli/Cargo.toml --target x86_64-apple-darwin & wait) && cp cli/target/aarch64-apple-darwin/release/agent-browser bin/agent-browser-darwin-arm64 && cp cli/target/x86_64-apple-darwin/release/agent-browser bin/agent-browser-darwin-x64",
     "build:windows": "npm run version:sync && docker compose -f docker/docker-compose.yml run --rm build-windows",
     "build:all-platforms": "npm run version:sync && (npm run build:linux & npm run build:windows & wait) && npm run build:macos",
-    "build:docker": "docker build -t agent-browser-builder -f docker/Dockerfile.build .",
+    "build:docker": "docker build --platform linux/amd64 -t agent-browser-builder -f docker/Dockerfile.build .",
     "release": "npm run version:sync && npm run build:all-platforms && npm publish",
     "postinstall": "node scripts/postinstall.js",
     "build:dashboard": "cd packages/dashboard && pnpm build"

--- a/scripts/build-all-platforms.sh
+++ b/scripts/build-all-platforms.sh
@@ -22,20 +22,22 @@ mkdir -p "$OUTPUT_DIR"
 
 # Build the Docker image if needed
 echo -e "${YELLOW}Building Docker cross-compilation image...${NC}"
-docker build -t agent-browser-builder -f "$PROJECT_ROOT/docker/Dockerfile.build" "$PROJECT_ROOT"
+docker build --platform linux/amd64 -t agent-browser-builder -f "$PROJECT_ROOT/docker/Dockerfile.build" "$PROJECT_ROOT"
 
 # Function to build for a target
 build_target() {
-    local target=$1
-    local output_name=$2
+    local rust_target=$1
+    local build_target=$2
+    local output_name=$3
     
-    echo -e "${YELLOW}Building for ${target}...${NC}"
+    echo -e "${YELLOW}Building for ${build_target}...${NC}"
     
     docker run --rm \
+        --platform linux/amd64 \
         -v "$PROJECT_ROOT/cli:/build" \
         -v "$OUTPUT_DIR:/output" \
         agent-browser-builder \
-        -c "cargo zigbuild --release --target ${target} && cp /build/target/${target}/release/agent-browser* /output/${output_name} && chmod +x /output/${output_name} 2>/dev/null || true"
+        -c "cargo zigbuild --release --target ${build_target} && cp /build/target/${rust_target}/release/agent-browser* /output/${output_name} && chmod +x /output/${output_name} 2>/dev/null || true"
     
     if [ -f "$OUTPUT_DIR/$output_name" ]; then
         echo -e "${GREEN}✓ Built ${output_name}${NC}"
@@ -47,25 +49,25 @@ build_target() {
 
 # Build for each platform
 # Linux x64
-build_target "x86_64-unknown-linux-gnu" "agent-browser-linux-x64"
+build_target "x86_64-unknown-linux-gnu" "x86_64-unknown-linux-gnu.2.28" "agent-browser-linux-x64"
 
 # Linux ARM64
-build_target "aarch64-unknown-linux-gnu" "agent-browser-linux-arm64"
+build_target "aarch64-unknown-linux-gnu" "aarch64-unknown-linux-gnu.2.28" "agent-browser-linux-arm64"
 
 # Windows x64
-build_target "x86_64-pc-windows-gnu" "agent-browser-win32-x64.exe"
+build_target "x86_64-pc-windows-gnu" "x86_64-pc-windows-gnu" "agent-browser-win32-x64.exe"
 
 # macOS x64 (via zig for cross-compilation)
-build_target "x86_64-apple-darwin" "agent-browser-darwin-x64"
+build_target "x86_64-apple-darwin" "x86_64-apple-darwin" "agent-browser-darwin-x64"
 
 # macOS ARM64 (via zig for cross-compilation)
-build_target "aarch64-apple-darwin" "agent-browser-darwin-arm64"
+build_target "aarch64-apple-darwin" "aarch64-apple-darwin" "agent-browser-darwin-arm64"
 
 # Linux musl x64 (Alpine)
-build_target "x86_64-unknown-linux-musl" "agent-browser-linux-musl-x64"
+build_target "x86_64-unknown-linux-musl" "x86_64-unknown-linux-musl" "agent-browser-linux-musl-x64"
 
 # Linux musl ARM64 (Alpine)
-build_target "aarch64-unknown-linux-musl" "agent-browser-linux-musl-arm64"
+build_target "aarch64-unknown-linux-musl" "aarch64-unknown-linux-musl" "agent-browser-linux-musl-arm64"
 
 echo ""
 echo -e "${GREEN}Build complete!${NC}"

--- a/scripts/build-all-platforms.sh
+++ b/scripts/build-all-platforms.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Build agent-browser for all platforms using Docker
 # Usage: ./scripts/build-all-platforms.sh
@@ -29,16 +29,25 @@ build_target() {
     local rust_target=$1
     local build_target=$2
     local output_name=$3
-    
+
     echo -e "${YELLOW}Building for ${build_target}...${NC}"
-    
+
+    rm -f "$OUTPUT_DIR/$output_name"
+
     docker run --rm \
         --platform linux/amd64 \
         -v "$PROJECT_ROOT/cli:/build" \
         -v "$OUTPUT_DIR:/output" \
         agent-browser-builder \
-        -c "cargo zigbuild --release --target ${build_target} && cp /build/target/${rust_target}/release/agent-browser* /output/${output_name} && chmod +x /output/${output_name} 2>/dev/null || true"
-    
+        -c "set -euo pipefail
+            cargo zigbuild --release --target ${build_target}
+            source_path=/build/target/${rust_target}/release/agent-browser
+            if [ -f \"\$source_path.exe\" ]; then
+                source_path=\"\$source_path.exe\"
+            fi
+            cp \"\$source_path\" /output/${output_name}
+            chmod +x /output/${output_name} 2>/dev/null || true"
+
     if [ -f "$OUTPUT_DIR/$output_name" ]; then
         echo -e "${GREEN}✓ Built ${output_name}${NC}"
     else


### PR DESCRIPTION
- Build GNU Linux release artifacts against glibc 2.28 with zigbuild.
- Add a release guard for newer GLIBC symbols.
- Align Docker release helpers with the pinned build target.

Closes #1415 