### PR TITLE
Ready: fix(tabs): stop event-discovered tabs from stealing the active tab

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -669,7 +669,13 @@ impl DaemonState {
                     }
 
                     let tab_id = mgr.assign_tab_id();
-                    mgr.add_page(super::browser::PageInfo {
+                    // Event-discovered target (e.g. a tab the human opened in the
+                    // shared Chrome, or a JS-opened popup): register it so it shows
+                    // in `tab list`, but do NOT activate it. Auto-activating here is
+                    // the active-tab steal. Explicit commands (`tab new`,
+                    // `window new`, `click --new-tab`) still activate via their own
+                    // paths.
+                    mgr.add_page_without_activation(super::browser::PageInfo {
                         tab_id,
                         label: None,
                         target_id: te.target_info.target_id.clone(),

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -131,6 +131,26 @@ fn active_page_index_after_removal(
     active_page_index
 }
 
+/// Decides the active page index after a page is appended.
+///
+/// A freshly appended page becomes active only when the caller explicitly
+/// activates it (an explicit user command such as `tab new` / `window new`) or
+/// when it is the first page (so a non-empty manager always has a valid active
+/// index). Event-discovered / human-opened tabs are appended with
+/// `activate = false` and must not steal the active pointer.
+fn active_page_index_after_add(
+    active_page_index: usize,
+    new_index: usize,
+    was_empty: bool,
+    activate: bool,
+) -> usize {
+    if was_empty || activate {
+        new_index
+    } else {
+        active_page_index
+    }
+}
+
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
@@ -1426,10 +1446,25 @@ impl BrowserManager {
         id
     }
 
+    /// Append a page and make it active. Use for explicit user commands
+    /// (`window new`, recording setup) where the new page should become active.
     pub fn add_page(&mut self, page: PageInfo) {
-        let index = self.pages.len();
+        self.add_page_with_activation(page, true);
+    }
+
+    /// Append a page WITHOUT activating it. Use for event-discovered targets
+    /// (`Target.targetCreated` drained from the shared Chrome) so a tab the
+    /// human opens never steals the agent's active tab.
+    pub fn add_page_without_activation(&mut self, page: PageInfo) {
+        self.add_page_with_activation(page, false);
+    }
+
+    fn add_page_with_activation(&mut self, page: PageInfo, activate: bool) {
+        let was_empty = self.pages.is_empty();
+        let new_index = self.pages.len();
         self.pages.push(page);
-        self.active_page_index = index;
+        self.active_page_index =
+            active_page_index_after_add(self.active_page_index, new_index, was_empty, activate);
     }
 
     pub fn update_page_target_info(&mut self, target: &TargetInfo) -> bool {
@@ -1862,6 +1897,27 @@ mod tests {
     #[test]
     fn test_active_page_index_after_removal_resets_when_last_page_disappears() {
         assert_eq!(active_page_index_after_removal(0, 0, 0), 0);
+    }
+
+    #[test]
+    fn test_active_page_index_after_add_first_page_always_activates() {
+        // The first page must become active even without explicit activation,
+        // so a manager that has pages always has a valid active index.
+        assert_eq!(active_page_index_after_add(0, 0, true, false), 0);
+        assert_eq!(active_page_index_after_add(0, 0, true, true), 0);
+    }
+
+    #[test]
+    fn test_active_page_index_after_add_discovered_tab_does_not_steal_active() {
+        // Event-discovered / human-opened tabs are appended without activation and
+        // must NOT move the active pointer (the active-tab steal fix).
+        assert_eq!(active_page_index_after_add(2, 5, false, false), 2);
+    }
+
+    #[test]
+    fn test_active_page_index_after_add_explicit_activation_moves_active() {
+        // Explicit user commands (`tab new`, `window new`) activate the new page.
+        assert_eq!(active_page_index_after_add(2, 5, false, true), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Stop event-discovered (`Target.targetCreated`) tabs — e.g. a tab the human opens in a shared Chrome — from silently stealing the daemon's active tab.

## Why

When the daemon is attached to a shared Chrome (e.g. over `--cdp`, or whenever a human / another client also drives the browser), every command first drains pending CDP target events. A `Target.targetCreated` for a tab someone else opens is registered via `add_page()`, which does `self.active_page_index = index` unconditionally — so a tab the **human** opens silently becomes the daemon's active tab, and the agent's next command (snapshot / click / fill) targets the wrong page. In a shared-Chrome / human-in-the-loop setup this is the dominant "my command went to the wrong tab" failure.

## What

- Split the activation decision out of `add_page()`:
  - `add_page()` keeps activating (explicit user commands, recording setup).
  - `add_page_without_activation()` appends without moving the active pointer.
  - a pure `active_page_index_after_add()` helper encodes the rule.
- The event-drain path (`apply_drained_events`, on `Target.targetCreated`) now uses `add_page_without_activation()`.
- Unit tests for the helper.

## How

`active_page_index_after_add(active, new_index, was_empty, activate)` returns the new index only when the caller explicitly activates or the manager was empty (first/only page) — mirroring the existing `active_page_index_after_removal` helper so the rule is unit-testable without a live `BrowserManager`.

Discovered tabs still appear in `tab list`, but never steal active. Explicit new-tab paths are unaffected — `tab new`, `window new`, and `click --new-tab` activate via their own code paths (they do not go through the event drain).

Behavior change to note: a popup opened by page JS (`window.open` / `target="_blank"` without `--new-tab`) also arrives via the discovery path, so it is now append-only too — interact with it via `tab switch`. A future refinement could special-case popups whose `openerId` is the active target (CDP `Target.targetCreated` carries `openerId`), but that is not modeled today, and re-introducing "a new target always steals active" is exactly the bug this fixes.

## Test plan

- [x] [auto] `cargo test --bin agent-browser` — `active_page_index_after_add` tests pass: first-page activates; discovered tab is append-only; explicit activation moves active.
- [ ] [one-shot-e2e] N/A — reproducing the live race needs a second concurrent tab-opener driving the same shared Chrome; the decision logic is fully covered by the pure-function unit tests above.
- [x] [manual] Inspected the single rewired call site (`apply_drained_events` -> `add_page_without_activation`) and confirmed explicit new-tab paths still activate via their own code paths.