### PR TITLE
Ready: fix(window): open `window new` in the default browser context

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1538,14 +1538,30 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         "window" => {
             const VALID: &[&str] = &["new"];
             match rest.first().copied() {
-                Some("new") => Ok(json!({ "id": id, "action": "window_new" })),
+                Some("new") => {
+                    // `window new` opens a window in the shared (logged-in)
+                    // context; `--isolated` opts into a fresh isolated context.
+                    let mut cmd = json!({ "id": id, "action": "window_new" });
+                    for arg in rest.iter().skip(1) {
+                        match *arg {
+                            "--isolated" => cmd["isolated"] = json!(true),
+                            other => {
+                                return Err(ParseError::UnknownSubcommand {
+                                    subcommand: other.to_string(),
+                                    valid_options: &["--isolated"],
+                                });
+                            }
+                        }
+                    }
+                    Ok(cmd)
+                }
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
                     valid_options: VALID,
                 }),
                 None => Err(ParseError::MissingArguments {
                     context: "window".to_string(),
-                    usage: "window <new>",
+                    usage: "window <new> [--isolated]",
                 }),
             }
         }
@@ -3240,6 +3256,30 @@ mod tests {
 
     fn args(s: &str) -> Vec<String> {
         s.split_whitespace().map(String::from).collect()
+    }
+
+    // === Window Tests ===
+
+    #[test]
+    fn test_window_new() {
+        let cmd = parse_command(&args("window new"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "window_new");
+        assert!(
+            cmd.get("isolated").is_none(),
+            "window new must default to the shared (logged-in) context"
+        );
+    }
+
+    #[test]
+    fn test_window_new_isolated() {
+        let cmd = parse_command(&args("window new --isolated"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "window_new");
+        assert_eq!(cmd["isolated"], true);
+    }
+
+    #[test]
+    fn test_window_new_rejects_unknown_flag() {
+        assert!(parse_command(&args("window new --bogus"), &default_flags()).is_err());
     }
 
     // === Cookies Tests ===

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -9401,24 +9401,47 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
     let (tab_id, session_id) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
 
-        // Create a new browser context
-        let context_result = mgr
-            .client
-            .send_command_no_params("Target.createBrowserContext", None)
-            .await?;
-        let context_id = context_result
-            .get("browserContextId")
-            .and_then(|v| v.as_str())
-            .ok_or("Failed to create browser context")?
-            .to_string();
+        // By default `window new` opens a real OS window in the browser's DEFAULT
+        // context, so it inherits the founder's login/cookies. The legacy behavior
+        // (a fresh, incognito-like BrowserContext that loses all session state —
+        // see vercel-labs/agent-browser#890) is now opt-in via `--isolated`.
+        //
+        // `new_window: true` makes it a window rather than a tab; `focus: false`
+        // (with `background: false`) opens it without stealing OS focus from the
+        // human's foreground window.
+        let isolated = cmd
+            .get("isolated")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let create_params = if isolated {
+            // Create a new browser context
+            let context_result = mgr
+                .client
+                .send_command_no_params("Target.createBrowserContext", None)
+                .await?;
+            let context_id = context_result
+                .get("browserContextId")
+                .and_then(|v| v.as_str())
+                .ok_or("Failed to create browser context")?
+                .to_string();
+
+            let mut params = super::cdp::types::CreateTargetParams::new("about:blank");
+            params.browser_context_id = Some(context_id);
+            params
+        } else {
+            super::cdp::types::CreateTargetParams {
+                url: "about:blank".to_string(),
+                new_window: Some(true),
+                background: Some(false),
+                focus: Some(false),
+                browser_context_id: None,
+            }
+        };
 
         let create_result: super::cdp::types::CreateTargetResult = mgr
             .client
-            .send_command_typed(
-                "Target.createTarget",
-                &json!({ "url": "about:blank", "browserContextId": context_id }),
-                None,
-            )
+            .send_command_typed("Target.createTarget", &create_params, None)
             .await?;
 
         let attach: super::cdp::types::AttachToTargetResult = mgr

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -661,9 +661,7 @@ impl BrowserManager {
                 .client
                 .send_command_typed(
                     "Target.createTarget",
-                    &CreateTargetParams {
-                        url: "about:blank".to_string(),
-                    },
+                    &CreateTargetParams::new("about:blank"),
                     None,
                 )
                 .await?;
@@ -1359,9 +1357,7 @@ impl BrowserManager {
             .client
             .send_command_typed(
                 "Target.createTarget",
-                &CreateTargetParams {
-                    url: "about:blank".to_string(),
-                },
+                &CreateTargetParams::new("about:blank"),
                 None,
             )
             .await?;
@@ -1524,9 +1520,7 @@ impl BrowserManager {
             .client
             .send_command_typed(
                 "Target.createTarget",
-                &CreateTargetParams {
-                    url: target_url.to_string(),
-                },
+                &CreateTargetParams::new(target_url),
                 None,
             )
             .await?;

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -141,6 +141,39 @@ pub struct SetDiscoverTargetsParams {
 #[serde(rename_all = "camelCase")]
 pub struct CreateTargetParams {
     pub url: String,
+    /// Create a new OS window rather than a tab. Off by default in Chrome.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_window: Option<bool>,
+    /// Create the target in the background. CDP documents that
+    /// `background: false` with `focus: false` opens the target while leaving
+    /// the current browser window unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+    /// Whether the new target should focus (and raise) its browser window.
+    /// Experimental in CDP; verified per-platform. `focus: false` avoids
+    /// stealing OS focus from the human's foreground window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focus: Option<bool>,
+    /// Browser context to create the page in. When omitted, the target is
+    /// created in the browser's default context (sharing the founder's
+    /// login/cookies). When set, the page is storage-isolated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_context_id: Option<String>,
+}
+
+impl CreateTargetParams {
+    /// A plain `Target.createTarget { url }` in the default context with no
+    /// window/focus overrides — wire-compatible with the original url-only
+    /// struct used by discovery, `ensure_page`, `tab new`, and temp targets.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            new_window: None,
+            background: None,
+            focus: None,
+            browser_context_id: None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -583,4 +616,59 @@ pub struct BrowserVersionInfo {
 #[allow(clippy::upper_case_acronyms)]
 pub mod generated {
     include!(concat!(env!("OUT_DIR"), "/cdp_generated.rs"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_target_params_new_serializes_url_only() {
+        // The `::new` constructor must keep the existing wire format (url-only) so
+        // the discovery / ensure_page / tab_new / temp-target call sites are
+        // byte-for-byte identical on the CDP wire.
+        let v = serde_json::to_value(CreateTargetParams::new("about:blank")).unwrap();
+        assert_eq!(v, serde_json::json!({ "url": "about:blank" }));
+    }
+
+    #[test]
+    fn create_target_params_default_context_window_serializes_camel_case_flags() {
+        // `window new` (login-preserving): a real OS window in the DEFAULT context.
+        let v = serde_json::to_value(CreateTargetParams {
+            url: "about:blank".to_string(),
+            new_window: Some(true),
+            background: Some(false),
+            focus: Some(false),
+            browser_context_id: None,
+        })
+        .unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "url": "about:blank",
+                "newWindow": true,
+                "background": false,
+                "focus": false
+            })
+        );
+        // Must be omitted so Chrome creates the target in the founder's
+        // default (logged-in) context rather than an incognito-like one.
+        assert!(v.get("browserContextId").is_none());
+    }
+
+    #[test]
+    fn create_target_params_isolated_includes_browser_context_id() {
+        let v = serde_json::to_value(CreateTargetParams {
+            url: "about:blank".to_string(),
+            new_window: Some(true),
+            background: None,
+            focus: None,
+            browser_context_id: Some("ctx-123".to_string()),
+        })
+        .unwrap();
+        assert_eq!(v["browserContextId"], "ctx-123");
+        // background/focus omitted when None.
+        assert!(v.get("background").is_none());
+        assert!(v.get("focus").is_none());
+    }
 }

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -118,9 +118,7 @@ async fn collect_storage_via_temp_target(
     let create_result: CreateTargetResult = client
         .send_command_typed(
             "Target.createTarget",
-            &CreateTargetParams {
-                url: "about:blank".to_string(),
-            },
+            &CreateTargetParams::new("about:blank"),
             None,
         )
         .await?;


### PR DESCRIPTION
## Summary

- Make `window new` open in the browser's **default** context, so it inherits the profile's existing login, instead of a fresh incognito-like context that is logged out.
- Preserve the old behavior behind a new `window new --isolated` flag.
- Give `CreateTargetParams` typed `newWindow` / `background` / `focus` / `browserContextId` fields + a `CreateTargetParams::new(url)` constructor.

## Why

`window new` creates a fresh browser context and opens the page inside it (`handle_window_new`): `Target.createBrowserContext` then `Target.createTarget { browserContextId }`. That context is incognito-like — it does **not** share the profile's cookies / localStorage / login. So when you attach to a logged-in Chrome (`--cdp` / `--profile`) and run `window new`, the new window is **logged out**, and automating a logged-in site in it fails. Same root cause as #890.

Repro — attach to a Chrome already logged into some site, then:

```
agent-browser --cdp <port> window new
agent-browser --cdp <port> tab <new-tab-id>
agent-browser --cdp <port> open https://<logged-in-site>/   # logged out
```

## What

- `handle_window_new` no longer calls `Target.createBrowserContext` by default; it creates the target in the default context.
- New opt-in `window new --isolated` reproduces the previous isolated-context behavior. The docs only described "New window" (never isolation), so the old default was effectively accidental.
- `CreateTargetParams` gains optional `newWindow` / `background` / `focus` / `browserContextId` (camelCase, omitted when `None`) and a `::new(url)` constructor; the four existing url-only call sites are migrated to it.
- Unit tests for the serialization contract and `window new [--isolated]` parsing.

## How

Open the window with `Target.createTarget { url, newWindow: true, focus: false, background: false }` and **no** `browserContextId`:

- `newWindow: true` -> a real OS window (not a tab).
- `focus: false` (+ `background: false`) -> opens without stealing OS focus from the user's foreground window.
- no `browserContextId` -> created in the default context -> login preserved.

The `::new(url)` constructor leaves all options `None`, so the migrated url-only call sites stay byte-for-byte identical on the wire.

Caveat for reviewers: per the Page Visibility spec the selected tab of a non-minimized, non-fully-occluded window stays `visible` even without OS focus, but a minimized / fully-occluded window still maps to `hidden`; `focus: false` is experimental and worth a sanity check on Linux/Windows; `newWindow` is not supported by the headless shell.

## Test plan

- [x] [auto] `cargo test --bin agent-browser` — `create_target_params_*` (serialization, incl. `browserContextId` omitted by default) and `test_window_new` / `test_window_new_isolated` / `test_window_new_rejects_unknown_flag` pass.
- [x] [one-shot-e2e] Built `--release` and attached to a logged-in Chrome over CDP: `window new` -> owned window reports `loggedIn: true`; `window new --isolated` -> `loggedIn: false`. Single run; the behavioral CDP path is not in CI.
- [x] [manual] Verified the four migrated `CreateTargetParams` call sites still serialize url-only via `::new()`.

Refs #890. Future work (out of scope): per-command tab addressing + per-tab ref maps (cf. closed #306) for full multi-client safety.