### PR TITLE
fix: add SHA-256 checksum verification for downloaded binaries

### DIFF
--- a/scripts/generate-checksums.sh
+++ b/scripts/generate-checksums.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# Download release binaries and generate SHA256SUMS.
+# Usage: ./scripts/generate-checksums.sh [version]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_FILE="$PROJECT_ROOT/SHA256SUMS"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+GITHUB_REPO="vercel-labs/agent-browser"
+
+if [ "${1:-}" ]; then
+  VERSION="${1#v}"
+else
+  VERSION="$(
+    curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases/latest" \
+      | node -e "let data=''; process.stdin.on('data', c => data += c); process.stdin.on('end', () => console.log(JSON.parse(data).tag_name.replace(/^v/, '')));"
+  )"
+fi
+
+BASE_URL="https://github.com/$GITHUB_REPO/releases/download/v$VERSION"
+
+BINARIES=(
+  "agent-browser-linux-x64"
+  "agent-browser-linux-arm64"
+  "agent-browser-win32-x64.exe"
+  "agent-browser-darwin-x64"
+  "agent-browser-darwin-arm64"
+  "agent-browser-linux-musl-x64"
+  "agent-browser-linux-musl-arm64"
+)
+
+echo "Generating checksums for v$VERSION"
+rm -f "$OUTPUT_FILE"
+
+for binary in "${BINARIES[@]}"; do
+  echo "Downloading $binary"
+  curl -fsSL "$BASE_URL/$binary" -o "$TMP_DIR/$binary"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    hash="$(sha256sum "$TMP_DIR/$binary" | awk '{print $1}')"
+  else
+    hash="$(shasum -a 256 "$TMP_DIR/$binary" | awk '{print $1}')"
+  fi
+
+  printf "%s  %s\n" "$hash" "$binary" >> "$OUTPUT_FILE"
+done
+
+echo "Wrote $OUTPUT_FILE"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -9,12 +9,13 @@
  * - Mac/Linux: Replaces symlink to point to native binary
  */
 
-import { existsSync, mkdirSync, chmodSync, createWriteStream, unlinkSync, writeFileSync, symlinkSync, lstatSync } from 'fs';
+import { existsSync, mkdirSync, chmodSync, createReadStream, createWriteStream, unlinkSync, writeFileSync, symlinkSync, lstatSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { platform, arch } from 'os';
 import { get } from 'https';
 import { execSync } from 'child_process';
+import { createHash } from 'crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
@@ -47,6 +48,7 @@ const version = packageJson.version;
 // GitHub release URL
 const GITHUB_REPO = 'vercel-labs/agent-browser';
 const DOWNLOAD_URL = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${binaryName}`;
+const CHECKSUMS_URL = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/SHA256SUMS`;
 
 async function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
@@ -78,6 +80,91 @@ async function downloadFile(url, dest) {
     
     request(url);
   });
+}
+
+async function fetchText(url) {
+  return new Promise((resolve, reject) => {
+    const request = (url) => {
+      get(url, (response) => {
+        // Handle redirects
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          response.resume();
+          request(response.headers.location);
+          return;
+        }
+
+        if (response.statusCode === 404) {
+          response.resume();
+          resolve(null);
+          return;
+        }
+
+        if (response.statusCode !== 200) {
+          response.resume();
+          reject(new Error(`Failed to download checksums: HTTP ${response.statusCode}`));
+          return;
+        }
+
+        response.setEncoding('utf8');
+        let body = '';
+        response.on('data', chunk => {
+          body += chunk;
+        });
+        response.on('end', () => resolve(body));
+      }).on('error', reject);
+    };
+
+    request(url);
+  });
+}
+
+function parseChecksums(text) {
+  const checksums = new Map();
+
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+
+    const match = line.match(/^([a-f0-9]{64})  (.+)$/i);
+    if (match) {
+      checksums.set(match[2], match[1].toLowerCase());
+    }
+  }
+
+  return checksums;
+}
+
+async function sha256File(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+async function verifyChecksum(filePath, filename) {
+  const checksumsText = await fetchText(CHECKSUMS_URL);
+
+  if (checksumsText === null) {
+    console.log('⚠ SHA256SUMS not found for this release; skipping checksum verification.');
+    return;
+  }
+
+  const checksums = parseChecksums(checksumsText);
+  const expectedHash = checksums.get(filename);
+
+  if (!expectedHash) {
+    throw new Error(`SHA256SUMS does not include ${filename}`);
+  }
+
+  const actualHash = await sha256File(filePath);
+  if (actualHash !== expectedHash) {
+    throw new Error(`Checksum mismatch for ${filename}: expected ${expectedHash}, got ${actualHash}`);
+  }
+
+  console.log(`✓ Verified SHA-256 checksum for ${filename}`);
 }
 
 /**
@@ -133,6 +220,14 @@ async function main() {
 
   try {
     await downloadFile(DOWNLOAD_URL, binaryPath);
+    try {
+      await verifyChecksum(binaryPath, binaryName);
+    } catch (err) {
+      try {
+        unlinkSync(binaryPath);
+      } catch {}
+      throw err;
+    }
 
     // Make executable on Unix
     if (platform() !== 'win32') {


### PR DESCRIPTION
Fixes #1422

## What changed

Added SHA-256 checksum verification for the downloaded native binary in `scripts/postinstall.js`. After downloading, the script fetches the `SHA256SUMS` file from the same GitHub release and verifies the hash before making the binary executable.

If the `SHA256SUMS` file is not available (older releases), the install proceeds with a warning. If the checksum file is present but the hash does not match, the downloaded binary is deleted and the install fails.

Also added `scripts/generate-checksums.sh` to produce the `SHA256SUMS` file for a given release. This can be run manually or integrated into the release pipeline later.

## Changes

- `scripts/postinstall.js`: added `crypto` and `createReadStream` imports, `fetchText()` helper for HTTPS GET with redirect handling, `parseChecksums()` to parse the standard `<hash>  <filename>` format, `sha256File()` to compute the hash of a file on disk, `verifyChecksum()` to orchestrate the check, and a verification call after `downloadFile()` in `main()`.
- `scripts/generate-checksums.sh`: new script that downloads all 7 platform binaries from a release and writes `SHA256SUMS`.

## Tests

- `node --check scripts/postinstall.js` passes (no syntax errors).
- `bash -n scripts/generate-checksums.sh` passes.
- Ran `node scripts/postinstall.js` locally: the missing `SHA256SUMS` path is handled gracefully with a warning, and the binary download continues as before.
- No new dependencies; uses Node.js built-in `crypto` module.

## Notes

The `SHA256SUMS` file does not exist in current releases yet. The verification is backward-compatible: it warns and proceeds when the file is missing. Once the release pipeline generates `SHA256SUMS` alongside the binaries, the verification will enforce integrity automatically.
