### PR TITLE
Fix stale snapshot refs silently actuating the wrong element after DOM-mutation renumbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,13 @@ control first, then run `snapshot` again before reusing refs.
 - **Fast**: No DOM re-query needed
 - **AI-friendly**: Snapshot + ref workflow is optimal for LLMs
 
+Refs are bound to the element they were minted for and survive repeated
+snapshots within a page: elements still in the DOM keep their ref ids, new
+elements get fresh ids, and ref numbers are never reused. Using a ref whose
+element left the DOM after a newer snapshot fails with a stale-ref error
+(`Stale ref: e2 ... Take a new snapshot`) instead of acting on a different
+element. Navigation clears all refs.
+
 ### CSS Selectors
 
 ```bash

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2547,7 +2547,11 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         urls: cmd.get("urls").and_then(|v| v.as_bool()).unwrap_or(false),
     };
 
-    state.ref_map.clear();
+    // Retire (rather than clear) the previous generation of refs: surviving
+    // nodes reclaim their ref ids inside take_snapshot, and refs whose nodes
+    // are gone fail with a stale-ref error instead of silently rebinding to
+    // whichever element now holds their number (#1443).
+    state.ref_map.begin_rebuild();
     let tree = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -2650,7 +2654,7 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     };
 
     if annotate {
-        state.ref_map.clear();
+        state.ref_map.begin_rebuild();
         let _ = snapshot::take_snapshot(
             &mgr.client,
             &session_id,
@@ -5705,10 +5709,7 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     // If selector is a ref (@e1), resolve the iframe element from the ref map
     if let Some(sel) = selector {
         if let Some(ref_id) = super::element::parse_ref(sel) {
-            let entry = state
-                .ref_map
-                .get(&ref_id)
-                .ok_or_else(|| format!("Unknown ref: {}", ref_id))?;
+            let entry = state.ref_map.resolve(&ref_id)?;
             let backend_node_id = entry
                 .backend_node_id
                 .ok_or_else(|| format!("Ref {} has no backend node id", ref_id))?;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3073,6 +3073,280 @@ async fn e2e_click_stale_ref_falls_back_to_role_name() {
 }
 
 // ---------------------------------------------------------------------------
+// Regression: stale snapshot refs after DOM-mutation renumbering (#1443)
+//
+// Snapshot refs were positional within the latest snapshot's registry. When
+// the DOM mutated and a new snapshot was taken, every ref shifted, so a ref
+// remembered from the previous snapshot silently actuated whichever element
+// now occupied that number. Refs must instead stay bound to the node they
+// were minted for: surviving nodes keep their ref ids across snapshots and
+// refs whose nodes left the DOM fail loudly instead of rebinding.
+// ---------------------------------------------------------------------------
+
+const RENUMBER_PROBE_URL: &str = "data:text/html,\
+    <button onclick=\"document.title=this.textContent\">Alpha</button>\
+    <button onclick=\"document.title=this.textContent\">Beta</button>\
+    <button onclick=\"document.title=this.textContent\">Gamma</button>";
+
+const INSERT_NEW_BUTTON_JS: &str = "document.body.insertBefore(\
+    Object.assign(document.createElement('button'),{textContent:'NEW'}),\
+    document.body.firstChild); 'ok'";
+
+#[tokio::test]
+#[ignore]
+async fn e2e_remembered_ref_keeps_meaning_after_resnapshot() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": RENUMBER_PROBE_URL }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // First snapshot: the agent remembers e2 == Beta.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+    assert!(
+        snapshot.contains("button \"Beta\" [ref=e2]"),
+        "Expected Beta to be e2 in the first snapshot, got:\n{}",
+        snapshot
+    );
+
+    // The page inserts a node before the buttons (what cmdk/Radix
+    // multi-selects do on every committed selection).
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": INSERT_NEW_BUTTON_JS }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A second snapshot is taken (renumbering hazard).
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Clicking the remembered ref must actuate Beta, not whichever element
+    // now occupies position 2.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "click", "selector": "@e2" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    let resp = execute_command(&json!({ "id": "7", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["title"],
+        "Beta",
+        "Remembered ref e2 must keep meaning Beta after the re-snapshot"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_resnapshot_preserves_ref_ids_for_surviving_nodes() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": RENUMBER_PROBE_URL }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+    assert!(
+        snapshot.contains("button \"Alpha\" [ref=e1]"),
+        "{}",
+        snapshot
+    );
+    assert!(
+        snapshot.contains("button \"Beta\" [ref=e2]"),
+        "{}",
+        snapshot
+    );
+    assert!(
+        snapshot.contains("button \"Gamma\" [ref=e3]"),
+        "{}",
+        snapshot
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": INSERT_NEW_BUTTON_JS }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Surviving nodes keep their ref ids; only the inserted node gets a
+    // fresh ref (numbers are never reused within a page).
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+    assert!(
+        snapshot.contains("button \"Alpha\" [ref=e1]"),
+        "Alpha must keep e1 across snapshots, got:\n{}",
+        snapshot
+    );
+    assert!(
+        snapshot.contains("button \"Beta\" [ref=e2]"),
+        "Beta must keep e2 across snapshots, got:\n{}",
+        snapshot
+    );
+    assert!(
+        snapshot.contains("button \"Gamma\" [ref=e3]"),
+        "Gamma must keep e3 across snapshots, got:\n{}",
+        snapshot
+    );
+    assert!(
+        snapshot.contains("button \"NEW\" [ref=e4]"),
+        "Inserted node must get a fresh ref, got:\n{}",
+        snapshot
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_ref_for_removed_node_fails_loudly_after_resnapshot() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": RENUMBER_PROBE_URL }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+    assert!(
+        snapshot.contains("button \"Beta\" [ref=e2]"),
+        "{}",
+        snapshot
+    );
+
+    // Remove Beta from the DOM entirely.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "document.querySelectorAll('button')[1].remove(); 'ok'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Clicking the ref of the removed node must fail with a teaching error,
+    // not silently rebind to another element.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "click", "selector": "@e2" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "Clicking a ref whose node left the DOM must fail, got: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let error = resp
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("snapshot"),
+        "Error should teach the agent to take a new snapshot, got: {}",
+        error
+    );
+
+    // No element may have been actuated.
+    let resp = execute_command(&json!({ "id": "7", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_ne!(get_data(&resp)["title"], "Alpha");
+    assert_ne!(get_data(&resp)["title"], "Gamma");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+// ---------------------------------------------------------------------------
 // Regression: Material Design checkbox/radio (#832)
 //
 // Material Design controls hide the native <input> off-screen and place

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -15,8 +15,18 @@ pub struct RefEntry {
     pub frame_id: Option<String>,
 }
 
+/// Registry of snapshot element refs (e1, e2, ...).
+///
+/// Refs are bound to node identity (backendNodeId), not to their position in
+/// the snapshot output: when a new snapshot is taken, `begin_rebuild` retires
+/// the previous generation and surviving nodes reclaim the ref id they were
+/// originally minted under (see `node_to_ref_index`). Ref numbers are never
+/// reused within a page, so a ref remembered from an earlier snapshot either
+/// still means the same element or fails resolution with a stale-ref error —
+/// it can never silently rebind to a different element (#1443).
 pub struct RefMap {
     map: HashMap<String, RefEntry>,
+    retired: HashMap<String, RefEntry>,
     next_ref: usize,
 }
 
@@ -24,8 +34,46 @@ impl RefMap {
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
+            retired: HashMap::new(),
             next_ref: 1,
         }
+    }
+
+    /// Start a new snapshot generation: move every live ref to the retired
+    /// set while keeping the ref counter, so the upcoming snapshot can
+    /// reclaim ids for surviving nodes and mint fresh, never-reused numbers
+    /// for new ones. Retired refs fail resolution with a stale-ref error.
+    pub fn begin_rebuild(&mut self) {
+        let map = std::mem::take(&mut self.map);
+        self.retired.extend(map);
+    }
+
+    /// Index of node identity to ref id across the live and retired sets,
+    /// used during snapshot minting to give a node back the ref id it was
+    /// originally minted under. Live entries win on collision.
+    pub fn node_to_ref_index(&self) -> HashMap<(Option<String>, i64), String> {
+        let mut index = HashMap::new();
+        for (ref_id, entry) in self.retired.iter().chain(self.map.iter()) {
+            if let Some(bid) = entry.backend_node_id {
+                index.insert((entry.frame_id.clone(), bid), ref_id.clone());
+            }
+        }
+        index
+    }
+
+    /// Resolve a ref id to its live entry, distinguishing refs that were
+    /// retired by a later snapshot (stale) from refs that never existed.
+    pub fn resolve(&self, ref_id: &str) -> Result<&RefEntry, String> {
+        if let Some(entry) = self.map.get(ref_id) {
+            return Ok(entry);
+        }
+        if self.retired.contains_key(ref_id) {
+            return Err(format!(
+                "Stale ref: {} was minted by an earlier snapshot and its element is no longer in the DOM. Take a new snapshot and use a fresh ref.",
+                ref_id
+            ));
+        }
+        Err(format!("Unknown ref: {}", ref_id))
     }
 
     pub fn add(
@@ -48,6 +96,7 @@ impl RefMap {
         nth: Option<usize>,
         frame_id: Option<&str>,
     ) {
+        self.retired.remove(&ref_id);
         self.map.insert(
             ref_id,
             RefEntry {
@@ -109,6 +158,7 @@ impl RefMap {
 
     pub fn clear(&mut self) {
         self.map.clear();
+        self.retired.clear();
         self.next_ref = 1;
     }
 
@@ -304,9 +354,7 @@ pub async fn resolve_element_center(
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<(f64, f64, String), String> {
     if let Some(ref_id) = parse_ref(selector_or_ref) {
-        let entry = ref_map
-            .get(&ref_id)
-            .ok_or_else(|| format!("Unknown ref: {}", ref_id))?;
+        let entry = ref_map.resolve(&ref_id)?;
 
         let effective_session_id =
             resolve_frame_session(entry.frame_id.as_deref(), session_id, iframe_sessions);
@@ -484,9 +532,7 @@ pub async fn resolve_element_object_id(
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<(String, String), String> {
     if let Some(ref_id) = parse_ref(selector_or_ref) {
-        let entry = ref_map
-            .get(&ref_id)
-            .ok_or_else(|| format!("Unknown ref: {}", ref_id))?;
+        let entry = ref_map.resolve(&ref_id)?;
 
         let effective_session_id =
             resolve_frame_session(entry.frame_id.as_deref(), session_id, iframe_sessions);
@@ -1374,6 +1420,100 @@ mod tests {
         assert!(map.get("e1").is_some());
         assert_eq!(map.get("e1").unwrap().role, "button");
         assert!(map.get("e2").is_none());
+    }
+
+    /// Simulate the snapshot minting loop: reclaim the ref id of an already
+    /// known node, or mint a fresh one.
+    fn mint(map: &mut RefMap, backend_node_id: i64, role: &str, name: &str) -> String {
+        let index = map.node_to_ref_index();
+        let ref_id = match index.get(&(None, backend_node_id)) {
+            Some(existing) => existing.clone(),
+            None => {
+                let n = map.next_ref_num();
+                map.set_next_ref_num(n + 1);
+                format!("e{}", n)
+            }
+        };
+        map.add(ref_id.clone(), Some(backend_node_id), role, name, None);
+        ref_id
+    }
+
+    #[test]
+    fn test_ref_map_rebuild_preserves_ids_for_surviving_nodes() {
+        let mut map = RefMap::new();
+        mint(&mut map, 101, "button", "Alpha");
+        mint(&mut map, 102, "button", "Beta");
+        mint(&mut map, 103, "button", "Gamma");
+
+        // New snapshot after the page inserted a node before the buttons.
+        map.begin_rebuild();
+        assert_eq!(mint(&mut map, 104, "button", "NEW"), "e4");
+        assert_eq!(mint(&mut map, 101, "button", "Alpha"), "e1");
+        assert_eq!(mint(&mut map, 102, "button", "Beta"), "e2");
+        assert_eq!(mint(&mut map, 103, "button", "Gamma"), "e3");
+
+        // e2 still resolves to the node it was minted for.
+        assert_eq!(map.resolve("e2").unwrap().backend_node_id, Some(102));
+    }
+
+    #[test]
+    fn test_ref_map_rebuild_retires_refs_for_missing_nodes() {
+        let mut map = RefMap::new();
+        mint(&mut map, 101, "button", "Alpha");
+        mint(&mut map, 102, "button", "Beta");
+
+        // New snapshot after Beta left the DOM.
+        map.begin_rebuild();
+        mint(&mut map, 101, "button", "Alpha");
+
+        assert!(map.resolve("e1").is_ok());
+        let err = map.resolve("e2").unwrap_err();
+        assert!(
+            err.contains("Stale ref") && err.contains("snapshot"),
+            "stale refs must get a teaching error, got: {}",
+            err
+        );
+        // Refs that never existed keep the original error shape.
+        assert_eq!(map.resolve("e9").unwrap_err(), "Unknown ref: e9");
+    }
+
+    #[test]
+    fn test_ref_map_rebuild_never_reuses_numbers() {
+        let mut map = RefMap::new();
+        mint(&mut map, 101, "button", "Alpha");
+        mint(&mut map, 102, "button", "Beta");
+
+        // Beta is gone; a new node appears. It must not take Beta's number.
+        map.begin_rebuild();
+        mint(&mut map, 101, "button", "Alpha");
+        assert_eq!(mint(&mut map, 103, "button", "Fresh"), "e3");
+    }
+
+    #[test]
+    fn test_ref_map_reappearing_node_reclaims_original_ref() {
+        let mut map = RefMap::new();
+        mint(&mut map, 101, "button", "Alpha");
+        mint(&mut map, 102, "button", "Beta");
+
+        // Beta disappears (e.g. hidden), then reappears one snapshot later.
+        map.begin_rebuild();
+        mint(&mut map, 101, "button", "Alpha");
+        assert!(map.resolve("e2").is_err());
+
+        map.begin_rebuild();
+        assert_eq!(mint(&mut map, 102, "button", "Beta"), "e2");
+        assert_eq!(map.resolve("e2").unwrap().backend_node_id, Some(102));
+    }
+
+    #[test]
+    fn test_ref_map_clear_resets_generations_and_counter() {
+        let mut map = RefMap::new();
+        mint(&mut map, 101, "button", "Alpha");
+        map.begin_rebuild();
+
+        map.clear();
+        assert_eq!(map.next_ref_num(), 1);
+        assert_eq!(map.resolve("e1").unwrap_err(), "Unknown ref: e1");
     }
 
     #[test]

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -377,6 +377,14 @@ pub async fn take_snapshot(
 
     let duplicates = tracker.get_duplicates();
 
+    // Nodes already known to the ref map (from the previous snapshot
+    // generation or the live map) reclaim the ref id they were minted
+    // under, so refs remembered across snapshots keep meaning the same
+    // element instead of being renumbered (#1443). Only genuinely new
+    // nodes consume fresh ref numbers.
+    let node_index = ref_map.node_to_ref_index();
+    let frame_key: Option<String> = frame_id.map(String::from);
+
     for (idx, nth) in &nodes_with_refs {
         let node = &tree_nodes[*idx];
         let key = format!("{}:{}", node.role, node.name);
@@ -386,8 +394,17 @@ pub async fn take_snapshot(
             None
         };
 
-        let ref_id = format!("e{}", next_ref);
-        next_ref += 1;
+        let reclaimed = node
+            .backend_node_id
+            .and_then(|bid| node_index.get(&(frame_key.clone(), bid)).cloned());
+        let ref_id = match reclaimed {
+            Some(existing) => existing,
+            None => {
+                let fresh = format!("e{}", next_ref);
+                next_ref += 1;
+                fresh
+            }
+        };
 
         ref_map.add_with_frame(
             ref_id.clone(),

--- a/docs/src/app/selectors/page.mdx
+++ b/docs/src/app/selectors/page.mdx
@@ -26,6 +26,15 @@ agent-browser hover @e4                   # Hover the link
 - **Fast** - No DOM re-query needed
 - **AI-friendly** - LLMs can reliably parse and use refs
 
+### Ref lifecycle
+
+Refs are bound to the element they were minted for and survive repeated
+snapshots within a page: elements still in the DOM keep their ref ids, new
+elements get fresh ids, and ref numbers are never reused. Using a ref whose
+element left the DOM after a newer snapshot fails with a stale-ref error
+(`Stale ref: e2 ... Take a new snapshot`) instead of acting on a different
+element. Navigation clears all refs.
+
 ## CSS selectors
 
 ```bash

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -24,10 +24,13 @@ agent-browser click @e3         # 3. Act on refs from the snapshot
 agent-browser snapshot -i       # 4. Re-snapshot after any page change
 ```
 
-Refs (`@e1`, `@e2`, ...) are assigned fresh on every snapshot. They become
-**stale the moment the page changes** — after clicks that navigate, form
-submits, dynamic re-renders, dialog opens. Always re-snapshot before your
-next ref interaction.
+Refs (`@e1`, `@e2`, ...) are bound to the element they were minted for and
+keep meaning that element across repeated snapshots within a page: surviving
+elements keep their refs, new elements get fresh numbers. **Navigation clears
+all refs** — re-snapshot after clicks that navigate, form submits, or tab
+switches. If an element left the DOM, its ref fails with a stale-ref error
+telling you to re-snapshot; after dynamic re-renders or dialog opens,
+re-snapshot to discover the new elements.
 
 ## Quickstart
 

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -80,19 +80,38 @@ agent-browser click @e12
 
 ## Ref Lifecycle
 
-**IMPORTANT**: Refs are invalidated when the page changes!
+Refs are bound to the element they were minted for, not to their position in
+the snapshot. Within a page, a ref keeps meaning the same element across
+repeated snapshots:
 
 ```bash
-# Get initial snapshot
 agent-browser snapshot -i
-# @e1 [button] "Next"
+# @e1 [button] "Alpha"
+# @e2 [button] "Beta"
 
-# Click triggers page change
-agent-browser click @e1
-
-# MUST re-snapshot to get new refs!
+# Page inserts a new element, then a new snapshot is taken
 agent-browser snapshot -i
-# @e1 [h1] "Page 2"  ← Different element now!
+# @e3 [button] "NEW"     ← new element gets a fresh ref
+# @e1 [button] "Alpha"   ← surviving elements keep their refs
+# @e2 [button] "Beta"
+
+agent-browser click @e2  # still clicks Beta
+```
+
+If a ref's element left the DOM, using it after a newer snapshot fails with a
+stale-ref error instead of acting on the wrong element:
+
+```
+✗ Stale ref: e2 was minted by an earlier snapshot and its element is no
+  longer in the DOM. Take a new snapshot and use a fresh ref.
+```
+
+**IMPORTANT**: Navigation (open, navigate, back, forward, reload, tab switch)
+clears all refs. Re-snapshot after navigating:
+
+```bash
+agent-browser click @e1            # Navigates to new page
+agent-browser snapshot -i          # Refs from the old page are gone
 ```
 
 ## Best Practices
@@ -189,10 +208,13 @@ agent-browser click @e5
 
 ## Troubleshooting
 
-### "Ref not found" Error
+### "Unknown ref" or "Stale ref" Error
+
+`Unknown ref` means the ref was never minted on this page (or navigation
+cleared it). `Stale ref` means the element left the DOM after a newer
+snapshot. Either way, re-snapshot:
 
 ```bash
-# Ref may have changed - re-snapshot
 agent-browser snapshot -i
 ```
 


### PR DESCRIPTION
Fixes #1443

## Problem

Snapshot refs (`e1`, `e2`, ...) were positional in the latest snapshot's registry. When the DOM mutated and a new snapshot renumbered the registry, a ref remembered from the previous snapshot resolved against the new numbering, silently clicking or filling whichever element now occupied that number and returning `✓ Done`. For LLM agents this is the worst failure shape: a wrong action reported as success (wrong multi-select options checked, wrong listings extracted; see #853 and the defensive re-snapshot tax measured in #1351).

```
agent-browser snapshot -i      # button "Beta" [ref=e2]   <- agent remembers e2 == Beta
agent-browser eval "...insert a node before the buttons..."
agent-browser snapshot -i      # everything shifted +1
agent-browser click @e2        # clicked Alpha, reported ✓ Done
```

## Fix

Bind refs to node identity (the shape described in PR #1112). Taking a snapshot now retires the previous ref generation instead of clearing it:

- **Surviving nodes reclaim their original ref id**, matched by `backendNodeId` + frame id. A remembered ref keeps meaning the node it was minted for.
- **New nodes get fresh numbers, and ref numbers are never reused within a page**, so a retired number can never be silently reoccupied.
- **Refs whose node left the DOM fail loudly** with a teaching error, mirroring the stable tab id error pattern:
  `Stale ref: e2 was minted by an earlier snapshot and its element is no longer in the DOM. Take a new snapshot and use a fresh ref.`
  Never-minted refs keep the existing `Unknown ref` error.
- Navigation, reload, tab switches, and launch still clear the registry entirely (the #1249 behavior is unchanged).
- The role+name re-query fallback for refs whose backend node died between snapshot and action (#806) is unchanged, and its e2e test still passes.

After the fix, the repro from the issue gives:

```
agent-browser snapshot -i
# - button "NEW"   [ref=e4]   <- new node gets a fresh ref
# - button "Alpha" [ref=e1]   <- surviving nodes keep their refs
# - button "Beta"  [ref=e2]
# - button "Gamma" [ref=e3]
agent-browser click @e2
agent-browser get title        # Beta
```

As a side effect, stable ref ids across snapshots reduce the defensive re-snapshot churn measured in #1351 and make repeated `snapshot` output diffable across re-renders.

## Tests

- Three e2e regression tests covering the issue's exact repro: a remembered ref keeps meaning the same element after a re-snapshot, surviving nodes keep their ids (new node gets a fresh one), and a removed node's ref fails loudly instead of actuating a neighbor. All three fail on `main` and pass with the fix.
- Seven `RefMap` unit tests for the retire/reclaim lifecycle: id preservation, stale vs unknown errors, numbers never reused, a node that disappears and reappears reclaims its original id, and full clear on navigation.
- Full suite: 745 unit tests and 73/74 e2e tests pass (the one failure is `e2e_recording_inherits_viewport`, which needs ffmpeg that the test environment lacks; unrelated to this change). `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Docs

Updated per AGENTS.md: README ref section, `skill-data/core/SKILL.md`, `skill-data/core/references/snapshot-refs.md` (ref lifecycle + troubleshooting), and the docs site selectors page now describe identity-bound refs, the stale-ref error, and that navigation still clears all refs.
