### PR TITLE
Restore session-name state on explicit launch

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2020,6 +2020,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
+        try_auto_restore_state(state).await;
         load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
         return Ok(json!({ "launched": true }));
@@ -2032,6 +2033,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
+        try_auto_restore_state(state).await;
         load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
         return Ok(json!({ "launched": true }));
@@ -2044,6 +2046,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.start_fetch_handler();
         state.start_dialog_handler();
         state.update_stream_client().await;
+        try_auto_restore_state(state).await;
         load_storage_state_or_rollback(state, &storage_state_owned).await?;
         apply_launch_init_scripts(state).await;
         return Ok(json!({ "launched": true }));
@@ -2082,6 +2085,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.start_dialog_handler();
                         state.update_stream_client().await;
                         write_provider_file(&state.session_id, provider);
+                        try_auto_restore_state(state).await;
                         load_storage_state_or_rollback(state, &storage_state_owned).await?;
                         apply_launch_init_scripts(state).await;
 
@@ -2176,9 +2180,12 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         }
     }
 
-    // Load storage state only after Fetch interception is active so replayed
-    // origin navigations go through the same domain and proxy handling as
-    // normal browser traffic.
+    // Auto-restore session-name state, then load storage state, only after
+    // Fetch interception is active so replayed origin navigations go through
+    // the same domain and proxy handling as normal browser traffic. An
+    // explicit --state file loads last so it wins over the auto-restored
+    // state, mirroring auto_launch().
+    try_auto_restore_state(state).await;
     load_storage_state_or_rollback(state, &storage_state_owned).await?;
 
     apply_launch_init_scripts(state).await;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5185,10 +5185,8 @@ async fn e2e_session_name_auto_restores_cookies() {
 
     // Session 2: fresh DaemonState with same session_name. Navigate without
     // explicit launch — this triggers auto_launch which calls
-    // try_auto_restore_state.
-    //
-    // NOTE: an explicit `launch` command skips auto_launch entirely, so
-    // session-name auto-restore only fires via the auto_launch path.
+    // try_auto_restore_state. (The explicit `launch` path is covered by
+    // e2e_session_name_restores_after_explicit_launch.)
     {
         let mut state = DaemonState::new();
 
@@ -5210,6 +5208,114 @@ async fn e2e_session_name_auto_restores_cookies() {
         assert!(
             found,
             "Cookie should be auto-restored via --session-name. Cookies found: {:?}",
+            cookies
+                .iter()
+                .map(|c| c["name"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+
+        let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    // Clean up auto-saved state files
+    let sessions_dir = dirs::home_dir()
+        .unwrap()
+        .join(".agent-browser")
+        .join("sessions");
+    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
+        for entry in entries.flatten() {
+            let fname = entry.file_name().to_string_lossy().to_string();
+            if fname.starts_with(&format!("{}-", session_name)) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
+/// Verify that session-name state is also auto-restored when the browser is
+/// started via an explicit `launch` command. The CLI sends an explicit launch
+/// whenever a launch-affecting flag is present (--headed, --executable-path,
+/// --proxy, ...), so without this path restoring, --session-name silently
+/// stops working as soon as any of those flags is used.
+#[tokio::test]
+#[ignore]
+async fn e2e_session_name_restores_after_explicit_launch() {
+    let session_name = format!(
+        "e2e-session-name-explicit-{}",
+        &uuid::Uuid::new_v4().to_string()[..8]
+    );
+
+    let env = EnvGuard::new(&["AGENT_BROWSER_SESSION_NAME"]);
+    env.set("AGENT_BROWSER_SESSION_NAME", &session_name);
+
+    // Session 1: launch, set a cookie, close (which auto-saves state)
+    {
+        let mut state = DaemonState::new();
+
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({
+                "id": "3",
+                "action": "cookies_set",
+                "name": "session_name_explicit_test",
+                "value": "auto_restored",
+                "domain": ".example.com",
+                "path": "/",
+                "expires": 2000000000
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(&json!({ "id": "5", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    // Session 2: fresh DaemonState with same session_name, started via an
+    // explicit `launch` command (as the CLI does when launch-affecting flags
+    // are present) instead of relying on auto_launch.
+    {
+        let mut state = DaemonState::new();
+
+        let resp = execute_command(
+            &json!({ "id": "10", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({ "id": "11", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp =
+            execute_command(&json!({ "id": "12", "action": "cookies_get" }), &mut state).await;
+        assert_success(&resp);
+        let cookies = get_data(&resp)["cookies"].as_array().unwrap();
+        let found = cookies
+            .iter()
+            .any(|c| c["name"] == "session_name_explicit_test" && c["value"] == "auto_restored");
+        assert!(
+            found,
+            "Cookie should be auto-restored via --session-name on explicit launch. Cookies found: {:?}",
             cookies
                 .iter()
                 .map(|c| c["name"].as_str().unwrap_or("?"))


### PR DESCRIPTION
## Problem

`--session-name` restore silently stops working as soon as any launch-affecting flag is present. Saving keeps working, so the next flag-less `close` can overwrite a previously good state file with an empty one.

The reason is that `try_auto_restore_state` is only called from `auto_launch`, the path taken when a command arrives before any explicit launch. The CLI sends an explicit `launch` command whenever one of `--headed`, `--executable-path`, `--profile`, `--proxy`, `--args`, `--user-agent`, `--engine` (and a few others, see `main.rs`) is set, and `handle_launch` never restores. The limitation was even noted in a comment in `e2e_session_name_auto_restores_cookies`.

Repro on 0.27.2:

```bash
# works: restores "v / c=v"
agent-browser --session s1 --session-name t open https://example.com
# ... set cookie + localStorage, close, reopen with --session-name t

# broken: returns "null / " with the exact same commands
AGENT_BROWSER_EXECUTABLE_PATH="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" \
  agent-browser --session s1 --session-name t open https://example.com
```

Fixes #1441. Also explains the reports in #1335: the env var itself forwards fine to the daemon, and restores correctly when no launch-affecting flag is involved, but any such flag (or a `config.json` with `executablePath`) routes through the explicit launch path and skips the restore.

## Fix

Call `try_auto_restore_state` from every connect/launch branch of `handle_launch` (cdp url, cdp port, auto-connect, provider, local launch), right before the explicit `--state` load so a `--state` file still wins. This mirrors the ordering already used in `auto_launch`. The reused-browser early return intentionally does not restore, matching the implicit path.

## Testing

- New e2e test `e2e_session_name_restores_after_explicit_launch` covering the explicit launch path; it fails on `main` and passes with this change.
- Existing `e2e_session_name_auto_restores_cookies` still passes (its stale comment about the limitation is updated).
- `cargo test`: 738 passed, 0 failed. `cargo fmt --check` and `cargo clippy` are clean.
- Manually verified the original repro with a Brave executable path and with `--headed`: cookies and localStorage now restore across a full daemon restart in both cases.