### PR TITLE
Fix silent failures: daemon close race, frame-scoped wait/eval, select no-match, find text picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ agent-browser screenshot --screenshot-dir ./shots    # Save to custom directory
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
 agent-browser pdf <path>              # Save as PDF
 agent-browser snapshot                # Accessibility tree with refs (best for AI)
-agent-browser eval <js>               # Run JavaScript (-b for base64, --stdin for piped input)
+agent-browser eval <js>               # Run JavaScript; supports top-level return/await
 agent-browser connect <port>          # Connect to browser via CDP
 agent-browser stream enable [--port <port>]  # Start runtime WebSocket streaming
 agent-browser stream status           # Show runtime streaming state and bound port
@@ -204,8 +204,8 @@ agent-browser find nth 2 "a" text
 ```bash
 agent-browser wait <selector>         # Wait for element to be visible
 agent-browser wait <ms>               # Wait for time (milliseconds)
-agent-browser wait --text "Welcome"   # Wait for text to appear (substring match)
-agent-browser wait --url "**/dash"    # Wait for URL pattern
+agent-browser wait --text "Welcome"   # Wait for text, case-insensitive
+agent-browser wait --url "**/dash"    # Wait for URL glob or substring
 agent-browser wait --load networkidle # Wait for load state
 agent-browser wait --fn "window.ready === true"  # Wait for JS condition
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2497,6 +2497,43 @@ async fn evaluate_in_same_process_frame(
             )
             .await
         }
+        Err(e) if e.contains("await is only valid") => {
+            evaluate_in_same_process_frame_with_top_level_await(
+                client, session_id, frame_id, script,
+            )
+            .await
+        }
+        other => other,
+    }
+}
+
+async fn evaluate_in_same_process_frame_with_top_level_await(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    script: &str,
+) -> Result<Value, String> {
+    // Most console-style top-level await snippets are expressions. Preserve
+    // their completion value first; if that parse fails, fall back to body
+    // semantics for statement blocks that perform side effects.
+    let expression_retry = evaluate_in_same_process_frame_once(
+        client,
+        session_id,
+        frame_id,
+        &format!("(async () => {{ return ({script}); }})()"),
+    )
+    .await;
+
+    match expression_retry {
+        Err(e) if e.contains("SyntaxError") => {
+            evaluate_in_same_process_frame_once(
+                client,
+                session_id,
+                frame_id,
+                &format!("(async () => {{ {script} }})()"),
+            )
+            .await
+        }
         other => other,
     }
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3162,6 +3162,16 @@ enum WaitRoute {
     SameProcessFrame(String),
 }
 
+fn wait_route(state: &DaemonState) -> WaitRoute {
+    match state.active_frame_id.as_deref() {
+        Some(frame_id) => match state.iframe_sessions.get(frame_id) {
+            Some(frame_session) => WaitRoute::FrameSession(frame_session.clone()),
+            None => WaitRoute::SameProcessFrame(frame_id.to_string()),
+        },
+        None => WaitRoute::Main,
+    }
+}
+
 async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
@@ -3170,13 +3180,7 @@ async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     // Honor an active `frame <sel>` selection for content waits, like element
     // resolution does: an OOPIF polls on its dedicated session, a same-process
     // frame polls through the owner element's contentDocument.
-    let frame_route = match state.active_frame_id.as_deref() {
-        Some(frame_id) => match state.iframe_sessions.get(frame_id) {
-            Some(frame_session) => WaitRoute::FrameSession(frame_session.clone()),
-            None => WaitRoute::SameProcessFrame(frame_id.to_string()),
-        },
-        None => WaitRoute::Main,
-    };
+    let frame_route = wait_route(state);
 
     if let Some(text) = cmd.get("text").and_then(|v| v.as_str()) {
         let quoted = serde_json::to_string(text).unwrap_or_default();
@@ -3225,37 +3229,20 @@ async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     }
 
     if let Some(url_pattern) = cmd.get("url").and_then(|v| v.as_str()) {
-        match &frame_route {
-            WaitRoute::Main => {
-                wait_for_url(&mgr.client, &session_id, url_pattern, timeout_ms).await?
-            }
-            WaitRoute::FrameSession(frame_session) => {
-                wait_for_url(&mgr.client, frame_session, url_pattern, timeout_ms).await?
-            }
-            WaitRoute::SameProcessFrame(frame_id) => {
-                let check = url_check_expression("doc.location.href", url_pattern);
-                poll_in_frame_until_true(&mgr.client, &session_id, frame_id, &check, timeout_ms)
-                    .await?
-            }
-        }
+        wait_for_url_on_route(
+            &mgr.client,
+            &session_id,
+            &frame_route,
+            url_pattern,
+            timeout_ms,
+        )
+        .await?;
         return Ok(json!({ "waited": "url", "url": url_pattern }));
     }
 
     if let Some(fn_str) = cmd.get("function").and_then(|v| v.as_str()) {
-        match &frame_route {
-            WaitRoute::Main => {
-                wait_for_function(&mgr.client, &session_id, fn_str, timeout_ms).await?
-            }
-            WaitRoute::FrameSession(frame_session) => {
-                wait_for_function(&mgr.client, frame_session, fn_str, timeout_ms).await?
-            }
-            WaitRoute::SameProcessFrame(frame_id) => {
-                let quoted = serde_json::to_string(fn_str).unwrap_or_default();
-                let check = format!("!!(doc.defaultView.eval({quoted}))");
-                poll_in_frame_until_true(&mgr.client, &session_id, frame_id, &check, timeout_ms)
-                    .await?
-            }
-        }
+        wait_for_function_on_route(&mgr.client, &session_id, &frame_route, fn_str, timeout_ms)
+            .await?;
         return Ok(json!({ "waited": "function" }));
     }
 
@@ -3506,6 +3493,25 @@ async fn wait_for_url(
     poll_until_true(client, session_id, &check_fn, timeout_ms).await
 }
 
+async fn wait_for_url_on_route(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    route: &WaitRoute,
+    pattern: &str,
+    timeout_ms: u64,
+) -> Result<(), String> {
+    match route {
+        WaitRoute::Main => wait_for_url(client, session_id, pattern, timeout_ms).await,
+        WaitRoute::FrameSession(frame_session) => {
+            wait_for_url(client, frame_session, pattern, timeout_ms).await
+        }
+        WaitRoute::SameProcessFrame(frame_id) => {
+            let check = url_check_expression("doc.location.href", pattern);
+            poll_in_frame_until_true(client, session_id, frame_id, &check, timeout_ms).await
+        }
+    }
+}
+
 /// `wait --url` accepts the glob patterns the docs advertise ("**/dashboard")
 /// as well as plain substrings. A glob used to be matched literally via
 /// includes(), so it could never succeed.
@@ -3575,6 +3581,115 @@ async fn wait_for_function(
 ) -> Result<(), String> {
     let check_fn = format!("!!({})", fn_str);
     poll_until_true(client, session_id, &check_fn, timeout_ms).await
+}
+
+async fn wait_for_function_on_route(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    route: &WaitRoute,
+    fn_str: &str,
+    timeout_ms: u64,
+) -> Result<(), String> {
+    match route {
+        WaitRoute::Main => wait_for_function(client, session_id, fn_str, timeout_ms).await,
+        WaitRoute::FrameSession(frame_session) => {
+            wait_for_function(client, frame_session, fn_str, timeout_ms).await
+        }
+        WaitRoute::SameProcessFrame(frame_id) => {
+            let quoted = serde_json::to_string(fn_str).unwrap_or_default();
+            let check = format!("!!(doc.defaultView.eval({quoted}))");
+            poll_in_frame_until_true(client, session_id, frame_id, &check, timeout_ms).await
+        }
+    }
+}
+
+async fn evaluate_wait_expression_on_session(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    expression: &str,
+) -> Result<Value, String> {
+    let result: super::cdp::types::EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &super::cdp::types::EvaluateParams {
+                expression: format!("({})", expression),
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(session_id),
+        )
+        .await?;
+
+    if let Some(details) = result.exception_details {
+        let msg = details
+            .exception
+            .as_ref()
+            .and_then(|e| e.description.as_deref())
+            .unwrap_or(&details.text);
+        return Err(format!("Evaluation error: {}", msg));
+    }
+
+    Ok(result.result.value.unwrap_or(Value::Null))
+}
+
+async fn evaluate_wait_expression_on_route(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    route: &WaitRoute,
+    expression: &str,
+) -> Result<Value, String> {
+    match route {
+        WaitRoute::Main => {
+            evaluate_wait_expression_on_session(client, session_id, expression).await
+        }
+        WaitRoute::FrameSession(frame_session) => {
+            evaluate_wait_expression_on_session(client, frame_session, expression).await
+        }
+        WaitRoute::SameProcessFrame(frame_id) => {
+            evaluate_in_same_process_frame(client, session_id, frame_id, expression).await
+        }
+    }
+}
+
+async fn current_url_on_route(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    route: &WaitRoute,
+) -> Result<String, String> {
+    match route {
+        WaitRoute::Main => evaluate_wait_expression_on_session(client, session_id, "location.href")
+            .await
+            .map(|v| v.as_str().unwrap_or("").to_string()),
+        WaitRoute::FrameSession(frame_session) => {
+            evaluate_wait_expression_on_session(client, frame_session, "location.href")
+                .await
+                .map(|v| v.as_str().unwrap_or("").to_string())
+        }
+        WaitRoute::SameProcessFrame(frame_id) => {
+            let owner_object_id =
+                super::element::frame_owner_object_id(client, session_id, frame_id).await?;
+            let result = client
+                .send_command(
+                    "Runtime.callFunctionOn",
+                    Some(json!({
+                        "objectId": owner_object_id,
+                        "functionDeclaration": "function() {
+                            const doc = this.contentDocument;
+                            return doc ? doc.location.href : '';
+                        }",
+                        "returnByValue": true,
+                    })),
+                    Some(session_id),
+                )
+                .await?;
+            Ok(result
+                .get("result")
+                .and_then(|r| r.get("value"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string())
+        }
+    }
 }
 
 /// wait_for_selector inside a same-process iframe selected via `frame <sel>`.
@@ -5836,14 +5951,24 @@ async fn handle_screencast_stop(state: &mut DaemonState) -> Result<Value, String
 async fn handle_waitforurl(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
+    let frame_route = wait_route(state);
     let url_pattern = cmd
         .get("url")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'url' parameter")?;
     let timeout_ms = state.timeout_ms(cmd);
 
-    wait_for_url(&mgr.client, &session_id, url_pattern, timeout_ms).await?;
-    let url = mgr.get_url().await.unwrap_or_default();
+    wait_for_url_on_route(
+        &mgr.client,
+        &session_id,
+        &frame_route,
+        url_pattern,
+        timeout_ms,
+    )
+    .await?;
+    let url = current_url_on_route(&mgr.client, &session_id, &frame_route)
+        .await
+        .unwrap_or_default();
     Ok(json!({ "url": url }))
 }
 
@@ -5867,28 +5992,27 @@ async fn handle_waitforloadstate(cmd: &Value, state: &DaemonState) -> Result<Val
 async fn handle_waitforfunction(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
+    let frame_route = wait_route(state);
     let expression = cmd
         .get("expression")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'expression' parameter")?;
     let timeout_ms = state.timeout_ms(cmd);
 
-    wait_for_function(&mgr.client, &session_id, expression, timeout_ms).await?;
+    wait_for_function_on_route(
+        &mgr.client,
+        &session_id,
+        &frame_route,
+        expression,
+        timeout_ms,
+    )
+    .await?;
 
-    let result: super::cdp::types::EvaluateResult = mgr
-        .client
-        .send_command_typed(
-            "Runtime.evaluate",
-            &super::cdp::types::EvaluateParams {
-                expression: format!("({})", expression),
-                return_by_value: Some(true),
-                await_promise: Some(true),
-            },
-            Some(&session_id),
-        )
-        .await?;
+    let result =
+        evaluate_wait_expression_on_route(&mgr.client, &session_id, &frame_route, expression)
+            .await?;
 
-    Ok(json!({ "result": result.result.value.unwrap_or(Value::Null) }))
+    Ok(json!({ "result": result }))
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2457,9 +2457,89 @@ async fn handle_evaluate(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
         .and_then(|v| v.as_str())
         .ok_or("Missing 'script' parameter")?;
 
-    let result = mgr.evaluate(script, None).await?;
+    // Honor an active `frame <sel>` selection, like element resolution does:
+    // an OOPIF evaluates on its dedicated session, a same-process frame
+    // evaluates in the frame's own realm through the owner element.
+    let result = match state.active_frame_id.as_deref() {
+        Some(frame_id) => match state.iframe_sessions.get(frame_id) {
+            Some(frame_session) => mgr.evaluate_on_session(frame_session, script).await?,
+            None => {
+                let session_id = mgr.active_session_id()?.to_string();
+                evaluate_in_same_process_frame(&mgr.client, &session_id, frame_id, script).await?
+            }
+        },
+        None => mgr.evaluate(script, None).await?,
+    };
     let url = mgr.get_url().await.unwrap_or_default();
     Ok(json!({ "result": result, "origin": url }))
+}
+
+/// `eval` inside a same-process iframe selected via `frame <sel>`: runs the
+/// script in the frame's own realm so document/window resolve to the frame.
+/// A page CSP that forbids 'unsafe-eval' rejects this loudly rather than
+/// letting the script silently evaluate against the top document.
+async fn evaluate_in_same_process_frame(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    script: &str,
+) -> Result<Value, String> {
+    match evaluate_in_same_process_frame_once(client, session_id, frame_id, script).await {
+        // Same top-level-return accommodation as evaluate_on_session. No
+        // `await` prefix here: win.eval has no REPL mode, and the IIFE's
+        // promise is already resolved by awaitPromise on callFunctionOn.
+        Err(e) if e.contains("Illegal return statement") => {
+            evaluate_in_same_process_frame_once(
+                client,
+                session_id,
+                frame_id,
+                &format!("(async () => {{ {script} }})()"),
+            )
+            .await
+        }
+        other => other,
+    }
+}
+
+async fn evaluate_in_same_process_frame_once(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    script: &str,
+) -> Result<Value, String> {
+    let owner_object_id =
+        super::element::frame_owner_object_id(client, session_id, frame_id).await?;
+    let result = client
+        .send_command(
+            "Runtime.callFunctionOn",
+            Some(json!({
+                "objectId": owner_object_id,
+                "functionDeclaration": "function(src) {
+                    const win = this.contentWindow;
+                    if (!win) throw new Error('Frame document is not available');
+                    return win.eval(src);
+                }",
+                "arguments": [{ "value": script }],
+                "returnByValue": true,
+                "awaitPromise": true,
+            })),
+            Some(session_id),
+        )
+        .await?;
+    if let Some(details) = result.get("exceptionDetails") {
+        let msg = details
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .or_else(|| details.get("text").and_then(|t| t.as_str()))
+            .unwrap_or("evaluation failed");
+        return Err(format!("Evaluation error: {}", msg));
+    }
+    Ok(result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(Value::Null))
 }
 
 async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
@@ -3026,13 +3106,47 @@ async fn handle_uncheck(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
     Ok(json!({ "unchecked": selector }))
 }
 
+/// Where a content wait (`wait --text/--selector/--url/--function`) polls
+/// while a `frame <sel>` selection is active.
+enum WaitRoute {
+    Main,
+    /// Out-of-process iframe with its own CDP session.
+    FrameSession(String),
+    /// Same-process iframe, reached through its owner element.
+    SameProcessFrame(String),
+}
+
 async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
     let timeout_ms = state.timeout_ms(cmd);
 
+    // Honor an active `frame <sel>` selection for content waits, like element
+    // resolution does: an OOPIF polls on its dedicated session, a same-process
+    // frame polls through the owner element's contentDocument.
+    let frame_route = match state.active_frame_id.as_deref() {
+        Some(frame_id) => match state.iframe_sessions.get(frame_id) {
+            Some(frame_session) => WaitRoute::FrameSession(frame_session.clone()),
+            None => WaitRoute::SameProcessFrame(frame_id.to_string()),
+        },
+        None => WaitRoute::Main,
+    };
+
     if let Some(text) = cmd.get("text").and_then(|v| v.as_str()) {
-        wait_for_text(&mgr.client, &session_id, text, timeout_ms).await?;
+        let quoted = serde_json::to_string(text).unwrap_or_default();
+        match &frame_route {
+            WaitRoute::Main => wait_for_text(&mgr.client, &session_id, text, timeout_ms).await?,
+            WaitRoute::FrameSession(frame_session) => {
+                wait_for_text(&mgr.client, frame_session, text, timeout_ms).await?
+            }
+            WaitRoute::SameProcessFrame(frame_id) => {
+                let check = format!(
+                    "(((doc.body && doc.body.innerText) || '')).toLowerCase().includes({quoted}.toLowerCase())"
+                );
+                poll_in_frame_until_true(&mgr.client, &session_id, frame_id, &check, timeout_ms)
+                    .await?
+            }
+        }
         return Ok(json!({ "waited": "text", "text": text }));
     }
 
@@ -3041,39 +3155,61 @@ async fn handle_wait(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
             .get("state")
             .and_then(|v| v.as_str())
             .unwrap_or("visible");
-        // Honor an active `frame <sel>` selection, like element resolution does.
-        match state.active_frame_id.as_deref() {
-            Some(frame_id) => match state.iframe_sessions.get(frame_id) {
-                Some(frame_session) => {
-                    wait_for_selector(&mgr.client, frame_session, selector, state_str, timeout_ms)
-                        .await?
-                }
-                None => {
-                    wait_for_selector_in_frame(
-                        &mgr.client,
-                        &session_id,
-                        frame_id,
-                        selector,
-                        state_str,
-                        timeout_ms,
-                    )
-                    .await?
-                }
-            },
-            None => {
+        match &frame_route {
+            WaitRoute::Main => {
                 wait_for_selector(&mgr.client, &session_id, selector, state_str, timeout_ms).await?
+            }
+            WaitRoute::FrameSession(frame_session) => {
+                wait_for_selector(&mgr.client, frame_session, selector, state_str, timeout_ms)
+                    .await?
+            }
+            WaitRoute::SameProcessFrame(frame_id) => {
+                wait_for_selector_in_frame(
+                    &mgr.client,
+                    &session_id,
+                    frame_id,
+                    selector,
+                    state_str,
+                    timeout_ms,
+                )
+                .await?
             }
         }
         return Ok(json!({ "waited": "selector", "selector": selector }));
     }
 
     if let Some(url_pattern) = cmd.get("url").and_then(|v| v.as_str()) {
-        wait_for_url(&mgr.client, &session_id, url_pattern, timeout_ms).await?;
+        match &frame_route {
+            WaitRoute::Main => {
+                wait_for_url(&mgr.client, &session_id, url_pattern, timeout_ms).await?
+            }
+            WaitRoute::FrameSession(frame_session) => {
+                wait_for_url(&mgr.client, frame_session, url_pattern, timeout_ms).await?
+            }
+            WaitRoute::SameProcessFrame(frame_id) => {
+                let check = url_check_expression("doc.location.href", url_pattern);
+                poll_in_frame_until_true(&mgr.client, &session_id, frame_id, &check, timeout_ms)
+                    .await?
+            }
+        }
         return Ok(json!({ "waited": "url", "url": url_pattern }));
     }
 
     if let Some(fn_str) = cmd.get("function").and_then(|v| v.as_str()) {
-        wait_for_function(&mgr.client, &session_id, fn_str, timeout_ms).await?;
+        match &frame_route {
+            WaitRoute::Main => {
+                wait_for_function(&mgr.client, &session_id, fn_str, timeout_ms).await?
+            }
+            WaitRoute::FrameSession(frame_session) => {
+                wait_for_function(&mgr.client, frame_session, fn_str, timeout_ms).await?
+            }
+            WaitRoute::SameProcessFrame(frame_id) => {
+                let quoted = serde_json::to_string(fn_str).unwrap_or_default();
+                let check = format!("!!(doc.defaultView.eval({quoted}))");
+                poll_in_frame_until_true(&mgr.client, &session_id, frame_id, &check, timeout_ms)
+                    .await?
+            }
+        }
         return Ok(json!({ "waited": "function" }));
     }
 
@@ -3320,11 +3456,54 @@ async fn wait_for_url(
     pattern: &str,
     timeout_ms: u64,
 ) -> Result<(), String> {
-    let check_fn = format!(
-        "location.href.includes({})",
-        serde_json::to_string(pattern).unwrap_or_default()
-    );
+    let check_fn = url_check_expression("location.href", pattern);
     poll_until_true(client, session_id, &check_fn, timeout_ms).await
+}
+
+/// `wait --url` accepts the glob patterns the docs advertise ("**/dashboard")
+/// as well as plain substrings. A glob used to be matched literally via
+/// includes(), so it could never succeed.
+fn url_check_expression(target: &str, pattern: &str) -> String {
+    if pattern.contains('*') {
+        format!(
+            "new RegExp({}).test({target})",
+            serde_json::to_string(&glob_to_js_regex(pattern)).unwrap_or_default()
+        )
+    } else {
+        format!(
+            "{target}.includes({})",
+            serde_json::to_string(pattern).unwrap_or_default()
+        )
+    }
+}
+
+/// Playwright-style URL glob: `**` crosses path segments, `*` stays within
+/// one, and `?` is literal (in URLs it is the query separator, not a
+/// wildcard). Anchored, but a trailing query/hash never breaks the match.
+fn glob_to_js_regex(glob: &str) -> String {
+    let mut re = String::from("^");
+    let chars: Vec<char> = glob.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '*' => {
+                if chars.get(i + 1) == Some(&'*') {
+                    re.push_str(".*");
+                    i += 1;
+                } else {
+                    re.push_str("[^/]*");
+                }
+            }
+            c if "\\.+()[]{}^$|?".contains(c) => {
+                re.push('\\');
+                re.push(c);
+            }
+            c => re.push(c),
+        }
+        i += 1;
+    }
+    re.push_str("([?#].*)?$");
+    re
 }
 
 async fn wait_for_text(
@@ -3333,8 +3512,10 @@ async fn wait_for_text(
     text: &str,
     timeout_ms: u64,
 ) -> Result<(), String> {
+    // Case-insensitive: agents guess casing ("upload" vs "Uploaded") and a
+    // case miss costs a full timeout.
     let check_fn = format!(
-        "(document.body.innerText || '').includes({})",
+        "(document.body.innerText || '').toLowerCase().includes({}.toLowerCase())",
         serde_json::to_string(text).unwrap_or_default()
     );
     poll_until_true(client, session_id, &check_fn, timeout_ms).await
@@ -3350,9 +3531,7 @@ async fn wait_for_function(
     poll_until_true(client, session_id, &check_fn, timeout_ms).await
 }
 
-/// wait_for_selector inside a same-process iframe selected via `frame <sel>`:
-/// polls through the owner element's contentDocument, which stays correct
-/// even if the frame navigates (the getter re-resolves every poll).
+/// wait_for_selector inside a same-process iframe selected via `frame <sel>`.
 async fn wait_for_selector_in_frame(
     client: &super::cdp::client::CdpClient,
     session_id: &str,
@@ -3361,8 +3540,6 @@ async fn wait_for_selector_in_frame(
     state: &str,
     timeout_ms: u64,
 ) -> Result<(), String> {
-    let owner_object_id =
-        super::element::frame_owner_object_id(client, session_id, frame_id).await?;
     let sel = serde_json::to_string(selector).unwrap_or_default();
     let check = match state {
         "attached" => format!("!!doc.querySelector({sel})"),
@@ -3385,6 +3562,22 @@ async fn wait_for_selector_in_frame(
             }})()"#,
         ),
     };
+    poll_in_frame_until_true(client, session_id, frame_id, &check, timeout_ms).await
+}
+
+/// Poll a boolean check inside a same-process iframe through the owner
+/// element's contentDocument (in scope as `doc`), which stays correct even if
+/// the frame navigates (the getter re-resolves every poll). Exceptions count
+/// as unsatisfied, matching poll_until_true.
+async fn poll_in_frame_until_true(
+    client: &super::cdp::client::CdpClient,
+    session_id: &str,
+    frame_id: &str,
+    check: &str,
+    timeout_ms: u64,
+) -> Result<(), String> {
+    let owner_object_id =
+        super::element::frame_owner_object_id(client, session_id, frame_id).await?;
     let function = format!(
         "function() {{ const doc = this.contentDocument; if (!doc) return false; return {check}; }}",
     );
@@ -6075,19 +6268,29 @@ async fn handle_semantic_locator(
             val = serde_json::to_string(value).unwrap_or_default(),
         ),
         _ => {
-            // "text" strategy
+            // "text" strategy. An element whose trimmed text equals the query
+            // beats the first substring hit in document order: `find text "2"`
+            // must pick the pagination link "2" over a price like "$24.99".
+            // The match report lets the agent see what was picked when the
+            // page had several candidates.
+            let value_json = serde_json::to_string(value).unwrap_or_default();
             format!(
                 r#"(() => {{
                     const all = document.querySelectorAll('*');
+                    let exact = null, partial = null, count = 0;
                     for (const el of all) {{
-                        if (el.children.length === 0 && {match_fn}) {{
-                            el.setAttribute('data-agent-browser-located', 'true');
-                            return true;
-                        }}
+                        if (el.children.length !== 0) continue;
+                        if (!({match_fn})) continue;
+                        count++;
+                        if (!exact && el.textContent.trim() === {value_json}) exact = el;
+                        if (!partial) partial = el;
                     }}
-                    return false;
+                    const el = exact || partial;
+                    if (!el) return null;
+                    el.setAttribute('data-agent-browser-located', 'true');
+                    const text = (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 60);
+                    return {{ desc: '<' + el.tagName.toLowerCase() + '> "' + text + '"', others: count - 1 }};
                 }})()"#,
-                match_fn = match_fn,
             )
         }
     };
@@ -6105,18 +6308,25 @@ async fn handle_semantic_locator(
         )
         .await?;
 
-    if !result
-        .result
-        .value
-        .as_ref()
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
+    // Bool for the attribute-based strategies, a match report for "text".
+    let located = result.result.value.unwrap_or(Value::Null);
+    let match_report = located.as_object().cloned();
+    if match_report.is_none() && !located.as_bool().unwrap_or(false) {
         return Err(format!("No element found by {} '{}'", strategy, value));
     }
 
     let selector = "[data-agent-browser-located='true']";
-    let action_result = execute_subaction(cmd, state, selector).await;
+    let mut action_result = execute_subaction(cmd, state, selector).await;
+    if let (Ok(Value::Object(obj)), Some(report)) = (&mut action_result, match_report) {
+        if let Some(desc) = report.get("desc").and_then(|v| v.as_str()) {
+            obj.insert("matched".to_string(), json!(desc));
+        }
+        if let Some(others) = report.get("others").and_then(|v| v.as_u64()) {
+            if others > 0 {
+                obj.insert("otherMatches".to_string(), json!(others));
+            }
+        }
+    }
 
     if let Some(ref browser) = state.browser {
         let _ = browser
@@ -8402,6 +8612,35 @@ mod tests {
     use super::*;
     use crate::test_utils::EnvGuard;
     use std::fs;
+
+    #[test]
+    fn test_url_check_expression_keeps_substring_semantics_without_glob() {
+        assert_eq!(
+            url_check_expression("location.href", "example.com/path"),
+            "location.href.includes(\"example.com/path\")"
+        );
+    }
+
+    #[test]
+    fn test_glob_to_js_regex_translates_url_globs() {
+        // `**` crosses segments, `*` stays within one, and a trailing
+        // query/hash never breaks the match.
+        assert_eq!(glob_to_js_regex("**/dashboard"), "^.*/dashboard([?#].*)?$");
+        assert_eq!(
+            glob_to_js_regex("**/orders/*/edit"),
+            "^.*/orders/[^/]*/edit([?#].*)?$"
+        );
+        // Regex metacharacters in the pattern are literal.
+        assert_eq!(
+            glob_to_js_regex("**/search.php"),
+            "^.*/search\\.php([?#].*)?$"
+        );
+        // `?` is the query separator in URLs, never a single-char wildcard.
+        assert_eq!(
+            glob_to_js_regex("**/item?id=*"),
+            "^.*/item\\?id=[^/]*([?#].*)?$"
+        );
+    }
 
     fn unique_socket_dir(label: &str) -> PathBuf {
         let nanos = std::time::SystemTime::now()

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2497,6 +2497,15 @@ async fn evaluate_in_same_process_frame(
             )
             .await
         }
+        Err(e) if e.contains("has already been declared") => {
+            evaluate_in_same_process_frame_once(
+                client,
+                session_id,
+                frame_id,
+                &format!("{{ {script} }}"),
+            )
+            .await
+        }
         Err(e) if e.contains("await is only valid") => {
             evaluate_in_same_process_frame_with_top_level_await(
                 client, session_id, frame_id, script,

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -759,17 +759,70 @@ impl BrowserManager {
 
     pub async fn evaluate(&self, script: &str, _args: Option<Value>) -> Result<Value, String> {
         let session_id = self.active_session_id()?.to_string();
+        self.evaluate_on_session(&session_id, script).await
+    }
 
+    /// Evaluate on an explicit session, e.g. an OOPIF's dedicated session
+    /// while a `frame <sel>` selection is active.
+    ///
+    /// The primary attempt has classic semantics (a returned Promise is
+    /// resolved by awaitPromise). Three agent-script footguns are absorbed
+    /// by targeted retries instead of surfacing as syntax lessons:
+    /// - a top-level `return` (Playwright-style function body) reruns as an
+    ///   async-IIFE body;
+    /// - re-declaring a top-level let/const from an earlier eval reruns
+    ///   block-scoped;
+    /// - top-level `await` reruns in REPL mode (DevTools-console semantics).
+    ///
+    /// REPL mode is retry-only because Chrome implements it with an async
+    /// wrapper: awaitPromise then resolves the wrapper, so an expression that
+    /// itself returns a Promise would serialize as an empty object.
+    pub async fn evaluate_on_session(
+        &self,
+        session_id: &str,
+        script: &str,
+    ) -> Result<Value, String> {
+        match self.evaluate_once(session_id, script, false).await {
+            Err(e) if e.contains("Illegal return statement") => {
+                self.evaluate_once(
+                    session_id,
+                    &format!("(async () => {{ {script} }})()"),
+                    false,
+                )
+                .await
+            }
+            Err(e) if e.contains("has already been declared") => {
+                // Block-scope the script: it shadows any same-named global
+                // binding left by an earlier eval (which even REPL mode
+                // cannot re-declare), and a block's completion value is its
+                // last statement's value.
+                self.evaluate_once(session_id, &format!("{{ {script} }}"), false)
+                    .await
+            }
+            Err(e) if e.contains("await is only valid") => {
+                self.evaluate_once(session_id, script, true).await
+            }
+            other => other,
+        }
+    }
+
+    async fn evaluate_once(
+        &self,
+        session_id: &str,
+        script: &str,
+        repl_mode: bool,
+    ) -> Result<Value, String> {
         let result: EvaluateResult = self
             .client
             .send_command_typed(
                 "Runtime.evaluate",
-                &EvaluateParams {
-                    expression: script.to_string(),
-                    return_by_value: Some(true),
-                    await_promise: Some(true),
-                },
-                Some(&session_id),
+                &json!({
+                    "expression": script,
+                    "returnByValue": true,
+                    "awaitPromise": true,
+                    "replMode": repl_mode,
+                }),
+                Some(session_id),
             )
             .await?;
 

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -191,6 +191,21 @@ impl DaemonSidecars {
     }
 }
 
+fn close_sidecar_files(
+    socket_dir: &std::path::Path,
+    session: &str,
+    endpoint_path: PathBuf,
+) -> Vec<PathBuf> {
+    vec![
+        endpoint_path,
+        socket_dir.join(format!("{}.pid", session)),
+        socket_dir.join(format!("{}.version", session)),
+        socket_dir.join(format!("{}.engine", session)),
+        socket_dir.join(format!("{}.provider", session)),
+        socket_dir.join(format!("{}.extensions", session)),
+    ]
+}
+
 #[cfg(unix)]
 async fn run_socket_server(
     socket_path: &PathBuf,
@@ -208,11 +223,11 @@ async fn run_socket_server(
         .parent()
         .unwrap_or(std::path::Path::new("."))
         .to_path_buf();
-    let sidecars = Arc::new(DaemonSidecars::new(vec![
+    let sidecars = Arc::new(DaemonSidecars::new(close_sidecar_files(
+        &socket_dir,
+        session,
         socket_path.clone(),
-        socket_dir.join(format!("{}.pid", session)),
-        socket_dir.join(format!("{}.version", session)),
-    ]));
+    )));
 
     let stream_file: Option<PathBuf> = if stream_server.is_some() {
         let dir = socket_path.parent().unwrap_or(std::path::Path::new("."));
@@ -342,11 +357,11 @@ async fn run_socket_server(
     let port_path = socket_dir.join(format!("{}.port", session));
     let _ = fs::write(&port_path, actual_port.to_string());
 
-    let sidecars = Arc::new(DaemonSidecars::new(vec![
+    let sidecars = Arc::new(DaemonSidecars::new(close_sidecar_files(
+        socket_dir,
+        session,
         port_path.clone(),
-        socket_dir.join(format!("{}.pid", session)),
-        socket_dir.join(format!("{}.version", session)),
-    ]));
+    )));
 
     let stream_file: Option<PathBuf> = if stream_server.is_some() {
         Some(socket_dir.join(format!("{}.stream", session)))
@@ -770,20 +785,27 @@ mod tests {
         ));
         fs::create_dir_all(&dir).unwrap();
         let sock = dir.join("s.sock");
-        let pid = dir.join("s.pid");
-        fs::write(&sock, "").unwrap();
-        fs::write(&pid, "123").unwrap();
+        let files = close_sidecar_files(&dir, "s", sock.clone());
+        for file in &files {
+            fs::write(file, "").unwrap();
+        }
 
-        let sidecars = DaemonSidecars::new(vec![sock.clone(), pid.clone()]);
+        let sidecars = DaemonSidecars::new(files.clone());
         assert!(!sidecars.is_closing());
 
         sidecars.begin_close();
 
         // The dying daemon must be invisible to ensure_daemon immediately:
-        // no socket to probe, no pid/version files for a successor to lose.
+        // no socket to probe, no pid/version files for a successor to lose,
+        // and no stale stream metadata for discovery to report.
         assert!(sidecars.is_closing());
-        assert!(!sock.exists());
-        assert!(!pid.exists());
+        for file in &files {
+            assert!(
+                !file.exists(),
+                "sidecar should be removed on close: {}",
+                file.display()
+            );
+        }
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -128,24 +128,66 @@ pub async fn run_daemon(session: &str) {
     )
     .await;
 
-    #[cfg(unix)]
-    {
-        let _ = fs::remove_file(&socket_path);
+    // Only clean up the sidecar files if this process is still the
+    // registered daemon for the session. After a `close` (sidecars already
+    // unlinked) or a stale-daemon kill, a successor daemon may have written
+    // fresh files at these paths during our shutdown grace window; deleting
+    // them here would make the successor unreachable and strand its browser.
+    let still_registered = fs::read_to_string(&pid_path)
+        .map(|s| s.trim() == process::id().to_string())
+        .unwrap_or(false);
+    if still_registered {
+        #[cfg(unix)]
+        {
+            let _ = fs::remove_file(&socket_path);
+        }
+        #[cfg(windows)]
+        {
+            let _ = fs::remove_file(socket_dir.join(format!("{}.port", session)));
+        }
+        let _ = fs::remove_file(&pid_path);
+        let _ = fs::remove_file(&version_path);
+        let _ = fs::remove_file(&stream_path);
+        let _ = fs::remove_file(socket_dir.join(format!("{}.engine", session)));
+        let _ = fs::remove_file(socket_dir.join(format!("{}.provider", session)));
+        let _ = fs::remove_file(socket_dir.join(format!("{}.extensions", session)));
     }
-    #[cfg(windows)]
-    {
-        let _ = fs::remove_file(socket_dir.join(format!("{}.port", session)));
-    }
-    let _ = fs::remove_file(&pid_path);
-    let _ = fs::remove_file(&version_path);
-    let _ = fs::remove_file(&stream_path);
-    let _ = fs::remove_file(socket_dir.join(format!("{}.engine", session)));
-    let _ = fs::remove_file(socket_dir.join(format!("{}.provider", session)));
-    let _ = fs::remove_file(socket_dir.join(format!("{}.extensions", session)));
 
     if let Err(e) = result {
         let _ = writeln!(std::io::stderr(), "Daemon error: {}", e);
         process::exit(1);
+    }
+}
+
+/// Sidecar files that make this daemon discoverable by CLI invocations.
+/// `handle_connection` unlinks them the moment a `close` command has been
+/// answered: ensure_daemon's liveness check is socket connectivity, so a
+/// fast follow-up command would otherwise connect to the dying daemon, get
+/// its browser launched there, and lose it when the daemon exits.
+struct DaemonSidecars {
+    closing: std::sync::atomic::AtomicBool,
+    files: Vec<PathBuf>,
+}
+
+impl DaemonSidecars {
+    fn new(files: Vec<PathBuf>) -> Self {
+        Self {
+            closing: std::sync::atomic::AtomicBool::new(false),
+            files,
+        }
+    }
+
+    /// Make this daemon invisible to new CLI invocations.
+    fn begin_close(&self) {
+        self.closing
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        for f in &self.files {
+            let _ = fs::remove_file(f);
+        }
+    }
+
+    fn is_closing(&self) -> bool {
+        self.closing.load(std::sync::atomic::Ordering::SeqCst)
     }
 }
 
@@ -161,6 +203,16 @@ async fn run_socket_server(
 
     let listener =
         UnixListener::bind(socket_path).map_err(|e| format!("Failed to bind socket: {}", e))?;
+
+    let socket_dir = socket_path
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .to_path_buf();
+    let sidecars = Arc::new(DaemonSidecars::new(vec![
+        socket_path.clone(),
+        socket_dir.join(format!("{}.pid", session)),
+        socket_dir.join(format!("{}.version", session)),
+    ]));
 
     let stream_file: Option<PathBuf> = if stream_server.is_some() {
         let dir = socket_path.parent().unwrap_or(std::path::Path::new("."));
@@ -192,12 +244,20 @@ async fn run_socket_server(
             accept_result = listener.accept() => {
                 match accept_result {
                     Ok((stream, _)) => {
+                        // A connection racing the post-`close` shutdown gets
+                        // dropped: the client treats the EOF as daemon-
+                        // unreachable and respawns a fresh daemon.
+                        if sidecars.is_closing() {
+                            drop(stream);
+                            continue;
+                        }
                         let state = state.clone();
                         let reset_tx = reset_tx.clone();
                         let sf = stream_file.clone();
                         let cn = close_notify.clone();
+                        let sc = sidecars.clone();
                         tokio::spawn(async move {
-                            handle_connection(stream, state, reset_tx, sf, cn).await;
+                            handle_connection(stream, state, reset_tx, sf, cn, sc).await;
                         });
                     }
                     Err(e) => {
@@ -282,6 +342,12 @@ async fn run_socket_server(
     let port_path = socket_dir.join(format!("{}.port", session));
     let _ = fs::write(&port_path, actual_port.to_string());
 
+    let sidecars = Arc::new(DaemonSidecars::new(vec![
+        port_path.clone(),
+        socket_dir.join(format!("{}.pid", session)),
+        socket_dir.join(format!("{}.version", session)),
+    ]));
+
     let stream_file: Option<PathBuf> = if stream_server.is_some() {
         Some(socket_dir.join(format!("{}.stream", session)))
     } else {
@@ -305,12 +371,20 @@ async fn run_socket_server(
             accept_result = listener.accept() => {
                 match accept_result {
                     Ok((stream, _)) => {
+                        // A connection racing the post-`close` shutdown gets
+                        // dropped: the client treats the EOF as daemon-
+                        // unreachable and respawns a fresh daemon.
+                        if sidecars.is_closing() {
+                            drop(stream);
+                            continue;
+                        }
                         let state = state.clone();
                         let reset_tx = reset_tx.clone();
                         let sf = stream_file.clone();
                         let cn = close_notify.clone();
+                        let sc = sidecars.clone();
                         tokio::spawn(async move {
-                            handle_connection(stream, state, reset_tx, sf, cn).await;
+                            handle_connection(stream, state, reset_tx, sf, cn, sc).await;
                         });
                     }
                     Err(e) => {
@@ -360,6 +434,7 @@ async fn handle_connection<S>(
     idle_reset_tx: Option<Arc<mpsc::Sender<()>>>,
     stream_file_cleanup: Option<PathBuf>,
     close_notify: Arc<Notify>,
+    sidecars: Arc<DaemonSidecars>,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
@@ -416,6 +491,12 @@ async fn handle_connection<S>(
                     if let Some(ref path) = stream_file_cleanup {
                         let _ = fs::remove_file(path);
                     }
+                    // Unlink the socket/pid/version sidecars BEFORE the grace
+                    // sleep. ensure_daemon probes the socket path, so a fast
+                    // follow-up command would otherwise reach this dying
+                    // daemon, auto-launch its browser here, and lose it when
+                    // the daemon exits below.
+                    sidecars.begin_close();
                     // Signal the daemon loop to exit gracefully instead of
                     // calling process::exit(), which skips destructors and
                     // can leave Chrome processes orphaned (issue #1113).
@@ -675,5 +756,35 @@ mod tests {
                 other
             ),
         }
+    }
+
+    #[test]
+    fn test_sidecars_begin_close_unlinks_files_and_flips_flag() {
+        let dir = std::env::temp_dir().join(format!(
+            "agent-browser-sidecars-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("s.sock");
+        let pid = dir.join("s.pid");
+        fs::write(&sock, "").unwrap();
+        fs::write(&pid, "123").unwrap();
+
+        let sidecars = DaemonSidecars::new(vec![sock.clone(), pid.clone()]);
+        assert!(!sidecars.is_closing());
+
+        sidecars.begin_close();
+
+        // The dying daemon must be invisible to ensure_daemon immediately:
+        // no socket to probe, no pid/version files for a successor to lose.
+        assert!(sidecars.is_closing());
+        assert!(!sock.exists());
+        assert!(!pid.exists());
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -417,7 +417,6 @@ async fn run_socket_server(
                 if let Some(ref mut mgr) = s.browser {
                     let _ = mgr.close().await;
                 }
-                let _ = fs::remove_file(&port_path);
                 break;
             }
             _ = reset_rx.recv(), if idle_timeout_ms.is_some() => {
@@ -426,7 +425,6 @@ async fn run_socket_server(
                 continue;
             }
             _ = close_notify.notified() => {
-                let _ = fs::remove_file(&port_path);
                 break;
             }
             _ = shutdown_signal() => {
@@ -434,7 +432,6 @@ async fn run_socket_server(
                 if let Some(ref mut mgr) = s.browser {
                     let _ = mgr.close().await;
                 }
-                let _ = fs::remove_file(&port_path);
                 break;
             }
         }

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -160,8 +160,8 @@ pub async fn run_daemon(session: &str) {
 }
 
 /// Sidecar files that make this daemon discoverable by CLI invocations.
-/// `handle_connection` unlinks them the moment a `close` command has been
-/// answered: ensure_daemon's liveness check is socket connectivity, so a
+/// `handle_connection` unlinks them before a `close` response is written:
+/// ensure_daemon's liveness check is socket connectivity, so a
 /// fast follow-up command would otherwise connect to the dying daemon, get
 /// its browser launched there, and lose it when the daemon exits.
 struct DaemonSidecars {
@@ -490,28 +490,55 @@ async fn handle_connection<S>(
                 }
 
                 let is_close = cmd.get("action").and_then(|v| v.as_str()) == Some("close");
+                let mut notify_close = false;
 
                 let response = {
                     let mut s = state.lock().await;
-                    execute_command(&cmd, &mut s).await
+                    // A command that was accepted before `close` unlinked the
+                    // socket can still be queued behind the state mutex. Drop
+                    // it after the close command marks this daemon invisible:
+                    // the client treats EOF as transient, reconnects, sees no
+                    // sidecars, and respawns a fresh daemon.
+                    if sidecars.is_closing() && !is_close {
+                        return;
+                    }
+
+                    let response = execute_command(&cmd, &mut s).await;
+                    if is_close
+                        && response
+                            .get("success")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false)
+                        && response
+                            .get("data")
+                            .and_then(|d| d.get("closed"))
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false)
+                    {
+                        if let Some(ref path) = stream_file_cleanup {
+                            let _ = fs::remove_file(path);
+                        }
+                        // Unlink the socket/pid/version sidecars before
+                        // releasing the state lock. Any connection already
+                        // queued behind this close will observe `is_closing`
+                        // above instead of launching work in a dying daemon.
+                        sidecars.begin_close();
+                        notify_close = true;
+                    }
+                    response
                 };
 
                 let mut resp = serde_json::to_string(&response).unwrap_or_default();
                 resp.push('\n');
                 if writer.write_all(resp.as_bytes()).await.is_err() {
+                    if notify_close {
+                        close_notify.notify_one();
+                        return;
+                    }
                     break;
                 }
 
-                if is_close {
-                    if let Some(ref path) = stream_file_cleanup {
-                        let _ = fs::remove_file(path);
-                    }
-                    // Unlink the socket/pid/version sidecars BEFORE the grace
-                    // sleep. ensure_daemon probes the socket path, so a fast
-                    // follow-up command would otherwise reach this dying
-                    // daemon, auto-launch its browser here, and lose it when
-                    // the daemon exits below.
-                    sidecars.begin_close();
+                if notify_close {
                     // Signal the daemon loop to exit gracefully instead of
                     // calling process::exit(), which skips destructors and
                     // can leave Chrome processes orphaned (issue #1113).
@@ -808,5 +835,40 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_closing_daemon_drops_non_close_command_without_response() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (mut client, server) = tokio::io::duplex(1024);
+        let state = std::sync::Arc::new(tokio::sync::Mutex::new(DaemonState::new()));
+        let close_notify = std::sync::Arc::new(tokio::sync::Notify::new());
+        let sidecars = std::sync::Arc::new(DaemonSidecars::new(Vec::new()));
+        sidecars.begin_close();
+
+        let task = tokio::spawn(handle_connection(
+            server,
+            state,
+            None,
+            None,
+            close_notify,
+            sidecars,
+        ));
+
+        client
+            .write_all(br#"{"id":"queued","action":"url"}"#)
+            .await
+            .unwrap();
+        client.write_all(b"\n").await.unwrap();
+
+        let mut buf = [0u8; 16];
+        let read = tokio::time::timeout(Duration::from_secs(1), client.read(&mut buf))
+            .await
+            .expect("closing daemon should drop queued command promptly")
+            .expect("duplex read should not fail");
+        assert_eq!(read, 0, "client should see EOF and respawn");
+
+        task.await.unwrap();
     }
 }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6065,6 +6065,24 @@ async fn e2e_frame_scoped_text_wait_eval_and_function_wait() {
     .await;
     assert_success(&resp);
 
+    // The CLI parser maps `wait --url` and `wait --fn` to the waitfor*
+    // daemon actions. Those variants must honor the selected frame too.
+    let resp = execute_command(
+        &json!({ "id": "7b", "action": "waitforfunction", "expression": "window.frameFlag === 42", "timeout": 5000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], true);
+
+    let resp = execute_command(
+        &json!({ "id": "7c", "action": "waitforurl", "url": "about:srcdoc", "timeout": 5000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], "about:srcdoc");
+
     let resp = execute_command(
         &json!({ "id": "8", "action": "evaluate", "script": "window.frameFlag" }),
         &mut state,

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6073,6 +6073,18 @@ async fn e2e_frame_scoped_text_wait_eval_and_function_wait() {
     assert_success(&resp);
     assert_eq!(get_data(&resp)["result"], 42);
 
+    let resp = execute_command(
+        &json!({ "id": "8b", "action": "evaluate", "script": "await Promise.resolve(window.frameFlag + 1)" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        43,
+        "top-level await should work inside a selected same-process iframe"
+    );
+
     // Back on the main frame the flag must not leak.
     let resp = execute_command(&json!({ "id": "9", "action": "mainframe" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6085,6 +6085,25 @@ async fn e2e_frame_scoped_text_wait_eval_and_function_wait() {
         "top-level await should work inside a selected same-process iframe"
     );
 
+    // Re-declaring the same const across evals must work in a selected
+    // same-process iframe too, not just the main frame and OOPIF sessions.
+    let resp = execute_command(
+        &json!({ "id": "8c", "action": "evaluate",
+                 "script": "const el = document.getElementById('msg'); el.id" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "msg");
+    let resp = execute_command(
+        &json!({ "id": "8d", "action": "evaluate",
+                 "script": "const el = document.getElementById('msg'); el.textContent" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "frame-ready");
+
     // Back on the main frame the flag must not leak.
     let resp = execute_command(&json!({ "id": "9", "action": "mainframe" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5572,3 +5572,704 @@ async fn e2e_removeinitscript_roundtrip() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+// ---------------------------------------------------------------------------
+// Agent-facing reliability regressions: scroll-into-view clicks, overlay
+// interception, dialog-opening clicks, select diagnostics, aria-label lookup,
+// frame-scoped selectors, and wait timeouts. Each of these was a silent or
+// hanging failure before v0.27.2; these tests pin the loud, prompt behavior.
+// ---------------------------------------------------------------------------
+
+fn inline_html_url(html: &str) -> String {
+    format!("data:text/html;base64,{}", STANDARD.encode(html))
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_click_scrolls_offscreen_element_into_view() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url(
+        r#"<title>t</title><div style="height:4000px"></div>
+        <button id="deep" onclick="document.title='clicked-deep'">Deep</button>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Off-viewport click used to dispatch outside the viewport and silently no-op.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#deep" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "clicked-deep");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_click_covered_by_overlay_reports_blocker() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url(
+        r#"<title>t</title>
+        <button id="target" onclick="document.title='clicked-target'">Buy</button>
+        <div id="overlay" onclick="document.title='clicked-overlay'"
+             style="position:fixed;inset:0;background:rgba(0,0,0,.4);z-index:10"></div>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The covered click must fail loudly and name the covering element,
+    // not report success while the overlay eats the input.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#target" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+    let error = resp
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("covered by") && error.contains("overlay"),
+        "error should name the blocker, got: {}",
+        error
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        get_data(&resp)["result"],
+        "t",
+        "covered click must not land"
+    );
+
+    // Clicking the covering element itself is always allowed.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "#overlay" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(get_data(&resp)["result"], "clicked-overlay");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_dialog_click_returns_promptly_then_fast_fails_until_accepted() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url(
+        r#"<button id="del" onclick="if (confirm('sure?')) document.title='confirmed'">Del</button>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A click that opens confirm() must return promptly with dialogOpened,
+    // not hang until the IPC read timeout.
+    let started = std::time::Instant::now();
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#del" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["dialogOpened"], true);
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "dialog-opening click should return promptly, took {:?}",
+        started.elapsed()
+    );
+
+    // Page-touching commands fail fast with instructions while the dialog is up.
+    let resp = execute_command(&json!({ "id": "4", "action": "snapshot" }), &mut state).await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+    let error = resp
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("dialog accept"),
+        "fast-fail should give resolution instructions, got: {}",
+        error
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "dialog", "response": "accept" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "confirmed");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_select_without_match_lists_available_options() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url(
+        r#"<select id="topic">
+            <option value="support">Support</option>
+            <option value="sales">Sales</option>
+        </select>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // No silent success: a value that matches nothing errors with the options.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "select", "selector": "#topic", "values": ["bogus"] }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+    let error = resp
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("Available options") && error.contains("sales"),
+        "error should list available options, got: {}",
+        error
+    );
+
+    // Selecting by visible label still works.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "select", "selector": "#topic", "values": ["Sales"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "document.getElementById('topic').value" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(get_data(&resp)["result"], "sales");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_find_label_matches_aria_label() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url(
+        r#"<title>t</title>
+        <button aria-label="Delete item 1" onclick="document.title='aria-clicked'">x</button>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Icon buttons are labelled via aria-label; getByLabel-style lookup must find them.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbylabel", "label": "Delete item 1", "subaction": "click" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(get_data(&resp)["result"], "aria-clicked");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_frame_scoped_css_selectors_and_wait() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // NOTE: srcdoc entities decode at the PARENT parse, so an inline handler
+    // with &quot;-nested quotes ends up invalid; a <script> avoids that.
+    let url = inline_html_url(
+        r#"<h1>Parent</h1>
+        <iframe id="fr" srcdoc='<input id="inner">
+            <button id="btn">Go</button>
+            <div id="out"></div>
+            <script>document.getElementById("btn").addEventListener("click", () => {
+                document.getElementById("out").textContent =
+                    document.getElementById("inner").value;
+            });</script>'></iframe>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "frame", "selector": "#fr" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // CSS selectors and selector waits must resolve inside the selected
+    // frame; they used to silently target the main document.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "wait", "selector": "#inner", "timeout": 5000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "fill", "selector": "#inner", "value": "hello frame" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "click", "selector": "#btn" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "gettext", "selector": "#out" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["text"], "hello frame");
+
+    // Back on the main frame, the same selector must not resolve.
+    let resp = execute_command(&json!({ "id": "8", "action": "mainframe" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "gettext", "selector": "#out" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_wait_selector_honors_timeout_parameter() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url("<p>empty</p>");
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let started = std::time::Instant::now();
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "wait", "selector": "#never", "timeout": 1200 }),
+        &mut state,
+    )
+    .await;
+    let elapsed = started.elapsed();
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+    let error = resp
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("timed out after 1200ms"),
+        "wait should report its configured timeout, got: {}",
+        error
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_millis(1100)
+            && elapsed < std::time::Duration::from_secs(6),
+        "wait should respect the 1200ms timeout, took {:?}",
+        elapsed
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_frame_scoped_text_wait_eval_and_function_wait() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The button mutates state inside the frame only, after a delay: text the
+    // parent document never contains, and a global on the frame's window.
+    // (srcdoc entities decode at the PARENT parse, so a <script> is used
+    // instead of an inline handler with nested quotes.)
+    let url = inline_html_url(
+        r#"<h1>parent-only</h1>
+        <iframe id="fr" srcdoc='<button id="go">Go</button>
+            <div id="msg">frame-idle</div>
+            <script>document.getElementById("go").addEventListener("click", () => {
+                setTimeout(() => {
+                    document.getElementById("msg").textContent = "frame-ready";
+                    window.frameFlag = 42;
+                }, 300);
+            });</script>'></iframe>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "frame", "selector": "#fr" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // eval must run in the frame's realm: its document, not the parent's.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.body.innerText" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let text = get_data(&resp)["result"].as_str().unwrap_or_default();
+    assert!(
+        text.contains("frame-idle") && !text.contains("parent-only"),
+        "eval should see the frame document, got: {}",
+        text
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "#go" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Text and function waits must observe the frame, not the main document
+    // (where neither the text nor the global ever appears).
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "wait", "text": "frame-ready", "timeout": 5000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "wait", "function": "window.frameFlag === 42", "timeout": 5000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "evaluate", "script": "window.frameFlag" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], 42);
+
+    // Back on the main frame the flag must not leak.
+    let resp = execute_command(&json!({ "id": "9", "action": "mainframe" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "10", "action": "evaluate", "script": "typeof window.frameFlag" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "undefined");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_eval_accepts_console_style_scripts() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url("<div id='x'>42</div>");
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Top-level return (Playwright-style function body) must work.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "evaluate",
+                 "script": "const el = document.getElementById('x'); return el.textContent;" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "42");
+
+    // Re-declaring the same const across evals must work (REPL-mode retry);
+    // it used to fail with "Identifier 'el' has already been declared".
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate",
+                 "script": "const el = document.getElementById('x'); el.tagName" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "DIV");
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate",
+                 "script": "const el = document.getElementById('x'); el.textContent" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "42");
+
+    // Top-level await must work.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate",
+                 "script": "await new Promise(r => setTimeout(() => r('done'), 10))" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "done");
+
+    // An expression that itself returns a Promise must resolve to its value
+    // (classic awaitPromise semantics — the REPL-mode retry must not change
+    // this path).
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "evaluate",
+                 "script": "Promise.resolve(7).then(v => v + 1)" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], 8);
+
+    // Real syntax errors still fail loudly.
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "evaluate", "script": "const = broken" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_wait_text_is_case_insensitive_and_url_accepts_globs() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = inline_html_url(
+        r#"<p id="s">idle</p>
+        <script>setTimeout(() => {
+            document.getElementById('s').textContent = 'Uploaded notes.txt';
+        }, 300)</script>"#,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Casing guesses ("upload" vs "Uploaded") must not cost a timeout.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "wait", "text": "upload", "timeout": 5000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The documented glob form must match (it used to be compared literally,
+    // so it could never succeed). The base64 payload may contain '/', which
+    // only `**` crosses.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "wait", "url": "data:text/html**", "timeout": 2000 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A glob that matches nothing still times out.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "wait", "url": "**/never-this-path", "timeout": 800 }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_find_text_prefers_exact_match_and_reports_pick() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // "$24.99" contains "2" and comes first in document order; the exact
+    // pagination link "2" must win anyway.
+    let url = inline_html_url(
+        r##"<title>t</title>
+        <span>$24.99</span>
+        <a href="#" onclick="document.title='paged'">2</a>"##,
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbytext", "text": "2", "subaction": "click" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let matched = get_data(&resp)["matched"].as_str().unwrap_or_default();
+    assert!(
+        matched.contains("<a>") && matched.contains("\"2\""),
+        "match report should describe the picked element, got: {}",
+        matched
+    );
+    assert_eq!(get_data(&resp)["otherMatches"], 1);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        get_data(&resp)["result"],
+        "paged",
+        "find text must click the exact match, not the first substring hit"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -441,19 +441,22 @@ pub async fn select_option(
     // Matching nothing must be an error, not a silent success: an agent that
     // selects a misspelled option otherwise sees "Done", and only discovers
     // the page state is wrong after more commands. List what was available.
+    // Decide matches BEFORE mutating: reading opt.selected back from the DOM
+    // is unreliable, because deselecting every option of a single-select
+    // makes the browser instantly re-select option 0, which then counts as a
+    // match and turns a typo into a silent success that also corrupted the
+    // selection.
     let js = r#"function(vals) {
             const options = Array.from(this.options);
-            let matched = 0;
-            for (const opt of options) {
-                opt.selected = vals.includes(opt.value) || vals.includes(opt.textContent.trim());
-                if (opt.selected) matched += 1;
-            }
-            if (matched === 0) {
+            const matches = options.map(opt =>
+                vals.includes(opt.value) || vals.includes(opt.textContent.trim()));
+            if (!matches.some(Boolean)) {
                 const available = options.map(o => o.value + ' ("' + o.textContent.trim() + '")').join(', ');
                 return { error: 'No option matched ' + JSON.stringify(vals) + '. Available options: ' + available };
             }
+            options.forEach((opt, i) => { opt.selected = matches[i]; });
             this.dispatchEvent(new Event('change', { bubbles: true }));
-            return { matched };
+            return { matched: matches.filter(Boolean).length };
         }"#
     .to_string();
 
@@ -473,6 +476,18 @@ pub async fn select_option(
             Some(&effective_session_id),
         )
         .await?;
+
+    // A thrown exception must not pass for success (e.g. the selector
+    // resolved to something without .options).
+    if let Some(details) = result.get("exceptionDetails") {
+        let msg = details
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .or_else(|| details.get("text").and_then(|t| t.as_str()))
+            .unwrap_or("selection script threw");
+        return Err(format!("Select failed: {}", msg));
+    }
 
     if let Some(error) = result
         .get("result")

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1665,10 +1665,10 @@ Waits for an element to appear, a timeout, or other conditions.
 Modes:
   <selector>           Wait for element to appear
   <ms>                 Wait for specified milliseconds
-  --url <pattern>      Wait for URL to match pattern
+  --url <pattern>      Wait for URL glob or substring
   --load <state>       Wait for load state (load, domcontentloaded, networkidle)
   --fn <expression>    Wait for JavaScript expression to be truthy
-  --text <text>        Wait for text to appear on page (substring match)
+  --text <text>        Wait for text to appear on page (case-insensitive)
   --download [path]    Wait for a download to complete (optionally save to path)
 
 Download Options (with --download):
@@ -1795,6 +1795,9 @@ agent-browser eval - Execute JavaScript
 Usage: agent-browser eval [options] <script>
 
 Executes JavaScript code in the browser context and returns the result.
+Scripts may use top-level return, top-level await, and repeated let/const
+declarations across calls. After `frame <selector>`, eval runs inside the
+selected frame.
 
 Options:
   -b, --base64         Decode script from base64 (avoids shell escaping issues)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1141,8 +1141,27 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
-        // Default success
-        println!("{} Done", color::success_indicator());
+        // Default success. A semantic-locator match report shows what was
+        // picked, so a wrong pick is visible immediately instead of after
+        // the next snapshot.
+        if let Some(matched) = data.get("matched").and_then(|v| v.as_str()) {
+            let others = data
+                .get("otherMatches")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            if others > 0 {
+                println!(
+                    "{} Done — matched {} ({} other matches on the page)",
+                    color::success_indicator(),
+                    matched,
+                    others
+                );
+            } else {
+                println!("{} Done — matched {}", color::success_indicator(), matched);
+            }
+        } else {
+            println!("{} Done", color::success_indicator());
+        }
     }
 
     print_warning(resp);

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -12,7 +12,13 @@ pub struct EnvGuard<'a> {
 
 impl<'a> EnvGuard<'a> {
     pub fn new(var_names: &[&str]) -> Self {
-        let lock = ENV_MUTEX.lock().unwrap();
+        // Recover from poisoning: a test that panics while holding the lock
+        // must not cascade-fail every later test that touches env vars. The
+        // guarded data is (), so there is no torn state to worry about; Drop
+        // restored the previous env values even during the panic unwind.
+        let lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let vars = var_names
             .iter()
             .map(|&name| (name.to_string(), std::env::var(name).ok()))

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -29,7 +29,7 @@ agent-browser screenshot --screenshot-dir ./shots    # Save to custom directory
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
 agent-browser pdf <path>              # Save page as PDF
 agent-browser snapshot                # Accessibility tree with refs
-agent-browser eval <js>               # Run JavaScript
+agent-browser eval <js>               # Run JavaScript; supports top-level return/await
 agent-browser connect <port|url>      # Connect to browser via CDP
 agent-browser stream enable [--port <port>]  # Start runtime WebSocket streaming
 agent-browser stream status           # Show runtime streaming state and bound port
@@ -107,8 +107,8 @@ agent-browser find nth 2 ".card" hover
 ```bash
 agent-browser wait <selector>         # Wait for element
 agent-browser wait <ms>               # Wait for time
-agent-browser wait --text "Welcome"   # Wait for text (substring match)
-agent-browser wait --url "**/dash"    # Wait for URL pattern
+agent-browser wait --text "Welcome"   # Wait for text, case-insensitive
+agent-browser wait --url "**/dash"    # Wait for URL glob or substring
 agent-browser wait --load networkidle # Wait for load state
 agent-browser wait --fn "condition"   # Wait for JS condition
 agent-browser wait --download [path]  # Wait for download

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -149,8 +149,8 @@ right wait for the situation:
 ```bash
 agent-browser wait @e1                     # until an element appears
 agent-browser wait 2000                    # dumb wait, milliseconds (last resort)
-agent-browser wait --text "Success"        # until the text appears on the page
-agent-browser wait --url "**/dashboard"    # until URL matches pattern (glob)
+agent-browser wait --text "Success"        # until the text appears (case-insensitive)
+agent-browser wait --url "**/dashboard"    # until URL matches glob or substring
 agent-browser wait --load networkidle      # until network idle (post-navigation)
 agent-browser wait --load domcontentloaded # until DOMContentLoaded
 agent-browser wait --fn "window.myApp.ready === true"  # until JS condition

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -231,8 +231,9 @@ EOF
 ```
 
 Prefer `eval --stdin` (heredoc) or `eval -b <base64>` for any JS with
-quotes or special characters. Inline `agent-browser eval "..."` works
-only for simple expressions.
+quotes or special characters. Scripts may use top-level `return`,
+top-level `await`, and repeated `let`/`const` declarations across calls.
+After `frame <selector>`, eval runs inside the selected frame.
 
 ### Screenshot
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -126,8 +126,8 @@ agent-browser record restart ./take2.webm # Stop current + start new
 ```bash
 agent-browser wait @e1                     # Wait for element
 agent-browser wait 2000                    # Wait milliseconds
-agent-browser wait --text "Success"        # Wait for text (or -t)
-agent-browser wait --url "**/dashboard"    # Wait for URL pattern (or -u)
+agent-browser wait --text "Success"        # Wait for text, case-insensitive (or -t)
+agent-browser wait --url "**/dashboard"    # Wait for URL glob or substring (or -u)
 agent-browser wait --load networkidle      # Wait for network idle (or -l)
 agent-browser wait --fn "window.ready"     # Wait for JS condition (or -f)
 ```
@@ -283,7 +283,7 @@ agent-browser eval -b "<base64>"             # Any JavaScript (base64 encoded)
 agent-browser eval --stdin                   # Read script from stdin
 ```
 
-Use `-b`/`--base64` or `--stdin` for reliable execution. Shell escaping with nested quotes and special characters is error-prone.
+Use `-b`/`--base64` or `--stdin` for reliable execution. Shell escaping with nested quotes and special characters is error-prone. Scripts may use a top-level `return`, top-level `await`, and re-declare `let`/`const` across calls. After `frame <selector>`, eval runs inside the selected frame.
 
 ```bash
 # Base64 encode your script, then:


### PR DESCRIPTION
- Fix a race where a command arriving right after `close` could reach the shutting-down daemon, launch a browser there, and silently lose it (with all tabs) when the daemon exited; the next command then saw a fresh browser at about:blank
- After `frame <selector>`, `eval` and `wait --text/--url/--function` now run inside the selected frame; they used to silently target the main document
- `select` with no matching option now fails and lists the available options; the old read-back of `opt.selected` let the browser's auto re-select of option 0 turn a typo into a silent success that also corrupted the selection
- Exceptions thrown inside the selection script surface as errors instead of passing for success
- `wait --url` now supports the documented glob form (`**/dashboard`); globs were previously compared literally and could never match, while plain substrings keep working
- `wait --text` matches case-insensitively
- `eval` accepts console-style scripts: top-level `return`, top-level `await`, and re-declaring `let`/`const` across calls, with classic semantics (including Promise resolution) unchanged otherwise
- `find text` prefers an exact text match over the first substring hit and reports what it picked, e.g. `Done — matched <a> "2" (1 other matches on the page)`
- Add e2e regression tests covering these behaviors, plus poison recovery in the test env guard so one failing test cannot cascade into unrelated failures
