### PR TITLE
Prepare v0.27.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # agent-browser
 
-## 0.27.2
+## 0.27.3
 
 <!-- release:start -->
+### Bug Fixes
+
+- Fixed **Windows ARM64 installs** by falling back to the Windows x64 binary during postinstall, avoiding failed downloads for a native ARM64 artifact that is not published (#1269)
+
+### Contributors
+
+- @EternalRights
+<!-- release:end -->
+
+## 0.27.2
+
 ### Bug Fixes
 
 - Fixed **click reliability** by scrolling off-viewport elements into view before resolving coordinates, handling JavaScript dialogs promptly, recovering mouse state after dialog-opening clicks, and detecting click interception by overlays before dispatching input (#1432, #1434)
@@ -23,7 +34,6 @@
 
 - @ctate
 - @heshamkhaledd
-<!-- release:end -->
 
 ## 0.27.1
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.27.2"
+version = "0.27.3"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.27.3
+
+<p className="text-[#888] text-sm">June 12, 2026</p>
+
+### Bug Fixes
+
+- Fixed **Windows ARM64 installs** by falling back to the Windows x64 binary during postinstall, avoiding failed downloads for a native ARM64 artifact that is not published (#1269)
+
+---
+
 ## v0.27.2
 
 <p className="text-[#888] text-sm">June 10, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bump package, Cargo, and dashboard versions to 0.27.3
- Add release notes for the Windows ARM64 install fallback
- Move release extraction markers to the 0.27.3 changelog entry