### PR TITLE
fix: reap failed Chrome launch child

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -60,6 +60,18 @@ impl ChromeProcess {
     }
 }
 
+fn terminate_failed_chrome_launch(child: &mut Child) {
+    let _ = child.kill();
+    #[cfg(unix)]
+    {
+        let pgid = child.id() as i32;
+        unsafe {
+            libc::kill(-pgid, libc::SIGKILL);
+        }
+    }
+    let _ = child.wait();
+}
+
 impl Drop for ChromeProcess {
     fn drop(&mut self) {
         self.kill();
@@ -401,7 +413,7 @@ fn try_launch_chrome(chrome_path: &Path, options: &LaunchOptions) -> Result<Chro
         Err(primary_err) => {
             // Fallback: scrape stderr (legacy behavior) for better diagnostics.
             let stderr = child.stderr.take().ok_or_else(|| {
-                let _ = child.kill();
+                terminate_failed_chrome_launch(&mut child);
                 cleanup_temp_dir(&temp_user_data_dir);
                 "Failed to capture Chrome stderr".to_string()
             })?;
@@ -409,7 +421,7 @@ fn try_launch_chrome(chrome_path: &Path, options: &LaunchOptions) -> Result<Chro
             match wait_for_ws_url_until(reader, deadline) {
                 Ok(url) => url,
                 Err(fallback_err) => {
-                    let _ = child.kill();
+                    terminate_failed_chrome_launch(&mut child);
                     cleanup_temp_dir(&temp_user_data_dir);
                     return Err(format!(
                         "{}\n(also tried parsing stderr) {}",
@@ -1272,6 +1284,36 @@ mod tests {
             .stderr(Stdio::null())
             .spawn()
             .unwrap()
+    }
+
+    #[cfg(unix)]
+    fn spawn_sleep_child() -> Child {
+        Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap()
+    }
+
+    #[cfg(windows)]
+    fn spawn_sleep_child() -> Child {
+        Command::new("cmd.exe")
+            .args(["/C", "ping -n 30 127.0.0.1 > NUL"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_terminate_failed_chrome_launch_reaps_child() {
+        let mut child = spawn_sleep_child();
+        terminate_failed_chrome_launch(&mut child);
+
+        assert!(matches!(child.try_wait(), Ok(Some(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1401.

Failed native Chrome launches could return after calling `child.kill()` without waiting on the spawned child. Since the error path never constructs `ChromeProcess`, the normal drop cleanup did not run, so failed launch attempts could leave unreaped Chrome children behind.

This adds a small failed-launch cleanup helper that kills the spawned child/process group and waits for the child before returning from the DevToolsActivePort/stderr fallback failure paths.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test test_terminate_failed_chrome_launch_reaps_child`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test native::cdp::chrome`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy`
- `git diff --check`

I also ran `PATH="$HOME/.cargo/bin:$PATH" cargo test`; it reached unrelated `native::stream::http` tests that fail in this checkout because the generated Unix socket path under the current workspace exceeds macOS `SUN_LEN` (`path must be shorter than SUN_LEN`).

Note: I used Codex while preparing this change, and reviewed the final diff and checks locally.
