### PR TITLE
fix: dispatch multi-byte keys (Æ/Ø/Å, accented letters) via press

### DIFF
--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -1182,8 +1182,10 @@ fn key_text(key_name: &str) -> Option<String> {
         "Tab" => Some("\t".to_string()),
         " " => Some(" ".to_string()),
         _ => {
-            // Single printable characters carry themselves as text.
-            if key_name.len() == 1 {
+            // Single printable characters carry themselves as text. Count chars,
+            // not bytes, so multi-byte characters (e.g. 'Æ', 'Ø', 'Å') are still
+            // treated as a single printable key and carry their own text.
+            if key_name.chars().count() == 1 {
                 Some(key_name.to_string())
             } else {
                 None
@@ -1209,7 +1211,11 @@ fn named_key_info(key: &str) -> (String, String, i32) {
         "pagedown" => ("PageDown".to_string(), "PageDown".to_string(), 34),
         "space" | " " => (" ".to_string(), "Space".to_string(), 32),
         _ => {
-            if key.len() == 1 {
+            // Use char count, not byte length: multi-byte UTF-8 characters such
+            // as 'Æ', 'Ø', 'Å' or 'é' are a single character but len() (bytes)
+            // is > 1, which would otherwise route them to the malformed
+            // named-key branch below and drop the text entirely.
+            if key.chars().count() == 1 {
                 let ch = key.chars().next().unwrap();
                 char_to_key_info(ch)
             } else {
@@ -1333,5 +1339,40 @@ mod tests {
         assert_eq!(key_text("ArrowUp"), None);
         assert_eq!(key_text("Backspace"), None);
         assert_eq!(key_text("Delete"), None);
+    }
+
+    /// Regression test: multi-byte UTF-8 letters (Danish Æ/Ø/Å and accented
+    /// chars) are a single *character* but more than one *byte*. The earlier
+    /// `key.len() == 1` / `key_name.len() == 1` byte-length checks failed for
+    /// them, so `press Æ` dispatched a keyDown with no `text` and the letter
+    /// was silently dropped (e.g. the danskespil.dk Krydsord board). Both
+    /// `named_key_info` and `key_text` must treat them as single printable keys.
+    #[test]
+    fn test_danish_letters_are_single_printable_keys() {
+        for key in ["Æ", "Ø", "Å", "æ", "ø", "å", "é"] {
+            assert!(
+                key.len() > 1,
+                "precondition: {:?} should be multi-byte to exercise the bug",
+                key
+            );
+
+            // named_key_info must route through char_to_key_info and keep the
+            // character itself as the `key`, not fall into the empty/0 branch.
+            let (name, _code, _vk) = named_key_info(key);
+            assert_eq!(
+                name, key,
+                "named_key_info({:?}) should keep the character as key, got {:?}",
+                key, name
+            );
+
+            // key_text must carry the character as the dispatched text so Chrome
+            // actually inserts it.
+            assert_eq!(
+                key_text(&name),
+                Some(key.to_string()),
+                "key_text({:?}) must carry the character as text",
+                name
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

`press`-ing a non-ASCII letter such as the Danish **Æ / Ø / Å** (or an accented
letter like **é**) silently does nothing — the character never appears in the
focused input. ASCII letters work fine.

Concrete reproduction: typing into the **danskespil.dk Krydsord** (crossword)
board via `agent-browser press Æ` — the letter is dropped.

## Root cause

In `cli/src/native/interaction.rs`, both `named_key_info` and `key_text` used
`key.len() == 1` to detect a single printable character:

```rust
if key.len() == 1 { /* treat as printable, carry its own text */ }
```

`str::len()` returns the **byte** length. Æ/Ø/Å are **2 bytes** each in UTF-8, so
the check failed for them, they fell through to the malformed named-key branch
(empty `code`, virtual key `0`, **no `text`**), and Chrome dropped the keystroke.
ASCII letters are 1 byte, so they passed — which is exactly why only the
non-ASCII letters broke.

The `type` path was already correct: it inserts printable characters via
`Input.insertText`, which is byte-agnostic. Only `press` was affected.

## Fix

Switch both checks from byte length to Unicode scalar count:

```rust
if key.chars().count() == 1 { ... }
```

A single Unicode character now routes through `char_to_key_info` and carries its
own `text`, so Chrome inserts it.

## Tests

- New regression test `test_danish_letters_are_single_printable_keys` asserts that
  for each of `Æ Ø Å æ ø å é`:
  - the value is genuinely multi-byte (precondition that exercises the bug), and
  - `named_key_info` keeps the character as the `key` (not the empty branch), and
  - `key_text` carries the character as the dispatched `text`.
- All 741 unit tests pass.

## Test plan

- [x] `cargo test` — 741 pass, 0 fail
- [x] Live verification: navigate to an `<input>`, focus it, then
      `press Æ`/`Ø`/`Å`/`æ`/`ø`/`å` — input value reads back `"ÆØÅæøå"`
      (previously empty)
- [x] ASCII letters and named keys (Enter, Tab, Backspace, …) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)