### PR TITLE
Ready: feat: keep non-foreground tabs operable (focus-emulate + tab new --background)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,11 @@ agent-browser network har stop [output.har]    # Stop and save HAR (temp path if
 agent-browser tab                              # List tabs (shows `tabId` and optional label)
 agent-browser tab new [url]                    # New tab (optionally with URL)
 agent-browser tab new --label docs [url]       # New tab with a user-assigned label
+agent-browser tab new --background [url]        # New tab without foregrounding it
 agent-browser tab <t<N>|label>                 # Switch to a tab by id or label
 agent-browser tab close [t<N>|label]           # Close a tab (defaults to active)
 agent-browser window new                       # New window
+agent-browser focus-emulate <on|off>           # Keep a backgrounded tab operable (focus/visibility emulation)
 ```
 
 Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused within a session, so scripts and agents can keep referring to the same tab even after other tabs are opened or closed. Positional integers like `tab 2` are **not** accepted; the `t` prefix disambiguates handles from indices and mirrors the `@e1` convention used for element refs.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -945,6 +945,24 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         // === Inspect ===
         "inspect" => Ok(json!({ "id": id, "action": "inspect" })),
 
+        // === Focus emulation ===
+        // Make the active tab behave as a focused, visible page even while it is
+        // backgrounded / occluded, so automation commits without raising the
+        // window or stealing the user's OS focus.
+        "focus-emulate" => {
+            let enabled = match (rest.first().map(|s| s.as_ref()), rest.len()) {
+                (Some("on"), 1) => true,
+                (Some("off"), 1) => false,
+                _ => {
+                    return Err(ParseError::MissingArguments {
+                        context: "focus-emulate".to_string(),
+                        usage: "focus-emulate <on|off>",
+                    })
+                }
+            };
+            Ok(json!({ "id": id, "action": "focus_emulate", "enabled": enabled }))
+        }
+
         // === Authentication Vault ===
         "auth" => {
             let sub = rest.first().map(|s| s.as_ref());
@@ -1503,6 +1521,13 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 cmd["label"] = json!(name);
                                 i += 2;
                             }
+                            // Open the tab in the background (not foregrounded), so
+                            // it does not steal the user's current tab/focus. Pair
+                            // with `focus-emulate on` to keep it operable while hidden.
+                            "--background" => {
+                                cmd["background"] = json!(true);
+                                i += 1;
+                            }
                             other if !other.starts_with("--") && cmd.get("url").is_none() => {
                                 cmd["url"] = json!(other);
                                 i += 1;
@@ -1510,7 +1535,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                             other => {
                                 return Err(ParseError::UnknownSubcommand {
                                     subcommand: other.to_string(),
-                                    valid_options: &["--label", "<url>"],
+                                    valid_options: &["--label", "--background", "<url>"],
                                 });
                             }
                         }
@@ -4113,6 +4138,25 @@ mod tests {
     }
 
     #[test]
+    fn test_tab_new_background() {
+        let cmd = parse_command(&args("tab new --background"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_new");
+        assert_eq!(cmd["background"], true);
+    }
+
+    #[test]
+    fn test_tab_new_background_with_url() {
+        let cmd = parse_command(
+            &args("tab new --background https://example.com"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "tab_new");
+        assert_eq!(cmd["background"], true);
+        assert_eq!(cmd["url"], "https://example.com");
+    }
+
+    #[test]
     fn test_tab_list() {
         let cmd = parse_command(&args("tab list"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "tab_list");
@@ -5783,6 +5827,27 @@ mod tests {
     fn test_inspect() {
         let cmd = parse_command(&args("inspect"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "inspect");
+    }
+
+    #[test]
+    fn test_focus_emulate_on() {
+        let cmd = parse_command(&args("focus-emulate on"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "focus_emulate");
+        assert_eq!(cmd["enabled"], true);
+    }
+
+    #[test]
+    fn test_focus_emulate_off() {
+        let cmd = parse_command(&args("focus-emulate off"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "focus_emulate");
+        assert_eq!(cmd["enabled"], false);
+    }
+
+    #[test]
+    fn test_focus_emulate_requires_on_or_off() {
+        assert!(parse_command(&args("focus-emulate"), &default_flags()).is_err());
+        assert!(parse_command(&args("focus-emulate maybe"), &default_flags()).is_err());
+        assert!(parse_command(&args("focus-emulate on extra"), &default_flags()).is_err());
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2457,6 +2457,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "url" => handle_url(state).await,
         "cdp_url" => handle_cdp_url(state),
         "inspect" => handle_inspect(state).await,
+        "focus_emulate" => handle_focus_emulate(cmd, state).await,
         "title" => handle_title(state).await,
         "content" => handle_content(state).await,
         "evaluate" => handle_evaluate(cmd, state).await,
@@ -2828,7 +2829,7 @@ async fn apply_tab_binding_on_attach(state: &mut DaemonState) -> Result<bool, St
                 // A pinned session never implicitly adopts an existing tab:
                 // start it on a fresh one.
                 if let Some(ref mut mgr) = state.browser {
-                    mgr.tab_new(None, None).await?;
+                    mgr.tab_new(None, None, false).await?;
                 }
                 true
             } else {
@@ -2877,7 +2878,7 @@ async fn open_fresh_tab_for_auto_connect(state: &mut DaemonState) -> Result<(), 
     let Some(ref mut mgr) = state.browser else {
         return Ok(());
     };
-    mgr.tab_new(None, None).await?;
+    mgr.tab_new(None, None, false).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let _ = mgr
         .client
@@ -5059,6 +5060,7 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
                     Some(&href)
                 },
                 None,
+                false,
             )
             .await?;
         }
@@ -6254,14 +6256,22 @@ async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
     let has_proxy_creds = state.proxy_credentials.read().await.is_some();
     let defer_url_until_controls =
         should_defer_url_until_network_controls(domain_filter.as_ref(), has_proxy_creds, url)?;
+    let background = cmd
+        .get("background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     state.ref_map.clear();
     state.active_iframe_sessions.clear();
     state.active_frame_id = None;
     let mut result = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-        mgr.tab_new(if defer_url_until_controls { None } else { url }, label)
-            .await?
+        mgr.tab_new(
+            if defer_url_until_controls { None } else { url },
+            label,
+            background,
+        )
+        .await?
     };
 
     install_network_controls_or_close(state, has_proxy_creds).await?;
@@ -6404,6 +6414,13 @@ async fn handle_user_agent(cmd: &Value, state: &DaemonState) -> Result<Value, St
         .ok_or("Missing 'userAgent' parameter")?;
     mgr.set_user_agent(ua).await?;
     Ok(json!({ "userAgent": ua }))
+}
+
+async fn handle_focus_emulate(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let enabled = cmd.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true);
+    mgr.set_focus_emulation(enabled).await?;
+    Ok(json!({ "focusEmulation": enabled }))
 }
 
 async fn handle_set_media(cmd: &Value, state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1500,6 +1500,7 @@ impl BrowserManager {
         &mut self,
         url: Option<&str>,
         label: Option<&str>,
+        background: bool,
     ) -> Result<Value, String> {
         if let Some(label) = label {
             if !is_valid_label(label) {
@@ -1520,15 +1521,17 @@ impl BrowserManager {
 
         let target_url = url.unwrap_or("about:blank");
 
+        // `--background` opens the tab without foregrounding it, so it does not
+        // steal the user's current tab/focus (pair with `focus-emulate on` to
+        // keep the hidden tab operable). The tab still becomes this daemon's
+        // active page, so subsequent commands target it.
+        let mut create_params = json!({ "url": target_url });
+        if background {
+            create_params["background"] = json!(true);
+        }
         let result: CreateTargetResult = self
             .client
-            .send_command_typed(
-                "Target.createTarget",
-                &CreateTargetParams {
-                    url: target_url.to_string(),
-                },
-                None,
-            )
+            .send_command_typed("Target.createTarget", &create_params, None)
             .await?;
 
         let attach: AttachToTargetResult = self
@@ -1810,6 +1813,23 @@ impl BrowserManager {
         }
         self.client
             .send_command("Emulation.setEmulatedMedia", Some(params), Some(session_id))
+            .await?;
+        Ok(())
+    }
+
+    /// Make the active page behave as a focused, active, visible page even when
+    /// its window/tab is backgrounded or occluded (CDP focus emulation). This
+    /// keeps automation working on a background tab — `document.visibilityState`
+    /// stays `visible`, `document.hasFocus()` is true, and rendering/rAF run —
+    /// without raising the window or stealing the user's OS focus. Per-target.
+    pub async fn set_focus_emulation(&self, enabled: bool) -> Result<(), String> {
+        let session_id = self.active_session_id()?;
+        self.client
+            .send_command(
+                "Emulation.setFocusEmulationEnabled",
+                Some(json!({ "enabled": enabled })),
+                Some(session_id),
+            )
             .await?;
         Ok(())
     }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2453,6 +2453,7 @@ Examples:
   agent-browser tab new
   agent-browser tab new https://example.com
   agent-browser tab new --label docs https://docs.example.com
+  agent-browser tab new --background https://example.com
   agent-browser tab t2
   agent-browser tab docs
   agent-browser tab close

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -225,9 +225,11 @@ See [Network](/network) for pre-navigation routing, request filters, HAR export,
 agent-browser tab                              # List tabs (each row shows tabId and label)
 agent-browser tab new [url]                    # New tab
 agent-browser tab new --label docs [url]       # New tab with a user-assigned label
+agent-browser tab new --background [url]        # New tab without foregrounding it
 agent-browser tab <t<N>|label>                 # Switch to a tab by id or label
 agent-browser tab close [t<N>|label]           # Close a tab (defaults to active)
 agent-browser window new                       # Open new browser window
+agent-browser focus-emulate <on|off>           # Keep a backgrounded tab operable (focus/visibility emulation)
 agent-browser frame <sel>                      # Switch to iframe by CSS selector
 agent-browser frame @e3                        # Switch to iframe by element ref
 agent-browser frame main                       # Back to main frame

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -205,12 +205,14 @@ agent-browser network har stop [output.har]    # Stop and save HAR
 agent-browser tab                              # List tabs with tabId and label
 agent-browser tab new [url]                    # New tab
 agent-browser tab new --label docs [url]       # New tab with a memorable label
+agent-browser tab new --background [url]        # New tab without foregrounding it
 agent-browser tab t2                           # Switch to tab by id
 agent-browser tab docs                         # Switch to tab by label
 agent-browser tab close                        # Close current tab
 agent-browser tab close t2                     # Close tab by id
 agent-browser tab close docs                   # Close tab by label
 agent-browser window new                       # New window
+agent-browser focus-emulate <on|off>           # Keep a backgrounded tab operable (focus/visibility emulation)
 ```
 
 Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused within a session, so the same id keeps referring to the same tab across commands. Positional integers are **not** accepted — `tab 2` errors with a teaching message; use `t2`.


### PR DESCRIPTION
## Summary

- `focus-emulate <on|off>` — emulate a focused/visible page on the active tab so automation works on a backgrounded tab.
- `tab new --background` — open a new tab without foregrounding it.
- Together they let an agent open and drive a tab in the background, without raising windows or stealing the user's current tab/focus.

## Why

When automating a browser that a human is also using, an agent often needs to work on a tab that is **not** the foreground tab. Chrome backgrounds non-foreground tabs: `document.visibilityState` becomes `hidden` and rendering / `requestAnimationFrame` is throttled, so clicks and visibility/focus-gated handlers silently no-op. The usual workaround — foregrounding the tab (`Page.bringToFront`) — steals the user's current tab, which is disruptive when a person is sharing the browser.

## What

- **`focus-emulate <on|off>`**: a new command that toggles CDP `Emulation.setFocusEmulationEnabled` on the active tab.
- **`tab new --background`**: a new flag on `tab new` that creates the target with CDP `background: true`. The tab still becomes the daemon's active page, so subsequent commands target it.
- Unit tests for both command parsers, and docs/help updates for both.

## How

- `focus-emulate on` sends `Emulation.setFocusEmulationEnabled { enabled: true }` to the active page's session, so it reports as focused + visible (and resumes rendering) even while backgrounded — without raising the window or taking OS focus. `off` reverts it.
- `tab new --background` passes `background: true` to `Target.createTarget` (built with `serde_json::json!`, matching the existing ad-hoc `createTarget` call), so the tab opens without foregrounding. No change to the typed `CreateTargetParams`, keeping the diff isolated.

## Test plan

- `cargo test --bin agent-browser` — parser tests pass: `test_focus_emulate_on` / `test_focus_emulate_off` / `test_focus_emulate_requires_on_or_off`, `test_tab_new_background` / `test_tab_new_background_with_url`.
- Built and run against a real Chrome over CDP: a background tab reports `visibilityState=hidden` and `requestAnimationFrame ≈ 0` ticks/s; after `focus-emulate on` it reports `visible`, `hasFocus()=true`, and `≈60` ticks/s. `tab new --background` opens a tab without foregrounding it, and the new tab is still the active page for subsequent commands.
- Docs/help updated for both new commands (`README.md`, `docs/src/app/commands/page.mdx`, `skill-data/core/references/commands.md`, `cli/src/output.rs`).

Note: this does not reintroduce scoped per-command tab dispatch (the removed `--tab`, #1250) — there is no per-command tab routing here; both additions act on the active tab.