### PR TITLE
Add plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ agent-browser --session-name secure open example.com
 agent-browser includes security features for safe AI agent deployments. All features are opt-in, and existing workflows are unaffected until you explicitly enable a feature:
 
 - **Authentication Vault**: Store credentials locally (always encrypted), reference by name. The LLM never sees passwords. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). A key is auto-generated at `~/.agent-browser/.encryption-key` if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
+- **Plugin System**: Extend agent-browser with external executable plugins. Plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol and declare capabilities such as `credential.read`, `browser.provider`, `launch.mutate`, or `command.run`.
 - **Content Boundary Markers**: Wrap page output in delimiters so LLMs can distinguish tool output from untrusted content: `--content-boundaries`
 - **Domain Allowlist**: Restrict navigation to trusted domains (wildcards like `*.example.com` also match the bare domain): `--allowed-domains "example.com,*.example.com"`. Sub-resource requests (scripts, images, fetch) and WebSocket/EventSource connections to non-allowed domains are also blocked. Include any CDN domains your target pages depend on (e.g., `*.cdn.example.com`).
 - **Action Policy**: Gate destructive actions with a static policy file: `--action-policy ./policy.json`
@@ -655,8 +656,95 @@ agent-browser includes security features for safe AI agent deployments. All feat
 | `AGENT_BROWSER_ACTION_POLICY`       | Path to action policy JSON file          |
 | `AGENT_BROWSER_CONFIRM_ACTIONS`     | Action categories requiring confirmation |
 | `AGENT_BROWSER_CONFIRM_INTERACTIVE` | Enable interactive confirmation prompts  |
+| `AGENT_BROWSER_PLUGINS`             | JSON plugin registry override            |
 
 See [Security documentation](https://agent-browser.dev/security) for details.
+
+### Plugin System
+
+Plugins let third-party tools integrate without becoming built-in agent-browser dependencies. Add a plugin from npm or GitHub:
+
+```bash
+agent-browser plugin add agent-browser-plugin-captcha
+agent-browser plugin add @company/agent-browser-plugin-vault --name vault
+agent-browser plugin add org/agent-browser-plugin-cloud-browser
+```
+
+References are resolved by shape: `name` uses npm, `@scope/name` uses npm, and `owner/repo` uses GitHub. `plugin add` writes `./agent-browser.json` by default; use `--global` for `~/.agent-browser/config.json`.
+
+Plugin packages should support `plugin.manifest` so `plugin add` can discover their name and capabilities automatically. If a plugin does not support manifests, pass `--capability <name>` during add.
+
+Plugins can also be configured manually in `agent-browser.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "vault",
+      "command": "agent-browser-plugin-vault",
+      "capabilities": ["credential.read"]
+    },
+    {
+      "name": "cloud-browser",
+      "command": "agent-browser-plugin-cloud-browser",
+      "capabilities": ["browser.provider"]
+    },
+    {
+      "name": "stealth",
+      "command": "agent-browser-plugin-stealth",
+      "capabilities": ["launch.mutate"]
+    },
+    {
+      "name": "captcha",
+      "command": "agent-browser-plugin-captcha",
+      "capabilities": ["command.run", "captcha.solve"]
+    }
+  ]
+}
+```
+
+Inspect configured plugins:
+
+```bash
+agent-browser plugin list
+agent-browser plugin show vault
+```
+
+Use a credential provider plugin for one login:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+Use a browser provider plugin:
+
+```bash
+agent-browser --provider cloud-browser open https://example.com
+```
+
+Use a launch mutator plugin for stealth or local launch customization. The plugin can append Chrome args, extensions, and init scripts before the browser starts:
+
+```bash
+agent-browser open https://example.com
+```
+
+Use a generic plugin command for domain-specific tools such as CAPTCHA solvers:
+
+```bash
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
+```
+
+The protocol request always includes `protocol`, `type`, `capability`, and `request`. A credential plugin receives `credential.resolve`, a browser provider receives `browser.launch`, a launch mutator receives `launch.mutate`, and generic commands receive the supplied request type. `plugin run` is for `command.run` and custom capabilities; core capabilities use their dedicated command paths. agent-browser keeps browser automation, redaction-sensitive output, and policy enforcement in core.
+
+Gate plugin access by capability action:
+
+```bash
+agent-browser --confirm-actions plugin:vault:credential.read auth login my-app --credential-provider vault --item "My App"
+agent-browser --confirm-actions plugin:cloud-browser:browser.provider --provider cloud-browser open https://example.com
+agent-browser --confirm-actions plugin:stealth:launch.mutate open https://example.com
+```
+
+Do not put vault tokens or passwords in plugin command args. Use the vault vendor's own login/session mechanism or environment outside agent-browser config.
 
 ## Snapshot Options
 
@@ -723,7 +811,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--ignore-https-errors` | Ignore HTTPS certificate errors (useful for self-signed certs) |
 | `--allow-file-access` | Allow file:// URLs to access local files (Chromium only) |
 | `--hide-scrollbars <bool>` | Hide native scrollbars in headless Chromium screenshots, enabled by default (or `AGENT_BROWSER_HIDE_SCROLLBARS` env) |
-| `-p, --provider <name>` | Cloud browser provider (or `AGENT_BROWSER_PROVIDER` env) |
+| `-p, --provider <name>` | Browser provider, including configured `browser.provider` plugins (or `AGENT_BROWSER_PROVIDER` env) |
 | `--device <name>` | iOS device name, e.g. "iPhone 15 Pro" (or `AGENT_BROWSER_IOS_DEVICE` env) |
 | `--json` | JSON output (for agents) |
 | `--annotate` | Annotated screenshot with numbered element labels (or `AGENT_BROWSER_ANNOTATE` env) |
@@ -820,7 +908,14 @@ Create an `agent-browser.json` file to set persistent defaults instead of repeat
   "profile": "./browser-data",
   "userAgent": "my-agent/1.0",
   "hideScrollbars": false,
-  "ignoreHttpsErrors": true
+  "ignoreHttpsErrors": true,
+  "plugins": [
+    {
+      "name": "vault",
+      "command": "agent-browser-plugin-vault",
+      "capabilities": ["credential.read"]
+    }
+  ]
 }
 ```
 
@@ -831,7 +926,7 @@ agent-browser --config ./ci-config.json open example.com
 AGENT_BROWSER_CONFIG=./ci-config.json agent-browser open example.com
 ```
 
-All options from the table above can be set in the config file using camelCase keys (e.g., `--executable-path` becomes `"executablePath"`, `--proxy-bypass` becomes `"proxyBypass"`). Unknown keys are ignored for forward compatibility.
+All options from the table above can be set in the config file using camelCase keys (e.g., `--executable-path` becomes `"executablePath"`, `--proxy-bypass` becomes `"proxyBypass"`). Plugins are configured with the `"plugins"` array shown above. Unknown keys are ignored for forward compatibility.
 
 A [JSON Schema](agent-browser.schema.json) is available for IDE autocomplete and validation. Add a `$schema` key to your config file to enable it:
 

--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ Use a credential provider plugin for one login:
 
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login --username-selector "#email" --password-selector "#password" --submit-selector "button[type=submit]"
 ```
 
 Use a browser provider plugin:

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ Use a generic plugin command for domain-specific tools such as CAPTCHA solvers:
 agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
 ```
 
-The protocol request always includes `protocol`, `type`, `capability`, and `request`. A credential plugin receives `credential.resolve`, a browser provider receives `browser.launch`, a launch mutator receives `launch.mutate`, and generic commands receive the supplied request type. `plugin run` is for `command.run` and custom capabilities; core capabilities use their dedicated command paths. agent-browser keeps browser automation, redaction-sensitive output, and policy enforcement in core.
+The protocol request always includes `protocol`, `type`, `capability`, and `request`. A credential plugin receives `credential.resolve`, a browser provider receives `browser.launch`, a launch mutator receives `launch.mutate`, and generic commands receive the supplied request type. `plugin run` is for `command.run` and custom capabilities; core capabilities and protocol request types use their dedicated command paths. agent-browser keeps browser automation, redaction-sensitive output, and policy enforcement in core.
 
 Gate plugin access by capability action:
 

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -164,6 +164,43 @@
     "headers": {
       "type": "string",
       "description": "Custom HTTP headers supplied as a JSON-formatted string."
+    },
+    "plugins": {
+      "type": "array",
+      "description": "External plugin registry. Project-level entries are appended after user-level entries, and duplicate names resolve to the later entry.",
+      "items": {
+        "type": "object",
+        "required": ["name", "command"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Plugin name used by commands such as auth login --credential-provider."
+          },
+          "command": {
+            "type": "string",
+            "description": "Executable path or command name for the plugin process."
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional arguments passed to the plugin process. Do not store secrets here."
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Capabilities declared by the plugin. Built-in capability names include credential.read, browser.provider, launch.mutate, and command.run; plugins may also declare custom names such as captcha.solve."
+          },
+          "source": {
+            "type": "string",
+            "description": "Optional source recorded by agent-browser plugin add, such as npm:agent-browser-plugin-example or github:owner/repo."
+          }
+        },
+        "additionalProperties": true
+      }
     }
   },
   "additionalProperties": true

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -950,7 +950,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     Ok(cmd)
                 }
                 Some("login") => {
-                    const AUTH_LOGIN_USAGE: &str = "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>]";
+                    const AUTH_LOGIN_USAGE: &str = "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>] [--username-selector <s>] [--password-selector <s>] [--submit-selector <s>]";
                     let name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                         context: "auth login".to_string(),
                         usage: AUTH_LOGIN_USAGE,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -950,49 +950,92 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     Ok(cmd)
                 }
                 Some("login") => {
+                    const AUTH_LOGIN_USAGE: &str = "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>]";
                     let name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                         context: "auth login".to_string(),
-                        usage: "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>]",
+                        usage: AUTH_LOGIN_USAGE,
                     })?;
-                    let mut credential_provider = None;
-                    let mut credential_item = None;
-                    let mut url = None;
-                    let mut username_selector = None;
-                    let mut password_selector = None;
-                    let mut submit_selector = None;
+                    let mut credential_provider: Option<String> = None;
+                    let mut credential_item: Option<String> = None;
+                    let mut url: Option<String> = None;
+                    let mut username_selector: Option<String> = None;
+                    let mut password_selector: Option<String> = None;
+                    let mut submit_selector: Option<String> = None;
 
                     let mut j = 2;
                     while j < rest.len() {
                         match rest[j] {
                             "--credential-provider" => {
-                                credential_provider = rest.get(j + 1).cloned();
+                                let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
+                                else {
+                                    return Err(ParseError::MissingArguments {
+                                        context: "auth login --credential-provider".to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                };
+                                credential_provider = Some((*value).to_string());
                                 j += 1;
                             }
                             "--item" => {
-                                credential_item = rest.get(j + 1).cloned();
+                                let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
+                                else {
+                                    return Err(ParseError::MissingArguments {
+                                        context: "auth login --item".to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                };
+                                credential_item = Some((*value).to_string());
                                 j += 1;
                             }
                             "--url" => {
-                                url = rest.get(j + 1).cloned();
+                                let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
+                                else {
+                                    return Err(ParseError::MissingArguments {
+                                        context: "auth login --url".to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                };
+                                url = Some((*value).to_string());
                                 j += 1;
                             }
                             "--username-selector" => {
-                                username_selector = rest.get(j + 1).cloned();
+                                let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
+                                else {
+                                    return Err(ParseError::MissingArguments {
+                                        context: "auth login --username-selector".to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                };
+                                username_selector = Some((*value).to_string());
                                 j += 1;
                             }
                             "--password-selector" => {
-                                password_selector = rest.get(j + 1).cloned();
+                                let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
+                                else {
+                                    return Err(ParseError::MissingArguments {
+                                        context: "auth login --password-selector".to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                };
+                                password_selector = Some((*value).to_string());
                                 j += 1;
                             }
                             "--submit-selector" => {
-                                submit_selector = rest.get(j + 1).cloned();
+                                let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
+                                else {
+                                    return Err(ParseError::MissingArguments {
+                                        context: "auth login --submit-selector".to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                };
+                                submit_selector = Some((*value).to_string());
                                 j += 1;
                             }
                             other => {
                                 if other.starts_with("--") {
                                     return Err(ParseError::InvalidValue {
                                         message: format!("unknown flag '{}' for auth login", other),
-                                        usage: "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>]",
+                                        usage: AUTH_LOGIN_USAGE,
                                     });
                                 }
                             }
@@ -5265,5 +5308,27 @@ mod tests {
         assert_eq!(cmd["usernameSelector"], "#login_field");
         assert_eq!(cmd["passwordSelector"], "#password");
         assert_eq!(cmd["submitSelector"], "input[type=submit]");
+    }
+
+    #[test]
+    fn test_auth_login_credential_provider_requires_value() {
+        let err = parse_command(
+            &args("auth login github --credential-provider"),
+            &default_flags(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, ParseError::MissingArguments { .. }));
+    }
+
+    #[test]
+    fn test_auth_login_item_does_not_consume_next_flag_as_value() {
+        let err = parse_command(
+            &args("auth login github --credential-provider vault --item --url https://github.com/login"),
+            &default_flags(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, ParseError::MissingArguments { .. }));
     }
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -952,9 +952,74 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 Some("login") => {
                     let name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                         context: "auth login".to_string(),
-                        usage: "agent-browser auth login <name>",
+                        usage: "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>]",
                     })?;
-                    Ok(json!({ "id": id, "action": "auth_login", "name": name }))
+                    let mut credential_provider = None;
+                    let mut credential_item = None;
+                    let mut url = None;
+                    let mut username_selector = None;
+                    let mut password_selector = None;
+                    let mut submit_selector = None;
+
+                    let mut j = 2;
+                    while j < rest.len() {
+                        match rest[j] {
+                            "--credential-provider" => {
+                                credential_provider = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--item" => {
+                                credential_item = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--url" => {
+                                url = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--username-selector" => {
+                                username_selector = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--password-selector" => {
+                                password_selector = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            "--submit-selector" => {
+                                submit_selector = rest.get(j + 1).cloned();
+                                j += 1;
+                            }
+                            other => {
+                                if other.starts_with("--") {
+                                    return Err(ParseError::InvalidValue {
+                                        message: format!("unknown flag '{}' for auth login", other),
+                                        usage: "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>]",
+                                    });
+                                }
+                            }
+                        }
+                        j += 1;
+                    }
+
+                    let mut cmd = json!({ "id": id, "action": "auth_login", "name": name });
+                    if let Some(provider) = credential_provider {
+                        cmd["credentialProvider"] = json!(provider);
+                    }
+                    if let Some(item) = credential_item {
+                        cmd["credentialItem"] = json!(item);
+                    }
+                    if let Some(url) = url {
+                        cmd["url"] = json!(url);
+                    }
+                    if let Some(us) = username_selector {
+                        cmd["usernameSelector"] = json!(us);
+                    }
+                    if let Some(ps) = password_selector {
+                        cmd["passwordSelector"] = json!(ps);
+                    }
+                    if let Some(ss) = submit_selector {
+                        cmd["submitSelector"] = json!(ss);
+                    }
+                    Ok(cmd)
                 }
                 Some("list") => Ok(json!({ "id": id, "action": "auth_list" })),
                 Some("delete") | Some("remove") => {
@@ -2796,6 +2861,7 @@ mod tests {
             default_timeout: None,
             no_auto_dialog: false,
             model: None,
+            plugins: Vec::new(),
             verbose: false,
             quiet: false,
         }
@@ -5180,5 +5246,24 @@ mod tests {
     fn test_batch_no_args_no_commands_field() {
         let cmd = parse_command(&args("batch"), &default_flags()).unwrap();
         assert!(cmd.get("commands").is_none());
+    }
+
+    #[test]
+    fn test_auth_login_credential_provider_flags() {
+        let cmd = parse_command(
+            &args(
+                "auth login github --credential-provider onepassword --item GitHub --url https://github.com/login --username-selector #login_field --password-selector #password --submit-selector input[type=submit]",
+            ),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "auth_login");
+        assert_eq!(cmd["name"], "github");
+        assert_eq!(cmd["credentialProvider"], "onepassword");
+        assert_eq!(cmd["credentialItem"], "GitHub");
+        assert_eq!(cmd["url"], "https://github.com/login");
+        assert_eq!(cmd["usernameSelector"], "#login_field");
+        assert_eq!(cmd["passwordSelector"], "#password");
+        assert_eq!(cmd["submitSelector"], "input[type=submit]");
     }
 }

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -415,6 +415,7 @@ pub struct DaemonOptions<'a> {
     pub default_timeout: Option<u64>,
     pub cdp: Option<&'a str>,
     pub no_auto_dialog: bool,
+    pub plugins: Option<&'a str>,
 }
 
 fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
@@ -511,6 +512,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if opts.no_auto_dialog {
         cmd.env("AGENT_BROWSER_NO_AUTO_DIALOG", "1");
+    }
+    if let Some(plugins) = opts.plugins {
+        cmd.env("AGENT_BROWSER_PLUGINS", plugins);
     }
 }
 

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -81,6 +81,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         default_timeout: None,
         cdp: None,
         no_auto_dialog: false,
+        plugins: None,
     };
 
     let started = Instant::now();

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -1,4 +1,5 @@
 use crate::color;
+use crate::plugins::PluginConfig;
 use serde::Deserialize;
 use std::env;
 use std::fs;
@@ -92,6 +93,7 @@ pub struct Config {
     pub idle_timeout: Option<String>,
     pub no_auto_dialog: Option<bool>,
     pub model: Option<String>,
+    pub plugins: Option<Vec<PluginConfig>>,
 }
 
 impl Config {
@@ -154,6 +156,13 @@ impl Config {
             idle_timeout: other.idle_timeout.or(self.idle_timeout),
             no_auto_dialog: other.no_auto_dialog.or(self.no_auto_dialog),
             model: other.model.or(self.model),
+            plugins: match (self.plugins, other.plugins) {
+                (Some(mut a), Some(b)) => {
+                    a.extend(b);
+                    Some(a)
+                }
+                (a, b) => b.or(a),
+            },
         }
     }
 }
@@ -335,6 +344,7 @@ pub struct Flags {
     pub default_timeout: Option<u64>, // AGENT_BROWSER_DEFAULT_TIMEOUT in ms
     pub no_auto_dialog: bool,
     pub model: Option<String>,
+    pub plugins: Vec<PluginConfig>,
     pub verbose: bool,
     pub quiet: bool,
 
@@ -410,6 +420,23 @@ pub fn parse_flags(args: &[String]) -> Flags {
     } else {
         config.enable.unwrap_or_default()
     };
+
+    let plugins = env::var("AGENT_BROWSER_PLUGINS")
+        .ok()
+        .and_then(
+            |raw| match serde_json::from_str::<Vec<PluginConfig>>(&raw) {
+                Ok(plugins) => Some(plugins),
+                Err(e) => {
+                    eprintln!(
+                        "{} invalid AGENT_BROWSER_PLUGINS value: {}",
+                        color::warning_indicator(),
+                        e
+                    );
+                    None
+                }
+            },
+        )
+        .unwrap_or_else(|| config.plugins.unwrap_or_default());
 
     let mut flags = Flags {
         json: env_var_is_truthy("AGENT_BROWSER_JSON") || config.json.unwrap_or(false),
@@ -514,6 +541,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         no_auto_dialog: env_var_is_truthy("AGENT_BROWSER_NO_AUTO_DIALOG")
             || config.no_auto_dialog.unwrap_or(false),
         model: env::var("AI_GATEWAY_MODEL").ok().or(config.model),
+        plugins,
         verbose: false,
         quiet: false,
         cli_executable_path: false,
@@ -1192,7 +1220,15 @@ mod tests {
             "allowFileAccess": true,
             "cdp": "9222",
             "autoConnect": true,
-            "headers": "{\"Auth\":\"token\"}"
+            "headers": "{\"Auth\":\"token\"}",
+            "plugins": [
+                {
+                    "name": "onepassword",
+                    "command": "agent-browser-plugin-1password",
+                    "args": ["--account", "team"],
+                    "capabilities": ["credential.read"]
+                }
+            ]
         }"#;
         let config: Config = serde_json::from_str(json).unwrap();
         assert_eq!(config.headed, Some(true));
@@ -1219,6 +1255,14 @@ mod tests {
         assert_eq!(config.cdp.as_deref(), Some("9222"));
         assert_eq!(config.auto_connect, Some(true));
         assert_eq!(config.headers.as_deref(), Some("{\"Auth\":\"token\"}"));
+        let plugin = &config.plugins.as_ref().unwrap()[0];
+        assert_eq!(plugin.name, "onepassword");
+        assert_eq!(plugin.command, "agent-browser-plugin-1password");
+        assert_eq!(
+            plugin.args,
+            vec!["--account".to_string(), "team".to_string()]
+        );
+        assert_eq!(plugin.capabilities, vec!["credential.read".to_string()]);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod flags;
 mod install;
 mod native;
 mod output;
+mod plugins;
 mod skills;
 #[cfg(test)]
 mod test_utils;
@@ -619,6 +620,15 @@ fn main() {
         return;
     }
 
+    // Handle plugin registry commands (doesn't need daemon)
+    if matches!(
+        clean.first().map(|s| s.as_str()),
+        Some("plugin") | Some("plugins")
+    ) {
+        plugins::run_plugin_command(&clean, &flags.plugins, flags.json);
+        return;
+    }
+
     // Handle session separately (doesn't need daemon)
     if clean.first().map(|s| s.as_str()) == Some("session") {
         run_session(&clean, &flags.session, flags.json);
@@ -696,6 +706,13 @@ fn main() {
         }
     }
 
+    // Send plugin config with commands so an already-running daemon can use
+    // current config without a restart. The daemon strips this from stream
+    // broadcasts before observers see the command payload.
+    if !flags.plugins.is_empty() {
+        cmd["plugins"] = json!(flags.plugins.clone());
+    }
+
     // Validate session name before starting daemon
     if let Some(ref name) = flags.session_name {
         if !validation::is_valid_session_name(name) {
@@ -743,6 +760,11 @@ fn main() {
     } else {
         (None, None, None)
     };
+    let plugin_registry_json = if flags.plugins.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&flags.plugins).unwrap_or_else(|_| "[]".to_string()))
+    };
     let daemon_opts = DaemonOptions {
         headed: flags.headed,
         debug: flags.debug,
@@ -774,6 +796,7 @@ fn main() {
         default_timeout: flags.default_timeout,
         cdp: flags.cdp.as_deref(),
         no_auto_dialog: flags.no_auto_dialog,
+        plugins: plugin_registry_json.as_deref(),
     };
 
     let daemon_result = match ensure_daemon(&flags.session, &daemon_opts) {
@@ -1047,6 +1070,9 @@ fn main() {
                 "action": "launch",
                 "provider": provider
             });
+            if !flags.plugins.is_empty() {
+                launch_cmd["plugins"] = json!(flags.plugins.clone());
+            }
 
             if let Some(ref cs) = flags.color_scheme {
                 launch_cmd["colorScheme"] = json!(cs);
@@ -1099,6 +1125,9 @@ fn main() {
             "action": "launch",
             "headless": !flags.headed
         });
+        if !flags.plugins.is_empty() {
+            launch_cmd["plugins"] = json!(flags.plugins.clone());
+        }
 
         let cmd_obj = launch_cmd
             .as_object_mut()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,9 +79,7 @@ fn apply_hide_scrollbars_launch_option(
 }
 
 fn attach_plugins_to_command(cmd: &mut serde_json::Value, plugins: &[plugins::PluginConfig]) {
-    if !plugins.is_empty() {
-        cmd["plugins"] = json!(plugins);
-    }
+    cmd["plugins"] = json!(plugins);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -868,11 +866,8 @@ fn main() {
     } else {
         (None, None, None)
     };
-    let plugin_registry_json = if flags.plugins.is_empty() {
-        None
-    } else {
-        Some(serde_json::to_string(&flags.plugins).unwrap_or_else(|_| "[]".to_string()))
-    };
+    let plugin_registry_json =
+        serde_json::to_string(&flags.plugins).unwrap_or_else(|_| "[]".to_string());
     let daemon_opts = DaemonOptions {
         headed: flags.headed,
         debug: flags.debug,
@@ -904,7 +899,7 @@ fn main() {
         default_timeout: flags.default_timeout,
         cdp: flags.cdp.as_deref(),
         no_auto_dialog: flags.no_auto_dialog,
-        plugins: plugin_registry_json.as_deref(),
+        plugins: Some(plugin_registry_json.as_str()),
     };
 
     let daemon_result = match ensure_daemon(&flags.session, &daemon_opts) {
@@ -1178,9 +1173,7 @@ fn main() {
                 "action": "launch",
                 "provider": provider
             });
-            if !flags.plugins.is_empty() {
-                launch_cmd["plugins"] = json!(flags.plugins.clone());
-            }
+            launch_cmd["plugins"] = json!(flags.plugins.clone());
 
             if let Some(ref cs) = flags.color_scheme {
                 launch_cmd["colorScheme"] = json!(cs);
@@ -1233,9 +1226,7 @@ fn main() {
             "action": "launch",
             "headless": !flags.headed
         });
-        if !flags.plugins.is_empty() {
-            launch_cmd["plugins"] = json!(flags.plugins.clone());
-        }
+        launch_cmd["plugins"] = json!(flags.plugins.clone());
 
         let cmd_obj = launch_cmd
             .as_object_mut()
@@ -1668,6 +1659,15 @@ mod tests {
 
         assert_eq!(cmd["plugins"][0]["name"], "stealth");
         assert_eq!(cmd["plugins"][0]["capabilities"][0], "launch.mutate");
+    }
+
+    #[test]
+    fn test_attach_plugins_to_command_adds_empty_registry_payload() {
+        let mut cmd = json!({ "action": "navigate", "url": "https://example.com" });
+
+        attach_plugins_to_command(&mut cmd, &[]);
+
+        assert_eq!(cmd["plugins"], json!([]));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,7 +27,7 @@ use windows_sys::Win32::System::Threading::OpenProcess;
 use commands::{gen_id, parse_command, ParseError};
 use connection::{
     cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
-    send_command, walk_daemons, DaemonOptions,
+    send_command, walk_daemons, DaemonOptions, Response,
 };
 use flags::{clean_args, parse_flags, Flags};
 use install::run_install;
@@ -76,6 +76,116 @@ fn apply_hide_scrollbars_launch_option(
     if should_send_hide_scrollbars_launch_option(cli_hide_scrollbars, hide_scrollbars) {
         launch_cmd["hideScrollbars"] = json!(hide_scrollbars);
     }
+}
+
+fn attach_plugins_to_command(cmd: &mut serde_json::Value, plugins: &[plugins::PluginConfig]) {
+    if !plugins.is_empty() {
+        cmd["plugins"] = json!(plugins);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfirmationPrompt {
+    action: String,
+    category: String,
+    description: String,
+    confirmation_id: String,
+}
+
+fn confirmation_prompt_from_data(data: &serde_json::Value) -> Option<ConfirmationPrompt> {
+    if data
+        .get("confirmation_required")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        return Some(ConfirmationPrompt {
+            action: action.clone(),
+            category: data
+                .get("category")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            description: data
+                .get("description")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(action.as_str())
+                .to_string(),
+            confirmation_id: data
+                .get("confirmation_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        });
+    }
+
+    data.get("result")
+        .and_then(|v| v.get("data"))
+        .and_then(confirmation_prompt_from_data)
+}
+
+fn confirmation_prompt_from_response(resp: &Response) -> Option<ConfirmationPrompt> {
+    resp.data.as_ref().and_then(confirmation_prompt_from_data)
+}
+
+fn run_interactive_confirmations(
+    mut resp: Response,
+    flags: &Flags,
+    output_opts: &OutputOptions,
+) -> Response {
+    while let Some(prompt) = confirmation_prompt_from_response(&resp) {
+        eprintln!("[agent-browser] Action requires confirmation:");
+        if prompt.category.is_empty() {
+            eprintln!("  {}", prompt.description);
+        } else {
+            eprintln!("  {}: {}", prompt.category, prompt.description);
+        }
+        eprint!("  Allow? [y/N]: ");
+
+        let mut input = String::new();
+        let approved = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            std::io::stdin().read_line(&mut input).is_ok()
+                && matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+        } else {
+            false
+        };
+
+        let confirm_cmd = if approved {
+            json!({
+                "id": gen_id(),
+                "action": "confirm",
+                "confirmationId": prompt.confirmation_id
+            })
+        } else {
+            json!({
+                "id": gen_id(),
+                "action": "deny",
+                "confirmationId": prompt.confirmation_id
+            })
+        };
+
+        match send_command(confirm_cmd, &flags.session) {
+            Ok(next_resp) => {
+                if !approved {
+                    eprintln!("{} Action denied", color::error_indicator());
+                    exit(1);
+                }
+                resp = next_resp;
+            }
+            Err(e) => {
+                eprintln!("{} {}", color::error_indicator(), e);
+                exit(1);
+            }
+        }
+    }
+
+    print_response_with_opts(&resp, None, output_opts);
+    resp
 }
 
 struct ParsedProxy {
@@ -709,9 +819,7 @@ fn main() {
     // Send plugin config with commands so an already-running daemon can use
     // current config without a restart. The daemon strips this from stream
     // broadcasts before observers see the command payload.
-    if !flags.plugins.is_empty() {
-        cmd["plugins"] = json!(flags.plugins.clone());
-    }
+    attach_plugins_to_command(&mut cmd, &flags.plugins);
 
     // Validate session name before starting daemon
     if let Some(ref name) = flags.session_name {
@@ -1258,61 +1366,15 @@ fn main() {
     let output_opts = OutputOptions::from_flags(&flags);
 
     match send_command_with_respawn(cmd.clone(), &flags.session, &daemon_opts) {
-        Ok(resp) => {
-            let success = resp.success;
-            // Handle interactive confirmation
-            if flags.confirm_interactive {
-                if let Some(data) = &resp.data {
-                    if data
-                        .get("confirmation_required")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false)
-                    {
-                        let desc = data
-                            .get("description")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown action");
-                        let category = data.get("category").and_then(|v| v.as_str()).unwrap_or("");
-                        let cid = data
-                            .get("confirmation_id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
-
-                        eprintln!("[agent-browser] Action requires confirmation:");
-                        eprintln!("  {}: {}", category, desc);
-                        eprint!("  Allow? [y/N]: ");
-
-                        let mut input = String::new();
-                        let approved = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-                            std::io::stdin().read_line(&mut input).is_ok()
-                                && matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
-                        } else {
-                            false
-                        };
-
-                        let confirm_cmd = if approved {
-                            json!({ "id": gen_id(), "action": "confirm", "confirmationId": cid })
-                        } else {
-                            json!({ "id": gen_id(), "action": "deny", "confirmationId": cid })
-                        };
-
-                        match send_command(confirm_cmd, &flags.session) {
-                            Ok(r) => {
-                                if !approved {
-                                    eprintln!("{} Action denied", color::error_indicator());
-                                    exit(1);
-                                }
-                                print_response_with_opts(&r, None, &output_opts);
-                            }
-                            Err(e) => {
-                                eprintln!("{} {}", color::error_indicator(), e);
-                                exit(1);
-                            }
-                        }
-                        return;
-                    }
+        Ok(mut resp) => {
+            if flags.confirm_interactive && confirmation_prompt_from_response(&resp).is_some() {
+                resp = run_interactive_confirmations(resp, &flags, &output_opts);
+                if !resp.success {
+                    exit(1);
                 }
+                return;
             }
+            let success = resp.success;
             // Extract action for context-specific output handling
             let action = cmd.get("action").and_then(|v| v.as_str());
             print_response_with_opts(&resp, action, &output_opts);
@@ -1408,7 +1470,7 @@ fn run_batch(
             continue;
         }
 
-        let parsed = match parse_command(cmd_args, flags) {
+        let mut parsed = match parse_command(cmd_args, flags) {
             Ok(c) => c,
             Err(e) => {
                 had_error = true;
@@ -1440,6 +1502,7 @@ fn run_batch(
             .get("action")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        attach_plugins_to_command(&mut parsed, &flags.plugins);
 
         match send_command_with_respawn(parsed, &flags.session, daemon_opts) {
             Ok(resp) => {
@@ -1589,5 +1652,49 @@ mod tests {
         let mut cli_true_cmd = json!({ "action": "launch" });
         apply_hide_scrollbars_launch_option(&mut cli_true_cmd, true, true);
         assert_eq!(cli_true_cmd["hideScrollbars"], true);
+    }
+
+    #[test]
+    fn test_attach_plugins_to_command_adds_registry_payload() {
+        let plugins = vec![crate::plugins::PluginConfig {
+            name: "stealth".to_string(),
+            command: "agent-browser-plugin-stealth".to_string(),
+            capabilities: vec!["launch.mutate".to_string()],
+            ..crate::plugins::PluginConfig::default()
+        }];
+        let mut cmd = json!({ "action": "navigate", "url": "https://example.com" });
+
+        attach_plugins_to_command(&mut cmd, &plugins);
+
+        assert_eq!(cmd["plugins"][0]["name"], "stealth");
+        assert_eq!(cmd["plugins"][0]["capabilities"][0], "launch.mutate");
+    }
+
+    #[test]
+    fn test_confirmation_prompt_from_response_finds_nested_confirm_result() {
+        let resp = Response {
+            success: true,
+            data: Some(json!({
+                "confirmed": true,
+                "action": "navigate",
+                "result": {
+                    "id": "original-command",
+                    "success": true,
+                    "data": {
+                        "confirmation_required": true,
+                        "confirmation_id": "original-command",
+                        "action": "plugin:stealth:launch.mutate"
+                    }
+                }
+            })),
+            error: None,
+            warning: None,
+        };
+
+        let prompt = confirmation_prompt_from_response(&resp).unwrap();
+
+        assert_eq!(prompt.action, "plugin:stealth:launch.mutate");
+        assert_eq!(prompt.description, "plugin:stealth:launch.mutate");
+        assert_eq!(prompt.confirmation_id, "original-command");
     }
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -64,6 +64,12 @@ pub struct PendingConfirmation {
     approved_actions: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+struct ActiveProviderSession {
+    session: providers::ProviderSession,
+    plugins: Vec<crate::plugins::PluginConfig>,
+}
+
 /// Captured request/response metadata used to export HAR 1.2 files.
 pub struct HarEntry {
     pub request_id: String,
@@ -271,6 +277,8 @@ pub struct DaemonState {
     pub viewport: Option<(i32, i32, f64, bool)>,
     /// Init script sources returned by launch mutator plugins for this launch.
     pub plugin_init_scripts: Vec<String>,
+    /// Provider cleanup metadata for the active external browser session.
+    active_provider_session: Option<ActiveProviderSession>,
     /// Actions already approved while replaying a confirmed command.
     confirmed_policy_actions: HashSet<String>,
 }
@@ -332,6 +340,7 @@ impl DaemonState {
                 .unwrap_or(25_000),
             viewport: None,
             plugin_init_scripts: Vec::new(),
+            active_provider_session: None,
             confirmed_policy_actions: HashSet::new(),
         }
     }
@@ -1207,6 +1216,42 @@ fn plugins_from_command_or_env(cmd: &Value) -> Vec<crate::plugins::PluginConfig>
         .unwrap_or_else(crate::plugins::plugins_from_env)
 }
 
+fn remember_active_provider_session(
+    state: &mut DaemonState,
+    session: Option<providers::ProviderSession>,
+    plugins: &[crate::plugins::PluginConfig],
+) {
+    state.active_provider_session = session.map(|session| ActiveProviderSession {
+        session,
+        plugins: plugins.to_vec(),
+    });
+}
+
+async fn close_active_provider_session(state: &mut DaemonState) {
+    if let Some(active) = state.active_provider_session.take() {
+        providers::close_provider_session_with_plugins(&active.session, &active.plugins).await;
+    }
+}
+
+pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(), String> {
+    let close_error = if let Some(mut mgr) = state.browser.take() {
+        mgr.close().await.err()
+    } else {
+        None
+    };
+
+    close_active_provider_session(state).await;
+    state.launch_hash = None;
+    state.screencasting = false;
+    state.reset_input_state();
+    state.update_stream_client().await;
+
+    if let Some(err) = close_error {
+        return Err(err);
+    }
+    Ok(())
+}
+
 fn provider_plugin_launch_options_from_command(cmd: &Value) -> Value {
     let mut options = serde_json::Map::new();
     if let Some(headless) = cmd.get("headless").and_then(|v| v.as_bool()) {
@@ -1408,14 +1453,8 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 
     if !skip_launch {
         if needs_launch {
-            if state.browser.is_some() {
-                if let Some(ref mut mgr) = state.browser {
-                    let _ = mgr.close().await;
-                }
-                state.browser = None;
-                state.screencasting = false;
-                state.reset_input_state();
-                state.update_stream_client().await;
+            if state.browser.is_some() || state.active_provider_session.is_some() {
+                let _ = close_current_browser(state).await;
             }
             if let Err(e) = auto_launch(state, plugins_from_command_or_env(cmd)).await {
                 return error_response(&id, &format!("Auto-launch failed: {}", e));
@@ -1801,6 +1840,7 @@ async fn auto_launch(
                 Ok(mgr) => {
                     state.reset_input_state();
                     state.browser = Some(mgr);
+                    remember_active_provider_session(state, conn.session.clone(), &plugins);
                     state.subscribe_to_browser_events();
                     state.start_fetch_handler();
                     state.start_dialog_handler();
@@ -2028,23 +2068,9 @@ async fn load_storage_state(state: &DaemonState, path: &Option<String>) -> Resul
 }
 
 async fn rollback_failed_launch(state: &mut DaemonState) -> Result<(), String> {
-    let close_error = if let Some(mut mgr) = state.browser.take() {
-        mgr.close().await.err()
-    } else {
-        None
-    };
-
-    state.launch_hash = None;
-    state.screencasting = false;
-    state.reset_input_state();
+    let close_result = close_current_browser(state).await;
     state.ref_map.clear();
-    state.update_stream_client().await;
-
-    if let Some(err) = close_error {
-        return Err(err);
-    }
-
-    Ok(())
+    close_result
 }
 
 async fn load_storage_state_or_rollback(
@@ -2194,13 +2220,8 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     };
 
     if needs_relaunch {
-        if let Some(ref mut b) = state.browser {
-            b.close().await?;
-            state.browser = None;
-            state.launch_hash = None;
-            state.screencasting = false;
-            state.reset_input_state();
-            state.update_stream_client().await;
+        if state.browser.is_some() || state.active_provider_session.is_some() {
+            close_current_browser(state).await?;
         }
     } else {
         load_storage_state(state, &storage_state_owned).await?;
@@ -2289,6 +2310,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                     Ok(mgr) => {
                         state.reset_input_state();
                         state.browser = Some(mgr);
+                        remember_active_provider_session(
+                            state,
+                            conn.session.clone(),
+                            &command_plugins,
+                        );
                         state.subscribe_to_browser_events();
                         state.start_fetch_handler();
                         state.start_dialog_handler();
@@ -2699,14 +2725,7 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
             }
         }
     }
-    if let Some(ref mut mgr) = state.browser {
-        mgr.close().await?;
-    }
-    state.browser = None;
-    state.launch_hash = None;
-    state.screencasting = false;
-    state.reset_input_state();
-    state.update_stream_client().await;
+    close_current_browser(state).await?;
 
     // Stop background Fetch handler
     if let Some(task) = state.fetch_handler_task.take() {
@@ -8842,6 +8861,49 @@ mod tests {
         let pending = state.pending_confirmation.as_ref().unwrap();
         assert_eq!(pending.action, "plugin:stealth:launch.mutate");
         assert!(pending.approved_actions.iter().any(|a| a == "navigate"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_close_current_browser_closes_active_provider_plugin_session() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let request_path = dir.path().join("browser-close-request.json");
+        let plugin_path = dir.path().join("mock-provider-plugin");
+        fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat > "$1"
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let mut state = DaemonState::new();
+        state.active_provider_session = Some(ActiveProviderSession {
+            session: providers::ProviderSession {
+                provider: "plugin:cloud-browser".to_string(),
+                session_id: r#"{"sessionId":"s1"}"#.to_string(),
+            },
+            plugins: vec![crate::plugins::PluginConfig {
+                name: "cloud-browser".to_string(),
+                command: plugin_path.to_string_lossy().to_string(),
+                args: vec![request_path.to_string_lossy().to_string()],
+                capabilities: vec![crate::plugins::CAPABILITY_BROWSER_PROVIDER.to_string()],
+                ..crate::plugins::PluginConfig::default()
+            }],
+        });
+
+        close_current_browser(&mut state).await.unwrap();
+
+        assert!(state.active_provider_session.is_none());
+        let request = fs::read_to_string(request_path).unwrap();
+        assert!(request.contains(r#""type":"browser.close""#));
+        assert!(request.contains(r#""sessionId":"s1""#));
     }
 
     #[tokio::test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -183,7 +183,7 @@ struct DrainedEvents {
 /// `storage_state` is handled separately in `handle_launch()`: explicit
 /// `storageState` launches always require a clean local browser so the loaded
 /// state replaces the prior session instead of merging into it.
-fn launch_hash(opts: &LaunchOptions) -> u64 {
+fn launch_hash(opts: &LaunchOptions, plugin_init_scripts: &[String]) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -200,6 +200,7 @@ fn launch_hash(opts: &LaunchOptions) -> u64 {
     opts.user_agent.hash(&mut h);
     opts.allow_file_access.hash(&mut h);
     opts.hide_scrollbars.hash(&mut h);
+    plugin_init_scripts.hash(&mut h);
     h.finish()
 }
 
@@ -1771,7 +1772,7 @@ async fn auto_launch(
                 }
                 Err(e) => {
                     if let Some(ref ps) = conn.session {
-                        providers::close_provider_session(ps).await;
+                        providers::close_provider_session_with_plugins(ps, &plugins).await;
                     }
                     return Err(format!("Provider '{}' connection failed: {}", p, e));
                 }
@@ -1780,7 +1781,7 @@ async fn auto_launch(
     }
 
     apply_launch_mutator_plugins(state, &mut options, plugins).await?;
-    let hash = launch_hash(&options);
+    let hash = launch_hash(&options, &state.plugin_init_scripts);
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
     state.browser = Some(mgr);
@@ -2132,7 +2133,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             .await?;
     }
 
-    let new_hash = launch_hash(&launch_options);
+    let new_hash = launch_hash(&launch_options, &state.plugin_init_scripts);
 
     // Hash comparison and fast process-exit check are evaluated before the
     // async is_connection_alive to skip the expensive CDP liveness probe
@@ -2276,7 +2277,8 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                     }
                     Err(e) => {
                         if let Some(ref ps) = conn.session {
-                            providers::close_provider_session(ps).await;
+                            providers::close_provider_session_with_plugins(ps, &command_plugins)
+                                .await;
                         }
                         return Err(e);
                     }
@@ -9022,6 +9024,20 @@ mod tests {
         guard.set("AGENT_BROWSER_HIDE_SCROLLBARS", "false");
         let opts = launch_options_from_env();
         assert!(!opts.hide_scrollbars);
+    }
+
+    #[test]
+    fn test_launch_hash_includes_plugin_init_scripts() {
+        let opts = LaunchOptions::default();
+        let no_scripts: Vec<String> = Vec::new();
+        let plugin_scripts = vec![
+            "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });".to_string(),
+        ];
+
+        assert_ne!(
+            launch_hash(&opts, &no_scripts),
+            launch_hash(&opts, &plugin_scripts)
+        );
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1174,9 +1174,10 @@ fn append_launch_mutator_policy_actions_for(
     actions: &mut Vec<String>,
     plugins: &[crate::plugins::PluginConfig],
 ) {
-    for plugin in plugins.iter().filter(|p| {
-        crate::plugins::plugin_has_capability(p, crate::plugins::CAPABILITY_LAUNCH_MUTATE)
-    }) {
+    for plugin in crate::plugins::resolved_plugins_with_capability(
+        plugins,
+        crate::plugins::CAPABILITY_LAUNCH_MUTATE,
+    ) {
         actions.push(crate::plugins::plugin_policy_action(
             &plugin.name,
             crate::plugins::CAPABILITY_LAUNCH_MUTATE,
@@ -1369,7 +1370,11 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             return json!({
                 "id": id,
                 "success": true,
-                "data": { "confirmation_required": true, "action": policy_action },
+                "data": {
+                    "confirmation_required": true,
+                    "confirmation_id": id,
+                    "action": policy_action
+                },
             });
         }
     }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1739,11 +1739,7 @@ async fn auto_launch(
         let p = provider.to_lowercase();
         // ios/safari are device providers handled via explicit launch command
         if !p.is_empty() && p != "ios" && p != "safari" {
-            let conn = if crate::plugins::find_plugin(&plugins, &p).is_some() {
-                providers::connect_plugin_provider_with_plugins(&p, &plugins).await?
-            } else {
-                providers::connect_provider(&p).await?
-            };
+            let conn = providers::connect_provider_with_plugins(&p, &plugins).await?;
             let ws_headers = if p == "agentcore" {
                 providers::take_agentcore_ws_headers()
             } else {
@@ -2223,12 +2219,8 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             }
             _ => {
                 let command_plugins = plugins_from_command_or_env(cmd);
-                let conn = if crate::plugins::find_plugin(&command_plugins, provider).is_some() {
-                    providers::connect_plugin_provider_with_plugins(provider, &command_plugins)
-                        .await?
-                } else {
-                    providers::connect_provider(provider).await?
-                };
+                let conn =
+                    providers::connect_provider_with_plugins(provider, &command_plugins).await?;
                 let provider_metadata = conn.metadata.clone();
 
                 let ws_headers = if provider.eq_ignore_ascii_case("agentcore") {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -267,6 +267,8 @@ pub struct DaemonState {
     /// Last viewport settings (width, height, deviceScaleFactor, mobile),
     /// re-applied to new contexts (e.g., recording).
     pub viewport: Option<(i32, i32, f64, bool)>,
+    /// Init script sources returned by launch mutator plugins for this launch.
+    pub plugin_init_scripts: Vec<String>,
 }
 
 impl DaemonState {
@@ -325,6 +327,7 @@ impl DaemonState {
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(25_000),
             viewport: None,
+            plugin_init_scripts: Vec::new(),
         }
     }
 
@@ -1162,74 +1165,44 @@ impl Drop for DaemonState {
     }
 }
 
-pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
-    let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
-    let id = cmd
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-
-    let cmd_start = std::time::Instant::now();
-
-    if let Some(ref server) = state.stream_server {
-        server.broadcast_command(action, &id, cmd);
+fn append_launch_mutator_policy_actions_for(
+    actions: &mut Vec<String>,
+    plugins: &[crate::plugins::PluginConfig],
+) {
+    for plugin in plugins.iter().filter(|p| {
+        crate::plugins::plugin_has_capability(p, crate::plugins::CAPABILITY_LAUNCH_MUTATE)
+    }) {
+        actions.push(crate::plugins::plugin_policy_action(
+            &plugin.name,
+            crate::plugins::CAPABILITY_LAUNCH_MUTATE,
+        ));
     }
+}
 
-    // Drain and apply pending CDP events (console, errors, screencast frames, target lifecycle)
-    state.drain_cdp_events_background().await;
-
-    // Keep element resolution in sync with the `frame` selection (see
-    // element::set_active_frame for why this is mirrored).
-    super::element::set_active_frame(state.active_frame_id.as_deref());
-
-    // Hot-reload and check action policy
-    if let Some(ref mut policy) = state.policy {
-        let _ = policy.reload();
-        match policy.check(action) {
-            PolicyResult::Allow => {}
-            PolicyResult::Deny(reason) => {
-                return error_response(
-                    &id,
-                    &format!("Action '{}' denied by policy: {}", action, reason),
-                );
-            }
-            PolicyResult::RequiresConfirmation => {
-                state.pending_confirmation = Some(PendingConfirmation {
-                    action: action.to_string(),
-                    cmd: cmd.clone(),
-                });
-                return json!({
-                    "id": id,
-                    "success": true,
-                    "data": { "confirmation_required": true, "action": action },
-                });
-            }
-        }
+fn append_browser_provider_policy_action_for(
+    actions: &mut Vec<String>,
+    provider: &str,
+    plugins: &[crate::plugins::PluginConfig],
+) {
+    if plugins.iter().any(|p| {
+        p.name == provider
+            && crate::plugins::plugin_has_capability(p, crate::plugins::CAPABILITY_BROWSER_PROVIDER)
+    }) {
+        actions.push(crate::plugins::plugin_policy_action(
+            provider,
+            crate::plugins::CAPABILITY_BROWSER_PROVIDER,
+        ));
     }
+}
 
-    // Check AGENT_BROWSER_CONFIRM_ACTIONS (category-based, independent of policy file)
-    if action != "confirm" && action != "deny" {
-        if let Some(ref ca) = state.confirm_actions {
-            if ca.requires_confirmation(action) {
-                state.pending_confirmation = Some(PendingConfirmation {
-                    action: action.to_string(),
-                    cmd: cmd.clone(),
-                });
-                return json!({
-                    "id": id,
-                    "success": true,
-                    "data": {
-                        "confirmation_required": true,
-                        "confirmation_id": id,
-                        "action": action,
-                    },
-                });
-            }
-        }
-    }
+fn plugins_from_command_or_env(cmd: &Value) -> Vec<crate::plugins::PluginConfig> {
+    cmd.get("plugins")
+        .and_then(|v| serde_json::from_value::<Vec<crate::plugins::PluginConfig>>(v.clone()).ok())
+        .unwrap_or_else(crate::plugins::plugins_from_env)
+}
 
-    let skip_launch = matches!(
+fn skip_launch_action(action: &str) -> bool {
+    matches!(
         action,
         "" | "launch"
             | "close"
@@ -1251,7 +1224,133 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             | "stream_enable"
             | "stream_disable"
             | "stream_status"
-    );
+    )
+}
+
+fn policy_actions_for_command(cmd: &Value, action: &str, state: &DaemonState) -> Vec<String> {
+    let mut actions = vec![action.to_string()];
+    if action == "auth_login" {
+        if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
+            actions.push(crate::plugins::plugin_policy_action(
+                provider,
+                crate::plugins::CAPABILITY_CREDENTIAL_READ,
+            ));
+        }
+    }
+    if action == "launch" {
+        let plugins = plugins_from_command_or_env(cmd);
+        if let Some(provider) = cmd.get("provider").and_then(|v| v.as_str()) {
+            append_browser_provider_policy_action_for(&mut actions, provider, &plugins);
+        }
+
+        let local_launch = cmd.get("provider").is_none()
+            && cmd.get("cdpUrl").is_none()
+            && cmd.get("cdpPort").is_none()
+            && !cmd
+                .get("autoConnect")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        if local_launch {
+            append_launch_mutator_policy_actions_for(&mut actions, &plugins);
+        }
+    } else if !skip_launch_action(action) && state.browser.is_none() {
+        let plugins = plugins_from_command_or_env(cmd);
+        let provider_launch = env::var("AGENT_BROWSER_PROVIDER")
+            .ok()
+            .map(|provider| provider.to_lowercase())
+            .filter(|provider| !provider.is_empty() && provider != "ios" && provider != "safari");
+        if let Some(provider) = provider_launch {
+            append_browser_provider_policy_action_for(&mut actions, &provider, &plugins);
+        } else {
+            append_launch_mutator_policy_actions_for(&mut actions, &plugins);
+        }
+    }
+    actions
+}
+
+pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
+    let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    let policy_actions = policy_actions_for_command(cmd, action, state);
+    let id = cmd
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let cmd_start = std::time::Instant::now();
+
+    if let Some(ref server) = state.stream_server {
+        let mut broadcast_cmd;
+        let cmd_for_broadcast = if cmd.get("plugins").is_some() {
+            broadcast_cmd = cmd.clone();
+            if let Some(obj) = broadcast_cmd.as_object_mut() {
+                obj.remove("plugins");
+            }
+            &broadcast_cmd
+        } else {
+            cmd
+        };
+        server.broadcast_command(action, &id, cmd_for_broadcast);
+    }
+
+    // Drain and apply pending CDP events (console, errors, screencast frames, target lifecycle)
+    state.drain_cdp_events_background().await;
+
+    // Keep element resolution in sync with the `frame` selection (see
+    // element::set_active_frame for why this is mirrored).
+    super::element::set_active_frame(state.active_frame_id.as_deref());
+
+    // Hot-reload and check action policy
+    if let Some(ref mut policy) = state.policy {
+        let _ = policy.reload();
+        for policy_action in &policy_actions {
+            match policy.check(policy_action) {
+                PolicyResult::Allow => {}
+                PolicyResult::Deny(reason) => {
+                    return error_response(
+                        &id,
+                        &format!("Action '{}' denied by policy: {}", policy_action, reason),
+                    );
+                }
+                PolicyResult::RequiresConfirmation => {
+                    state.pending_confirmation = Some(PendingConfirmation {
+                        action: policy_action.to_string(),
+                        cmd: cmd.clone(),
+                    });
+                    return json!({
+                        "id": id,
+                        "success": true,
+                        "data": { "confirmation_required": true, "action": policy_action },
+                    });
+                }
+            }
+        }
+    }
+
+    // Check AGENT_BROWSER_CONFIRM_ACTIONS (category-based, independent of policy file)
+    if action != "confirm" && action != "deny" {
+        if let Some(ref ca) = state.confirm_actions {
+            for policy_action in &policy_actions {
+                if ca.requires_confirmation(policy_action) {
+                    state.pending_confirmation = Some(PendingConfirmation {
+                        action: policy_action.to_string(),
+                        cmd: cmd.clone(),
+                    });
+                    return json!({
+                        "id": id,
+                        "success": true,
+                        "data": {
+                            "confirmation_required": true,
+                            "confirmation_id": id,
+                            "action": policy_action,
+                        },
+                    });
+                }
+            }
+        }
+    }
+
+    let skip_launch = skip_launch_action(action);
     if !skip_launch {
         // Check if existing connection is stale and needs re-launch.
         // First do a fast, non-blocking check: did the browser process crash/exit?
@@ -1272,7 +1371,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 state.reset_input_state();
                 state.update_stream_client().await;
             }
-            if let Err(e) = auto_launch(state).await {
+            if let Err(e) = auto_launch(state, plugins_from_command_or_env(cmd)).await {
                 return error_response(&id, &format!("Auto-launch failed: {}", e));
             }
         }
@@ -1573,8 +1672,12 @@ async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
     Ok(mgr)
 }
 
-async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
+async fn auto_launch(
+    state: &mut DaemonState,
+    plugins: Vec<crate::plugins::PluginConfig>,
+) -> Result<(), String> {
     let mut options = launch_options_from_env();
+    state.plugin_init_scripts.clear();
 
     // Use the stream server's viewport dimensions for --window-size so the
     // content area matches the desired viewport from the start.
@@ -1635,7 +1738,11 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
         let p = provider.to_lowercase();
         // ios/safari are device providers handled via explicit launch command
         if !p.is_empty() && p != "ios" && p != "safari" {
-            let conn = providers::connect_provider(&p).await?;
+            let conn = if crate::plugins::find_plugin(&plugins, &p).is_some() {
+                providers::connect_plugin_provider_with_plugins(&p, &plugins).await?
+            } else {
+                providers::connect_provider(&p).await?
+            };
             let ws_headers = if p == "agentcore" {
                 providers::take_agentcore_ws_headers()
             } else {
@@ -1672,6 +1779,7 @@ async fn auto_launch(state: &mut DaemonState) -> Result<(), String> {
         }
     }
 
+    apply_launch_mutator_plugins(state, &mut options, plugins).await?;
     let hash = launch_hash(&options);
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
@@ -1742,6 +1850,52 @@ async fn apply_launch_init_scripts(state: &DaemonState) {
             }
         }
     }
+
+    for source in &state.plugin_init_scripts {
+        let _ = mgr.add_script_to_evaluate(source).await;
+    }
+}
+
+async fn apply_launch_mutator_plugins(
+    state: &mut DaemonState,
+    options: &mut LaunchOptions,
+    plugins: Vec<crate::plugins::PluginConfig>,
+) -> Result<(), String> {
+    state.plugin_init_scripts.clear();
+    if plugins.is_empty() {
+        return Ok(());
+    }
+
+    let request = json!({
+        "session": state.session_id,
+        "launchOptions": {
+            "headless": options.headless,
+            "engine": env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
+            "args": options.args.clone(),
+            "extensions": options.extensions.clone(),
+            "userAgent": options.user_agent.clone(),
+            "colorScheme": options.color_scheme.clone(),
+            "downloadPath": options.download_path.clone(),
+            "hideScrollbars": options.hide_scrollbars,
+            "allowFileAccess": options.allow_file_access,
+        }
+    });
+
+    for mutation in crate::plugins::launch_mutations_from_plugins(&plugins, request).await? {
+        options.args.extend(mutation.args);
+        if !mutation.extensions.is_empty() {
+            options
+                .extensions
+                .get_or_insert_with(Vec::new)
+                .extend(mutation.extensions);
+        }
+        if let Some(user_agent) = mutation.user_agent {
+            options.user_agent = Some(user_agent);
+        }
+        state.plugin_init_scripts.extend(mutation.init_scripts);
+    }
+
+    Ok(())
 }
 
 fn launch_options_from_env() -> LaunchOptions {
@@ -1888,6 +2042,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         .get("autoConnect")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let provider_name = cmd.get("provider").and_then(|v| v.as_str());
 
     let extensions: Option<Vec<String>> =
         cmd.get("extensions").and_then(|v| v.as_array()).map(|arr| {
@@ -1898,7 +2053,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     let storage_state = cmd.get("storageState").and_then(|v| v.as_str());
     let storage_state_owned = storage_state.map(|s| s.to_string());
 
-    let launch_options = LaunchOptions {
+    let mut launch_options = LaunchOptions {
         headless,
         executable_path: cmd
             .get("executablePath")
@@ -1968,6 +2123,14 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         viewport_size: None,
         use_real_keychain: false,
     };
+
+    state.plugin_init_scripts.clear();
+    let local_launch =
+        cdp_url.is_none() && cdp_port.is_none() && !auto_connect && provider_name.is_none();
+    if local_launch {
+        apply_launch_mutator_plugins(state, &mut launch_options, plugins_from_command_or_env(cmd))
+            .await?;
+    }
 
     let new_hash = launch_hash(&launch_options);
 
@@ -2049,7 +2212,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         return Ok(json!({ "launched": true }));
     }
 
-    if let Some(provider) = cmd.get("provider").and_then(|v| v.as_str()) {
+    if let Some(provider) = provider_name {
         match provider.to_lowercase().as_str() {
             "ios" => {
                 return launch_ios(cmd, state).await;
@@ -2058,7 +2221,14 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                 return launch_safari(cmd, state).await;
             }
             _ => {
-                let conn = providers::connect_provider(provider).await?;
+                let command_plugins = plugins_from_command_or_env(cmd);
+                let conn = if crate::plugins::find_plugin(&command_plugins, provider).is_some() {
+                    providers::connect_plugin_provider_with_plugins(provider, &command_plugins)
+                        .await?
+                } else {
+                    providers::connect_provider(provider).await?
+                };
+                let provider_metadata = conn.metadata.clone();
 
                 let ws_headers = if provider.eq_ignore_ascii_case("agentcore") {
                     providers::take_agentcore_ws_headers()
@@ -2091,6 +2261,14 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                                 "provider": provider,
                                 "agentCoreSessionId": info.session_id,
                                 "agentCoreLiveViewUrl": info.live_view_url
+                            }));
+                        }
+
+                        if let Some(metadata) = provider_metadata {
+                            return Ok(json!({
+                                "launched": true,
+                                "provider": provider,
+                                "providerMetadata": metadata
                             }));
                         }
 
@@ -7728,13 +7906,57 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .get("name")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'name'")?;
-    let cred = auth::credentials_get_full(name)?;
+    let url_override = cmd.get("url").and_then(|v| v.as_str());
+    let cred = if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
+        let command_plugins = cmd
+            .get("plugins")
+            .and_then(|v| {
+                serde_json::from_value::<Vec<crate::plugins::PluginConfig>>(v.clone()).ok()
+            })
+            .unwrap_or_else(crate::plugins::plugins_from_env);
+        let resolved = crate::plugins::resolve_credential_with_plugins(
+            provider,
+            &command_plugins,
+            crate::plugins::CredentialResolveRequest {
+                profile_name: name,
+                item_ref: cmd.get("credentialItem").and_then(|v| v.as_str()),
+                url: url_override,
+            },
+        )
+        .await?;
+        auth::AuthProfile {
+            name: name.to_string(),
+            url: url_override
+                .map(String::from)
+                .or(resolved.url)
+                .unwrap_or_default(),
+            username: resolved.username,
+            password: resolved.password,
+            username_selector: resolved.username_selector,
+            password_selector: resolved.password_selector,
+            submit_selector: resolved.submit_selector,
+            created_at: None,
+            last_login_at: None,
+        }
+    } else {
+        let mut profile = auth::credentials_get_full(name)?;
+        if let Some(url) = url_override {
+            profile.url = url.to_string();
+        }
+        profile
+    };
     if cred.url.is_empty() {
         return Err("Credential has no URL".to_string());
     }
-    let url = cred.url;
-    let username = cred.username;
-    let password = cred.password;
+    let auth::AuthProfile {
+        url,
+        username,
+        password,
+        username_selector: stored_username_selector,
+        password_selector: stored_password_selector,
+        submit_selector: stored_submit_selector,
+        ..
+    } = cred;
 
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     mgr.navigate(&url, AUTH_LOGIN_WAIT_UNTIL).await?;
@@ -7771,17 +7993,17 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .get("usernameSelector")
         .and_then(|v| v.as_str())
         .map(String::from)
-        .or(cred.username_selector);
+        .or(stored_username_selector);
     let password_sel = cmd
         .get("passwordSelector")
         .and_then(|v| v.as_str())
         .map(String::from)
-        .or(cred.password_selector);
+        .or(stored_password_selector);
     let submit_sel = cmd
         .get("submitSelector")
         .and_then(|v| v.as_str())
         .map(String::from)
-        .or(cred.submit_selector);
+        .or(stored_submit_selector);
 
     // Find and fill username
     let user_sel = if let Some(s) = username_sel {
@@ -8412,6 +8634,59 @@ mod tests {
             "agent-browser-{label}-{}-{nanos}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn test_policy_actions_use_command_plugins_for_auto_launch_mutators() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
+        guard.remove("AGENT_BROWSER_PROVIDER");
+        let state = DaemonState::new();
+        let cmd = json!({
+            "action": "navigate",
+            "id": "policy-plugin-1",
+            "url": "https://example.com",
+            "plugins": [
+                {
+                    "name": "stealth",
+                    "command": "agent-browser-plugin-stealth",
+                    "capabilities": ["launch.mutate"]
+                }
+            ]
+        });
+
+        let actions = policy_actions_for_command(&cmd, "navigate", &state);
+
+        assert_eq!(actions[0], "navigate");
+        assert!(actions.contains(&"plugin:stealth:launch.mutate".to_string()));
+    }
+
+    #[test]
+    fn test_policy_actions_use_command_plugins_for_provider_auto_launch() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
+        guard.set("AGENT_BROWSER_PROVIDER", "browserbox");
+        let state = DaemonState::new();
+        let cmd = json!({
+            "action": "navigate",
+            "id": "policy-plugin-2",
+            "url": "https://example.com",
+            "plugins": [
+                {
+                    "name": "browserbox",
+                    "command": "agent-browser-plugin-browserbox",
+                    "capabilities": ["browser.provider"]
+                },
+                {
+                    "name": "stealth",
+                    "command": "agent-browser-plugin-stealth",
+                    "capabilities": ["launch.mutate"]
+                }
+            ]
+        });
+
+        let actions = policy_actions_for_command(&cmd, "navigate", &state);
+
+        assert!(actions.contains(&"plugin:browserbox:browser.provider".to_string()));
+        assert!(!actions.contains(&"plugin:stealth:launch.mutate".to_string()));
     }
 
     #[tokio::test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1199,13 +1199,27 @@ fn append_browser_provider_policy_action_for(
     provider: &str,
     plugins: &[crate::plugins::PluginConfig],
 ) {
-    if plugins.iter().any(|p| {
-        p.name == provider
-            && crate::plugins::plugin_has_capability(p, crate::plugins::CAPABILITY_BROWSER_PROVIDER)
+    if crate::plugins::find_plugin(plugins, provider).is_some_and(|plugin| {
+        crate::plugins::plugin_has_capability(plugin, crate::plugins::CAPABILITY_BROWSER_PROVIDER)
     }) {
         actions.push(crate::plugins::plugin_policy_action(
             provider,
             crate::plugins::CAPABILITY_BROWSER_PROVIDER,
+        ));
+    }
+}
+
+fn append_credential_policy_action_for(
+    actions: &mut Vec<String>,
+    provider: &str,
+    plugins: &[crate::plugins::PluginConfig],
+) {
+    if crate::plugins::find_plugin(plugins, provider).is_some_and(|plugin| {
+        crate::plugins::plugin_has_capability(plugin, crate::plugins::CAPABILITY_CREDENTIAL_READ)
+    }) {
+        actions.push(crate::plugins::plugin_policy_action(
+            provider,
+            crate::plugins::CAPABILITY_CREDENTIAL_READ,
         ));
     }
 }
@@ -1301,10 +1315,8 @@ fn policy_actions_for_command(
     let mut actions = vec![action.to_string()];
     if action == "auth_login" {
         if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
-            actions.push(crate::plugins::plugin_policy_action(
-                provider,
-                crate::plugins::CAPABILITY_CREDENTIAL_READ,
-            ));
+            let plugins = plugins_from_command_or_env(cmd);
+            append_credential_policy_action_for(&mut actions, provider, &plugins);
         }
     }
     if action == "launch" {
@@ -1862,6 +1874,7 @@ async fn auto_launch(
     }
 
     apply_launch_mutator_plugins(state, &mut options, plugins).await?;
+    write_extensions_file_from_paths(&state.session_id, options.extensions.as_deref());
     let hash = launch_hash(&options, &state.plugin_init_scripts);
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
@@ -2381,7 +2394,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     state.engine = engine.as_deref().unwrap_or("chrome").to_string();
     write_engine_file(&state.session_id, &state.engine);
-    write_extensions_file(&state.session_id);
+    write_extensions_file_from_paths(&state.session_id, launch_options.extensions.as_deref());
     state.reset_input_state();
     state.browser = Some(BrowserManager::launch(launch_options, engine.as_deref()).await?);
     state.launch_hash = Some(new_hash);
@@ -5669,6 +5682,25 @@ fn write_extensions_file(session_id: &str) {
     let _ = fs::remove_file(extensions_file_path(session_id));
 }
 
+fn write_extensions_file_from_paths(session_id: &str, extensions: Option<&[String]>) {
+    let Some(paths) = extensions else {
+        write_extensions_file(session_id);
+        return;
+    };
+
+    let joined = paths
+        .iter()
+        .map(|path| path.trim())
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>()
+        .join(",");
+    if joined.is_empty() {
+        let _ = fs::remove_file(extensions_file_path(session_id));
+    } else {
+        let _ = fs::write(extensions_file_path(session_id), joined);
+    }
+}
+
 fn remove_extensions_file(session_id: &str) {
     let _ = fs::remove_file(extensions_file_path(session_id));
 }
@@ -7968,6 +8000,9 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .get("name")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'name'")?;
+    if state.browser.is_none() {
+        return Err("Browser not launched".to_string());
+    }
     let url_override = cmd.get("url").and_then(|v| v.as_str());
     let cred = if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
         let command_plugins = cmd
@@ -8775,6 +8810,59 @@ mod tests {
         assert!(!actions.contains(&"plugin:stealth:launch.mutate".to_string()));
     }
 
+    #[test]
+    fn test_policy_actions_use_resolved_provider_plugin_capability() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
+        guard.set("AGENT_BROWSER_PROVIDER", "browserbox");
+        let cmd = json!({
+            "action": "navigate",
+            "id": "policy-plugin-duplicate-provider",
+            "url": "https://example.com",
+            "plugins": [
+                {
+                    "name": "browserbox",
+                    "command": "global-browserbox",
+                    "capabilities": ["browser.provider"]
+                },
+                {
+                    "name": "browserbox",
+                    "command": "project-browserbox",
+                    "capabilities": ["command.run"]
+                }
+            ]
+        });
+
+        let actions = policy_actions_for_command(&cmd, "navigate", true);
+
+        assert_eq!(actions, vec!["navigate".to_string()]);
+    }
+
+    #[test]
+    fn test_policy_actions_use_resolved_credential_plugin_capability() {
+        let cmd = json!({
+            "action": "auth_login",
+            "id": "policy-plugin-duplicate-credential",
+            "name": "example",
+            "credentialProvider": "vault",
+            "plugins": [
+                {
+                    "name": "vault",
+                    "command": "global-vault",
+                    "capabilities": ["credential.read"]
+                },
+                {
+                    "name": "vault",
+                    "command": "project-vault",
+                    "capabilities": ["command.run"]
+                }
+            ]
+        });
+
+        let actions = policy_actions_for_command(&cmd, "auth_login", false);
+
+        assert_eq!(actions, vec!["auth_login".to_string()]);
+    }
+
     #[tokio::test]
     async fn test_policy_denies_plugin_action_before_base_confirmation() {
         let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
@@ -8861,6 +8949,49 @@ mod tests {
         let pending = state.pending_confirmation.as_ref().unwrap();
         assert_eq!(pending.action, "plugin:stealth:launch.mutate");
         assert!(pending.approved_actions.iter().any(|a| a == "navigate"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_auth_login_does_not_resolve_plugin_without_browser() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let marker_path = dir.path().join("credential-plugin-invoked");
+        let plugin_path = dir.path().join("mock-credential-plugin");
+        fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+printf invoked > "$1"
+cat >/dev/null
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{"username":"user","password":"pass","url":"https://example.com/login"}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let mut state = DaemonState::new();
+        let cmd = json!({
+            "id": "auth-plugin-no-browser",
+            "action": "auth_login",
+            "name": "example",
+            "credentialProvider": "mock",
+            "plugins": [
+                {
+                    "name": "mock",
+                    "command": plugin_path.to_string_lossy(),
+                    "args": [marker_path.to_string_lossy()],
+                    "capabilities": ["credential.read"]
+                }
+            ]
+        });
+
+        let err = handle_auth_login(&cmd, &mut state).await.unwrap_err();
+
+        assert_eq!(err, "Browser not launched");
+        assert!(!marker_path.exists());
     }
 
     #[cfg(unix)]
@@ -9253,6 +9384,37 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             launch_hash(&opts, &no_scripts),
             launch_hash(&opts, &plugin_scripts)
         );
+    }
+
+    #[test]
+    fn test_write_extensions_file_from_paths_uses_final_extensions() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_EXTENSIONS"]);
+        let dir = tempfile::tempdir().unwrap();
+        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().unwrap());
+        guard.set("AGENT_BROWSER_EXTENSIONS", "/env/ext");
+        let extensions = vec![
+            " /plugin/ext ".to_string(),
+            "".to_string(),
+            "/plugin/other".to_string(),
+        ];
+
+        write_extensions_file_from_paths("metadata-test", Some(&extensions));
+
+        let content = fs::read_to_string(extensions_file_path("metadata-test")).unwrap();
+        assert_eq!(content, "/plugin/ext,/plugin/other");
+    }
+
+    #[test]
+    fn test_write_extensions_file_from_paths_falls_back_to_env() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_EXTENSIONS"]);
+        let dir = tempfile::tempdir().unwrap();
+        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().unwrap());
+        guard.set("AGENT_BROWSER_EXTENSIONS", "/env/ext");
+
+        write_extensions_file_from_paths("metadata-env-test", None);
+
+        let content = fs::read_to_string(extensions_file_path("metadata-env-test")).unwrap();
+        assert_eq!(content, "/env/ext");
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1202,6 +1202,19 @@ fn plugins_from_command_or_env(cmd: &Value) -> Vec<crate::plugins::PluginConfig>
         .unwrap_or_else(crate::plugins::plugins_from_env)
 }
 
+fn provider_plugin_launch_options_from_command(cmd: &Value) -> Value {
+    let mut options = serde_json::Map::new();
+    if let Some(headless) = cmd.get("headless").and_then(|v| v.as_bool()) {
+        options.insert("headed".to_string(), json!(!headless));
+    }
+    for key in ["engine", "userAgent", "colorScheme"] {
+        if let Some(value) = cmd.get(key) {
+            options.insert(key.to_string(), value.clone());
+        }
+    }
+    Value::Object(options)
+}
+
 fn skip_launch_action(action: &str) -> bool {
     matches!(
         action,
@@ -2219,8 +2232,12 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             }
             _ => {
                 let command_plugins = plugins_from_command_or_env(cmd);
-                let conn =
-                    providers::connect_provider_with_plugins(provider, &command_plugins).await?;
+                let conn = providers::connect_provider_with_plugins_and_options(
+                    provider,
+                    &command_plugins,
+                    Some(provider_plugin_launch_options_from_command(cmd)),
+                )
+                .await?;
                 let provider_metadata = conn.metadata.clone();
 
                 let ws_headers = if provider.eq_ignore_ascii_case("agentcore") {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -61,6 +61,7 @@ const AUTH_LOGIN_PREFERRED_SELECTOR_WINDOW_MS: u64 = 5_000;
 pub struct PendingConfirmation {
     pub action: String,
     pub cmd: Value,
+    approved_actions: Vec<String>,
 }
 
 /// Captured request/response metadata used to export HAR 1.2 files.
@@ -270,6 +271,8 @@ pub struct DaemonState {
     pub viewport: Option<(i32, i32, f64, bool)>,
     /// Init script sources returned by launch mutator plugins for this launch.
     pub plugin_init_scripts: Vec<String>,
+    /// Actions already approved while replaying a confirmed command.
+    confirmed_policy_actions: HashSet<String>,
 }
 
 impl DaemonState {
@@ -329,6 +332,7 @@ impl DaemonState {
                 .unwrap_or(25_000),
             viewport: None,
             plugin_init_scripts: Vec::new(),
+            confirmed_policy_actions: HashSet::new(),
         }
     }
 
@@ -1229,6 +1233,8 @@ fn skip_launch_action(action: &str) -> bool {
             | "auth_show"
             | "auth_delete"
             | "auth_list"
+            | "confirm"
+            | "deny"
             | "state_list"
             | "state_show"
             | "state_clear"
@@ -1317,6 +1323,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // Hot-reload and check action policy
     if let Some(ref mut policy) = state.policy {
         let _ = policy.reload();
+        let mut confirmation_required: Option<String> = None;
         for policy_action in &policy_actions {
             match policy.check(policy_action) {
                 PolicyResult::Allow => {}
@@ -1327,17 +1334,25 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                     );
                 }
                 PolicyResult::RequiresConfirmation => {
-                    state.pending_confirmation = Some(PendingConfirmation {
-                        action: policy_action.to_string(),
-                        cmd: cmd.clone(),
-                    });
-                    return json!({
-                        "id": id,
-                        "success": true,
-                        "data": { "confirmation_required": true, "action": policy_action },
-                    });
+                    if !state.confirmed_policy_actions.contains(policy_action)
+                        && confirmation_required.is_none()
+                    {
+                        confirmation_required = Some(policy_action.to_string());
+                    }
                 }
             }
+        }
+        if let Some(policy_action) = confirmation_required {
+            state.pending_confirmation = Some(PendingConfirmation {
+                action: policy_action.clone(),
+                cmd: cmd.clone(),
+                approved_actions: state.confirmed_policy_actions.iter().cloned().collect(),
+            });
+            return json!({
+                "id": id,
+                "success": true,
+                "data": { "confirmation_required": true, "action": policy_action },
+            });
         }
     }
 
@@ -1345,10 +1360,14 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     if action != "confirm" && action != "deny" {
         if let Some(ref ca) = state.confirm_actions {
             for policy_action in &policy_actions {
+                if state.confirmed_policy_actions.contains(policy_action) {
+                    continue;
+                }
                 if ca.requires_confirmation(policy_action) {
                     state.pending_confirmation = Some(PendingConfirmation {
                         action: policy_action.to_string(),
                         cmd: cmd.clone(),
+                        approved_actions: state.confirmed_policy_actions.iter().cloned().collect(),
                     });
                     return json!({
                         "id": id,
@@ -8167,12 +8186,16 @@ async fn handle_confirm(_cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .take()
         .ok_or("No pending confirmation")?;
 
-    // Temporarily remove policy and confirm_actions to avoid re-triggering confirmation
-    let policy = state.policy.take();
-    let confirm_actions = state.confirm_actions.take();
+    let mut approved_actions = pending.approved_actions.clone();
+    if !approved_actions.iter().any(|a| a == &pending.action) {
+        approved_actions.push(pending.action.clone());
+    }
+    let previous_confirmed = std::mem::replace(
+        &mut state.confirmed_policy_actions,
+        approved_actions.into_iter().collect(),
+    );
     let result = Box::pin(execute_command(&pending.cmd, state)).await;
-    state.policy = policy;
-    state.confirm_actions = confirm_actions;
+    state.confirmed_policy_actions = previous_confirmed;
 
     Ok(json!({ "confirmed": true, "action": pending.action, "result": result }))
 }
@@ -8698,6 +8721,94 @@ mod tests {
 
         assert!(actions.contains(&"plugin:browserbox:browser.provider".to_string()));
         assert!(!actions.contains(&"plugin:stealth:launch.mutate".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_policy_denies_plugin_action_before_base_confirmation() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
+        guard.remove("AGENT_BROWSER_PROVIDER");
+        let dir = tempfile::tempdir().unwrap();
+        let policy_path = dir.path().join("policy.json");
+        fs::write(
+            &policy_path,
+            r#"{"confirm":["navigate"],"deny":["plugin:stealth:launch.mutate"]}"#,
+        )
+        .unwrap();
+
+        let mut state = DaemonState::new();
+        state.policy = Some(ActionPolicy::load(policy_path.to_str().unwrap()).unwrap());
+        let cmd = json!({
+            "action": "navigate",
+            "id": "policy-plugin-deny",
+            "url": "https://example.com",
+            "plugins": [
+                {
+                    "name": "stealth",
+                    "command": "agent-browser-plugin-stealth",
+                    "capabilities": ["launch.mutate"]
+                }
+            ]
+        });
+
+        let resp = execute_command(&cmd, &mut state).await;
+
+        assert_eq!(resp["success"], false);
+        assert!(resp["error"]
+            .as_str()
+            .unwrap()
+            .contains("plugin:stealth:launch.mutate"));
+        assert!(state.pending_confirmation.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_confirm_rechecks_unapproved_plugin_action() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
+        guard.remove("AGENT_BROWSER_PROVIDER");
+        let dir = tempfile::tempdir().unwrap();
+        let policy_path = dir.path().join("policy.json");
+        fs::write(
+            &policy_path,
+            r#"{"confirm":["navigate","plugin:stealth:launch.mutate"]}"#,
+        )
+        .unwrap();
+
+        let mut state = DaemonState::new();
+        state.policy = Some(ActionPolicy::load(policy_path.to_str().unwrap()).unwrap());
+        let cmd = json!({
+            "action": "navigate",
+            "id": "policy-plugin-confirm",
+            "url": "https://example.com",
+            "plugins": [
+                {
+                    "name": "stealth",
+                    "command": "agent-browser-plugin-stealth",
+                    "capabilities": ["launch.mutate"]
+                }
+            ]
+        });
+
+        let first = execute_command(&cmd, &mut state).await;
+        assert_eq!(first["data"]["confirmation_required"], true);
+        assert_eq!(first["data"]["action"], "navigate");
+
+        let second = execute_command(
+            &json!({ "id": "policy-plugin-confirm-2", "action": "confirm" }),
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(second["success"], true);
+        assert_eq!(
+            second["data"]["result"]["data"]["confirmation_required"],
+            true
+        );
+        assert_eq!(
+            second["data"]["result"]["data"]["action"],
+            "plugin:stealth:launch.mutate"
+        );
+        let pending = state.pending_confirmation.as_ref().unwrap();
+        assert_eq!(pending.action, "plugin:stealth:launch.mutate");
+        assert!(pending.approved_actions.iter().any(|a| a == "navigate"));
     }
 
     #[tokio::test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1247,7 +1247,11 @@ fn skip_launch_action(action: &str) -> bool {
     )
 }
 
-fn policy_actions_for_command(cmd: &Value, action: &str, state: &DaemonState) -> Vec<String> {
+fn policy_actions_for_command(
+    cmd: &Value,
+    action: &str,
+    needs_implicit_launch: bool,
+) -> Vec<String> {
     let mut actions = vec![action.to_string()];
     if action == "auth_login" {
         if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
@@ -1273,7 +1277,7 @@ fn policy_actions_for_command(cmd: &Value, action: &str, state: &DaemonState) ->
         if local_launch {
             append_launch_mutator_policy_actions_for(&mut actions, &plugins);
         }
-    } else if !skip_launch_action(action) && state.browser.is_none() {
+    } else if !skip_launch_action(action) && needs_implicit_launch {
         let plugins = plugins_from_command_or_env(cmd);
         let provider_launch = env::var("AGENT_BROWSER_PROVIDER")
             .ok()
@@ -1290,7 +1294,6 @@ fn policy_actions_for_command(cmd: &Value, action: &str, state: &DaemonState) ->
 
 pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
-    let policy_actions = policy_actions_for_command(cmd, action, state);
     let id = cmd
         .get("id")
         .and_then(|v| v.as_str())
@@ -1319,6 +1322,21 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // Keep element resolution in sync with the `frame` selection (see
     // element::set_active_frame for why this is mirrored).
     super::element::set_active_frame(state.active_frame_id.as_deref());
+
+    let skip_launch = skip_launch_action(action);
+    let needs_launch = if !skip_launch {
+        // Check if existing connection is stale and needs re-launch.
+        // This must happen before policy evaluation so plugin capability
+        // actions are gated when recovery relaunches would invoke plugins.
+        if let Some(ref mut mgr) = state.browser {
+            mgr.has_process_exited() || !mgr.is_connection_alive().await
+        } else {
+            true
+        }
+    } else {
+        false
+    };
+    let policy_actions = policy_actions_for_command(cmd, action, needs_launch);
 
     // Hot-reload and check action policy
     if let Some(ref mut policy) = state.policy {
@@ -1383,17 +1401,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         }
     }
 
-    let skip_launch = skip_launch_action(action);
     if !skip_launch {
-        // Check if existing connection is stale and needs re-launch.
-        // First do a fast, non-blocking check: did the browser process crash/exit?
-        // This avoids a 3-second CDP timeout when Chrome is already dead.
-        let needs_launch = if let Some(ref mut mgr) = state.browser {
-            mgr.has_process_exited() || !mgr.is_connection_alive().await
-        } else {
-            true
-        };
-
         if needs_launch {
             if state.browser.is_some() {
                 if let Some(ref mut mgr) = state.browser {
@@ -8674,7 +8682,6 @@ mod tests {
     fn test_policy_actions_use_command_plugins_for_auto_launch_mutators() {
         let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
         guard.remove("AGENT_BROWSER_PROVIDER");
-        let state = DaemonState::new();
         let cmd = json!({
             "action": "navigate",
             "id": "policy-plugin-1",
@@ -8688,17 +8695,38 @@ mod tests {
             ]
         });
 
-        let actions = policy_actions_for_command(&cmd, "navigate", &state);
+        let actions = policy_actions_for_command(&cmd, "navigate", true);
 
         assert_eq!(actions[0], "navigate");
         assert!(actions.contains(&"plugin:stealth:launch.mutate".to_string()));
     }
 
     #[test]
+    fn test_policy_actions_skip_auto_launch_mutators_when_browser_is_healthy() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
+        guard.remove("AGENT_BROWSER_PROVIDER");
+        let cmd = json!({
+            "action": "navigate",
+            "id": "policy-plugin-healthy",
+            "url": "https://example.com",
+            "plugins": [
+                {
+                    "name": "stealth",
+                    "command": "agent-browser-plugin-stealth",
+                    "capabilities": ["launch.mutate"]
+                }
+            ]
+        });
+
+        let actions = policy_actions_for_command(&cmd, "navigate", false);
+
+        assert_eq!(actions, vec!["navigate".to_string()]);
+    }
+
+    #[test]
     fn test_policy_actions_use_command_plugins_for_provider_auto_launch() {
         let guard = EnvGuard::new(&["AGENT_BROWSER_PROVIDER"]);
         guard.set("AGENT_BROWSER_PROVIDER", "browserbox");
-        let state = DaemonState::new();
         let cmd = json!({
             "action": "navigate",
             "id": "policy-plugin-2",
@@ -8717,7 +8745,7 @@ mod tests {
             ]
         });
 
-        let actions = policy_actions_for_command(&cmd, "navigate", &state);
+        let actions = policy_actions_for_command(&cmd, "navigate", true);
 
         assert!(actions.contains(&"plugin:browserbox:browser.provider".to_string()));
         assert!(!actions.contains(&"plugin:stealth:launch.mutate".to_string()));

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::signal;
 use tokio::sync::{mpsc, Notify, RwLock};
 
-use super::actions::{execute_command, DaemonState};
+use super::actions::{close_current_browser, execute_command, DaemonState};
 use super::cdp::client::CdpClient;
 use super::state;
 use super::stream::StreamServer;
@@ -207,15 +207,15 @@ async fn run_socket_server(
             }
             _ = drain_interval.tick() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    if mgr.has_process_exited() {
-                        let _ = mgr.close().await;
-                        s.browser = None;
-                        s.screencasting = false;
-                        s.update_stream_client().await;
-                    } else {
-                        s.drain_cdp_events_background().await;
-                    }
+                let process_exited = s
+                    .browser
+                    .as_mut()
+                    .map(|mgr| mgr.has_process_exited())
+                    .unwrap_or(false);
+                if process_exited {
+                    let _ = close_current_browser(&mut s).await;
+                } else if s.browser.is_some() {
+                    s.drain_cdp_events_background().await;
                 }
             }
             _ = async {
@@ -225,9 +225,7 @@ async fn run_socket_server(
                 }
             }, if idle_timeout_ms.is_some() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                let _ = close_current_browser(&mut s).await;
                 break;
             }
             _ = reset_rx.recv(), if idle_timeout_ms.is_some() => {
@@ -243,9 +241,7 @@ async fn run_socket_server(
             }
             _ = shutdown_signal() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                let _ = close_current_browser(&mut s).await;
                 break;
             }
         }
@@ -325,9 +321,7 @@ async fn run_socket_server(
                 }
             }, if idle_timeout_ms.is_some() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                let _ = close_current_browser(&mut s).await;
                 let _ = fs::remove_file(&port_path);
                 break;
             }
@@ -342,9 +336,7 @@ async fn run_socket_server(
             }
             _ = shutdown_signal() => {
                 let mut s = state.lock().await;
-                if let Some(ref mut mgr) = s.browser {
-                    let _ = mgr.close().await;
-                }
+                let _ = close_current_browser(&mut s).await;
                 let _ = fs::remove_file(&port_path);
                 break;
             }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -77,11 +77,19 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
 
 /// Close a provider session (call on CDP connect failure).
 pub async fn close_provider_session(session: &ProviderSession) {
+    let plugins = crate::plugins::plugins_from_env();
+    close_provider_session_with_plugins(session, &plugins).await;
+}
+
+/// Close a provider session with the plugin registry that created it.
+pub async fn close_provider_session_with_plugins(
+    session: &ProviderSession,
+    plugins: &[crate::plugins::PluginConfig],
+) {
     if let Some(plugin_name) = session.provider.strip_prefix("plugin:") {
-        let plugins = crate::plugins::plugins_from_env();
         if let Ok(cleanup) = serde_json::from_str::<Value>(&session.session_id) {
             let _ =
-                crate::plugins::close_browser_provider_with_plugins(plugin_name, &plugins, cleanup)
+                crate::plugins::close_browser_provider_with_plugins(plugin_name, plugins, cleanup)
                     .await;
         }
         return;
@@ -866,5 +874,45 @@ mod tests {
         // Should be None after take
         let taken_again = take_agentcore_ws_headers();
         assert!(taken_again.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_plugin_provider_cleanup_uses_supplied_registry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let marker_path = dir.path().join("cleanup-request.json");
+        let plugin_path = dir.path().join("mock-cleanup-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat > "$1"
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let session = ProviderSession {
+            provider: "plugin:cloud-browser".to_string(),
+            session_id: r#"{"sessionId":"s1"}"#.to_string(),
+        };
+        let plugins = vec![crate::plugins::PluginConfig {
+            name: "cloud-browser".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            args: vec![marker_path.to_string_lossy().to_string()],
+            capabilities: vec![crate::plugins::CAPABILITY_BROWSER_PROVIDER.to_string()],
+            ..crate::plugins::PluginConfig::default()
+        }];
+
+        rt.block_on(close_provider_session_with_plugins(&session, &plugins));
+
+        let request = std::fs::read_to_string(marker_path).unwrap();
+        assert!(request.contains(r#""type":"browser.close""#));
+        assert!(request.contains(r#""sessionId":"s1""#));
     }
 }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -19,6 +19,7 @@ pub struct ProviderConnection {
     pub session: Option<ProviderSession>,
     /// If true, the WebSocket IS the page session (no Target.* commands).
     pub direct_page: bool,
+    pub metadata: Option<Value>,
 }
 
 /// Connects to the specified browser provider and returns a CDP WebSocket URL
@@ -31,6 +32,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                metadata: None,
             })
         }
         "browserless" => {
@@ -39,6 +41,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                metadata: None,
             })
         }
         "browser-use" | "browseruse" => {
@@ -47,6 +50,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                metadata: None,
             })
         }
         "kernel" => {
@@ -55,6 +59,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                metadata: None,
             })
         }
         "agentcore" => {
@@ -63,17 +68,25 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 ws_url: url,
                 session,
                 direct_page: false,
+                metadata: None,
             })
         }
-        _ => Err(format!(
-            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore",
-            provider_name
-        )),
+        _ => connect_plugin_provider(provider_name).await,
     }
 }
 
 /// Close a provider session (call on CDP connect failure).
 pub async fn close_provider_session(session: &ProviderSession) {
+    if let Some(plugin_name) = session.provider.strip_prefix("plugin:") {
+        let plugins = crate::plugins::plugins_from_env();
+        if let Ok(cleanup) = serde_json::from_str::<Value>(&session.session_id) {
+            let _ =
+                crate::plugins::close_browser_provider_with_plugins(plugin_name, &plugins, cleanup)
+                    .await;
+        }
+        return;
+    }
+
     let client = reqwest::Client::new();
     match session.provider.as_str() {
         "browserbase" => {
@@ -129,6 +142,47 @@ pub async fn close_provider_session(session: &ProviderSession) {
         }
         _ => {}
     }
+}
+
+async fn connect_plugin_provider(provider_name: &str) -> Result<ProviderConnection, String> {
+    let plugins = crate::plugins::plugins_from_env();
+    connect_plugin_provider_with_plugins(provider_name, &plugins).await
+}
+
+pub async fn connect_plugin_provider_with_plugins(
+    provider_name: &str,
+    plugins: &[crate::plugins::PluginConfig],
+) -> Result<ProviderConnection, String> {
+    if crate::plugins::find_plugin(&plugins, provider_name).is_none() {
+        return Err(format!(
+            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, or a configured plugin with browser.provider",
+            provider_name
+        ));
+    }
+
+    let request = json!({
+        "provider": provider_name,
+        "session": env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
+        "launchOptions": {
+            "headed": env::var("AGENT_BROWSER_HEADED").is_ok(),
+            "engine": env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
+            "userAgent": env::var("AGENT_BROWSER_USER_AGENT").ok(),
+            "colorScheme": env::var("AGENT_BROWSER_COLOR_SCHEME").ok(),
+        }
+    });
+    let browser =
+        crate::plugins::connect_browser_provider_with_plugins(provider_name, plugins, request)
+            .await?;
+    let session = browser.cleanup.as_ref().map(|cleanup| ProviderSession {
+        provider: format!("plugin:{}", provider_name),
+        session_id: serde_json::to_string(cleanup).unwrap_or_else(|_| "{}".to_string()),
+    });
+    Ok(ProviderConnection {
+        ws_url: browser.cdp_url,
+        session,
+        direct_page: browser.direct_page,
+        metadata: browser.metadata,
+    })
 }
 
 async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), String> {

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -25,6 +25,17 @@ pub struct ProviderConnection {
 /// Connects to the specified browser provider and returns a CDP WebSocket URL
 /// along with session info for cleanup on failure.
 pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection, String> {
+    let plugins = crate::plugins::plugins_from_env();
+    connect_provider_with_plugins(provider_name, &plugins).await
+}
+
+/// Connects to a built-in provider or a plugin provider from the supplied
+/// registry. Callers that already loaded config must use this helper so policy
+/// checks and provider execution consult the same plugin list.
+pub async fn connect_provider_with_plugins(
+    provider_name: &str,
+    plugins: &[crate::plugins::PluginConfig],
+) -> Result<ProviderConnection, String> {
     match provider_name.to_lowercase().as_str() {
         "browserbase" => {
             let (url, session) = connect_browserbase().await?;
@@ -71,7 +82,7 @@ pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection,
                 metadata: None,
             })
         }
-        _ => connect_plugin_provider(provider_name).await,
+        _ => connect_plugin_provider_with_plugins(provider_name, plugins).await,
     }
 }
 
@@ -152,11 +163,6 @@ pub async fn close_provider_session_with_plugins(
     }
 }
 
-async fn connect_plugin_provider(provider_name: &str) -> Result<ProviderConnection, String> {
-    let plugins = crate::plugins::plugins_from_env();
-    connect_plugin_provider_with_plugins(provider_name, &plugins).await
-}
-
 pub async fn connect_plugin_provider_with_plugins(
     provider_name: &str,
     plugins: &[crate::plugins::PluginConfig],
@@ -172,7 +178,7 @@ pub async fn connect_plugin_provider_with_plugins(
         "provider": provider_name,
         "session": env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
         "launchOptions": {
-            "headed": env::var("AGENT_BROWSER_HEADED").is_ok(),
+            "headed": env_var_is_truthy("AGENT_BROWSER_HEADED"),
             "engine": env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
             "userAgent": env::var("AGENT_BROWSER_USER_AGENT").ok(),
             "colorScheme": env::var("AGENT_BROWSER_COLOR_SCHEME").ok(),
@@ -191,6 +197,13 @@ pub async fn connect_plugin_provider_with_plugins(
         direct_page: browser.direct_page,
         metadata: browser.metadata,
     })
+}
+
+fn env_var_is_truthy(name: &str) -> bool {
+    match env::var(name) {
+        Ok(val) => !matches!(val.to_ascii_lowercase().as_str(), "0" | "false" | "no" | ""),
+        Err(_) => false,
+    }
 }
 
 async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), String> {
@@ -812,11 +825,30 @@ async fn close_agentcore_session(session_id: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::EnvGuard;
 
     #[test]
     fn test_connect_provider_unknown() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PLUGINS"]);
+        guard.remove("AGENT_BROWSER_PLUGINS");
+
         let rt = tokio::runtime::Runtime::new().unwrap();
         let result = rt.block_on(connect_provider("unknown-provider"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown provider"));
+    }
+
+    #[test]
+    fn test_connect_provider_with_supplied_registry_does_not_fallback_to_env_plugins() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_PLUGINS"]);
+        guard.set(
+            "AGENT_BROWSER_PLUGINS",
+            r#"[{"name":"env-cloud","command":"should-not-run","capabilities":["browser.provider"]}]"#,
+        );
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(connect_provider_with_plugins("env-cloud", &[]));
+
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Unknown provider"));
     }
@@ -914,5 +946,51 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         let request = std::fs::read_to_string(marker_path).unwrap();
         assert!(request.contains(r#""type":"browser.close""#));
         assert!(request.contains(r#""sessionId":"s1""#));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_plugin_provider_falsey_headed_env_is_false() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let guard = EnvGuard::new(&[
+            "AGENT_BROWSER_HEADED",
+            "AGENT_BROWSER_ENGINE",
+            "AGENT_BROWSER_SESSION",
+        ]);
+        guard.set("AGENT_BROWSER_HEADED", "false");
+        guard.set("AGENT_BROWSER_ENGINE", "chrome");
+        guard.set("AGENT_BROWSER_SESSION", "provider-test");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let request_path = dir.path().join("browser-launch-request.json");
+        let plugin_path = dir.path().join("mock-provider-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat > "$1"
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cdpUrl":"ws://127.0.0.1:9222/devtools/browser/test"}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let plugins = vec![crate::plugins::PluginConfig {
+            name: "cloud-browser".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            args: vec![request_path.to_string_lossy().to_string()],
+            capabilities: vec![crate::plugins::CAPABILITY_BROWSER_PROVIDER.to_string()],
+            ..crate::plugins::PluginConfig::default()
+        }];
+
+        rt.block_on(connect_provider_with_plugins("cloud-browser", &plugins))
+            .unwrap();
+
+        let request: Value =
+            serde_json::from_str(&std::fs::read_to_string(request_path).unwrap()).unwrap();
+        assert_eq!(request["request"]["launchOptions"]["headed"], false);
     }
 }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -7,7 +7,7 @@ use serde_json::{json, Value};
 use std::env;
 
 /// Provider session info for cleanup on failure.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProviderSession {
     pub provider: String,
     pub session_id: String,

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -36,6 +36,18 @@ pub async fn connect_provider_with_plugins(
     provider_name: &str,
     plugins: &[crate::plugins::PluginConfig],
 ) -> Result<ProviderConnection, String> {
+    connect_provider_with_plugins_and_options(provider_name, plugins, None).await
+}
+
+/// Connects to a built-in provider or plugin provider with launch options
+/// supplied by the command that requested the provider. Built-in providers keep
+/// their existing environment-based behavior; plugin providers receive these
+/// options in the stdio protocol request.
+pub async fn connect_provider_with_plugins_and_options(
+    provider_name: &str,
+    plugins: &[crate::plugins::PluginConfig],
+    launch_options: Option<Value>,
+) -> Result<ProviderConnection, String> {
     match provider_name.to_lowercase().as_str() {
         "browserbase" => {
             let (url, session) = connect_browserbase().await?;
@@ -82,7 +94,10 @@ pub async fn connect_provider_with_plugins(
                 metadata: None,
             })
         }
-        _ => connect_plugin_provider_with_plugins(provider_name, plugins).await,
+        _ => {
+            connect_plugin_provider_with_plugins_and_options(provider_name, plugins, launch_options)
+                .await
+        }
     }
 }
 
@@ -167,6 +182,14 @@ pub async fn connect_plugin_provider_with_plugins(
     provider_name: &str,
     plugins: &[crate::plugins::PluginConfig],
 ) -> Result<ProviderConnection, String> {
+    connect_plugin_provider_with_plugins_and_options(provider_name, plugins, None).await
+}
+
+pub async fn connect_plugin_provider_with_plugins_and_options(
+    provider_name: &str,
+    plugins: &[crate::plugins::PluginConfig],
+    launch_options: Option<Value>,
+) -> Result<ProviderConnection, String> {
     if crate::plugins::find_plugin(&plugins, provider_name).is_none() {
         return Err(format!(
             "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, or a configured plugin with browser.provider",
@@ -174,15 +197,34 @@ pub async fn connect_plugin_provider_with_plugins(
         ));
     }
 
+    let mut plugin_launch_options = serde_json::Map::new();
+    plugin_launch_options.insert(
+        "headed".to_string(),
+        json!(env_var_is_truthy("AGENT_BROWSER_HEADED")),
+    );
+    plugin_launch_options.insert(
+        "engine".to_string(),
+        json!(env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string())),
+    );
+    plugin_launch_options.insert(
+        "userAgent".to_string(),
+        json!(env::var("AGENT_BROWSER_USER_AGENT").ok()),
+    );
+    plugin_launch_options.insert(
+        "colorScheme".to_string(),
+        json!(env::var("AGENT_BROWSER_COLOR_SCHEME").ok()),
+    );
+
+    if let Some(Value::Object(command_options)) = launch_options {
+        for (key, value) in command_options {
+            plugin_launch_options.insert(key, value);
+        }
+    }
+
     let request = json!({
         "provider": provider_name,
         "session": env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
-        "launchOptions": {
-            "headed": env_var_is_truthy("AGENT_BROWSER_HEADED"),
-            "engine": env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
-            "userAgent": env::var("AGENT_BROWSER_USER_AGENT").ok(),
-            "colorScheme": env::var("AGENT_BROWSER_COLOR_SCHEME").ok(),
-        }
+        "launchOptions": Value::Object(plugin_launch_options),
     });
     let browser =
         crate::plugins::connect_browser_provider_with_plugins(provider_name, plugins, request)
@@ -992,5 +1034,70 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
         let request: Value =
             serde_json::from_str(&std::fs::read_to_string(request_path).unwrap()).unwrap();
         assert_eq!(request["request"]["launchOptions"]["headed"], false);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_plugin_provider_receives_command_launch_options() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let guard = EnvGuard::new(&[
+            "AGENT_BROWSER_COLOR_SCHEME",
+            "AGENT_BROWSER_ENGINE",
+            "AGENT_BROWSER_HEADED",
+            "AGENT_BROWSER_SESSION",
+            "AGENT_BROWSER_USER_AGENT",
+        ]);
+        guard.set("AGENT_BROWSER_COLOR_SCHEME", "light");
+        guard.set("AGENT_BROWSER_ENGINE", "chrome");
+        guard.set("AGENT_BROWSER_HEADED", "false");
+        guard.set("AGENT_BROWSER_SESSION", "provider-test");
+        guard.set("AGENT_BROWSER_USER_AGENT", "env-agent");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let request_path = dir.path().join("browser-launch-request.json");
+        let plugin_path = dir.path().join("mock-provider-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat > "$1"
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cdpUrl":"ws://127.0.0.1:9222/devtools/browser/test"}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let plugins = vec![crate::plugins::PluginConfig {
+            name: "cloud-browser".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            args: vec![request_path.to_string_lossy().to_string()],
+            capabilities: vec![crate::plugins::CAPABILITY_BROWSER_PROVIDER.to_string()],
+            ..crate::plugins::PluginConfig::default()
+        }];
+
+        rt.block_on(connect_provider_with_plugins_and_options(
+            "cloud-browser",
+            &plugins,
+            Some(json!({
+                "colorScheme": "dark",
+                "engine": "lightpanda",
+                "headed": true,
+                "userAgent": "cli-agent"
+            })),
+        ))
+        .unwrap();
+
+        let request: Value =
+            serde_json::from_str(&std::fs::read_to_string(request_path).unwrap()).unwrap();
+        assert_eq!(request["request"]["launchOptions"]["colorScheme"], "dark");
+        assert_eq!(request["request"]["launchOptions"]["engine"], "lightpanda");
+        assert_eq!(request["request"]["launchOptions"]["headed"], true);
+        assert_eq!(
+            request["request"]["launchOptions"]["userAgent"],
+            "cli-agent"
+        );
     }
 }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -190,7 +190,7 @@ pub async fn connect_plugin_provider_with_plugins_and_options(
     plugins: &[crate::plugins::PluginConfig],
     launch_options: Option<Value>,
 ) -> Result<ProviderConnection, String> {
-    if crate::plugins::find_plugin(&plugins, provider_name).is_none() {
+    if crate::plugins::find_plugin(plugins, provider_name).is_none() {
         return Err(format!(
             "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, or a configured plugin with browser.provider",
             provider_name

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -130,6 +130,44 @@ fn format_stream_status_text(action: Option<&str>, data: &serde_json::Value) -> 
     }
 }
 
+fn confirmation_data(data: &serde_json::Value) -> Option<&serde_json::Value> {
+    if data
+        .get("confirmation_required")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Some(data);
+    }
+
+    data.get("result")
+        .and_then(|v| v.get("data"))
+        .and_then(confirmation_data)
+}
+
+fn print_confirmation_required(data: &serde_json::Value) {
+    let action = data.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    let category = data.get("category").and_then(|v| v.as_str()).unwrap_or("");
+    let description = data
+        .get("description")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(action);
+    let cid = data
+        .get("confirmation_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(action);
+
+    println!("Confirmation required:");
+    if category.is_empty() {
+        println!("  {}", description);
+    } else {
+        println!("  {}: {}", category, description);
+    }
+    println!("  Run: agent-browser confirm {}", cid);
+    println!("  Or:  agent-browser deny {}", cid);
+}
+
 fn format_metric_ms(value: Option<f64>) -> String {
     value
         .map(|v| format!("{}ms", format_compact_number(v)))
@@ -1104,24 +1142,8 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         }
 
         // Confirmation required (for orchestrator use)
-        if data
-            .get("confirmation_required")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            let category = data.get("category").and_then(|v| v.as_str()).unwrap_or("");
-            let description = data
-                .get("description")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let cid = data
-                .get("confirmation_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            println!("Confirmation required:");
-            println!("  {}: {}", category, description);
-            println!("  Run: agent-browser confirm {}", cid);
-            println!("  Or:  agent-browser deny {}", cid);
+        if let Some(pending) = confirmation_data(data) {
+            print_confirmation_required(pending);
             return;
         }
         if data
@@ -2252,6 +2274,9 @@ Plugin Login Options:
   --credential-provider <p> Resolve credentials from configured plugin <p>
   --item <ref>              Provider-specific vault item reference
   --url <url>               Login URL override
+  --username-selector <s>   Username selector override for this login
+  --password-selector <s>   Password selector override for this login
+  --submit-selector <s>     Submit selector override for this login
 
 Login behavior:
   auth login waits for form selectors to appear before filling/clicking.
@@ -3209,8 +3234,10 @@ Batch:
 Auth Vault:
   auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)
   auth login <name>          Login using saved credentials (waits for form fields)
-  auth login <name> --credential-provider <plugin>
+  auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
                              Resolve credentials from a configured plugin
+  auth login <name> --username-selector <s> --password-selector <s>
+                             Override selectors for one login
   auth list                  List saved auth profiles
   auth show <name>           Show auth profile metadata
   auth delete <name>         Delete auth profile

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2248,9 +2248,15 @@ Save Options:
   --password-selector <s>  Custom CSS selector for password field
   --submit-selector <s>    Custom CSS selector for submit button
 
+Plugin Login Options:
+  --credential-provider <p> Resolve credentials from configured plugin <p>
+  --item <ref>              Provider-specific vault item reference
+  --url <url>               Login URL override
+
 Login behavior:
   auth login waits for form selectors to appear before filling/clicking.
   Selector wait timeout follows the default action timeout.
+  Plugin credentials are resolved just-in-time and are not saved locally.
 
 Global Options:
   --json                   Output as JSON
@@ -2260,6 +2266,7 @@ Examples:
   echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
   agent-browser auth save github --url https://github.com/login --username user --password pass
   agent-browser auth login github
+  agent-browser auth login my-app --credential-provider vault --item "My App"
   agent-browser auth list
   agent-browser auth show github
   agent-browser auth delete github
@@ -2999,6 +3006,69 @@ Environment:
 "##
         }
 
+        "plugin" | "plugins" => {
+            r##"
+agent-browser plugin - Manage configured plugins
+
+Usage: agent-browser plugin [subcommand]
+
+Subcommands:
+  add <ref>                Add a plugin from npm or GitHub
+  list                     List configured plugins (default)
+  show <name>              Show one configured plugin
+  run <name> <type>        Run a command.run or custom plugin request
+
+Plugins are configured in agent-browser.json. A plugin entry declares a name,
+an executable command, optional args, and capabilities. Plugins run as
+external processes over the agent-browser.plugin.v1 stdio JSON protocol.
+
+Add sources:
+  <name>                   npm package, e.g. agent-browser-plugin-captcha
+  @<scope>/<name>          scoped npm package
+  <owner>/<repo>           GitHub repository
+
+Add options:
+  --name <name>            Override the configured plugin name
+  --capability <name>      Declare a capability if the plugin has no manifest
+  --global                 Write ~/.agent-browser/config.json instead of ./agent-browser.json
+  --no-manifest            Skip plugin.manifest discovery
+
+plugin add asks the package for plugin.manifest to discover name and
+capabilities. Use --capability when adding older plugins without a manifest.
+
+Capabilities:
+  credential.read          Resolve credentials for auth login
+  browser.provider         Launch/connect an external browser provider
+  launch.mutate            Append local launch args, extensions, or init scripts
+  command.run              Accept arbitrary namespaced plugin requests
+
+Core capabilities use dedicated command paths. Use auth login for
+credential.read, --provider for browser.provider, and a local launch for
+launch.mutate.
+
+Example config:
+  {{
+    "plugins": [
+      {{
+        "name": "vault",
+        "command": "agent-browser-plugin-vault",
+        "capabilities": ["credential.read"]
+      }}
+    ]
+  }}
+
+Examples:
+  agent-browser plugin add agent-browser-plugin-captcha
+  agent-browser plugin add org/agent-browser-plugin-cloud-browser
+  agent-browser plugin add @company/agent-browser-plugin-vault --name vault
+  agent-browser plugin list
+  agent-browser plugin show vault
+  agent-browser plugin run captcha captcha.solve --payload '{{"siteKey":"...","url":"https://example.com"}}'
+  agent-browser auth login my-app --credential-provider vault --item "My App"
+  agent-browser --provider cloud-browser open https://example.com
+"##
+        }
+
         _ => return false,
     };
     println!("{}", help.trim());
@@ -3139,9 +3209,17 @@ Batch:
 Auth Vault:
   auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)
   auth login <name>          Login using saved credentials (waits for form fields)
+  auth login <name> --credential-provider <plugin>
+                             Resolve credentials from a configured plugin
   auth list                  List saved auth profiles
   auth show <name>           Show auth profile metadata
   auth delete <name>         Delete auth profile
+
+Plugins:
+  plugin add <ref>           Add a plugin from npm or GitHub
+  plugin [list]              List configured plugins
+  plugin show <name>         Show one configured plugin
+  plugin run <name> <type>   Run a command.run or custom plugin request
 
 Confirmation:
   confirm <id>               Approve a pending action
@@ -3206,7 +3284,7 @@ Options:
   --allow-file-access        Allow file:// URLs to access local files (Chromium only)
   --hide-scrollbars <bool>   Hide native scrollbars in headless Chromium screenshots (default: true)
                              Use --hide-scrollbars false to keep scrollbars visible
-  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore
+  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
   --json                     JSON output
   --annotate                 Annotated screenshot with numbered labels and legend
@@ -3252,6 +3330,9 @@ Configuration:
   Example agent-browser.json:
     {{"headed": true, "hideScrollbars": false, "proxy": "http://localhost:8080"}}
 
+  Plugin example:
+    {{"plugins":[{{"name":"vault","command":"agent-browser-plugin-vault","capabilities":["credential.read"]}},{{"name":"stealth","command":"agent-browser-plugin-stealth","capabilities":["launch.mutate"]}}]}}
+
 Environment:
   AGENT_BROWSER_CONFIG           Path to config file (or use --config)
   AGENT_BROWSER_SESSION          Session name (default: "default")
@@ -3267,7 +3348,7 @@ Environment:
   AGENT_BROWSER_ANNOTATE         Annotated screenshot with numbered labels and legend
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
-  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore)
+  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_HIDE_SCROLLBARS  Hide scrollbars in headless Chromium screenshots (default: true)
@@ -3289,6 +3370,7 @@ Environment:
   AGENT_BROWSER_CONFIRM_INTERACTIVE Enable interactive confirmation prompts
   AGENT_BROWSER_NO_AUTO_DIALOG   Disable automatic dismissal of alert/beforeunload dialogs
   AGENT_BROWSER_ENGINE           Browser engine: chrome (default), lightpanda
+  AGENT_BROWSER_PLUGINS          JSON plugin registry override
   HTTP_PROXY / HTTPS_PROXY       Standard proxy env vars (fallback if AGENT_BROWSER_PROXY not set)
   ALL_PROXY                      SOCKS proxy (fallback for proxy)
   NO_PROXY                       Bypass proxy for hosts (fallback for proxy-bypass)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3042,9 +3042,9 @@ Capabilities:
   launch.mutate            Append local launch args, extensions, or init scripts
   command.run              Accept arbitrary namespaced plugin requests
 
-Core capabilities use dedicated command paths. Use auth login for
-credential.read, --provider for browser.provider, and a local launch for
-launch.mutate.
+Core capabilities and protocol request types use dedicated command paths.
+Use auth login for credential.read, --provider for browser.provider, and
+a local launch for launch.mutate.
 
 Example config:
   {{

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -201,11 +201,15 @@ async fn invoke_plugin_process(
     timeout_secs: u64,
     expose_plugin_error: bool,
 ) -> Result<serde_json::Value, String> {
-    let mut child = tokio::process::Command::new(&plugin.command)
+    let mut command = tokio::process::Command::new(&plugin.command);
+    command
         .args(&plugin.args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    let mut child = command
         .spawn()
         .map_err(|e| format!("Failed to start plugin '{}': {}", plugin.name, e))?;
 
@@ -1230,5 +1234,51 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"launch":{"arg
         assert_eq!(mutations[0].extensions, vec!["/tmp/ext".to_string()]);
         assert_eq!(mutations[0].user_agent.as_deref(), Some("plugin-agent"));
         assert_eq!(mutations[0].init_scripts.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timed_out_plugin_is_killed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let marker_path = dir.path().join("plugin-finished");
+        let plugin_path = dir.path().join("mock-slow-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat >/dev/null
+sleep 2
+printf done > "$1"
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let plugin = PluginConfig {
+            name: "slow".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            args: vec![marker_path.to_string_lossy().to_string()],
+            capabilities: vec![CAPABILITY_COMMAND_RUN.to_string()],
+            ..PluginConfig::default()
+        };
+
+        let err = invoke_plugin(
+            &plugin,
+            "slow.run",
+            CAPABILITY_COMMAND_RUN,
+            json!({}),
+            1,
+            true,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.contains("timed out"));
+        tokio::time::sleep(std::time::Duration::from_millis(2_500)).await;
+        assert!(!marker_path.exists());
     }
 }

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -177,6 +177,23 @@ pub fn plugin_has_capability(plugin: &PluginConfig, capability: &str) -> bool {
     plugin.capabilities.iter().any(|c| c == capability)
 }
 
+pub fn resolved_plugins_with_capability<'a>(
+    plugins: &'a [PluginConfig],
+    capability: &str,
+) -> Vec<&'a PluginConfig> {
+    let mut resolved = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for plugin in plugins.iter().rev() {
+        if seen.insert(plugin.name.as_str()) {
+            if plugin_has_capability(plugin, capability) {
+                resolved.push(plugin);
+            }
+        }
+    }
+    resolved.reverse();
+    resolved
+}
+
 async fn invoke_plugin(
     plugin: &PluginConfig,
     request_type: &str,
@@ -387,10 +404,7 @@ pub async fn launch_mutations_from_plugins(
     request: serde_json::Value,
 ) -> Result<Vec<LaunchMutation>, String> {
     let mut mutations = Vec::new();
-    for plugin in plugins
-        .iter()
-        .filter(|p| plugin_has_capability(p, CAPABILITY_LAUNCH_MUTATE))
-    {
+    for plugin in resolved_plugins_with_capability(plugins, CAPABILITY_LAUNCH_MUTATE) {
         let response = invoke_plugin(
             plugin,
             "launch.mutate",
@@ -968,6 +982,57 @@ mod tests {
         ];
 
         assert_eq!(find_plugin(&plugins, "vault").unwrap().command, "second");
+    }
+
+    #[test]
+    fn resolved_plugins_with_capability_prefers_last_duplicate_name() {
+        let plugins = vec![
+            PluginConfig {
+                name: "stealth".to_string(),
+                command: "user-stealth".to_string(),
+                capabilities: vec![CAPABILITY_LAUNCH_MUTATE.to_string()],
+                ..PluginConfig::default()
+            },
+            PluginConfig {
+                name: "captcha".to_string(),
+                command: "captcha".to_string(),
+                capabilities: vec![CAPABILITY_COMMAND_RUN.to_string()],
+                ..PluginConfig::default()
+            },
+            PluginConfig {
+                name: "stealth".to_string(),
+                command: "project-stealth".to_string(),
+                capabilities: vec![CAPABILITY_LAUNCH_MUTATE.to_string()],
+                ..PluginConfig::default()
+            },
+        ];
+
+        let resolved = resolved_plugins_with_capability(&plugins, CAPABILITY_LAUNCH_MUTATE);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].command, "project-stealth");
+    }
+
+    #[test]
+    fn resolved_plugins_with_capability_later_duplicate_can_disable_capability() {
+        let plugins = vec![
+            PluginConfig {
+                name: "stealth".to_string(),
+                command: "user-stealth".to_string(),
+                capabilities: vec![CAPABILITY_LAUNCH_MUTATE.to_string()],
+                ..PluginConfig::default()
+            },
+            PluginConfig {
+                name: "stealth".to_string(),
+                command: "project-stealth".to_string(),
+                capabilities: vec![CAPABILITY_COMMAND_RUN.to_string()],
+                ..PluginConfig::default()
+            },
+        ];
+
+        let resolved = resolved_plugins_with_capability(&plugins, CAPABILITY_LAUNCH_MUTATE);
+
+        assert!(resolved.is_empty());
     }
 
     #[test]

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -1,0 +1,1234 @@
+//! External plugin protocol support.
+//!
+//! Plugins run out-of-process and communicate over a small stdio JSON protocol.
+//! Core agent-browser keeps ownership of browser automation, policy checks, and
+//! redaction-sensitive flows; credential plugins only resolve secrets on demand.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
+
+pub const PROTOCOL_VERSION: &str = "agent-browser.plugin.v1";
+pub const TYPE_PLUGIN_MANIFEST: &str = "plugin.manifest";
+pub const CAPABILITY_CREDENTIAL_READ: &str = "credential.read";
+pub const CAPABILITY_BROWSER_PROVIDER: &str = "browser.provider";
+pub const CAPABILITY_LAUNCH_MUTATE: &str = "launch.mutate";
+pub const CAPABILITY_COMMAND_RUN: &str = "command.run";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct PluginConfig {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+impl Default for PluginConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            command: String::new(),
+            args: Vec::new(),
+            capabilities: Vec::new(),
+            source: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CredentialResolveRequest<'a> {
+    pub profile_name: &'a str,
+    pub item_ref: Option<&'a str>,
+    pub url: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedCredential {
+    pub username: String,
+    pub password: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub otp: Option<String>,
+    #[serde(default)]
+    pub username_selector: Option<String>,
+    #[serde(default)]
+    pub password_selector: Option<String>,
+    #[serde(default)]
+    pub submit_selector: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserProviderResult {
+    #[serde(alias = "wsUrl", alias = "connectUrl", alias = "cdp_url")]
+    pub cdp_url: String,
+    #[serde(default)]
+    pub direct_page: bool,
+    #[serde(default)]
+    pub cleanup: Option<serde_json::Value>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchMutation {
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    /// JavaScript source to register before page scripts run.
+    #[serde(default)]
+    pub init_scripts: Vec<String>,
+    #[serde(default)]
+    pub user_agent: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialPluginResponse {
+    protocol: String,
+    success: bool,
+    #[serde(default)]
+    credential: Option<ResolvedCredential>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BrowserProviderPluginResponse {
+    protocol: String,
+    success: bool,
+    #[serde(default)]
+    browser: Option<BrowserProviderResult>,
+    #[serde(default)]
+    data: Option<BrowserProviderResult>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LaunchMutationPluginResponse {
+    protocol: String,
+    success: bool,
+    #[serde(default)]
+    launch: Option<LaunchMutation>,
+    #[serde(default)]
+    data: Option<LaunchMutation>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+struct PluginManifest {
+    name: Option<String>,
+    capabilities: Vec<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PluginManifestResponse {
+    protocol: String,
+    success: bool,
+    #[serde(default)]
+    manifest: Option<PluginManifest>,
+    #[serde(default)]
+    data: Option<PluginManifest>,
+}
+
+pub fn plugins_from_env() -> Vec<PluginConfig> {
+    std::env::var("AGENT_BROWSER_PLUGINS")
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Vec<PluginConfig>>(&raw).ok())
+        .unwrap_or_default()
+}
+
+pub fn find_plugin<'a>(plugins: &'a [PluginConfig], name: &str) -> Option<&'a PluginConfig> {
+    plugins.iter().rev().find(|p| p.name == name)
+}
+
+pub fn plugin_policy_action(provider: &str, capability: &str) -> String {
+    format!("plugin:{}:{}", provider, capability)
+}
+
+fn validate_plugin(plugin: &PluginConfig, capability: &str) -> Result<(), String> {
+    if plugin.name.trim().is_empty() {
+        return Err("Plugin entry is missing a name".to_string());
+    }
+    if plugin.command.trim().is_empty() {
+        return Err(format!("Plugin '{}' is missing a command", plugin.name));
+    }
+    if !plugin.capabilities.iter().any(|c| c == capability) {
+        return Err(format!(
+            "Plugin '{}' does not declare required capability '{}'",
+            plugin.name, capability
+        ));
+    }
+    Ok(())
+}
+
+pub fn plugin_has_capability(plugin: &PluginConfig, capability: &str) -> bool {
+    plugin.capabilities.iter().any(|c| c == capability)
+}
+
+async fn invoke_plugin(
+    plugin: &PluginConfig,
+    request_type: &str,
+    capability: &str,
+    request: serde_json::Value,
+    timeout_secs: u64,
+    expose_plugin_error: bool,
+) -> Result<serde_json::Value, String> {
+    validate_plugin(plugin, capability)?;
+    let payload = json!({
+        "protocol": PROTOCOL_VERSION,
+        "type": request_type,
+        "capability": capability,
+        "request": request,
+    });
+    invoke_plugin_process(plugin, payload, timeout_secs, expose_plugin_error).await
+}
+
+async fn invoke_plugin_process(
+    plugin: &PluginConfig,
+    payload: serde_json::Value,
+    timeout_secs: u64,
+    expose_plugin_error: bool,
+) -> Result<serde_json::Value, String> {
+    let mut child = tokio::process::Command::new(&plugin.command)
+        .args(&plugin.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to start plugin '{}': {}", plugin.name, e))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        let input = serde_json::to_vec(&payload)
+            .map_err(|e| format!("Failed to encode plugin request: {}", e))?;
+        stdin
+            .write_all(&input)
+            .await
+            .map_err(|e| format!("Failed to write plugin request: {}", e))?;
+    }
+    drop(child.stdin.take());
+
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(timeout_secs),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| format!("Plugin '{}' timed out", plugin.name))?
+    .map_err(|e| format!("Plugin '{}' failed: {}", plugin.name, e))?;
+
+    if !output.status.success() {
+        return Err(format!("Plugin '{}' exited unsuccessfully", plugin.name));
+    }
+
+    let response: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|_| format!("Plugin '{}' returned invalid JSON", plugin.name))?;
+    let protocol = response
+        .get("protocol")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if protocol != PROTOCOL_VERSION {
+        return Err(format!(
+            "Plugin '{}' used unsupported protocol '{}'",
+            plugin.name, protocol
+        ));
+    }
+    if !response
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        if expose_plugin_error {
+            let error = response
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("plugin returned success=false");
+            return Err(format!("Plugin '{}' failed: {}", plugin.name, error));
+        }
+        return Err(format!("Plugin '{}' returned success=false", plugin.name));
+    }
+
+    Ok(response)
+}
+
+pub async fn resolve_credential_with_plugins(
+    provider: &str,
+    plugins: &[PluginConfig],
+    request: CredentialResolveRequest<'_>,
+) -> Result<ResolvedCredential, String> {
+    let plugin = find_plugin(&plugins, provider)
+        .ok_or_else(|| format!("Credential plugin '{}' is not configured", provider))?;
+    let response = invoke_plugin(
+        plugin,
+        "credential.resolve",
+        CAPABILITY_CREDENTIAL_READ,
+        json!({
+            "profileName": request.profile_name,
+            "itemRef": request.item_ref,
+            "url": request.url,
+        }),
+        15,
+        false,
+    )
+    .await?;
+    let response: CredentialPluginResponse = serde_json::from_value(response)
+        .map_err(|_| format!("Credential plugin '{}' returned invalid JSON", provider))?;
+    if response.protocol != PROTOCOL_VERSION {
+        return Err(format!(
+            "Credential plugin '{}' used unsupported protocol '{}'",
+            provider, response.protocol
+        ));
+    }
+    if !response.success {
+        return Err(format!(
+            "Credential plugin '{}' could not resolve credentials",
+            provider
+        ));
+    }
+    let credential = response
+        .credential
+        .ok_or_else(|| format!("Credential plugin '{}' returned no credential", provider))?;
+    if credential.username.is_empty() || credential.password.is_empty() {
+        return Err(format!(
+            "Credential plugin '{}' returned an incomplete credential",
+            provider
+        ));
+    }
+    Ok(credential)
+}
+
+pub async fn connect_browser_provider_with_plugins(
+    provider: &str,
+    plugins: &[PluginConfig],
+    request: serde_json::Value,
+) -> Result<BrowserProviderResult, String> {
+    let plugin = find_plugin(plugins, provider)
+        .ok_or_else(|| format!("Browser provider plugin '{}' is not configured", provider))?;
+    let response = invoke_plugin(
+        plugin,
+        "browser.launch",
+        CAPABILITY_BROWSER_PROVIDER,
+        request,
+        60,
+        false,
+    )
+    .await?;
+    let response: BrowserProviderPluginResponse =
+        serde_json::from_value(response).map_err(|_| {
+            format!(
+                "Browser provider plugin '{}' returned invalid JSON",
+                provider
+            )
+        })?;
+    if response.protocol != PROTOCOL_VERSION {
+        return Err(format!(
+            "Browser provider plugin '{}' used unsupported protocol '{}'",
+            provider, response.protocol
+        ));
+    }
+    if !response.success {
+        return Err(format!(
+            "Browser provider plugin '{}' could not launch browser",
+            provider
+        ));
+    }
+    let browser = response
+        .browser
+        .or(response.data)
+        .ok_or_else(|| format!("Browser provider plugin '{}' returned no browser", provider))?;
+    if browser.cdp_url.is_empty() {
+        return Err(format!(
+            "Browser provider plugin '{}' returned an empty CDP URL",
+            provider
+        ));
+    }
+    Ok(browser)
+}
+
+pub async fn close_browser_provider_with_plugins(
+    provider: &str,
+    plugins: &[PluginConfig],
+    cleanup: serde_json::Value,
+) -> Result<(), String> {
+    let Some(plugin) = find_plugin(plugins, provider) else {
+        return Ok(());
+    };
+    if !plugin_has_capability(plugin, CAPABILITY_BROWSER_PROVIDER) {
+        return Ok(());
+    }
+    let _ = invoke_plugin(
+        plugin,
+        "browser.close",
+        CAPABILITY_BROWSER_PROVIDER,
+        cleanup,
+        15,
+        false,
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn launch_mutations_from_plugins(
+    plugins: &[PluginConfig],
+    request: serde_json::Value,
+) -> Result<Vec<LaunchMutation>, String> {
+    let mut mutations = Vec::new();
+    for plugin in plugins
+        .iter()
+        .filter(|p| plugin_has_capability(p, CAPABILITY_LAUNCH_MUTATE))
+    {
+        let response = invoke_plugin(
+            plugin,
+            "launch.mutate",
+            CAPABILITY_LAUNCH_MUTATE,
+            request.clone(),
+            15,
+            false,
+        )
+        .await?;
+        let response: LaunchMutationPluginResponse =
+            serde_json::from_value(response).map_err(|_| {
+                format!(
+                    "Launch mutator plugin '{}' returned invalid JSON",
+                    plugin.name
+                )
+            })?;
+        if response.protocol != PROTOCOL_VERSION {
+            return Err(format!(
+                "Launch mutator plugin '{}' used unsupported protocol '{}'",
+                plugin.name, response.protocol
+            ));
+        }
+        if !response.success {
+            return Err(format!(
+                "Launch mutator plugin '{}' could not mutate launch options",
+                plugin.name
+            ));
+        }
+        if let Some(mutation) = response.launch.or(response.data) {
+            mutations.push(mutation);
+        }
+    }
+    Ok(mutations)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PluginSourceKind {
+    Npm,
+    Github,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PluginSource {
+    kind: PluginSourceKind,
+    reference: String,
+    install_spec: String,
+    source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PluginConfigScope {
+    Project,
+    Global,
+}
+
+struct PluginAddOptions {
+    reference: String,
+    name: Option<String>,
+    capabilities: Vec<String>,
+    scope: PluginConfigScope,
+    no_manifest: bool,
+}
+
+fn parse_plugin_source(reference: &str) -> Result<PluginSource, String> {
+    let trimmed = reference.trim();
+    if trimmed.is_empty() {
+        return Err("plugin add requires a package or repository reference".to_string());
+    }
+    if trimmed.starts_with('@') {
+        return Ok(PluginSource {
+            kind: PluginSourceKind::Npm,
+            reference: trimmed.to_string(),
+            install_spec: trimmed.to_string(),
+            source: format!("npm:{}", trimmed),
+        });
+    }
+
+    let parts: Vec<&str> = trimmed.split('/').collect();
+    if parts.len() == 2
+        && !parts[0].is_empty()
+        && !parts[1].is_empty()
+        && !trimmed.starts_with('.')
+        && !trimmed.starts_with('/')
+        && !trimmed.contains(':')
+    {
+        return Ok(PluginSource {
+            kind: PluginSourceKind::Github,
+            reference: trimmed.to_string(),
+            install_spec: format!("github:{}", trimmed),
+            source: format!("github:{}", trimmed),
+        });
+    }
+
+    Ok(PluginSource {
+        kind: PluginSourceKind::Npm,
+        reference: trimmed.to_string(),
+        install_spec: trimmed.to_string(),
+        source: format!("npm:{}", trimmed),
+    })
+}
+
+fn parse_plugin_add_args(args: &[String]) -> Result<PluginAddOptions, String> {
+    let mut reference = None;
+    let mut name = None;
+    let mut capabilities = Vec::new();
+    let mut scope = PluginConfigScope::Project;
+    let mut no_manifest = false;
+    let mut i = 2;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--name" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err("plugin add --name requires a value".to_string());
+                };
+                name = Some(value.clone());
+                i += 1;
+            }
+            "--capability" | "--capabilities" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(format!("plugin add {} requires a value", args[i]));
+                };
+                capabilities.extend(
+                    value
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(String::from),
+                );
+                i += 1;
+            }
+            "--global" => {
+                scope = PluginConfigScope::Global;
+            }
+            "--project" => {
+                scope = PluginConfigScope::Project;
+            }
+            "--no-manifest" => {
+                no_manifest = true;
+            }
+            other if other.starts_with("--") => {
+                return Err(format!("unknown flag '{}' for plugin add", other));
+            }
+            value => {
+                if reference.is_some() {
+                    return Err(format!("unexpected argument '{}' for plugin add", value));
+                }
+                reference = Some(value.to_string());
+            }
+        }
+        i += 1;
+    }
+
+    Ok(PluginAddOptions {
+        reference: reference
+            .ok_or_else(|| "plugin add requires a package or repository reference".to_string())?,
+        name,
+        capabilities,
+        scope,
+        no_manifest,
+    })
+}
+
+async fn discover_plugin_manifest(plugin: &PluginConfig) -> Result<PluginManifest, String> {
+    let payload = json!({
+        "protocol": PROTOCOL_VERSION,
+        "type": TYPE_PLUGIN_MANIFEST,
+        "capability": TYPE_PLUGIN_MANIFEST,
+        "request": {},
+    });
+
+    let response = invoke_plugin_process(plugin, payload, 60, true).await?;
+    let response: PluginManifestResponse = serde_json::from_value(response)
+        .map_err(|_| format!("Plugin '{}' returned invalid manifest JSON", plugin.name))?;
+    if response.protocol != PROTOCOL_VERSION {
+        return Err(format!(
+            "Plugin '{}' used unsupported protocol '{}'",
+            plugin.name, response.protocol
+        ));
+    }
+    if !response.success {
+        return Err(format!("Plugin '{}' returned success=false", plugin.name));
+    }
+    response
+        .manifest
+        .or(response.data)
+        .ok_or_else(|| format!("Plugin '{}' returned no manifest", plugin.name))
+}
+
+fn derive_plugin_name(source: &PluginSource) -> String {
+    let raw = match source.kind {
+        PluginSourceKind::Npm => package_name_without_version(&source.reference),
+        PluginSourceKind::Github => source
+            .reference
+            .rsplit('/')
+            .next()
+            .unwrap_or(&source.reference)
+            .to_string(),
+    };
+    raw.strip_prefix("agent-browser-plugin-")
+        .or_else(|| raw.strip_prefix("plugin-"))
+        .unwrap_or(&raw)
+        .to_string()
+}
+
+fn package_name_without_version(reference: &str) -> String {
+    if reference.starts_with('@') {
+        let mut parts = reference.splitn(2, '/');
+        let scope = parts.next().unwrap_or_default();
+        let name = parts.next().unwrap_or(scope);
+        return name
+            .rsplit_once('@')
+            .map(|(pkg, _)| pkg)
+            .unwrap_or(name)
+            .to_string();
+    }
+    reference.split('@').next().unwrap_or(reference).to_string()
+}
+
+fn validate_plugin_name(name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("plugin name cannot be empty".to_string());
+    }
+    if name.chars().any(|c| c.is_whitespace() || c == ':') {
+        return Err("plugin name cannot contain whitespace or ':'".to_string());
+    }
+    Ok(())
+}
+
+fn config_path_for_scope(scope: &PluginConfigScope) -> Result<PathBuf, String> {
+    match scope {
+        PluginConfigScope::Project => Ok(PathBuf::from("agent-browser.json")),
+        PluginConfigScope::Global => dirs::home_dir()
+            .map(|d| d.join(".agent-browser").join("config.json"))
+            .ok_or_else(|| "Could not determine home directory".to_string()),
+    }
+}
+
+fn read_config_json(path: &Path) -> Result<serde_json::Value, String> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read config {}: {}", path.display(), e))?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("Config {} is invalid JSON: {}", path.display(), e))?;
+    if !value.is_object() {
+        return Err(format!("Config {} must be a JSON object", path.display()));
+    }
+    Ok(value)
+}
+
+fn write_config_json(path: &Path, value: &serde_json::Value) -> Result<(), String> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "Failed to create config directory {}: {}",
+                parent.display(),
+                e
+            )
+        })?;
+    }
+    let raw = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("Failed to encode config JSON: {}", e))?;
+    fs::write(path, format!("{}\n", raw))
+        .map_err(|e| format!("Failed to write config {}: {}", path.display(), e))
+}
+
+fn upsert_plugin_config(path: &Path, plugin: &PluginConfig) -> Result<(), String> {
+    let mut value = read_config_json(path)?;
+    let obj = value
+        .as_object_mut()
+        .ok_or_else(|| format!("Config {} must be a JSON object", path.display()))?;
+    let plugins_value = obj
+        .entry("plugins".to_string())
+        .or_insert_with(|| json!([]));
+    let plugins = plugins_value
+        .as_array_mut()
+        .ok_or_else(|| format!("Config {} field 'plugins' must be an array", path.display()))?;
+    plugins.retain(|entry| {
+        entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|name| name != plugin.name)
+            .unwrap_or(true)
+    });
+    plugins.push(
+        serde_json::to_value(plugin)
+            .map_err(|e| format!("Failed to encode plugin config: {}", e))?,
+    );
+    write_config_json(path, &value)
+}
+
+fn build_plugin_config_from_add(
+    source: &PluginSource,
+    options: &PluginAddOptions,
+    manifest: Option<PluginManifest>,
+) -> Result<PluginConfig, String> {
+    let manifest_name = manifest.as_ref().and_then(|m| m.name.clone());
+    let name = options
+        .name
+        .clone()
+        .or(manifest_name)
+        .unwrap_or_else(|| derive_plugin_name(source));
+    validate_plugin_name(&name)?;
+
+    let capabilities = if options.capabilities.is_empty() {
+        manifest.map(|m| m.capabilities).unwrap_or_default()
+    } else {
+        options.capabilities.clone()
+    };
+    if capabilities.is_empty() {
+        return Err(
+            "Plugin did not declare capabilities; rerun with --capability <name> or use a plugin that supports plugin.manifest"
+                .to_string(),
+        );
+    }
+
+    Ok(PluginConfig {
+        name,
+        command: "npx".to_string(),
+        args: vec!["-y".to_string(), source.install_spec.clone()],
+        capabilities,
+        source: Some(source.source.clone()),
+    })
+}
+
+fn print_plugin_added(plugin: &PluginConfig, path: &Path, json_output: bool) {
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "success": true,
+                "plugin": plugin,
+                "configPath": path.display().to_string(),
+            })
+        );
+        return;
+    }
+
+    println!("Added plugin '{}'", plugin.name);
+    println!("Config: {}", path.display());
+    if let Some(source) = &plugin.source {
+        println!("Source: {}", source);
+    }
+    println!("Command: {} {}", plugin.command, plugin.args.join(" "));
+    println!("Capabilities: {}", plugin.capabilities.join(", "));
+}
+
+fn add_plugin_command(args: &[String], json_output: bool) -> Result<(), String> {
+    let options = parse_plugin_add_args(args)?;
+    let source = parse_plugin_source(&options.reference)?;
+    let provisional = PluginConfig {
+        name: options
+            .name
+            .clone()
+            .unwrap_or_else(|| derive_plugin_name(&source)),
+        command: "npx".to_string(),
+        args: vec!["-y".to_string(), source.install_spec.clone()],
+        capabilities: Vec::new(),
+        source: Some(source.source.clone()),
+    };
+
+    let manifest = if options.no_manifest {
+        None
+    } else {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+        match rt.block_on(discover_plugin_manifest(&provisional)) {
+            Ok(manifest) => Some(manifest),
+            Err(e) if options.capabilities.is_empty() => {
+                return Err(format!(
+                    "{}. Rerun with --capability <name> to add the plugin without manifest discovery.",
+                    e
+                ));
+            }
+            Err(_) => None,
+        }
+    };
+
+    let plugin = build_plugin_config_from_add(&source, &options, manifest)?;
+    let path = config_path_for_scope(&options.scope)?;
+    upsert_plugin_config(&path, &plugin)?;
+    print_plugin_added(&plugin, &path, json_output);
+    Ok(())
+}
+
+pub fn run_plugin_command(args: &[String], plugins: &[PluginConfig], json_output: bool) {
+    let sub = args.get(1).map(|s| s.as_str()).unwrap_or("list");
+    match sub {
+        "list" => print_plugin_list(plugins, json_output),
+        "add" | "install" => {
+            if let Err(e) = add_plugin_command(args, json_output) {
+                print_plugin_error(&e, json_output);
+                std::process::exit(1);
+            }
+        }
+        "show" => {
+            let Some(name) = args.get(2) else {
+                print_plugin_error("plugin show requires a plugin name", json_output);
+                std::process::exit(1);
+            };
+            match find_plugin(plugins, name) {
+                Some(plugin) => print_plugin(plugin, json_output),
+                None => {
+                    print_plugin_error(
+                        &format!("Plugin '{}' is not configured", name),
+                        json_output,
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+        "run" => {
+            let Some(name) = args.get(2) else {
+                print_plugin_error("plugin run requires a plugin name", json_output);
+                std::process::exit(1);
+            };
+            let Some(request_type) = args.get(3) else {
+                print_plugin_error("plugin run requires a request type", json_output);
+                std::process::exit(1);
+            };
+            let payload = match parse_run_payload(args) {
+                Ok(payload) => payload,
+                Err(e) => {
+                    print_plugin_error(&e, json_output);
+                    std::process::exit(1);
+                }
+            };
+            let Some(plugin) = find_plugin(plugins, name) else {
+                print_plugin_error(&format!("Plugin '{}' is not configured", name), json_output);
+                std::process::exit(1);
+            };
+            if is_core_capability(request_type) {
+                print_plugin_error(
+                    &format!(
+                        "plugin run cannot invoke core capability '{}'; use the dedicated agent-browser command path",
+                        request_type
+                    ),
+                    json_output,
+                );
+                std::process::exit(1);
+            }
+            let capability = if plugin_has_capability(plugin, request_type) {
+                request_type.as_str()
+            } else {
+                CAPABILITY_COMMAND_RUN
+            };
+            let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+            match rt.block_on(invoke_plugin(
+                plugin,
+                request_type,
+                capability,
+                payload,
+                60,
+                true,
+            )) {
+                Ok(response) => println!("{}", response),
+                Err(e) => {
+                    print_plugin_error(&e, json_output);
+                    std::process::exit(1);
+                }
+            }
+        }
+        _ => {
+            print_plugin_error(
+                &format!(
+                    "Unknown plugin subcommand '{}'. Valid options: add, list, show, run",
+                    sub
+                ),
+                json_output,
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn parse_run_payload(args: &[String]) -> Result<serde_json::Value, String> {
+    let mut payload = json!({});
+    let mut i = 4;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--payload" => {
+                let Some(raw) = args.get(i + 1) else {
+                    return Err("plugin run --payload requires JSON".to_string());
+                };
+                payload = serde_json::from_str(raw)
+                    .map_err(|e| format!("plugin run --payload is invalid JSON: {}", e))?;
+                i += 1;
+            }
+            other => {
+                return Err(format!("unknown flag '{}' for plugin run", other));
+            }
+        }
+        i += 1;
+    }
+    Ok(payload)
+}
+
+fn is_core_capability(capability: &str) -> bool {
+    matches!(
+        capability,
+        CAPABILITY_CREDENTIAL_READ | CAPABILITY_BROWSER_PROVIDER | CAPABILITY_LAUNCH_MUTATE
+    )
+}
+
+fn print_plugin_list(plugins: &[PluginConfig], json_output: bool) {
+    if json_output {
+        println!("{}", json!({ "plugins": plugins }));
+        return;
+    }
+    if plugins.is_empty() {
+        println!("No plugins configured");
+        return;
+    }
+    for plugin in plugins {
+        let capabilities = if plugin.capabilities.is_empty() {
+            "(no capabilities)".to_string()
+        } else {
+            plugin.capabilities.join(", ")
+        };
+        println!("{}  {}", plugin.name, capabilities);
+    }
+}
+
+fn print_plugin(plugin: &PluginConfig, json_output: bool) {
+    if json_output {
+        println!("{}", json!({ "plugin": plugin }));
+        return;
+    }
+    println!("Name: {}", plugin.name);
+    println!("Command: {}", plugin.command);
+    if !plugin.args.is_empty() {
+        println!("Args: {}", plugin.args.join(" "));
+    }
+    if plugin.capabilities.is_empty() {
+        println!("Capabilities: (none)");
+    } else {
+        println!("Capabilities: {}", plugin.capabilities.join(", "));
+    }
+}
+
+fn print_plugin_error(message: &str, json_output: bool) {
+    if json_output {
+        println!("{}", json!({ "success": false, "error": message }));
+    } else {
+        eprintln!("{}", message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_plugin_prefers_last_entry() {
+        let plugins = vec![
+            PluginConfig {
+                name: "vault".to_string(),
+                command: "first".to_string(),
+                capabilities: vec![CAPABILITY_CREDENTIAL_READ.to_string()],
+                ..PluginConfig::default()
+            },
+            PluginConfig {
+                name: "vault".to_string(),
+                command: "second".to_string(),
+                capabilities: vec![CAPABILITY_CREDENTIAL_READ.to_string()],
+                ..PluginConfig::default()
+            },
+        ];
+
+        assert_eq!(find_plugin(&plugins, "vault").unwrap().command, "second");
+    }
+
+    #[test]
+    fn plugin_policy_action_is_capability_scoped() {
+        assert_eq!(
+            plugin_policy_action("onepassword", CAPABILITY_CREDENTIAL_READ),
+            "plugin:onepassword:credential.read"
+        );
+    }
+
+    #[test]
+    fn plugin_run_rejects_core_capabilities() {
+        assert!(is_core_capability(CAPABILITY_CREDENTIAL_READ));
+        assert!(is_core_capability(CAPABILITY_BROWSER_PROVIDER));
+        assert!(is_core_capability(CAPABILITY_LAUNCH_MUTATE));
+        assert!(!is_core_capability(CAPABILITY_COMMAND_RUN));
+        assert!(!is_core_capability("captcha.solve"));
+    }
+
+    #[test]
+    fn plugin_add_source_detection_matches_reference_shape() {
+        let npm = parse_plugin_source("agent-browser-plugin-captcha").unwrap();
+        assert_eq!(npm.kind, PluginSourceKind::Npm);
+        assert_eq!(npm.install_spec, "agent-browser-plugin-captcha");
+        assert_eq!(npm.source, "npm:agent-browser-plugin-captcha");
+        assert_eq!(derive_plugin_name(&npm), "captcha");
+
+        let scoped = parse_plugin_source("@acme/agent-browser-plugin-vault").unwrap();
+        assert_eq!(scoped.kind, PluginSourceKind::Npm);
+        assert_eq!(scoped.install_spec, "@acme/agent-browser-plugin-vault");
+        assert_eq!(scoped.source, "npm:@acme/agent-browser-plugin-vault");
+        assert_eq!(derive_plugin_name(&scoped), "vault");
+
+        let github = parse_plugin_source("vercel-labs/agent-browser-plugin-browserbox").unwrap();
+        assert_eq!(github.kind, PluginSourceKind::Github);
+        assert_eq!(
+            github.install_spec,
+            "github:vercel-labs/agent-browser-plugin-browserbox"
+        );
+        assert_eq!(
+            github.source,
+            "github:vercel-labs/agent-browser-plugin-browserbox"
+        );
+        assert_eq!(derive_plugin_name(&github), "browserbox");
+    }
+
+    #[test]
+    fn plugin_add_builds_config_from_manual_capabilities() {
+        let args = vec![
+            "plugin".to_string(),
+            "add".to_string(),
+            "agent-browser-plugin-captcha".to_string(),
+            "--capability".to_string(),
+            "command.run".to_string(),
+            "--capability".to_string(),
+            "captcha.solve".to_string(),
+            "--no-manifest".to_string(),
+        ];
+        let options = parse_plugin_add_args(&args).unwrap();
+        let source = parse_plugin_source(&options.reference).unwrap();
+        let plugin = build_plugin_config_from_add(&source, &options, None).unwrap();
+
+        assert_eq!(plugin.name, "captcha");
+        assert_eq!(plugin.command, "npx");
+        assert_eq!(
+            plugin.args,
+            vec!["-y".to_string(), "agent-browser-plugin-captcha".to_string()]
+        );
+        assert_eq!(
+            plugin.capabilities,
+            vec!["command.run".to_string(), "captcha.solve".to_string()]
+        );
+        assert_eq!(
+            plugin.source.as_deref(),
+            Some("npm:agent-browser-plugin-captcha")
+        );
+    }
+
+    #[test]
+    fn plugin_config_upsert_replaces_existing_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent-browser.json");
+        fs::write(
+            &path,
+            r#"{"headed":true,"plugins":[{"name":"captcha","command":"old","capabilities":["command.run"]}]}"#,
+        )
+        .unwrap();
+
+        let plugin = PluginConfig {
+            name: "captcha".to_string(),
+            command: "npx".to_string(),
+            args: vec!["-y".to_string(), "agent-browser-plugin-captcha".to_string()],
+            capabilities: vec!["command.run".to_string(), "captcha.solve".to_string()],
+            source: Some("npm:agent-browser-plugin-captcha".to_string()),
+        };
+
+        upsert_plugin_config(&path, &plugin).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(value["headed"], true);
+        let plugins = value["plugins"].as_array().unwrap();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0]["name"], "captcha");
+        assert_eq!(plugins[0]["command"], "npx");
+        assert_eq!(plugins[0]["source"], "npm:agent-browser-plugin-captcha");
+        assert_eq!(plugins[0]["capabilities"][1], "captcha.solve");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_credential_uses_configured_stdio_plugin() {
+        use crate::test_utils::EnvGuard;
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = EnvGuard::new(&["AGENT_BROWSER_PLUGINS"]);
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_path = dir.path().join("mock-credential-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{"username":"user","password":"pass","url":"https://example.com/login"}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let registry = serde_json::to_string(&vec![PluginConfig {
+            name: "mock".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            capabilities: vec![CAPABILITY_CREDENTIAL_READ.to_string()],
+            ..PluginConfig::default()
+        }])
+        .unwrap();
+        _guard.set("AGENT_BROWSER_PLUGINS", &registry);
+
+        let plugins = plugins_from_env();
+        let credential = resolve_credential_with_plugins(
+            "mock",
+            &plugins,
+            CredentialResolveRequest {
+                profile_name: "example",
+                item_ref: Some("Example"),
+                url: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(credential.username, "user");
+        assert_eq!(credential.password, "pass");
+        assert_eq!(credential.url.as_deref(), Some("https://example.com/login"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn credential_plugin_failure_does_not_echo_plugin_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_path = dir.path().join("mock-failing-credential-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":false,"error":"secret-token-value"}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let plugins = vec![PluginConfig {
+            name: "mock".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            capabilities: vec![CAPABILITY_CREDENTIAL_READ.to_string()],
+            ..PluginConfig::default()
+        }];
+
+        let err = resolve_credential_with_plugins(
+            "mock",
+            &plugins,
+            CredentialResolveRequest {
+                profile_name: "example",
+                item_ref: Some("Example"),
+                url: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.contains("success=false"));
+        assert!(!err.contains("secret-token-value"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn browser_provider_plugin_returns_cdp_connection() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_path = dir.path().join("mock-browser-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cdpUrl":"ws://127.0.0.1:9222/devtools/browser/test","directPage":true,"metadata":{"sessionId":"s1"},"cleanup":{"sessionId":"s1"}}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let plugins = vec![PluginConfig {
+            name: "browserbox".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            capabilities: vec![CAPABILITY_BROWSER_PROVIDER.to_string()],
+            ..PluginConfig::default()
+        }];
+
+        let browser = connect_browser_provider_with_plugins("browserbox", &plugins, json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(browser.cdp_url, "ws://127.0.0.1:9222/devtools/browser/test");
+        assert!(browser.direct_page);
+        assert_eq!(browser.metadata.unwrap()["sessionId"], "s1");
+        assert_eq!(browser.cleanup.unwrap()["sessionId"], "s1");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn launch_mutator_plugin_returns_launch_changes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_path = dir.path().join("mock-launch-plugin");
+        std::fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"launch":{"args":["--disable-blink-features=AutomationControlled"],"extensions":["/tmp/ext"],"initScripts":["Object.defineProperty(navigator,\"webdriver\",{get:()=>undefined});"],"userAgent":"plugin-agent"}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let plugins = vec![PluginConfig {
+            name: "stealth".to_string(),
+            command: plugin_path.to_string_lossy().to_string(),
+            capabilities: vec![CAPABILITY_LAUNCH_MUTATE.to_string()],
+            ..PluginConfig::default()
+        }];
+
+        let mutations = launch_mutations_from_plugins(&plugins, json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(mutations.len(), 1);
+        assert_eq!(
+            mutations[0].args,
+            vec!["--disable-blink-features=AutomationControlled".to_string()]
+        );
+        assert_eq!(mutations[0].extensions, vec!["/tmp/ext".to_string()]);
+        assert_eq!(mutations[0].user_agent.as_deref(), Some("plugin-agent"));
+        assert_eq!(mutations[0].init_scripts.len(), 1);
+    }
+}

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -18,7 +18,7 @@ pub const CAPABILITY_BROWSER_PROVIDER: &str = "browser.provider";
 pub const CAPABILITY_LAUNCH_MUTATE: &str = "launch.mutate";
 pub const CAPABILITY_COMMAND_RUN: &str = "command.run";
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
 pub struct PluginConfig {
     pub name: String,
@@ -27,18 +27,6 @@ pub struct PluginConfig {
     pub capabilities: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-}
-
-impl Default for PluginConfig {
-    fn default() -> Self {
-        Self {
-            name: String::new(),
-            command: String::new(),
-            args: Vec::new(),
-            capabilities: Vec::new(),
-            source: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -184,10 +172,8 @@ pub fn resolved_plugins_with_capability<'a>(
     let mut resolved = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for plugin in plugins.iter().rev() {
-        if seen.insert(plugin.name.as_str()) {
-            if plugin_has_capability(plugin, capability) {
-                resolved.push(plugin);
-            }
+        if seen.insert(plugin.name.as_str()) && plugin_has_capability(plugin, capability) {
+            resolved.push(plugin);
         }
     }
     resolved.reverse();
@@ -287,7 +273,7 @@ pub async fn resolve_credential_with_plugins(
     plugins: &[PluginConfig],
     request: CredentialResolveRequest<'_>,
 ) -> Result<ResolvedCredential, String> {
-    let plugin = find_plugin(&plugins, provider)
+    let plugin = find_plugin(plugins, provider)
         .ok_or_else(|| format!("Credential plugin '{}' is not configured", provider))?;
     let response = invoke_plugin(
         plugin,

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -823,10 +823,10 @@ pub fn run_plugin_command(args: &[String], plugins: &[PluginConfig], json_output
                 print_plugin_error(&format!("Plugin '{}' is not configured", name), json_output);
                 std::process::exit(1);
             };
-            if is_core_capability(request_type) {
+            if is_core_plugin_entrypoint(request_type) {
                 print_plugin_error(
                     &format!(
-                        "plugin run cannot invoke core capability '{}'; use the dedicated agent-browser command path",
+                        "plugin run cannot invoke core plugin entrypoint '{}'; use the dedicated agent-browser command path",
                         request_type
                     ),
                     json_output,
@@ -889,10 +889,16 @@ fn parse_run_payload(args: &[String]) -> Result<serde_json::Value, String> {
     Ok(payload)
 }
 
-fn is_core_capability(capability: &str) -> bool {
+fn is_core_plugin_entrypoint(entrypoint: &str) -> bool {
     matches!(
-        capability,
-        CAPABILITY_CREDENTIAL_READ | CAPABILITY_BROWSER_PROVIDER | CAPABILITY_LAUNCH_MUTATE
+        entrypoint,
+        CAPABILITY_CREDENTIAL_READ
+            | CAPABILITY_BROWSER_PROVIDER
+            | CAPABILITY_LAUNCH_MUTATE
+            | TYPE_PLUGIN_MANIFEST
+            | "credential.resolve"
+            | "browser.launch"
+            | "browser.close"
     )
 }
 
@@ -973,12 +979,17 @@ mod tests {
     }
 
     #[test]
-    fn plugin_run_rejects_core_capabilities() {
-        assert!(is_core_capability(CAPABILITY_CREDENTIAL_READ));
-        assert!(is_core_capability(CAPABILITY_BROWSER_PROVIDER));
-        assert!(is_core_capability(CAPABILITY_LAUNCH_MUTATE));
-        assert!(!is_core_capability(CAPABILITY_COMMAND_RUN));
-        assert!(!is_core_capability("captcha.solve"));
+    fn plugin_run_rejects_core_entrypoints() {
+        assert!(is_core_plugin_entrypoint(CAPABILITY_CREDENTIAL_READ));
+        assert!(is_core_plugin_entrypoint(CAPABILITY_BROWSER_PROVIDER));
+        assert!(is_core_plugin_entrypoint(CAPABILITY_LAUNCH_MUTATE));
+        assert!(is_core_plugin_entrypoint("credential.resolve"));
+        assert!(is_core_plugin_entrypoint("browser.launch"));
+        assert!(is_core_plugin_entrypoint("browser.close"));
+        assert!(is_core_plugin_entrypoint("launch.mutate"));
+        assert!(is_core_plugin_entrypoint(TYPE_PLUGIN_MANIFEST));
+        assert!(!is_core_plugin_entrypoint(CAPABILITY_COMMAND_RUN));
+        assert!(!is_core_plugin_entrypoint("captcha.solve"));
     }
 
     #[test]

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -164,6 +164,43 @@
     "headers": {
       "type": "string",
       "description": "Custom HTTP headers supplied as a JSON-formatted string."
+    },
+    "plugins": {
+      "type": "array",
+      "description": "External plugin registry. Project-level entries are appended after user-level entries, and duplicate names resolve to the later entry.",
+      "items": {
+        "type": "object",
+        "required": ["name", "command"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Plugin name used by commands such as auth login --credential-provider."
+          },
+          "command": {
+            "type": "string",
+            "description": "Executable path or command name for the plugin process."
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional arguments passed to the plugin process. Do not store secrets here."
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Capabilities declared by the plugin. Built-in capability names include credential.read, browser.provider, launch.mutate, and command.run; plugins may also declare custom names such as captcha.solve."
+          },
+          "source": {
+            "type": "string",
+            "description": "Optional source recorded by agent-browser plugin add, such as npm:agent-browser-plugin-example or github:owner/repo."
+          }
+        },
+        "additionalProperties": true
+      }
     }
   },
   "additionalProperties": true

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -91,7 +91,7 @@ This enables control of:
   <tbody>
     <tr><td><code>--session &lt;name&gt;</code></td><td>Use isolated session</td></tr>
     <tr><td><code>--profile &lt;path&gt;</code></td><td>Persistent browser profile directory</td></tr>
-    <tr><td><code>-p &lt;provider&gt;</code></td><td>Cloud browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>)</td></tr>
+    <tr><td><code>-p &lt;provider&gt;</code></td><td>Browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>, <code>agentcore</code>, or a configured <code>browser.provider</code> plugin)</td></tr>
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>
     <tr><td><code>--executable-path</code></td><td>Custom browser executable</td></tr>
     <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (comma-separated)</td></tr>
@@ -111,10 +111,10 @@ This enables control of:
 
 ## Cloud providers
 
-Use the `-p` flag to connect to a cloud browser provider instead of launching a local browser:
+Use the `-p` flag to connect to a cloud browser provider or configured `browser.provider` plugin instead of launching a local browser:
 
 ```bash
 agent-browser -p browserbase open https://example.com
 ```
 
-See the [Providers](/providers/browser-use) section for setup and configuration of each supported provider: [Browser Use](/providers/browser-use), [Browserbase](/providers/browserbase), [Browserless](/providers/browserless), and [Kernel](/providers/kernel).
+See the [Providers](/providers/browser-use) section for setup and configuration of each built-in provider: [Browser Use](/providers/browser-use), [Browserbase](/providers/browserbase), [Browserless](/providers/browserless), [Kernel](/providers/kernel), and [AgentCore](/providers/agentcore).

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -312,9 +312,16 @@ See [Debugging](/debugging) for console, error, dialog, trace, highlight, and De
 ```bash
 agent-browser auth save <name> [opts]    # Save auth profile
 agent-browser auth login <name>          # Login using saved credentials
+agent-browser auth login <name> --credential-provider <plugin> [--item <ref>]
+                                          # Resolve credentials from plugin
 agent-browser auth list                  # List saved profiles (names and URLs only)
 agent-browser auth show <name>           # Show profile metadata (no passwords)
 agent-browser auth delete <name>         # Delete a saved profile
+agent-browser plugin add <ref>           # Add a plugin from npm or GitHub
+agent-browser plugin list                # List configured plugins
+agent-browser plugin show <name>         # Show one configured plugin
+agent-browser plugin run <name> <type> --payload <json>
+                                          # Run an arbitrary plugin request
 ```
 
 Save options:
@@ -329,9 +336,32 @@ Save options:
 
 `auth login` navigates with `load` and then waits for the username/password/submit selectors to appear before interacting. This improves reliability on SPA login pages where fields render after initial page load.
 
+Plugin login options:
+
+- `--credential-provider <plugin>`: resolve credentials from a configured plugin
+- `--item <ref>`: provider-specific vault item reference
+- `--url <url>`: login URL override
+- `--username-selector <sel>`: selector override for this login
+- `--password-selector <sel>`: selector override for this login
+- `--submit-selector <sel>`: selector override for this login
+
+Credential provider plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol. They return credentials to the daemon for a single login and agent-browser does not save those credentials locally.
+
+Other plugin capabilities use the same protocol:
+
+- `browser.provider`: use the plugin with `--provider <name>` to return a CDP WebSocket URL
+- `launch.mutate`: append local launch args, extensions, or init scripts before Chrome starts
+- `command.run`: run arbitrary namespaced requests through `agent-browser plugin run`
+
+`plugin run` is for `command.run` and custom capabilities. Core capabilities use their dedicated command paths.
+
 ```bash
 echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
 agent-browser auth login github
+agent-browser plugin add agent-browser-plugin-vault --name vault
+agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser --provider cloud-browser open https://example.com
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
 agent-browser auth list
 ```
 
@@ -495,7 +525,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --ignore-https-errors    # Ignore HTTPS certificate errors
 --allow-file-access      # Allow file:// URLs to access local files (Chromium only)
 --hide-scrollbars <bool> # Hide native scrollbars in headless Chromium screenshots
--p, --provider <name>    # Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore)
+-p, --provider <name>    # Browser provider or configured provider plugin
 --device <name>          # iOS device name (e.g., "iPhone 15 Pro")
 --json                   # JSON output (for scripts)
 --annotate               # Annotated screenshot with numbered element labels

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -312,8 +312,10 @@ See [Debugging](/debugging) for console, error, dialog, trace, highlight, and De
 ```bash
 agent-browser auth save <name> [opts]    # Save auth profile
 agent-browser auth login <name>          # Login using saved credentials
-agent-browser auth login <name> --credential-provider <plugin> [--item <ref>]
+agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
                                           # Resolve credentials from plugin
+agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>]
+                                          # Override selectors for one login
 agent-browser auth list                  # List saved profiles (names and URLs only)
 agent-browser auth show <name>           # Show profile metadata (no passwords)
 agent-browser auth delete <name>         # Delete a saved profile

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -353,7 +353,7 @@ Other plugin capabilities use the same protocol:
 - `launch.mutate`: append local launch args, extensions, or init scripts before Chrome starts
 - `command.run`: run arbitrary namespaced requests through `agent-browser plugin run`
 
-`plugin run` is for `command.run` and custom capabilities. Core capabilities use their dedicated command paths.
+`plugin run` is for `command.run` and custom capabilities. Core capabilities and protocol request types use their dedicated command paths.
 
 ```bash
 echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -97,6 +97,7 @@ Global launch, output, provider, and chat options can be set in the config file 
     <tr><td><code>noAutoDialog</code></td><td><code>--no-auto-dialog</code></td><td>boolean</td></tr>
     <tr><td><code>model</code></td><td><code>--model</code></td><td>string</td></tr>
     <tr><td><code>headers</code></td><td><code>--headers</code></td><td>string (JSON)</td></tr>
+    <tr><td><code>plugins</code></td><td>(config only)</td><td>plugin config[]</td></tr>
   </tbody>
 </table>
 
@@ -173,6 +174,54 @@ Extensions from user-level and project-level configs are **concatenated**, not r
 
 The `AGENT_BROWSER_EXTENSIONS` environment variable and CLI `--extension` flags follow the standard priority rules (env replaces config, CLI appends).
 
+## Plugins
+
+Configure external plugins with the `plugins` array:
+
+See [Plugins](/plugins) for the plugin author protocol and implementation examples.
+Use `agent-browser plugin add <ref>` to create this config automatically.
+
+```json
+{
+  "plugins": [
+    {
+      "name": "vault",
+      "command": "agent-browser-plugin-vault",
+      "args": [],
+      "capabilities": ["credential.read"]
+    },
+    {
+      "name": "cloud-browser",
+      "command": "agent-browser-plugin-cloud-browser",
+      "capabilities": ["browser.provider"]
+    },
+    {
+      "name": "stealth",
+      "command": "agent-browser-plugin-stealth",
+      "capabilities": ["launch.mutate"]
+    },
+    {
+      "name": "captcha",
+      "command": "agent-browser-plugin-captcha",
+      "capabilities": ["command.run", "captcha.solve"]
+    }
+  ]
+}
+```
+
+Project-level plugin entries are appended after user-level entries. If two entries use the same name, agent-browser resolves the later entry, so a project can override a user default. `AGENT_BROWSER_PLUGINS` can replace config discovery with a JSON array using the same shape.
+
+Do not put vault tokens or passwords in plugin command args. Use the vault vendor's own login/session mechanism or environment outside agent-browser config.
+
+```bash
+agent-browser plugin list
+agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser --provider cloud-browser open https://example.com
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
+```
+
+`plugin run` is for `command.run` and custom capabilities. Core capabilities use their dedicated command paths.
+
 ## Environment Variables
 
 These environment variables configure additional daemon and runtime behavior:
@@ -197,7 +246,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>NO_PROXY</code></td><td>Standard proxy bypass fallback.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_ARGS</code></td><td>Comma or newline separated browser launch arguments.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_USER_AGENT</code></td><td>Custom User-Agent string.</td><td>(browser default)</td></tr>
-    <tr><td><code>AGENT_BROWSER_PROVIDER</code></td><td>Browser provider such as <code>ios</code>, <code>browserbase</code>, <code>kernel</code>, <code>browseruse</code>, <code>browserless</code>, or <code>agentcore</code>.</td><td>(local browser)</td></tr>
+    <tr><td><code>AGENT_BROWSER_PROVIDER</code></td><td>Browser provider such as <code>ios</code>, <code>browserbase</code>, <code>kernel</code>, <code>browseruse</code>, <code>browserless</code>, <code>agentcore</code>, or a configured <code>browser.provider</code> plugin name.</td><td>(local browser)</td></tr>
     <tr><td><code>AGENT_BROWSER_HIDE_SCROLLBARS</code></td><td>Hide native scrollbars in headless Chromium screenshots.</td><td><code>true</code></td></tr>
     <tr><td><code>AGENT_BROWSER_COLOR_SCHEME</code></td><td>Color scheme preference (<code>dark</code>, <code>light</code>, <code>no-preference</code>).</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_DOWNLOAD_PATH</code></td><td>Default directory for browser downloads.</td><td>(temp directory)</td></tr>
@@ -225,6 +274,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_CONFIRM_INTERACTIVE</code></td><td>Enable interactive confirmation prompts (auto-denies if stdin is not a TTY).</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_ENGINE</code></td><td>Browser engine to use: <code>chrome</code> (default), <code>lightpanda</code>.</td><td><code>chrome</code></td></tr>
     <tr><td><code>AGENT_BROWSER_NO_AUTO_DIALOG</code></td><td>Disable automatic dismissal of <code>alert</code>/<code>beforeunload</code> dialogs.</td><td>(disabled)</td></tr>
+    <tr><td><code>AGENT_BROWSER_PLUGINS</code></td><td>JSON plugin registry override.</td><td>(config discovery)</td></tr>
     <tr><td><code>AGENT_BROWSER_SCREENSHOT_DIR</code></td><td>Default screenshot output directory.</td><td>(temp directory)</td></tr>
     <tr><td><code>AGENT_BROWSER_SCREENSHOT_QUALITY</code></td><td>JPEG screenshot quality from 0 to 100.</td><td>(format default)</td></tr>
     <tr><td><code>AGENT_BROWSER_SCREENSHOT_FORMAT</code></td><td>Screenshot format: <code>png</code> or <code>jpeg</code>.</td><td><code>png</code></td></tr>

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -220,7 +220,7 @@ agent-browser --provider cloud-browser open https://example.com
 agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
 ```
 
-`plugin run` is for `command.run` and custom capabilities. Core capabilities use their dedicated command paths.
+`plugin run` is for `command.run` and custom capabilities. Core capabilities and protocol request types use their dedicated command paths.
 
 ## Environment Variables
 

--- a/docs/src/app/plugins/layout.tsx
+++ b/docs/src/app/plugins/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("plugins");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/plugins/page.mdx
+++ b/docs/src/app/plugins/page.mdx
@@ -1,0 +1,409 @@
+# Plugins
+
+Plugins let agent-browser integrate with external tools without adding those tools to core. A plugin is a local executable that reads one JSON request from stdin and writes one JSON response to stdout.
+
+Use plugins for vault-backed login, custom browser providers, local launch customization, and domain-specific commands such as CAPTCHA solving.
+
+## When to write a plugin
+
+Write a plugin when the integration needs vendor SDKs, local CLIs, credentials, paid APIs, or behavior that should not become an agent-browser dependency.
+
+Good plugin fits:
+
+- Resolve login credentials from an external vault
+- Launch a browser through a hosted provider and return a CDP WebSocket URL
+- Add local Chrome launch arguments, extensions, or init scripts
+- Run a namespaced command such as `captcha.solve`
+
+Keep browser automation itself in agent-browser. A plugin should provide data or launch configuration, then let agent-browser continue driving the browser.
+
+## What to build as a plugin
+
+These are good places for plugin authors to start:
+
+- **New cloud browser providers**: Hosted browser platforms are good models for `browser.provider`. Existing built-ins can stay in core for compatibility, but new providers should usually start as plugins.
+- **Vault integrations**: Password managers, secret stores, and enterprise SSO helpers fit `credential.read`. Keep the local encrypted auth vault in core, but put vendor-specific vault access in plugins.
+- **Stealth and anti-detection**: These techniques change quickly and can be risky to support in core. They fit `launch.mutate` plugins that append launch args, extensions, init scripts, or user-agent overrides.
+- **CAPTCHA solvers**: CAPTCHA integrations are plugin territory because they involve third-party APIs, credentials, policy concerns, and fast vendor churn. They can use `command.run` or a custom capability such as `captcha.solve`.
+- **Vendor-specific auth helpers**: Login helpers for a specific app, IdP, or enterprise flow should live outside core unless they become generic browser automation primitives.
+
+## Add a plugin someone else built
+
+Use `plugin add` with the package or repository name:
+
+```bash
+agent-browser plugin add agent-browser-plugin-captcha
+agent-browser plugin add @company/agent-browser-plugin-vault --name vault
+agent-browser plugin add org/agent-browser-plugin-cloud-browser
+```
+
+agent-browser chooses the source from the reference:
+
+<table>
+  <thead>
+    <tr><th>Reference</th><th>Source</th><th>Example</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>name</code></td><td>npm package</td><td><code>agent-browser-plugin-captcha</code></td></tr>
+    <tr><td><code>@scope/name</code></td><td>scoped npm package</td><td><code>@company/agent-browser-plugin-vault</code></td></tr>
+    <tr><td><code>owner/repo</code></td><td>GitHub repository</td><td><code>org/agent-browser-plugin-cloud-browser</code></td></tr>
+  </tbody>
+</table>
+
+`plugin add` writes `./agent-browser.json` by default. Use `--global` to write `~/.agent-browser/config.json` instead.
+
+During add, agent-browser runs the package once and asks for `plugin.manifest`. A plugin manifest declares the plugin name and capabilities. If a plugin does not support manifests yet, use the capabilities from the plugin README:
+
+```bash
+agent-browser plugin add agent-browser-plugin-captcha --capability command.run --capability captcha.solve --no-manifest
+```
+
+Verify the plugin is configured:
+
+```bash
+agent-browser plugin list
+agent-browser plugin show captcha
+```
+
+Then use it through the command path for its capability:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser --provider cloud-browser open https://example.com
+agent-browser open https://example.com
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"abc","url":"https://example.com"}'
+```
+
+`launch.mutate` plugins run automatically for local launches such as `agent-browser open`.
+
+## Configure a plugin
+
+`plugin add` creates this config for you. You can also edit the `plugins` array manually:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "vault",
+      "command": "agent-browser-plugin-vault",
+      "args": [],
+      "capabilities": ["credential.read"]
+    },
+    {
+      "name": "captcha",
+      "command": "agent-browser-plugin-captcha",
+      "capabilities": ["command.run", "captcha.solve"]
+    }
+  ]
+}
+```
+
+Inspect the registry:
+
+```bash
+agent-browser plugin list
+agent-browser plugin show vault
+```
+
+`AGENT_BROWSER_PLUGINS` can replace config discovery with a JSON array using the same shape.
+
+Do not put API tokens, vault tokens, or passwords in plugin `args`. Use the vendor's own CLI login, keychain, environment, or session mechanism outside agent-browser config.
+
+## Protocol
+
+agent-browser starts the executable, writes this envelope to stdin, waits for stdout, and parses stdout as JSON:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "type": "credential.resolve",
+  "capability": "credential.read",
+  "request": {}
+}
+```
+
+Every successful response must include the same protocol and `success: true`:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "success": true,
+  "data": {}
+}
+```
+
+Only stdout is parsed. Write no logs to stdout. agent-browser suppresses plugin stderr for core integrations, so use files or your own debug mode when developing.
+
+Core integrations suppress plugin-provided error text in user-facing errors to reduce accidental secret exposure. Generic `plugin run` keeps plugin error text because it is a developer-facing command.
+
+## Plugin manifest
+
+Support `plugin.manifest` so users can add your plugin without manually entering capabilities:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "type": "plugin.manifest",
+  "capability": "plugin.manifest",
+  "request": {}
+}
+```
+
+Return the plugin name and capabilities:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "success": true,
+  "manifest": {
+    "name": "captcha",
+    "capabilities": ["command.run", "captcha.solve"],
+    "description": "Solve CAPTCHA challenges through Example CAPTCHA"
+  }
+}
+```
+
+With a manifest, users can run:
+
+```bash
+agent-browser plugin add agent-browser-plugin-captcha
+```
+
+Without a manifest, users must pass `--capability` flags during add.
+
+## Capabilities
+
+<table>
+  <thead>
+    <tr><th>Capability</th><th>Request type</th><th>How users invoke it</th><th>Response field</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>credential.read</code></td><td><code>credential.resolve</code></td><td><code>auth login --credential-provider &lt;name&gt;</code></td><td><code>credential</code></td></tr>
+    <tr><td><code>browser.provider</code></td><td><code>browser.launch</code>, <code>browser.close</code></td><td><code>--provider &lt;name&gt;</code></td><td><code>browser</code></td></tr>
+    <tr><td><code>launch.mutate</code></td><td><code>launch.mutate</code></td><td>Any local launch</td><td><code>launch</code></td></tr>
+    <tr><td><code>command.run</code></td><td>Custom request type</td><td><code>plugin run &lt;name&gt; &lt;type&gt;</code></td><td><code>data</code></td></tr>
+  </tbody>
+</table>
+
+Plugins may declare custom capabilities such as `captcha.solve`. `plugin run` can invoke `command.run` and custom capabilities, but it cannot invoke core capabilities directly. Use the dedicated command path for `credential.read`, `browser.provider`, and `launch.mutate`.
+
+## Minimal plugin
+
+This plugin implements `captcha.solve` and returns a fake token:
+
+```js
+#!/usr/bin/env node
+
+const chunks = [];
+for await (const chunk of process.stdin) {
+  chunks.push(chunk);
+}
+
+const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+function reply(body) {
+  process.stdout.write(
+    JSON.stringify({
+      protocol: "agent-browser.plugin.v1",
+      success: true,
+      ...body,
+    })
+  );
+}
+
+if (input.protocol !== "agent-browser.plugin.v1") {
+  process.stdout.write(
+    JSON.stringify({
+      protocol: "agent-browser.plugin.v1",
+      success: false,
+      error: "unsupported protocol",
+    })
+  );
+  process.exit(0);
+}
+
+if (input.type === "plugin.manifest") {
+  reply({
+    manifest: {
+      name: "captcha",
+      capabilities: ["command.run", "captcha.solve"],
+      description: "Example CAPTCHA plugin",
+    },
+  });
+  process.exit(0);
+}
+
+if (input.type === "captcha.solve") {
+  reply({
+    data: {
+      token: "example-token",
+      siteKey: input.request.siteKey,
+      url: input.request.url,
+    },
+  });
+  process.exit(0);
+}
+
+process.stdout.write(
+  JSON.stringify({
+    protocol: "agent-browser.plugin.v1",
+    success: false,
+    error: `unsupported request type: ${input.type}`,
+  })
+);
+```
+
+Make it executable and configure it:
+
+```bash
+chmod +x ./agent-browser-plugin-captcha
+```
+
+```json
+{
+  "plugins": [
+    {
+      "name": "captcha",
+      "command": "./agent-browser-plugin-captcha",
+      "capabilities": ["command.run", "captcha.solve"]
+    }
+  ]
+}
+```
+
+Run it:
+
+```bash
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"abc","url":"https://example.com"}'
+```
+
+## Credential plugin
+
+A credential plugin receives:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "type": "credential.resolve",
+  "capability": "credential.read",
+  "request": {
+    "profileName": "my-app",
+    "itemRef": "My App",
+    "url": "https://app.example.com/login"
+  }
+}
+```
+
+Return `credential`:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "success": true,
+  "credential": {
+    "username": "alice@example.com",
+    "password": "secret",
+    "url": "https://app.example.com/login",
+    "usernameSelector": "#username",
+    "passwordSelector": "#password",
+    "submitSelector": "input[type=submit]"
+  }
+}
+```
+
+Use it for one login:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+For external vaults, prefer calling the vendor CLI from the plugin and relying on its existing local session. Do not pass vault tokens in `agent-browser.json`.
+
+## Browser provider plugin
+
+A browser provider plugin receives `browser.launch` and returns a CDP URL:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "success": true,
+  "browser": {
+    "cdpUrl": "ws://127.0.0.1:9222/devtools/browser/session",
+    "directPage": false,
+    "metadata": {
+      "sessionId": "provider-session-id"
+    },
+    "cleanup": {
+      "sessionId": "provider-session-id"
+    }
+  }
+}
+```
+
+Then users launch through the plugin name:
+
+```bash
+agent-browser --provider cloud-browser open https://example.com
+```
+
+If `cleanup` is returned and connection fails, agent-browser later sends it back as the request body for `browser.close`.
+
+## Launch mutator plugin
+
+A launch mutator receives local launch options before Chrome starts and can append arguments, extensions, init scripts, or a user agent:
+
+```json
+{
+  "protocol": "agent-browser.plugin.v1",
+  "success": true,
+  "launch": {
+    "args": ["--disable-blink-features=AutomationControlled"],
+    "extensions": ["/absolute/path/to/extension"],
+    "initScripts": [
+      "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });"
+    ],
+    "userAgent": "my-agent/1.0"
+  }
+}
+```
+
+Configure it with `launch.mutate`, then use any local launch command:
+
+```bash
+agent-browser open https://example.com
+```
+
+Launch mutators do not run for CDP connections or remote browser providers because those browsers are already running outside the local launch path.
+
+## Policy and confirmation
+
+Plugin access is exposed as capability-scoped policy actions:
+
+```bash
+agent-browser --confirm-actions plugin:vault:credential.read auth login my-app --credential-provider vault --item "My App"
+agent-browser --confirm-actions plugin:cloud-browser:browser.provider --provider cloud-browser open https://example.com
+agent-browser --confirm-actions plugin:stealth:launch.mutate open https://example.com
+```
+
+The action string is `plugin:<name>:<capability>`.
+
+## Packaging guidance
+
+For npm packages, expose a `bin` command with no required stdout logs:
+
+```json
+{
+  "name": "agent-browser-plugin-example",
+  "bin": {
+    "agent-browser-plugin-example": "./bin/plugin.js"
+  }
+}
+```
+
+Keep the plugin small and explicit:
+
+- Declare only the capabilities it actually supports
+- Read exactly one request from stdin
+- Write exactly one JSON response to stdout
+- Keep secrets out of command-line arguments
+- Let agent-browser handle navigation, selectors, screenshots, state, and policy

--- a/docs/src/app/plugins/page.mdx
+++ b/docs/src/app/plugins/page.mdx
@@ -185,7 +185,7 @@ Without a manifest, users must pass `--capability` flags during add.
   </tbody>
 </table>
 
-Plugins may declare custom capabilities such as `captcha.solve`. `plugin run` can invoke `command.run` and custom capabilities, but it cannot invoke core capabilities directly. Use the dedicated command path for `credential.read`, `browser.provider`, and `launch.mutate`.
+Plugins may declare custom capabilities such as `captcha.solve`. `plugin run` can invoke `command.run` and custom capabilities, but it cannot invoke core capabilities or protocol request types directly. Use the dedicated command path for `credential.read`, `browser.provider`, and `launch.mutate`.
 
 ## Minimal plugin
 

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -9,6 +9,7 @@ All security features are opt-in. By default, agent-browser imposes no restricti
 These features are designed to mitigate the following threats when an LLM-based agent drives a browser:
 
 - **Credential exposure** -- Passwords stored in the auth vault are never included in LLM context. The CLI handles vault operations locally; credentials do not pass through the daemon's IPC channel.
+- **Plugin secret access**: Credential provider plugins run out-of-process and only receive a structured credential resolution request. Core agent-browser keeps browser automation, policy checks, and redaction-sensitive output handling.
 - **Prompt injection via page content** -- Malicious pages can embed text that looks like tool output or system instructions. Content boundary markers (`--content-boundaries`) let the orchestrator distinguish trusted tool output from untrusted page content.
 - **Unauthorized navigation / data exfiltration** -- A compromised or manipulated agent could navigate to attacker-controlled domains to exfiltrate data. The domain allowlist (`--allowed-domains`) blocks navigations, sub-resource requests, WebSocket connections, EventSource streams, and `sendBeacon` calls to non-allowed domains.
 - **Unauthorized destructive actions** -- Action policy (`--action-policy`) and confirmation gating (`--confirm-actions`) prevent the agent from performing dangerous operations (eval, downloads, uploads) without explicit approval.
@@ -19,6 +20,8 @@ These features are designed to mitigate the following threats when an LLM-based 
 - **WebSocket/EventSource blocking is best-effort.** It works by overriding browser constructors via an init script. If the `eval` action category is allowed, page scripts could theoretically restore the original constructors. Deny `eval` via `--action-policy` for maximum protection.
 - **Domain filter timing on remote connections.** When connecting to a pre-existing browser via CDP or a cloud provider, pages may have already loaded content before the domain filter is installed. agent-browser navigates disallowed pages to `about:blank` after the filter is active, but resources loaded before that point are not retroactively blocked.
 - **Content boundaries are defense-in-depth.** They rely on the LLM and orchestrator respecting the structural markers. A sufficiently capable adversarial page could attempt to mimic the boundary format, though the per-process CSPRNG nonce makes this impractical to predict.
+- **Plugins are local executables.** Install credential plugins only from maintainers you trust. agent-browser limits the data it sends to plugins and supports policy gates, but it does not sandbox arbitrary local executables.
+- **Plugin config is not secret storage.** Do not put vault tokens or passwords in plugin command args. Use the vendor's own login/session mechanism or environment outside agent-browser config.
 - **Confirmation timeout.** Pending confirmations auto-deny after 60 seconds. Orchestrators must respond within that window.
 - **Non-TTY auto-deny.** When `--confirm-interactive` is set but stdin is not a terminal (e.g., piped input), actions are automatically denied to prevent accidental approval in non-interactive contexts.
 
@@ -63,6 +66,79 @@ agent-browser auth save myapp \
 Profiles are stored in `~/.agent-browser/auth/` and always encrypted with AES-256-GCM. If `AGENT_BROWSER_ENCRYPTION_KEY` is not set, a key is auto-generated at `~/.agent-browser/.encryption-key` on first use. Back up this file or set the environment variable explicitly for portability.
 
 File permissions are enforced on both Unix (`chmod 600`/`700`) and Windows (`icacls` restricted to the current user) to prevent other users from reading encryption keys or auth profiles.
+
+### Plugins
+
+Plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol. Configure them in `agent-browser.json`:
+
+See [Plugins](/plugins) for the plugin author protocol and implementation examples.
+Use `agent-browser plugin add <ref>` to create plugin config automatically.
+
+```json
+{
+  "plugins": [
+    {
+      "name": "vault",
+      "command": "agent-browser-plugin-vault",
+      "capabilities": ["credential.read"]
+    },
+    {
+      "name": "cloud-browser",
+      "command": "agent-browser-plugin-cloud-browser",
+      "capabilities": ["browser.provider"]
+    },
+    {
+      "name": "stealth",
+      "command": "agent-browser-plugin-stealth",
+      "capabilities": ["launch.mutate"]
+    },
+    {
+      "name": "captcha",
+      "command": "agent-browser-plugin-captcha",
+      "capabilities": ["command.run", "captcha.solve"]
+    }
+  ]
+}
+```
+
+Inspect configured plugins:
+
+```bash
+agent-browser plugin list
+agent-browser plugin show vault
+```
+
+Use the plugin for login:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+Use a plugin as a browser provider:
+
+```bash
+agent-browser --provider cloud-browser open https://example.com
+```
+
+Use a generic plugin command:
+
+```bash
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
+```
+
+Credential plugins receive `credential.resolve` and return username, password, and optionally URL or selector metadata. Browser provider plugins receive `browser.launch` and return a CDP WebSocket URL. Launch mutator plugins receive `launch.mutate` and can append local launch args, extensions, or init script source before Chrome starts. Generic command plugins receive the request type passed to `plugin run`.
+
+`plugin run` is for `command.run` and custom capabilities. Core capabilities use their dedicated command paths so credential, browser-provider, and launch-mutator access stays inside the normal policy gates.
+
+agent-browser keeps browser automation, redaction-sensitive output, and policy enforcement in core. Credential plugin secrets do not appear in command arguments, dashboard events, or normal command output.
+
+Gate plugin access with capability actions:
+
+```bash
+agent-browser --confirm-actions plugin:vault:credential.read auth login my-app --credential-provider vault --item "My App"
+agent-browser --confirm-actions plugin:cloud-browser:browser.provider --provider cloud-browser open https://example.com
+agent-browser --confirm-actions plugin:stealth:launch.mutate open https://example.com
+```
 
 ## Content Boundary Markers
 
@@ -173,7 +249,7 @@ Example policy (restrictive):
   </tbody>
 </table>
 
-Auth vault operations (`auth save`, `auth login`, `auth list`, `auth show`, `auth delete`) and other internal/meta operations bypass action policy enforcement since they are trusted local operations. Domain allowlist restrictions still apply to `auth login` navigations.
+Auth vault operations keep secrets out of normal command output and LLM context. Domain allowlist restrictions still apply to `auth login` navigations. Plugin-backed logins also expose the capability action `plugin:<name>:credential.read` for policy and confirmation gates.
 
 ## Action Confirmation
 
@@ -225,6 +301,7 @@ Affected output types: `snapshot`, `get text`, `get html`, `eval`, `console`.
     <tr><td><code>AGENT_BROWSER_CONFIRM_ACTIONS</code></td><td>Comma-separated action categories requiring confirmation</td></tr>
     <tr><td><code>AGENT_BROWSER_CONFIRM_INTERACTIVE</code></td><td>Enable interactive confirmation prompts</td></tr>
     <tr><td><code>AGENT_BROWSER_ENCRYPTION_KEY</code></td><td>64-char hex key for AES-256-GCM encryption (auth vault + sessions)</td></tr>
+    <tr><td><code>AGENT_BROWSER_PLUGINS</code></td><td>JSON plugin registry override</td></tr>
   </tbody>
 </table>
 

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -128,7 +128,7 @@ agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url"
 
 Credential plugins receive `credential.resolve` and return username, password, and optionally URL or selector metadata. Browser provider plugins receive `browser.launch` and return a CDP WebSocket URL. Launch mutator plugins receive `launch.mutate` and can append local launch args, extensions, or init script source before Chrome starts. Generic command plugins receive the request type passed to `plugin run`.
 
-`plugin run` is for `command.run` and custom capabilities. Core capabilities use their dedicated command paths so credential, browser-provider, and launch-mutator access stays inside the normal policy gates.
+`plugin run` is for `command.run` and custom capabilities. Core capabilities and protocol request types use their dedicated command paths so credential, browser-provider, and launch-mutator access stays inside the normal policy gates.
 
 agent-browser keeps browser automation, redaction-sensitive output, and policy enforcement in core. Credential plugin secrets do not appear in command arguments, dashboard events, or normal command output.
 

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -23,6 +23,7 @@ export const navigation: NavSection[] = [
     items: [
       { name: "Commands", href: "/commands" },
       { name: "Configuration", href: "/configuration" },
+      { name: "Plugins", href: "/plugins" },
       { name: "Selectors", href: "/selectors" },
       { name: "Snapshots", href: "/snapshots" },
     ],

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -5,6 +5,7 @@ export const PAGE_TITLES: Record<string, string> = {
   skills: "Skills",
   commands: "Commands",
   configuration: "Configuration",
+  plugins: "Plugins",
   selectors: "Selectors",
   snapshots: "Snapshots",
   sessions: "Sessions",

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -192,6 +192,26 @@ agent-browser auth save my-app --url https://app.example.com/login \
 agent-browser auth login my-app    # fills + clicks, waits for form
 ```
 
+If credentials live in an external vault, use a configured credential provider
+plugin instead of putting secrets in the command line:
+
+```bash
+agent-browser plugin add agent-browser-plugin-vault --name vault
+agent-browser plugin list
+agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+Plugins can also provide browser providers, launch mutators such as stealth
+setup, and arbitrary namespaced commands:
+
+```bash
+agent-browser --provider cloud-browser open https://example.com
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
+```
+
+`plugin run` is for `command.run` and custom capabilities. Core capabilities
+use their dedicated command paths.
+
 ### Persist session across runs
 
 ```bash
@@ -470,7 +490,7 @@ That pulls in:
 
 - `references/commands.md` — every command, flag, alias
 - `references/snapshot-refs.md` — deep dive on the snapshot + ref model
-- `references/authentication.md` — auth vault, credential handling
+- `references/authentication.md` — auth vault, credential plugins, credential handling
 - `references/trust-boundaries.md` — safety rules for driving a real browser
 - `references/session-management.md` — persistence, multi-session workflows
 - `references/profiling.md` — Chrome DevTools tracing and profiling

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -199,6 +199,7 @@ plugin instead of putting secrets in the command line:
 agent-browser plugin add agent-browser-plugin-vault --name vault
 agent-browser plugin list
 agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login --username-selector "#email" --password-selector "#password"
 ```
 
 Plugins can also provide browser providers, launch mutators such as stealth

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -210,7 +210,7 @@ agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url"
 ```
 
 `plugin run` is for `command.run` and custom capabilities. Core capabilities
-use their dedicated command paths.
+and protocol request types use their dedicated command paths.
 
 ### Persist session across runs
 

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -10,6 +10,7 @@ Login flows, session persistence, OAuth, 2FA, and authenticated browsing.
 - [Persistent Profiles](#persistent-profiles)
 - [Session Persistence](#session-persistence)
 - [Basic Login Flow](#basic-login-flow)
+- [Plugins](#plugins)
 - [Saving Authentication State](#saving-authentication-state)
 - [Restoring Authentication](#restoring-authentication)
 - [OAuth / SSO Flows](#oauth--sso-flows)
@@ -139,6 +140,80 @@ agent-browser wait --load networkidle
 # Verify login succeeded
 agent-browser get url  # Should be dashboard, not login
 ```
+
+## Plugins
+
+Use credential provider plugins when credentials live in external vault software. Plugins are configured in `agent-browser.json` and run as external executables over the `agent-browser.plugin.v1` stdio JSON protocol.
+
+Add a plugin with `plugin add`. A plain `name` or `@scope/name` resolves from npm; `owner/repo` resolves from GitHub:
+
+```bash
+agent-browser plugin add agent-browser-plugin-vault --name vault
+agent-browser plugin add @company/agent-browser-plugin-vault --name vault
+agent-browser plugin add org/agent-browser-plugin-cloud-browser
+```
+
+```json
+{
+  "plugins": [
+    {
+      "name": "vault",
+      "command": "agent-browser-plugin-vault",
+      "capabilities": ["credential.read"]
+    },
+    {
+      "name": "cloud-browser",
+      "command": "agent-browser-plugin-cloud-browser",
+      "capabilities": ["browser.provider"]
+    },
+    {
+      "name": "stealth",
+      "command": "agent-browser-plugin-stealth",
+      "capabilities": ["launch.mutate"]
+    },
+    {
+      "name": "captcha",
+      "command": "agent-browser-plugin-captcha",
+      "capabilities": ["command.run", "captcha.solve"]
+    }
+  ]
+}
+```
+
+Inspect configured plugins before use:
+
+```bash
+agent-browser plugin list
+agent-browser plugin show vault
+```
+
+Resolve credentials just-in-time for one login:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+Use a plugin as a browser provider or a generic domain command:
+
+```bash
+agent-browser --provider cloud-browser open https://example.com
+agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
+```
+
+`plugin run` is for `command.run` and custom capabilities. Core capabilities
+use their dedicated command paths.
+
+Use `--url`, `--username-selector`, `--password-selector`, and `--submit-selector` on `auth login` to override plugin-provided metadata for the current login only.
+
+Gate plugin secret access separately from normal login automation:
+
+```bash
+agent-browser --confirm-actions plugin:vault:credential.read auth login my-app --credential-provider vault --item "My App"
+agent-browser --confirm-actions plugin:cloud-browser:browser.provider --provider cloud-browser open https://example.com
+agent-browser --confirm-actions plugin:stealth:launch.mutate open https://example.com
+```
+
+Do not put vault tokens or passwords in plugin command args. Use the vault vendor's own login/session mechanism or environment outside agent-browser config.
 
 ## Saving Authentication State
 

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -201,7 +201,7 @@ agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url"
 ```
 
 `plugin run` is for `command.run` and custom capabilities. Core capabilities
-use their dedicated command paths.
+and protocol request types use their dedicated command paths.
 
 Use `--url`, `--username-selector`, `--password-selector`, and `--submit-selector` on `auth login` to override plugin-provided metadata for the current login only.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -296,6 +296,35 @@ Array.from(links).map(a => a.href);
 EOF
 ```
 
+## Authentication and Plugins
+
+```bash
+agent-browser auth save <name> --url <url> --username <user> --password-stdin
+agent-browser auth login <name>          # Login using saved credentials
+agent-browser auth login <name> --credential-provider <plugin> [--item <ref>]
+agent-browser auth list                  # List saved auth profiles
+agent-browser auth show <name>           # Show profile metadata, no passwords
+agent-browser auth delete <name>         # Delete a saved profile
+agent-browser plugin add <ref>           # Add a plugin from npm or GitHub
+agent-browser plugin list                # List configured plugins
+agent-browser plugin show <name>         # Show one configured plugin
+agent-browser plugin run <name> <type> --payload <json>
+                                          # Run an arbitrary plugin request
+```
+
+Credential provider plugins run out-of-process over the
+`agent-browser.plugin.v1` stdio JSON protocol and must declare
+`credential.read`. Use `--confirm-actions plugin:<name>:credential.read`
+to require explicit approval before a plugin resolves secrets.
+
+Other capabilities use the same protocol:
+- `browser.provider`: `agent-browser --provider <name> open <url>`
+- `launch.mutate`: append local launch args, extensions, or init scripts
+- `command.run`: `agent-browser plugin run <name> <type> --payload <json>`
+
+`plugin run` is for `command.run` and custom capabilities. Core capabilities
+use their dedicated command paths.
+
 ## State Management
 
 ```bash
@@ -310,7 +339,7 @@ agent-browser --session <name> ...    # Isolated browser session
 agent-browser --json ...              # JSON output for parsing
 agent-browser --headed ...            # Show browser window (not headless)
 agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
-agent-browser -p <provider> ...       # Cloud browser provider (--provider)
+agent-browser -p <provider> ...       # Browser provider or configured provider plugin
 agent-browser --proxy <url> ...       # Use proxy server
 agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy
 agent-browser --headers <json> ...    # HTTP headers scoped to URL's origin
@@ -396,8 +425,9 @@ AGENT_BROWSER_EXTENSIONS="/ext1,/ext2"       # Comma-separated extension paths
 AGENT_BROWSER_INIT_SCRIPTS="/a.js,/b.js"     # Comma-separated init script paths
 AGENT_BROWSER_ENABLE="react-devtools"        # Comma-separated built-in init script features
 AGENT_BROWSER_HIDE_SCROLLBARS="false"        # Keep native scrollbars visible in headless Chromium screenshots
-AGENT_BROWSER_PROVIDER="browserbase"         # Cloud browser provider
+AGENT_BROWSER_PROVIDER="browserbase"         # Browser provider or configured provider plugin
 AGENT_BROWSER_STREAM_PORT="9223"             # Override WebSocket streaming port (default: OS-assigned)
 AGENT_BROWSER_CONFIG="./agent-browser.json"  # Custom config file
 AGENT_BROWSER_CDP="9222"                     # Connect daemon to CDP port or WebSocket URL
+AGENT_BROWSER_PLUGINS='[{"name":"vault","command":"agent-browser-plugin-vault","capabilities":["credential.read"]},{"name":"stealth","command":"agent-browser-plugin-stealth","capabilities":["launch.mutate"]}]'
 ```

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -301,7 +301,8 @@ EOF
 ```bash
 agent-browser auth save <name> --url <url> --username <user> --password-stdin
 agent-browser auth login <name>          # Login using saved credentials
-agent-browser auth login <name> --credential-provider <plugin> [--item <ref>]
+agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
+agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>]
 agent-browser auth list                  # List saved auth profiles
 agent-browser auth show <name>           # Show profile metadata, no passwords
 agent-browser auth delete <name>         # Delete a saved profile

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -323,7 +323,7 @@ Other capabilities use the same protocol:
 - `command.run`: `agent-browser plugin run <name> <type> --payload <json>`
 
 `plugin run` is for `command.run` and custom capabilities. Core capabilities
-use their dedicated command paths.
+and protocol request types use their dedicated command paths.
 
 ## State Management
 


### PR DESCRIPTION
- Add stdio plugin protocol with capability-scoped auth, browser provider, launch mutation, custom command flows
- Add `plugin add` DX for npm, scoped npm, and GitHub refs with manifest discovery and config updates
- Document plugin authoring, installation, policy gates, examples across docs and skills