### PR TITLE
Fix agent-facing reliability bugs and cut warm command latency to ~1ms

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -363,10 +363,19 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 match rest[i] {
                     "--clear" => clear = true,
                     "--delay" => {
-                        if let Some(Ok(ms)) = rest.get(i + 1).map(|s| s.parse::<u64>()) {
-                            delay = Some(ms);
-                            i += 1;
-                        }
+                        // Error rather than silently drop a malformed value;
+                        // a dropped flag would type its argument into the field.
+                        let raw = rest
+                            .get(i + 1)
+                            .ok_or_else(|| ParseError::MissingArguments {
+                                context: "type --delay".to_string(),
+                                usage: "type <selector> <text> [--clear] [--delay <ms>]",
+                            })?;
+                        delay = Some(raw.parse::<u64>().map_err(|_| ParseError::InvalidValue {
+                            message: format!("--delay expects a number in ms, got '{}'", raw),
+                            usage: "type <selector> <text> [--clear] [--delay <ms>]",
+                        })?);
+                        i += 1;
                     }
                     other => text_parts.push(other),
                 }
@@ -574,12 +583,19 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             let mut rest = rest.clone();
             let mut timeout_ms: Option<u64> = None;
             if let Some(idx) = rest.iter().position(|&s| s == "--timeout") {
-                if let Some(Ok(ms)) = rest.get(idx + 1).map(|s| s.parse::<u64>()) {
-                    timeout_ms = Some(ms);
-                    rest.drain(idx..=idx + 1);
-                } else {
-                    rest.remove(idx);
-                }
+                // Error rather than silently drop a malformed value; a dropped
+                // flag would leave its argument to be misread as a selector.
+                let raw = rest
+                    .get(idx + 1)
+                    .ok_or_else(|| ParseError::MissingArguments {
+                        context: "wait --timeout".to_string(),
+                        usage: "wait <selector|ms|--url|--load|--fn|--text> [--timeout <ms>]",
+                    })?;
+                timeout_ms = Some(raw.parse::<u64>().map_err(|_| ParseError::InvalidValue {
+                    message: format!("--timeout expects a number in ms, got '{}'", raw),
+                    usage: "wait <selector|ms|--url|--load|--fn|--text> [--timeout <ms>]",
+                })?);
+                rest.drain(idx..=idx + 1);
             }
             let with_timeout = |mut cmd: Value| {
                 if let Some(ms) = timeout_ms {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -350,9 +350,36 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         "type" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
                 context: "type".to_string(),
-                usage: "type <selector> <text>",
+                usage: "type <selector> <text> [--clear] [--delay <ms>]",
             })?;
-            Ok(json!({ "id": id, "action": "type", "selector": sel, "text": rest[1..].join(" ") }))
+            // The daemon has always supported clear/delay, but the CLI used
+            // to join every remaining arg into the text, so `--clear` was
+            // literally typed into the field with a success response.
+            let mut clear = false;
+            let mut delay: Option<u64> = None;
+            let mut text_parts: Vec<&str> = Vec::new();
+            let mut i = 1;
+            while i < rest.len() {
+                match rest[i] {
+                    "--clear" => clear = true,
+                    "--delay" => {
+                        if let Some(Ok(ms)) = rest.get(i + 1).map(|s| s.parse::<u64>()) {
+                            delay = Some(ms);
+                            i += 1;
+                        }
+                    }
+                    other => text_parts.push(other),
+                }
+                i += 1;
+            }
+            let mut cmd = json!({ "id": id, "action": "type", "selector": sel, "text": text_parts.join(" ") });
+            if clear {
+                cmd["clear"] = json!(true);
+            }
+            if let Some(ms) = delay {
+                cmd["delay"] = json!(ms);
+            }
+            Ok(cmd)
         }
         "hover" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -540,6 +540,27 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Wait ===
         "wait" => {
+            // --timeout applies to EVERY wait variant (the docs advertise
+            // e.g. `wait --url "**/dashboard" --timeout 120000`); it used to
+            // be parsed only for --text/--download and silently ignored
+            // elsewhere. Extract it first so variants parse independently.
+            let mut rest = rest.clone();
+            let mut timeout_ms: Option<u64> = None;
+            if let Some(idx) = rest.iter().position(|&s| s == "--timeout") {
+                if let Some(Ok(ms)) = rest.get(idx + 1).map(|s| s.parse::<u64>()) {
+                    timeout_ms = Some(ms);
+                    rest.drain(idx..=idx + 1);
+                } else {
+                    rest.remove(idx);
+                }
+            }
+            let with_timeout = |mut cmd: Value| {
+                if let Some(ms) = timeout_ms {
+                    cmd["timeout"] = json!(ms);
+                }
+                cmd
+            };
+
             // Check for --url flag: wait --url "**/dashboard"
             if let Some(idx) = rest.iter().position(|&s| s == "--url" || s == "-u") {
                 let url = rest
@@ -548,7 +569,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         context: "wait --url".to_string(),
                         usage: "wait --url <pattern>",
                     })?;
-                return Ok(json!({ "id": id, "action": "waitforurl", "url": url }));
+                return Ok(with_timeout(
+                    json!({ "id": id, "action": "waitforurl", "url": url }),
+                ));
             }
 
             // Check for --load flag: wait --load networkidle
@@ -559,7 +582,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         context: "wait --load".to_string(),
                         usage: "wait --load <state>",
                     })?;
-                return Ok(json!({ "id": id, "action": "waitforloadstate", "state": state }));
+                return Ok(with_timeout(
+                    json!({ "id": id, "action": "waitforloadstate", "state": state }),
+                ));
             }
 
             // Check for --fn flag: wait --fn "window.ready === true"
@@ -570,10 +595,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         context: "wait --fn".to_string(),
                         usage: "wait --fn <expression>",
                     })?;
-                return Ok(json!({ "id": id, "action": "waitforfunction", "expression": expr }));
+                return Ok(with_timeout(
+                    json!({ "id": id, "action": "waitforfunction", "expression": expr }),
+                ));
             }
 
-            // Check for --text flag: wait --text "Welcome" [--timeout ms]
+            // Check for --text flag: wait --text "Welcome"
             if let Some(idx) = rest.iter().position(|&s| s == "--text" || s == "-t") {
                 let text = rest
                     .get(idx + 1)
@@ -581,16 +608,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         context: "wait --text".to_string(),
                         usage: "wait --text <text>",
                     })?;
-                let mut cmd = json!({ "id": id, "action": "wait", "text": text });
-                if let Some(t_idx) = rest.iter().position(|&s| s == "--timeout") {
-                    if let Some(Ok(ms)) = rest.get(t_idx + 1).map(|s| s.parse::<u64>()) {
-                        cmd["timeout"] = json!(ms);
-                    }
-                }
-                return Ok(cmd);
+                return Ok(with_timeout(
+                    json!({ "id": id, "action": "wait", "text": text }),
+                ));
             }
 
-            // Check for --download flag: wait --download [path] [--timeout ms]
+            // Check for --download flag: wait --download [path]
             if rest.iter().any(|&s| s == "--download" || s == "-d") {
                 let mut cmd = json!({ "id": id, "action": "waitfordownload" });
                 // Check for optional path (first non-flag argument after --download)
@@ -603,15 +626,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         cmd["path"] = json!(path);
                     }
                 }
-                // Check for optional timeout
-                if let Some(idx) = rest.iter().position(|&s| s == "--timeout") {
-                    if let Some(timeout_str) = rest.get(idx + 1) {
-                        if let Ok(timeout) = timeout_str.parse::<u64>() {
-                            cmd["timeout"] = json!(timeout);
-                        }
-                    }
-                }
-                return Ok(cmd);
+                return Ok(with_timeout(cmd));
             }
 
             // Default: selector or timeout
@@ -619,7 +634,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 if let Ok(timeout) = arg.parse::<u64>() {
                     Ok(json!({ "id": id, "action": "wait", "timeout": timeout }))
                 } else {
-                    Ok(json!({ "id": id, "action": "wait", "selector": arg }))
+                    Ok(with_timeout(
+                        json!({ "id": id, "action": "wait", "selector": arg }),
+                    ))
                 }
             } else {
                 Err(ParseError::MissingArguments {

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -848,21 +848,21 @@ fn has_os_error(error: &str, code: u32) -> bool {
     error.contains(&format!("(os error {})", code))
 }
 
-/// Socket read timeout for one request. The 30s floor covers ordinary
-/// commands; commands carrying an explicit operation timeout (e.g.
-/// `wait --timeout 120000`) get that plus margin, so the daemon can report
-/// a proper operation timeout instead of the client dying with EAGAIN at
-/// 30s and the retry loop re-sending the whole long-running command.
+/// Socket read timeout for one request. Ordinary commands get a 30s floor.
+/// Commands carrying an operation timeout (the wait family, which
+/// parse_command stamps with AGENT_BROWSER_DEFAULT_TIMEOUT when no explicit
+/// --timeout is given) get that timeout plus margin, so the daemon can report
+/// a proper operation timeout instead of the client dying with EAGAIN at 30s
+/// and the retry loop re-sending the whole long-running command.
+///
+/// The env var is deliberately NOT consulted here. Reading it would apply a
+/// long wait budget to every command, so a genuinely hung daemon on a simple
+/// `url`/`title`/`snapshot` call would take the full budget to surface
+/// instead of 30s. Only commands that actually carry a `timeout` field get
+/// the extended budget, and that field is set client-side per invocation,
+/// avoiding the daemon's spawn-time env snapshot drifting from the client.
 fn read_timeout_for(cmd: &Value) -> Duration {
-    let op_ms = cmd
-        .get("timeout")
-        .and_then(|v| v.as_u64())
-        .or_else(|| {
-            std::env::var("AGENT_BROWSER_DEFAULT_TIMEOUT")
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-        })
-        .unwrap_or(0);
+    let op_ms = cmd.get("timeout").and_then(|v| v.as_u64()).unwrap_or(0);
     Duration::from_millis(op_ms.saturating_add(10_000).max(30_000))
 }
 

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -847,10 +847,28 @@ fn has_os_error(error: &str, code: u32) -> bool {
     error.contains(&format!("(os error {})", code))
 }
 
+/// Socket read timeout for one request. The 30s floor covers ordinary
+/// commands; commands carrying an explicit operation timeout (e.g.
+/// `wait --timeout 120000`) get that plus margin, so the daemon can report
+/// a proper operation timeout instead of the client dying with EAGAIN at
+/// 30s and the retry loop re-sending the whole long-running command.
+fn read_timeout_for(cmd: &Value) -> Duration {
+    let op_ms = cmd
+        .get("timeout")
+        .and_then(|v| v.as_u64())
+        .or_else(|| {
+            std::env::var("AGENT_BROWSER_DEFAULT_TIMEOUT")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+        })
+        .unwrap_or(0);
+    Duration::from_millis(op_ms.saturating_add(10_000).max(30_000))
+}
+
 fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
     let mut stream = connect(session)?;
 
-    stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+    stream.set_read_timeout(Some(read_timeout_for(cmd))).ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
     let mut json_str = serde_json::to_string(cmd).map_err(|e| e.to_string())?;

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -812,6 +812,7 @@ pub fn send_command(cmd: Value, session: &str) -> Result<Response, String> {
 /// - EAGAIN/EWOULDBLOCK (os error 35 on macOS, 11 on Linux)
 /// - EOF errors (daemon closed connection before responding)
 /// - Connection reset/broken pipe (daemon crashed or restarting)
+///
 /// Connection refused / missing socket are NOT transient: no daemon is
 /// listening, so backing off cannot help. Callers use daemon_unreachable()
 /// to respawn via ensure_daemon and retry once instead.

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -580,26 +580,26 @@ pub fn ensure_daemon(session: &str, opts: &DaemonOptions) -> Result<DaemonResult
     // Socket connectivity is the sole liveness check — no PID check — so
     // callers in a different PID namespace (e.g. unshare) can still reuse
     // an existing daemon they can reach over the socket.
+    //
+    // No settle-sleep here: this runs on every CLI invocation, so a fixed
+    // delay would tax every command (a 150ms sleep used to dominate warm
+    // command latency). The rare race where the daemon exits right after
+    // this check is handled at request time: callers respawn via
+    // ensure_daemon when the request fails with daemon_unreachable().
     if daemon_ready(session) {
-        // Double-check it's actually responsive by waiting and checking again
-        // This handles the race condition where daemon is shutting down
-        // (daemon has a 100ms shutdown delay, so we wait longer)
-        thread::sleep(Duration::from_millis(150));
-        if daemon_ready(session) {
-            // Check version: if the running daemon is from a different CLI
-            // version (e.g. after an upgrade), kill it and start a fresh one.
-            if !daemon_version_matches(session) {
-                eprintln!(
-                    "{} Daemon version mismatch detected, restarting...",
-                    crate::color::warning_indicator()
-                );
-                kill_stale_daemon(session);
-                // Fall through to spawn a new daemon below
-            } else {
-                return Ok(DaemonResult {
-                    already_running: true,
-                });
-            }
+        // Check version: if the running daemon is from a different CLI
+        // version (e.g. after an upgrade), kill it and start a fresh one.
+        if !daemon_version_matches(session) {
+            eprintln!(
+                "{} Daemon version mismatch detected, restarting...",
+                crate::color::warning_indicator()
+            );
+            kill_stale_daemon(session);
+            // Fall through to spawn a new daemon below
+        } else {
+            return Ok(DaemonResult {
+                already_running: true,
+            });
         }
     }
 
@@ -807,28 +807,44 @@ pub fn send_command(cmd: Value, session: &str) -> Result<Response, String> {
     ))
 }
 
-/// Check if an error is transient and worth retrying.
+/// Check if an error is transient and worth retrying against the SAME daemon.
 /// Transient errors include:
 /// - EAGAIN/EWOULDBLOCK (os error 35 on macOS, 11 on Linux)
 /// - EOF errors (daemon closed connection before responding)
 /// - Connection reset/broken pipe (daemon crashed or restarting)
-/// - Connection refused/socket not found (daemon still starting)
+/// Connection refused / missing socket are NOT transient: no daemon is
+/// listening, so backing off cannot help. Callers use daemon_unreachable()
+/// to respawn via ensure_daemon and retry once instead.
 fn is_transient_error(error: &str) -> bool {
-    error.contains("os error 35") // EAGAIN on macOS
-        || error.contains("os error 11") // EAGAIN on Linux
+    has_os_error(error, 35) // EAGAIN on macOS
+        || has_os_error(error, 11) // EAGAIN on Linux
         || error.contains("WouldBlock")
         || error.contains("Resource temporarily unavailable")
         || error.contains("EOF")
         || error.contains("line 1 column 0") // Empty JSON response
         || error.contains("Connection reset")
         || error.contains("Broken pipe")
-        || error.contains("os error 54") // Connection reset by peer (macOS)
-        || error.contains("os error 104") // Connection reset by peer (Linux)
-        || error.contains("os error 2") // No such file or directory (socket gone)
-        || error.contains("os error 61") // Connection refused (macOS)
-        || error.contains("os error 111") // Connection refused (Linux)
-        || error.contains("os error 10061") // Connection refused (Windows)
-        || error.contains("os error 10054") // Connection reset by peer (Windows)
+        || has_os_error(error, 54) // Connection reset by peer (macOS)
+        || has_os_error(error, 104) // Connection reset by peer (Linux)
+        || has_os_error(error, 10054) // Connection reset by peer (Windows)
+}
+
+/// True when the error means no daemon is listening on the session socket
+/// (exited or never started), as opposed to a live-but-busy daemon. The
+/// remedy is a respawn through ensure_daemon, not a retry.
+pub fn daemon_unreachable(error: &str) -> bool {
+    error.contains("Failed to connect")
+        || has_os_error(error, 2) // No such file or directory (socket gone)
+        || has_os_error(error, 61) // Connection refused (macOS)
+        || has_os_error(error, 111) // Connection refused (Linux)
+        || has_os_error(error, 10061) // Connection refused (Windows)
+}
+
+/// Exact `(os error N)` match. Bare substring checks like "os error 11"
+/// also matched "os error 111" (connection refused on Linux), which made
+/// EAGAIN handling swallow refused connections.
+fn has_os_error(error: &str, code: u32) -> bool {
+    error.contains(&format!("(os error {})", code))
 }
 
 fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
@@ -983,32 +999,35 @@ mod tests {
         ));
     }
 
+    // Connection refused / missing socket mean no daemon is listening:
+    // not transient (retry can't help), handled by respawn via
+    // daemon_unreachable instead.
     #[test]
-    fn test_is_transient_error_socket_not_found() {
-        assert!(is_transient_error(
-            "Failed to connect: No such file or directory (os error 2)"
-        ));
+    fn test_socket_not_found_is_unreachable_not_transient() {
+        let error = "Failed to connect: No such file or directory (os error 2)";
+        assert!(!is_transient_error(error));
+        assert!(daemon_unreachable(error));
     }
 
     #[test]
-    fn test_is_transient_error_connection_refused_macos() {
-        assert!(is_transient_error(
-            "Failed to connect: Connection refused (os error 61)"
-        ));
+    fn test_connection_refused_macos_is_unreachable_not_transient() {
+        let error = "Failed to connect: Connection refused (os error 61)";
+        assert!(!is_transient_error(error));
+        assert!(daemon_unreachable(error));
     }
 
     #[test]
-    fn test_is_transient_error_connection_refused_linux() {
-        assert!(is_transient_error(
-            "Failed to connect: Connection refused (os error 111)"
-        ));
+    fn test_connection_refused_linux_is_unreachable_not_transient() {
+        let error = "Failed to connect: Connection refused (os error 111)";
+        assert!(!is_transient_error(error));
+        assert!(daemon_unreachable(error));
     }
 
     #[test]
-    fn test_is_transient_error_connection_refused_windows() {
-        assert!(is_transient_error(
-            "Failed to connect: No connection could be made because the target machine actively refused it. (os error 10061)"
-        ));
+    fn test_connection_refused_windows_is_unreachable_not_transient() {
+        let error = "Failed to connect: No connection could be made because the target machine actively refused it. (os error 10061)";
+        assert!(!is_transient_error(error));
+        assert!(daemon_unreachable(error));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1222,25 +1222,13 @@ fn main() {
                 .map(commands::shell_words_split)
                 .collect::<Vec<Vec<String>>>()
         });
-        run_batch(&flags, bail, arg_commands);
+        run_batch(&flags, &daemon_opts, bail, arg_commands);
         return;
     }
 
     let output_opts = OutputOptions::from_flags(&flags);
 
-    // ensure_daemon no longer pays a settle-sleep on every command, so a
-    // daemon that exited right after its liveness check surfaces here as an
-    // unreachable socket. Respawn once and retry before reporting failure.
-    let first_attempt = send_command(cmd.clone(), &flags.session);
-    let send_result = match first_attempt {
-        Err(ref e) if daemon_unreachable(e) => match ensure_daemon(&flags.session, &daemon_opts) {
-            Ok(_) => send_command(cmd.clone(), &flags.session),
-            Err(_) => first_attempt,
-        },
-        other => other,
-    };
-
-    match send_result {
+    match send_command_with_respawn(cmd.clone(), &flags.session, &daemon_opts) {
         Ok(resp) => {
             let success = resp.success;
             // Handle interactive confirmation
@@ -1314,7 +1302,31 @@ fn main() {
     }
 }
 
-fn run_batch(flags: &Flags, bail: bool, arg_commands: Option<Vec<Vec<String>>>) {
+/// send_command plus the daemon-shutdown-race recovery: ensure_daemon no
+/// longer pays a settle-sleep on every invocation, so a daemon that exited
+/// right after its liveness check surfaces as an unreachable socket on the
+/// request itself. Respawn once and retry before reporting failure.
+fn send_command_with_respawn(
+    cmd: serde_json::Value,
+    session: &str,
+    daemon_opts: &DaemonOptions,
+) -> Result<connection::Response, String> {
+    let first_attempt = send_command(cmd.clone(), session);
+    match first_attempt {
+        Err(ref e) if daemon_unreachable(e) => match ensure_daemon(session, daemon_opts) {
+            Ok(_) => send_command(cmd, session),
+            Err(_) => first_attempt,
+        },
+        other => other,
+    }
+}
+
+fn run_batch(
+    flags: &Flags,
+    daemon_opts: &DaemonOptions,
+    bail: bool,
+    arg_commands: Option<Vec<Vec<String>>>,
+) {
     let commands: Vec<Vec<String>> = if let Some(cmds) = arg_commands {
         cmds
     } else {
@@ -1400,7 +1412,7 @@ fn run_batch(flags: &Flags, bail: bool, arg_commands: Option<Vec<Vec<String>>>) 
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        match send_command(parsed, &flags.session) {
+        match send_command_with_respawn(parsed, &flags.session, daemon_opts) {
             Ok(resp) => {
                 if flags.json {
                     results.push(json!({

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,8 +26,7 @@ use windows_sys::Win32::System::Threading::OpenProcess;
 use commands::{gen_id, parse_command, ParseError};
 use connection::{
     cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
-    send_command, walk_daemons,
-    DaemonOptions,
+    send_command, walk_daemons, DaemonOptions,
 };
 use flags::{clean_args, parse_flags, Flags};
 use install::run_install;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,7 +25,8 @@ use windows_sys::Win32::System::Threading::OpenProcess;
 
 use commands::{gen_id, parse_command, ParseError};
 use connection::{
-    cleanup_stale_files, ensure_daemon, get_socket_dir, is_pid_alive, send_command, walk_daemons,
+    cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
+    send_command, walk_daemons,
     DaemonOptions,
 };
 use flags::{clean_args, parse_flags, Flags};
@@ -1228,7 +1229,19 @@ fn main() {
 
     let output_opts = OutputOptions::from_flags(&flags);
 
-    match send_command(cmd.clone(), &flags.session) {
+    // ensure_daemon no longer pays a settle-sleep on every command, so a
+    // daemon that exited right after its liveness check surfaces here as an
+    // unreachable socket. Respawn once and retry before reporting failure.
+    let first_attempt = send_command(cmd.clone(), &flags.session);
+    let send_result = match first_attempt {
+        Err(ref e) if daemon_unreachable(e) => match ensure_daemon(&flags.session, &daemon_opts) {
+            Ok(_) => send_command(cmd.clone(), &flags.session),
+            Err(_) => first_attempt,
+        },
+        other => other,
+    };
+
+    match send_result {
         Ok(resp) => {
             let success = resp.success;
             // Handle interactive confirmation

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -150,6 +150,9 @@ pub struct PendingDialog {
     pub message: String,
     pub url: String,
     pub default_prompt: Option<String>,
+    /// Flat CDP session the dialog opened on. A dialog on a background tab
+    /// must not block commands targeting the active tab.
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -245,6 +248,9 @@ pub struct DaemonState {
     pub mouse_state: MouseState,
     /// Tracks the currently open JavaScript dialog (alert/confirm/prompt), if any.
     pub pending_dialog: Option<PendingDialog>,
+    /// A mouse button left logically down because a dialog opened between
+    /// mousePressed and mouseReleased; released when the dialog is resolved.
+    pub pending_pointer_release: Option<super::interaction::PendingRelease>,
     /// When true, automatically dismiss `beforeunload` dialogs and accept `alert`
     /// dialogs so they never block the agent.  Enabled by default.
     pub auto_dialog: bool,
@@ -302,6 +308,7 @@ impl DaemonState {
             dialog_handler_task: None,
             mouse_state: MouseState::default(),
             pending_dialog: None,
+            pending_pointer_release: None,
             auto_dialog: !matches!(
                 env::var("AGENT_BROWSER_NO_AUTO_DIALOG").as_deref(),
                 Ok("1" | "true" | "yes")
@@ -1106,6 +1113,7 @@ impl DaemonState {
                                         message: dialog_event.message,
                                         url: dialog_event.url,
                                         default_prompt: dialog_event.default_prompt,
+                                        session_id: event.session_id.clone(),
                                     });
                                 }
                             }
@@ -1293,10 +1301,33 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // any command that touches the page would hang until the client read
     // timeout. Fail fast with instructions instead. Actions in skip_launch
     // never touch the page; dialog/screenshot/url/title are browser-side.
+    // Only a dialog on the ACTIVE tab blocks: one on a background tab leaves
+    // the active tab's renderer responsive.
     if let Some(ref dialog) = state.pending_dialog {
-        let safe_during_dialog =
-            skip_launch || matches!(action, "dialog" | "screenshot" | "url" | "title");
-        if !safe_during_dialog {
+        let active_session = state
+            .browser
+            .as_ref()
+            .and_then(|m| m.active_session_id().ok().map(|s| s.to_string()));
+        let on_active_tab = match (&dialog.session_id, &active_session) {
+            (Some(dialog_sid), Some(active_sid)) => dialog_sid == active_sid,
+            // No session on the event = top-level page dialog; no browser = be safe.
+            _ => true,
+        };
+        // Tab and session management must stay usable: switching or closing
+        // tabs is exactly how an agent escapes a tab blocked by a dialog.
+        let safe_during_dialog = skip_launch
+            || matches!(
+                action,
+                "dialog"
+                    | "screenshot"
+                    | "url"
+                    | "title"
+                    | "tab_list"
+                    | "tab_new"
+                    | "tab_switch"
+                    | "tab_close"
+            );
+        if on_active_tab && !safe_during_dialog {
             return error_response(
                 &id,
                 &format!(
@@ -2715,7 +2746,7 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     let button = cmd.get("button").and_then(|v| v.as_str()).unwrap_or("left");
     let click_count = cmd.get("clickCount").and_then(|v| v.as_i64()).unwrap_or(1) as i32;
 
-    let dialog_opened = interaction::click(
+    let result = interaction::click(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -2726,7 +2757,8 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     )
     .await?;
 
-    if dialog_opened {
+    if result.dialog_opened {
+        state.pending_pointer_release = result.pending_release;
         return Ok(json!({ "clicked": selector, "dialogOpened": true }));
     }
     Ok(json!({ "clicked": selector }))
@@ -2740,7 +2772,7 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .and_then(|v| v.as_str())
         .ok_or("Missing 'selector' parameter")?;
 
-    let dialog_opened = interaction::dblclick(
+    let result = interaction::dblclick(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -2748,7 +2780,8 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &state.iframe_sessions,
     )
     .await?;
-    if dialog_opened {
+    if result.dialog_opened {
+        state.pending_pointer_release = result.pending_release;
         return Ok(json!({ "clicked": selector, "dialogOpened": true }));
     }
     Ok(json!({ "clicked": selector }))
@@ -4809,6 +4842,15 @@ async fn handle_dialog(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     let result = mgr.handle_dialog(accept, prompt_text).await;
     state.pending_dialog = None;
     result?;
+
+    // If a click's mousedown opened this dialog, the button is still logically
+    // down. Release it now that the page is unblocked so the next click does
+    // not register as a drag or double-click.
+    if let Some(release) = state.pending_pointer_release.take() {
+        if let Some(ref mgr) = state.browser {
+            let _ = interaction::dispatch_pending_release(&mgr.client, &release).await;
+        }
+    }
     Ok(json!({ "handled": true, "accepted": accept }))
 }
 
@@ -5778,7 +5820,7 @@ async fn execute_subaction(
 
     match subaction {
         "click" => {
-            let dialog_opened = interaction::click(
+            let result = interaction::click(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
@@ -5788,7 +5830,8 @@ async fn execute_subaction(
                 &state.iframe_sessions,
             )
             .await?;
-            if dialog_opened {
+            if result.dialog_opened {
+                state.pending_pointer_release = result.pending_release;
                 return Ok(json!({ "clicked": selector, "dialogOpened": true }));
             }
             Ok(json!({ "clicked": selector }))

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1282,6 +1282,24 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         );
     }
 
+    // A pending confirm/prompt dialog blocks the renderer's main thread, so
+    // any command that touches the page would hang until the client read
+    // timeout. Fail fast with instructions instead. Actions in skip_launch
+    // never touch the page; dialog/screenshot/url/title are browser-side.
+    if let Some(ref dialog) = state.pending_dialog {
+        let safe_during_dialog =
+            skip_launch || matches!(action, "dialog" | "screenshot" | "url" | "title");
+        if !safe_during_dialog {
+            return error_response(
+                &id,
+                &format!(
+                    "A JavaScript {} dialog is blocking the page: \"{}\". Resolve it with `dialog accept` or `dialog dismiss`, then retry `{}`.",
+                    dialog.dialog_type, dialog.message, action
+                ),
+            );
+        }
+    }
+
     let result = match action {
         "launch" => handle_launch(cmd, state).await,
         "navigate" => handle_navigate(cmd, state).await,
@@ -1452,6 +1470,10 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
     };
+
+    // Re-drain so a dialog opened by THIS command is reflected in the warning
+    // below; events are otherwise only drained at the start of a command.
+    state.drain_cdp_events_background().await;
 
     // Auto-report pending JavaScript dialog so agents know why commands may hang
     if action != "dialog" {
@@ -2686,7 +2708,7 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     let button = cmd.get("button").and_then(|v| v.as_str()).unwrap_or("left");
     let click_count = cmd.get("clickCount").and_then(|v| v.as_i64()).unwrap_or(1) as i32;
 
-    interaction::click(
+    let dialog_opened = interaction::click(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -2697,6 +2719,9 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     )
     .await?;
 
+    if dialog_opened {
+        return Ok(json!({ "clicked": selector, "dialogOpened": true }));
+    }
     Ok(json!({ "clicked": selector }))
 }
 
@@ -2708,7 +2733,7 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .and_then(|v| v.as_str())
         .ok_or("Missing 'selector' parameter")?;
 
-    interaction::dblclick(
+    let dialog_opened = interaction::dblclick(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -2716,6 +2741,9 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &state.iframe_sessions,
     )
     .await?;
+    if dialog_opened {
+        return Ok(json!({ "clicked": selector, "dialogOpened": true }));
+    }
     Ok(json!({ "clicked": selector }))
 }
 
@@ -4680,8 +4708,12 @@ async fn handle_dialog(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         .unwrap_or(true);
     let prompt_text = cmd.get("promptText").and_then(|v| v.as_str());
 
-    mgr.handle_dialog(accept, prompt_text).await?;
+    // Clear tracked state even if Chrome reports no dialog (e.g. it was
+    // already resolved and the closed event was missed); otherwise a stale
+    // pending_dialog would make every page command fail fast forever.
+    let result = mgr.handle_dialog(accept, prompt_text).await;
     state.pending_dialog = None;
+    result?;
     Ok(json!({ "handled": true, "accepted": accept }))
 }
 
@@ -5651,7 +5683,7 @@ async fn execute_subaction(
 
     match subaction {
         "click" => {
-            interaction::click(
+            let dialog_opened = interaction::click(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
@@ -5661,6 +5693,9 @@ async fn execute_subaction(
                 &state.iframe_sessions,
             )
             .await?;
+            if dialog_opened {
+                return Ok(json!({ "clicked": selector, "dialogOpened": true }));
+            }
             Ok(json!({ "clicked": selector }))
         }
         "fill" => {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5875,17 +5875,38 @@ async fn handle_semantic_locator(
     };
 
     let query = match strategy {
-        "label" => format!(
-            r#"(() => {{
-                const label = Array.from(document.querySelectorAll('label')).find(el => {match_fn});
-                if (!label) return false;
-                const forId = label.getAttribute('for');
-                const target = forId ? document.getElementById(forId) : label.querySelector('input,select,textarea');
-                if (target) {{ target.setAttribute('data-agent-browser-located', 'true'); return true; }}
+        // Like Playwright's getByLabel: match <label> associations AND
+        // aria-label / aria-labelledby. Icon buttons and custom controls
+        // are usually labelled via aria-label only.
+        "label" => {
+            let value_json = serde_json::to_string(value).unwrap_or_default();
+            let matches_fn = if exact {
+                format!("(s) => !!s && s.trim() === {value_json}")
+            } else {
+                format!("(s) => !!s && s.includes({value_json})")
+            };
+            format!(
+                r#"(() => {{
+                const matches = {matches_fn};
+                const label = Array.from(document.querySelectorAll('label')).find(el => matches(el.textContent));
+                if (label) {{
+                    const forId = label.getAttribute('for');
+                    const target = forId ? document.getElementById(forId) : label.querySelector('input,select,textarea');
+                    if (target) {{ target.setAttribute('data-agent-browser-located', 'true'); return true; }}
+                }}
+                const aria = Array.from(document.querySelectorAll('[aria-label]')).find(el => matches(el.getAttribute('aria-label')));
+                if (aria) {{ aria.setAttribute('data-agent-browser-located', 'true'); return true; }}
+                const referenced = Array.from(document.querySelectorAll('[aria-labelledby]')).find(el => {{
+                    const text = el.getAttribute('aria-labelledby').split(/\s+/)
+                        .map(id => {{ const r = document.getElementById(id); return r ? r.textContent : ''; }})
+                        .join(' ');
+                    return matches(text);
+                }});
+                if (referenced) {{ referenced.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
             }})()"#,
-            match_fn = match_fn,
-        ),
+            )
+        }
         "placeholder" => format!(
             r#"(() => {{
                 const el = document.querySelector('input[placeholder={val}], textarea[placeholder={val}]');

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3028,8 +3028,7 @@ async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
                 }
             },
             None => {
-                wait_for_selector(&mgr.client, &session_id, selector, state_str, timeout_ms)
-                    .await?
+                wait_for_selector(&mgr.client, &session_id, selector, state_str, timeout_ms).await?
             }
         }
         return Ok(json!({ "waited": "selector", "selector": selector }));
@@ -3329,7 +3328,8 @@ async fn wait_for_selector_in_frame(
     state: &str,
     timeout_ms: u64,
 ) -> Result<(), String> {
-    let owner_object_id = super::element::frame_owner_object_id(client, session_id, frame_id).await?;
+    let owner_object_id =
+        super::element::frame_owner_object_id(client, session_id, frame_id).await?;
     let sel = serde_json::to_string(selector).unwrap_or_default();
     let check = match state {
         "attached" => format!("!!doc.querySelector({sel})"),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -310,10 +310,13 @@ impl DaemonState {
             stream_server: None,
             launch_hash: None,
             engine: env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
+            // README documents 25s, intentionally below the CLI's 30s IPC
+            // read timeout so the daemon reports a proper timeout error
+            // instead of the client dying with EAGAIN and retrying.
             default_timeout_ms: env::var("AGENT_BROWSER_DEFAULT_TIMEOUT")
                 .ok()
                 .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(30_000),
+                .unwrap_or(25_000),
             viewport: None,
         }
     }
@@ -8869,10 +8872,11 @@ mod tests {
 
     #[test]
     fn test_default_timeout_ms_fallback() {
-        // When AGENT_BROWSER_DEFAULT_TIMEOUT is unset, DaemonState uses 30000
+        // When AGENT_BROWSER_DEFAULT_TIMEOUT is unset, DaemonState uses the
+        // documented 25s default (below the CLI's 30s IPC read timeout).
         env::remove_var("AGENT_BROWSER_DEFAULT_TIMEOUT");
         let state = DaemonState::new();
-        assert_eq!(state.default_timeout_ms, 30_000);
+        assert_eq!(state.default_timeout_ms, 25_000);
     }
 
     #[tokio::test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1171,6 +1171,10 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // Drain and apply pending CDP events (console, errors, screencast frames, target lifecycle)
     state.drain_cdp_events_background().await;
 
+    // Keep element resolution in sync with the `frame` selection (see
+    // element::set_active_frame for why this is mirrored).
+    super::element::set_active_frame(state.active_frame_id.as_deref());
+
     // Hot-reload and check action policy
     if let Some(ref mut policy) = state.policy {
         let _ = policy.reload();
@@ -3004,7 +3008,30 @@ async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
             .get("state")
             .and_then(|v| v.as_str())
             .unwrap_or("visible");
-        wait_for_selector(&mgr.client, &session_id, selector, state_str, timeout_ms).await?;
+        // Honor an active `frame <sel>` selection, like element resolution does.
+        match state.active_frame_id.as_deref() {
+            Some(frame_id) => match state.iframe_sessions.get(frame_id) {
+                Some(frame_session) => {
+                    wait_for_selector(&mgr.client, frame_session, selector, state_str, timeout_ms)
+                        .await?
+                }
+                None => {
+                    wait_for_selector_in_frame(
+                        &mgr.client,
+                        &session_id,
+                        frame_id,
+                        selector,
+                        state_str,
+                        timeout_ms,
+                    )
+                    .await?
+                }
+            },
+            None => {
+                wait_for_selector(&mgr.client, &session_id, selector, state_str, timeout_ms)
+                    .await?
+            }
+        }
         return Ok(json!({ "waited": "selector", "selector": selector }));
     }
 
@@ -3289,6 +3316,71 @@ async fn wait_for_function(
 ) -> Result<(), String> {
     let check_fn = format!("!!({})", fn_str);
     poll_until_true(client, session_id, &check_fn, timeout_ms).await
+}
+
+/// wait_for_selector inside a same-process iframe selected via `frame <sel>`:
+/// polls through the owner element's contentDocument, which stays correct
+/// even if the frame navigates (the getter re-resolves every poll).
+async fn wait_for_selector_in_frame(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    selector: &str,
+    state: &str,
+    timeout_ms: u64,
+) -> Result<(), String> {
+    let owner_object_id = super::element::frame_owner_object_id(client, session_id, frame_id).await?;
+    let sel = serde_json::to_string(selector).unwrap_or_default();
+    let check = match state {
+        "attached" => format!("!!doc.querySelector({sel})"),
+        "detached" => format!("!doc.querySelector({sel})"),
+        "hidden" => format!(
+            r#"(() => {{
+                const el = doc.querySelector({sel});
+                if (!el) return true;
+                const s = doc.defaultView.getComputedStyle(el);
+                return s.display === 'none' || s.visibility === 'hidden' || parseFloat(s.opacity) === 0;
+            }})()"#,
+        ),
+        _ => format!(
+            r#"(() => {{
+                const el = doc.querySelector({sel});
+                if (!el) return false;
+                const r = el.getBoundingClientRect();
+                const s = doc.defaultView.getComputedStyle(el);
+                return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none';
+            }})()"#,
+        ),
+    };
+    let function = format!(
+        "function() {{ const doc = this.contentDocument; if (!doc) return false; return {check}; }}",
+    );
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    loop {
+        let result = client
+            .send_command(
+                "Runtime.callFunctionOn",
+                Some(json!({
+                    "objectId": owner_object_id,
+                    "functionDeclaration": function,
+                    "returnByValue": true,
+                })),
+                Some(session_id),
+            )
+            .await?;
+        let satisfied = result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if satisfied {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!("Wait timed out after {}ms", timeout_ms));
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
 }
 
 async fn poll_until_true(

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -163,6 +163,7 @@ pub async fn resolve_element_center(
 
         // Try cached backend_node_id first (fast path)
         if let Some(backend_node_id) = entry.backend_node_id {
+            scroll_node_into_view(client, effective_session_id, backend_node_id).await;
             let result: Result<DomGetBoxModelResult, String> = client
                 .send_command_typed(
                     "DOM.getBoxModel",
@@ -193,6 +194,7 @@ pub async fn resolve_element_center(
             iframe_sessions,
         )
         .await?;
+        scroll_node_into_view(client, effective_session_id, fresh_id).await;
         let result: DomGetBoxModelResult = client
             .send_command_typed(
                 "DOM.getBoxModel",
@@ -211,6 +213,20 @@ pub async fn resolve_element_center(
     // CSS selector
     let (x, y) = resolve_by_selector(client, session_id, selector_or_ref).await?;
     Ok((x, y, session_id.to_string()))
+}
+
+/// Coordinates from DOM.getBoxModel are viewport-relative, and input events
+/// only land inside the viewport, so make sure the node is visible first.
+/// Best effort: a node that cannot be scrolled (display:none, detached) will
+/// fail in DOM.getBoxModel with a clearer error anyway.
+async fn scroll_node_into_view(client: &CdpClient, session_id: &str, backend_node_id: i64) {
+    let _ = client
+        .send_command(
+            "DOM.scrollIntoViewIfNeeded",
+            Some(serde_json::json!({ "backendNodeId": backend_node_id })),
+            Some(session_id),
+        )
+        .await;
 }
 
 pub async fn resolve_element_object_id(
@@ -428,11 +444,21 @@ fn build_count_elements_js(selector: &str) -> String {
 
 fn build_selector_js(selector: &str) -> String {
     let find_expr = build_find_element_js(selector);
+    // Input events dispatch at viewport coordinates, so an element outside the
+    // viewport must be scrolled into view first or the click lands on nothing.
     format!(
         r#"(() => {{
             const el = {find_expr};
             if (!el) return null;
-            const rect = el.getBoundingClientRect();
+            const inView = (r) => r.width > 0 && r.height > 0 &&
+                r.bottom > 0 && r.right > 0 &&
+                r.top < (window.innerHeight || document.documentElement.clientHeight) &&
+                r.left < (window.innerWidth || document.documentElement.clientWidth);
+            let rect = el.getBoundingClientRect();
+            if (!inView(rect)) {{
+                el.scrollIntoView({{ block: 'center', inline: 'center', behavior: 'instant' }});
+                rect = el.getBoundingClientRect();
+            }}
             return {{ x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }};
         }})()"#,
     )

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -250,7 +250,10 @@ async fn resolve_center_in_same_process_frame(
     let y = value.and_then(|v| v.get("y")).and_then(|v| v.as_f64());
     match (x, y) {
         (Some(x), Some(y)) => Ok((x, y)),
-        _ => Err(format!("Element not found in the selected frame: {}", selector)),
+        _ => Err(format!(
+            "Element not found in the selected frame: {}",
+            selector
+        )),
     }
 }
 

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -146,6 +146,145 @@ pub fn parse_ref(input: &str) -> Option<String> {
     None
 }
 
+/// Mirror of DaemonState.active_frame_id, refreshed before every command
+/// (commands are serialized by the daemon's state lock, so this cannot
+/// race). It lets CSS-selector resolution honor `frame <sel>` without
+/// threading a parameter through every interaction signature; snapshot refs
+/// already carry their frame through the ref map.
+static ACTIVE_FRAME: std::sync::OnceLock<std::sync::Mutex<Option<String>>> =
+    std::sync::OnceLock::new();
+
+pub fn set_active_frame(frame_id: Option<&str>) {
+    *ACTIVE_FRAME
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .unwrap() = frame_id.map(String::from);
+}
+
+fn active_frame() -> Option<String> {
+    ACTIVE_FRAME.get().and_then(|m| m.lock().unwrap().clone())
+}
+
+/// Object handle for the <iframe> element that owns a frame, resolved on the
+/// parent session. Works for same-process frames where no dedicated CDP
+/// session exists.
+pub(super) async fn frame_owner_object_id(
+    client: &CdpClient,
+    session_id: &str,
+    frame_id: &str,
+) -> Result<String, String> {
+    let owner = client
+        .send_command(
+            "DOM.getFrameOwner",
+            Some(serde_json::json!({ "frameId": frame_id })),
+            Some(session_id),
+        )
+        .await?;
+    let backend_node_id = owner
+        .get("backendNodeId")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| format!("Could not resolve the owner element of frame {}", frame_id))?;
+    let result: DomResolveNodeResult = client
+        .send_command_typed(
+            "DOM.resolveNode",
+            &DomResolveNodeParams {
+                backend_node_id: Some(backend_node_id),
+                node_id: None,
+                object_group: Some("agent-browser".to_string()),
+            },
+            Some(session_id),
+        )
+        .await?;
+    result
+        .object
+        .object_id
+        .ok_or_else(|| format!("No objectId for the owner element of frame {}", frame_id))
+}
+
+/// Find a selector inside a same-process iframe and return its center in
+/// top-level viewport coordinates (input events dispatch in that space).
+/// Same-origin access to contentDocument is what makes this possible; a
+/// cross-origin frame never takes this path because it has its own session.
+async fn resolve_center_in_same_process_frame(
+    client: &CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    selector: &str,
+) -> Result<(f64, f64), String> {
+    let owner_object_id = frame_owner_object_id(client, session_id, frame_id).await?;
+    let find_expr = build_find_element_js_in("doc", selector);
+    let function = format!(
+        r#"function() {{
+            const doc = this.contentDocument;
+            if (!doc) return null;
+            const el = {find_expr};
+            if (!el) return null;
+            if (el.scrollIntoViewIfNeeded) el.scrollIntoViewIfNeeded(true);
+            else el.scrollIntoView({{ block: 'center', inline: 'center' }});
+            const rect = el.getBoundingClientRect();
+            let x = rect.x + rect.width / 2;
+            let y = rect.y + rect.height / 2;
+            let win = doc.defaultView;
+            while (win && win.frameElement) {{
+                const frameRect = win.frameElement.getBoundingClientRect();
+                x += frameRect.x + win.frameElement.clientLeft;
+                y += frameRect.y + win.frameElement.clientTop;
+                win = win.parent;
+            }}
+            return {{ x: x, y: y }};
+        }}"#,
+    );
+    let result = client
+        .send_command(
+            "Runtime.callFunctionOn",
+            Some(serde_json::json!({
+                "objectId": owner_object_id,
+                "functionDeclaration": function,
+                "returnByValue": true,
+            })),
+            Some(session_id),
+        )
+        .await?;
+    let value = result.get("result").and_then(|r| r.get("value"));
+    let x = value.and_then(|v| v.get("x")).and_then(|v| v.as_f64());
+    let y = value.and_then(|v| v.get("y")).and_then(|v| v.as_f64());
+    match (x, y) {
+        (Some(x), Some(y)) => Ok((x, y)),
+        _ => Err(format!("Element not found in the selected frame: {}", selector)),
+    }
+}
+
+/// Find a selector inside a same-process iframe and return its object handle.
+async fn resolve_object_in_same_process_frame(
+    client: &CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    selector: &str,
+) -> Result<String, String> {
+    let owner_object_id = frame_owner_object_id(client, session_id, frame_id).await?;
+    let find_expr = build_find_element_js_in("doc", selector);
+    let function = format!(
+        "function() {{ const doc = this.contentDocument; if (!doc) return null; return {find_expr}; }}",
+    );
+    let result = client
+        .send_command(
+            "Runtime.callFunctionOn",
+            Some(serde_json::json!({
+                "objectId": owner_object_id,
+                "functionDeclaration": function,
+                "returnByValue": false,
+            })),
+            Some(session_id),
+        )
+        .await?;
+    result
+        .get("result")
+        .and_then(|r| r.get("objectId"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| format!("Element not found in the selected frame: {}", selector))
+}
+
 pub async fn resolve_element_center(
     client: &CdpClient,
     session_id: &str,
@@ -210,7 +349,19 @@ pub async fn resolve_element_center(
         return Ok((x, y, effective_session_id.to_string()));
     }
 
-    // CSS selector
+    // CSS selector: honor an active `frame <sel>` selection.
+    if let Some(frame_id) = active_frame() {
+        // Cross-process iframe: its dedicated session's main frame IS the
+        // iframe, so plain document-rooted resolution works there.
+        if let Some(frame_session) = iframe_sessions.get(&frame_id) {
+            let (x, y) = resolve_by_selector(client, frame_session, selector_or_ref).await?;
+            return Ok((x, y, frame_session.clone()));
+        }
+        let (x, y) =
+            resolve_center_in_same_process_frame(client, session_id, &frame_id, selector_or_ref)
+                .await?;
+        return Ok((x, y, session_id.to_string()));
+    }
     let (x, y) = resolve_by_selector(client, session_id, selector_or_ref).await?;
     Ok((x, y, session_id.to_string()))
 }
@@ -295,7 +446,33 @@ pub async fn resolve_element_object_id(
         return Ok((object_id, effective_session_id.to_string()));
     }
 
-    // Selector fallback (CSS or XPath)
+    // Selector fallback (CSS or XPath): honor an active `frame <sel>` selection.
+    if let Some(frame_id) = active_frame() {
+        if let Some(frame_session) = iframe_sessions.get(&frame_id) {
+            let js = build_find_element_js(selector_or_ref);
+            let result: EvaluateResult = client
+                .send_command_typed(
+                    "Runtime.evaluate",
+                    &EvaluateParams {
+                        expression: js,
+                        return_by_value: Some(false),
+                        await_promise: Some(false),
+                    },
+                    Some(frame_session.as_str()),
+                )
+                .await?;
+            let object_id = result
+                .result
+                .object_id
+                .ok_or_else(|| format!("Element not found: {}", selector_or_ref))?;
+            return Ok((object_id, frame_session.clone()));
+        }
+        let object_id =
+            resolve_object_in_same_process_frame(client, session_id, &frame_id, selector_or_ref)
+                .await?;
+        return Ok((object_id, session_id.to_string()));
+    }
+
     let js = build_find_element_js(selector_or_ref);
     let result: EvaluateResult = client
         .send_command_typed(
@@ -414,15 +591,21 @@ pub(super) fn extract_ax_string(value: &Option<AXValue>) -> String {
 
 /// Build a JS expression that finds a DOM element by CSS selector or XPath.
 fn build_find_element_js(selector: &str) -> String {
+    build_find_element_js_in("document", selector)
+}
+
+/// Same as build_find_element_js but rooted at an arbitrary Document
+/// expression (e.g. an iframe's contentDocument).
+fn build_find_element_js_in(root: &str, selector: &str) -> String {
     if let Some(xpath) = selector.strip_prefix("xpath=") {
         format!(
-            "document.evaluate({}, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue",
-            serde_json::to_string(xpath).unwrap_or_default()
+            "{root}.evaluate({xpath}, {root}, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue",
+            xpath = serde_json::to_string(xpath).unwrap_or_default(),
         )
     } else {
         format!(
-            "document.querySelector({})",
-            serde_json::to_string(selector).unwrap_or_default()
+            "{root}.querySelector({selector})",
+            selector = serde_json::to_string(selector).unwrap_or_default(),
         )
     }
 }

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -6,9 +6,25 @@ use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 use super::element::{resolve_element_center, resolve_element_object_id, RefMap};
 
-/// Returns true if a JavaScript dialog opened while the click was being
-/// dispatched (the click sequence stops there; the page is blocked until the
-/// dialog is resolved with `dialog accept` / `dialog dismiss`).
+/// Outcome of a click. `dialog_opened` is true if a JavaScript dialog opened
+/// mid-sequence (the page is then blocked until `dialog accept`/`dismiss`).
+/// `pending_release` is set only when the dialog opened after mousePressed but
+/// before mouseReleased: the button is logically held until the caller
+/// dispatches the release (done once the dialog is resolved), otherwise the
+/// next click would register as a drag or double-click.
+#[derive(Default)]
+pub struct ClickResult {
+    pub dialog_opened: bool,
+    pub pending_release: Option<PendingRelease>,
+}
+
+pub struct PendingRelease {
+    pub session_id: String,
+    pub x: f64,
+    pub y: f64,
+    pub button: String,
+}
+
 pub async fn click(
     client: &CdpClient,
     session_id: &str,
@@ -17,7 +33,7 @@ pub async fn click(
     button: &str,
     click_count: i32,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<bool, String> {
+) -> Result<ClickResult, String> {
     let (x, y, effective_session_id) = resolve_element_center(
         client,
         session_id,
@@ -26,7 +42,19 @@ pub async fn click(
         iframe_sessions,
     )
     .await?;
-    dispatch_click(client, &effective_session_id, x, y, button, click_count).await
+    // A click-triggered dialog can fire on the frame's own session (OOPIF) or
+    // on the top-level page session; both count as "ours". A dialog on any
+    // other session belongs to a background tab and must not abort this click.
+    dispatch_click(
+        client,
+        &effective_session_id,
+        &[effective_session_id.as_str(), session_id],
+        x,
+        y,
+        button,
+        click_count,
+    )
+    .await
 }
 
 pub async fn dblclick(
@@ -35,7 +63,7 @@ pub async fn dblclick(
     ref_map: &RefMap,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<bool, String> {
+) -> Result<ClickResult, String> {
     click(
         client,
         session_id,
@@ -915,6 +943,7 @@ pub async fn tap_touch(
 async fn dispatch_mouse_or_dialog(
     client: &CdpClient,
     session_id: &str,
+    accept_sessions: &[&str],
     params: &DispatchMouseEventParams,
 ) -> Result<bool, String> {
     use tokio::sync::broadcast::error::RecvError;
@@ -932,7 +961,20 @@ async fn dispatch_mouse_or_dialog(
             }
             event = events.recv() => {
                 match event {
-                    Ok(e) if e.method == "Page.javascriptDialogOpening" => return Ok(true),
+                    Ok(e) if e.method == "Page.javascriptDialogOpening" => {
+                        // Only a dialog on this click's frame/page session
+                        // aborts it; a background-tab dialog must not. A
+                        // session-less event has no flat session and is
+                        // treated as the top-level page (i.e. ours).
+                        let ours = match e.session_id.as_deref() {
+                            Some(sid) => accept_sessions.contains(&sid),
+                            None => true,
+                        };
+                        if ours {
+                            return Ok(true);
+                        }
+                        continue;
+                    }
                     Ok(_) => continue,
                     Err(RecvError::Lagged(_)) => continue,
                     Err(RecvError::Closed) => {
@@ -945,19 +987,20 @@ async fn dispatch_mouse_or_dialog(
     }
 }
 
-/// Returns true if a JavaScript dialog opened mid-click (sequence aborted).
 async fn dispatch_click(
     client: &CdpClient,
     session_id: &str,
+    accept_sessions: &[&str],
     x: f64,
     y: f64,
     button: &str,
     click_count: i32,
-) -> Result<bool, String> {
+) -> Result<ClickResult, String> {
     // Move
     if dispatch_mouse_or_dialog(
         client,
         session_id,
+        accept_sessions,
         &DispatchMouseEventParams {
             event_type: "mouseMoved".to_string(),
             x,
@@ -972,7 +1015,11 @@ async fn dispatch_click(
     )
     .await?
     {
-        return Ok(true);
+        // No button was pressed yet, nothing to release.
+        return Ok(ClickResult {
+            dialog_opened: true,
+            pending_release: None,
+        });
     }
 
     let button_value = match button {
@@ -985,6 +1032,7 @@ async fn dispatch_click(
     if dispatch_mouse_or_dialog(
         client,
         session_id,
+        accept_sessions,
         &DispatchMouseEventParams {
             event_type: "mousePressed".to_string(),
             x,
@@ -999,13 +1047,26 @@ async fn dispatch_click(
     )
     .await?
     {
-        return Ok(true);
+        // Dialog opened from the mousedown handler: the button is held and the
+        // release will never arrive on its own. Hand the caller what it needs
+        // to release once the dialog is resolved.
+        return Ok(ClickResult {
+            dialog_opened: true,
+            pending_release: Some(PendingRelease {
+                session_id: session_id.to_string(),
+                x,
+                y,
+                button: button.to_string(),
+            }),
+        });
     }
 
-    // Release
-    dispatch_mouse_or_dialog(
+    // Release. A dialog here fired from the click/mouseup handler, which runs
+    // after the button is already up, so there is nothing left to release.
+    let dialog_opened = dispatch_mouse_or_dialog(
         client,
         session_id,
+        accept_sessions,
         &DispatchMouseEventParams {
             event_type: "mouseReleased".to_string(),
             x,
@@ -1018,7 +1079,37 @@ async fn dispatch_click(
             modifiers: None,
         },
     )
-    .await
+    .await?;
+    Ok(ClickResult {
+        dialog_opened,
+        pending_release: None,
+    })
+}
+
+/// Best-effort mouseReleased to clear a button left logically down when a
+/// dialog opened mid-click. Called after the dialog is resolved.
+pub async fn dispatch_pending_release(
+    client: &CdpClient,
+    release: &PendingRelease,
+) -> Result<(), String> {
+    client
+        .send_command_typed::<_, Value>(
+            "Input.dispatchMouseEvent",
+            &DispatchMouseEventParams {
+                event_type: "mouseReleased".to_string(),
+                x: release.x,
+                y: release.y,
+                button: Some(release.button.clone()),
+                buttons: Some(0),
+                click_count: Some(1),
+                delta_x: None,
+                delta_y: None,
+                modifiers: None,
+            },
+            Some(&release.session_id),
+        )
+        .await?;
+    Ok(())
 }
 
 fn char_to_key_info(ch: char) -> (String, String, i32) {

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -6,6 +6,9 @@ use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 use super::element::{resolve_element_center, resolve_element_object_id, RefMap};
 
+/// Returns true if a JavaScript dialog opened while the click was being
+/// dispatched (the click sequence stops there; the page is blocked until the
+/// dialog is resolved with `dialog accept` / `dialog dismiss`).
 pub async fn click(
     client: &CdpClient,
     session_id: &str,
@@ -14,7 +17,7 @@ pub async fn click(
     button: &str,
     click_count: i32,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let (x, y, effective_session_id) = resolve_element_center(
         client,
         session_id,
@@ -32,7 +35,7 @@ pub async fn dblclick(
     ref_map: &RefMap,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     click(
         client,
         session_id,
@@ -884,6 +887,46 @@ pub async fn tap_touch(
     Ok(())
 }
 
+/// Dispatches one mouse event and waits for the browser to ack it, but
+/// returns Ok(true) if a JavaScript dialog opens first. A synchronous dialog
+/// (confirm/prompt/alert in the event handler) blocks the renderer's main
+/// thread, so the input ack cannot arrive until the dialog is resolved;
+/// without this the command hangs until the client read timeout and the agent
+/// never sees the pending-dialog warning.
+async fn dispatch_mouse_or_dialog(
+    client: &CdpClient,
+    session_id: &str,
+    params: &DispatchMouseEventParams,
+) -> Result<bool, String> {
+    use tokio::sync::broadcast::error::RecvError;
+
+    // Subscribe before sending so the dialog event cannot slip past us.
+    let mut events = client.subscribe();
+    let send =
+        client.send_command_typed::<_, Value>("Input.dispatchMouseEvent", params, Some(session_id));
+    tokio::pin!(send);
+    loop {
+        tokio::select! {
+            res = &mut send => {
+                res?;
+                return Ok(false);
+            }
+            event = events.recv() => {
+                match event {
+                    Ok(e) if e.method == "Page.javascriptDialogOpening" => return Ok(true),
+                    Ok(_) => continue,
+                    Err(RecvError::Lagged(_)) => continue,
+                    Err(RecvError::Closed) => {
+                        (&mut send).await?;
+                        return Ok(false);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Returns true if a JavaScript dialog opened mid-click (sequence aborted).
 async fn dispatch_click(
     client: &CdpClient,
     session_id: &str,
@@ -891,25 +934,27 @@ async fn dispatch_click(
     y: f64,
     button: &str,
     click_count: i32,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     // Move
-    client
-        .send_command_typed::<_, Value>(
-            "Input.dispatchMouseEvent",
-            &DispatchMouseEventParams {
-                event_type: "mouseMoved".to_string(),
-                x,
-                y,
-                button: None,
-                buttons: None,
-                click_count: None,
-                delta_x: None,
-                delta_y: None,
-                modifiers: None,
-            },
-            Some(session_id),
-        )
-        .await?;
+    if dispatch_mouse_or_dialog(
+        client,
+        session_id,
+        &DispatchMouseEventParams {
+            event_type: "mouseMoved".to_string(),
+            x,
+            y,
+            button: None,
+            buttons: None,
+            click_count: None,
+            delta_x: None,
+            delta_y: None,
+            modifiers: None,
+        },
+    )
+    .await?
+    {
+        return Ok(true);
+    }
 
     let button_value = match button {
         "right" => 2,
@@ -918,44 +963,43 @@ async fn dispatch_click(
     };
 
     // Press
-    client
-        .send_command_typed::<_, Value>(
-            "Input.dispatchMouseEvent",
-            &DispatchMouseEventParams {
-                event_type: "mousePressed".to_string(),
-                x,
-                y,
-                button: Some(button.to_string()),
-                buttons: Some(button_value),
-                click_count: Some(click_count),
-                delta_x: None,
-                delta_y: None,
-                modifiers: None,
-            },
-            Some(session_id),
-        )
-        .await?;
+    if dispatch_mouse_or_dialog(
+        client,
+        session_id,
+        &DispatchMouseEventParams {
+            event_type: "mousePressed".to_string(),
+            x,
+            y,
+            button: Some(button.to_string()),
+            buttons: Some(button_value),
+            click_count: Some(click_count),
+            delta_x: None,
+            delta_y: None,
+            modifiers: None,
+        },
+    )
+    .await?
+    {
+        return Ok(true);
+    }
 
     // Release
-    client
-        .send_command_typed::<_, Value>(
-            "Input.dispatchMouseEvent",
-            &DispatchMouseEventParams {
-                event_type: "mouseReleased".to_string(),
-                x,
-                y,
-                button: Some(button.to_string()),
-                buttons: Some(0),
-                click_count: Some(click_count),
-                delta_x: None,
-                delta_y: None,
-                modifiers: None,
-            },
-            Some(session_id),
-        )
-        .await?;
-
-    Ok(())
+    dispatch_mouse_or_dialog(
+        client,
+        session_id,
+        &DispatchMouseEventParams {
+            event_type: "mouseReleased".to_string(),
+            x,
+            y,
+            button: Some(button.to_string()),
+            buttons: Some(0),
+            click_count: Some(click_count),
+            delta_x: None,
+            delta_y: None,
+            modifiers: None,
+        },
+    )
+    .await
 }
 
 fn char_to_key_info(ch: char) -> (String, String, i32) {

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -410,16 +410,26 @@ pub async fn select_option(
     )
     .await?;
 
+    // Matching nothing must be an error, not a silent success: an agent that
+    // selects a misspelled option otherwise sees "Done", and only discovers
+    // the page state is wrong after more commands. List what was available.
     let js = r#"function(vals) {
             const options = Array.from(this.options);
+            let matched = 0;
             for (const opt of options) {
                 opt.selected = vals.includes(opt.value) || vals.includes(opt.textContent.trim());
+                if (opt.selected) matched += 1;
+            }
+            if (matched === 0) {
+                const available = options.map(o => o.value + ' ("' + o.textContent.trim() + '")').join(', ');
+                return { error: 'No option matched ' + JSON.stringify(vals) + '. Available options: ' + available };
             }
             this.dispatchEvent(new Event('change', { bubbles: true }));
+            return { matched };
         }"#
     .to_string();
 
-    client
+    let result = client
         .send_command_typed::<_, Value>(
             "Runtime.callFunctionOn",
             &CallFunctionOnParams {
@@ -435,6 +445,15 @@ pub async fn select_option(
             Some(&effective_session_id),
         )
         .await?;
+
+    if let Some(error) = result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .and_then(|v| v.get("error"))
+        .and_then(|e| e.as_str())
+    {
+        return Err(error.to_string());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- Scroll elements into view before clicking; off-viewport clicks silently no-oped while reporting success
- Return promptly with a `dialogOpened` flag when a click opens a JavaScript dialog, instead of hanging until the client read timeout (`os error 35`)
- Fail fast with resolution instructions when page commands run while a confirm/prompt dialog is pending
- Remove the unconditional 150ms settle-sleep paid by every CLI invocation; warm commands drop from ~152ms to ~1ms, with the daemon-shutdown race handled by respawn-and-retry at request time
- Honor `--timeout` on every `wait` variant and restore the documented 25s default; long waits no longer die at the client's fixed 30s read timeout and re-send themselves
- Match `aria-label` and `aria-labelledby` in `find label`, mirroring Playwright's getByLabel semantics
- Error on `select` when no option matches, listing the available values and labels instead of silently succeeding
- Parse `--clear` and `--delay` on `type`; they were previously typed into the field as literal text
- Make CSS selectors and `wait` honor the frame selected via `frame <sel>` (same-process and cross-process iframes); previously only snapshot was frame-scoped
- Match os error codes exactly; EAGAIN handling ("os error 11") was substring-matching ECONNREFUSED ("os error 111")
