### PR TITLE
feat(providers): add Firecrawl as a built-in browser provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1611,6 +1611,36 @@ When enabled, agent-browser connects to a Browserbase session instead of launchi
 
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview).
 
+### Firecrawl
+
+[Firecrawl](https://firecrawl.dev) provides a managed cloud browser (proxies, anti-bot, persistent login profiles, live view) via its Browser Sandbox. Use it when running agent-browser in environments where a local browser isn't feasible.
+
+To enable Firecrawl, use the `-p` flag:
+
+```bash
+export FIRECRAWL_API_KEY="fc-your-api-key"
+agent-browser -p firecrawl open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=firecrawl
+export FIRECRAWL_API_KEY="fc-your-api-key"
+agent-browser open https://example.com
+```
+
+Optional configuration via environment variables:
+
+| Variable                 | Description                                                        | Default                     |
+| ------------------------ | ------------------------------------------------------------------ | --------------------------- |
+| `FIRECRAWL_API_URL`      | Base API URL (for self-hosted Firecrawl)                           | `https://api.firecrawl.dev` |
+| `FIRECRAWL_PROFILE_NAME` | Persistent profile to load (cookies/localStorage/login state)      | —                           |
+
+When enabled, agent-browser creates a Firecrawl browser session (`POST /v2/browser`), connects to the returned CDP URL instead of launching a local browser, and deletes the session on close. All commands work identically.
+
+Get your API key from the [Firecrawl Dashboard](https://www.firecrawl.dev/app).
+
 ### Browser Use
 
 [Browser Use](https://browser-use.com) provides cloud browser infrastructure for AI agents. Use it when running agent-browser in environments where a local browser isn't available (serverless, CI/CD, etc.).

--- a/README.md
+++ b/README.md
@@ -1637,7 +1637,7 @@ Optional configuration via environment variables:
 | `FIRECRAWL_API_URL`      | Base API URL (for self-hosted Firecrawl)                           | `https://api.firecrawl.dev` |
 | `FIRECRAWL_PROFILE_NAME` | Persistent profile to load (cookies/localStorage/login state)      | —                           |
 
-When enabled, agent-browser creates a Firecrawl browser session (`POST /v2/browser`), connects to the returned CDP URL instead of launching a local browser, and deletes the session on close. All commands work identically.
+When enabled, agent-browser creates a Firecrawl browser session (`POST /v2/interact`), connects to the returned CDP URL instead of launching a local browser, and deletes the session on close. All commands work identically.
 
 Get your API key from the [Firecrawl Dashboard](https://www.firecrawl.dev/app).
 

--- a/cli/src/doctor/providers.rs
+++ b/cli/src/doctor/providers.rs
@@ -1,6 +1,6 @@
 //! Check remote browser providers: API key presence for Browserless,
-//! Browserbase, Browser Use, Kernel, AgentCore (AWS), Appium for iOS, and
-//! the AI Gateway chat key. Info-level unless the provider is selected
+//! Browserbase, Browser Use, Firecrawl, Kernel, AgentCore (AWS), Appium for
+//! iOS, and the AI Gateway chat key. Info-level unless the provider is selected
 //! via `AGENT_BROWSER_PROVIDER`.
 
 use std::env;
@@ -33,6 +33,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         ("browserless", &["BROWSERLESS_API_KEY"], "Browserless"),
         ("browserbase", &["BROWSERBASE_API_KEY"], "Browserbase"),
         ("browseruse", &["BROWSER_USE_API_KEY"], "Browser Use"),
+        ("firecrawl", &["FIRECRAWL_API_KEY"], "Firecrawl"),
         ("kernel", &["KERNEL_API_KEY"], "Kernel"),
     ];
 

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -1,7 +1,8 @@
 //! Browser provider connections for remote CDP sessions.
 //!
-//! Supports AgentCore, Browserbase, Browserless, Browser Use, and Kernel providers.
-//! Each provider returns a CDP WebSocket URL for connecting via BrowserManager.
+//! Supports AgentCore, Browserbase, Browserless, Browser Use, Firecrawl, and
+//! Kernel providers. Each provider returns a CDP WebSocket URL for connecting
+//! via BrowserManager.
 
 use serde_json::{json, Value};
 use std::env;
@@ -69,6 +70,15 @@ pub async fn connect_provider_with_plugins_and_options(
         }
         "browser-use" | "browseruse" => {
             let (url, session) = connect_browser_use().await?;
+            Ok(ProviderConnection {
+                ws_url: url,
+                session,
+                direct_page: false,
+                metadata: None,
+            })
+        }
+        "firecrawl" => {
+            let (url, session) = connect_firecrawl().await?;
             Ok(ProviderConnection {
                 ws_url: url,
                 session,
@@ -170,6 +180,21 @@ pub async fn close_provider_session_with_plugins(
                     .await;
             }
         }
+        "firecrawl" => {
+            if let Ok(api_key) = env::var("FIRECRAWL_API_KEY") {
+                let api_url = env::var("FIRECRAWL_API_URL")
+                    .unwrap_or_else(|_| "https://api.firecrawl.dev".to_string());
+                let _ = client
+                    .delete(format!(
+                        "{}/v2/browser/{}",
+                        api_url.trim_end_matches('/'),
+                        session.session_id
+                    ))
+                    .header("Authorization", format!("Bearer {}", api_key))
+                    .send()
+                    .await;
+            }
+        }
         "agentcore" => {
             // AgentCore session cleanup is handled via signed DELETE request
             let _ = close_agentcore_session(&session.session_id).await;
@@ -192,7 +217,7 @@ pub async fn connect_plugin_provider_with_plugins_and_options(
 ) -> Result<ProviderConnection, String> {
     if crate::plugins::find_plugin(plugins, provider_name).is_none() {
         return Err(format!(
-            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, or a configured plugin with browser.provider",
+            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, firecrawl, kernel, agentcore, or a configured plugin with browser.provider",
             provider_name
         ));
     }
@@ -388,6 +413,72 @@ async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), Stri
     let ws_url = format!("wss://connect.browser-use.com?apiKey={}", api_key);
 
     Ok((ws_url, None))
+}
+
+async fn connect_firecrawl() -> Result<(String, Option<ProviderSession>), String> {
+    let api_key = env::var("FIRECRAWL_API_KEY")
+        .map_err(|_| "FIRECRAWL_API_KEY environment variable is not set")?;
+    let api_url =
+        env::var("FIRECRAWL_API_URL").unwrap_or_else(|_| "https://api.firecrawl.dev".to_string());
+
+    let url = format!("{}/v2/browser", api_url.trim_end_matches('/'));
+
+    // Optional persistent profile (cookies/localStorage/login state) by name.
+    let mut body = json!({});
+    if let Ok(profile) = env::var("FIRECRAWL_PROFILE_NAME") {
+        if !profile.is_empty() {
+            body.as_object_mut()
+                .unwrap()
+                .insert("profile".to_string(), json!({ "name": profile }));
+        }
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Firecrawl request failed: {}", e))?;
+
+    let status = response.status();
+    let resp_body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Firecrawl response: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "Firecrawl API error ({}): {}",
+            status.as_u16(),
+            resp_body
+        ));
+    }
+
+    let json: Value = serde_json::from_str(&resp_body)
+        .map_err(|e| format!("Invalid Firecrawl response: {}", e))?;
+
+    let session_id = json
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let ws_url = json
+        .get("cdpUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Firecrawl response missing cdpUrl".to_string())?;
+
+    Ok((
+        ws_url,
+        Some(ProviderSession {
+            provider: "firecrawl".to_string(),
+            session_id,
+        }),
+    ))
 }
 
 async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -186,7 +186,7 @@ pub async fn close_provider_session_with_plugins(
                     .unwrap_or_else(|_| "https://api.firecrawl.dev".to_string());
                 let _ = client
                     .delete(format!(
-                        "{}/v2/browser/{}",
+                        "{}/v2/interact/{}",
                         api_url.trim_end_matches('/'),
                         session.session_id
                     ))
@@ -421,7 +421,7 @@ async fn connect_firecrawl() -> Result<(String, Option<ProviderSession>), String
     let api_url =
         env::var("FIRECRAWL_API_URL").unwrap_or_else(|_| "https://api.firecrawl.dev".to_string());
 
-    let url = format!("{}/v2/browser", api_url.trim_end_matches('/'));
+    let url = format!("{}/v2/interact", api_url.trim_end_matches('/'));
 
     // Optional persistent profile (cookies/localStorage/login state) by name.
     let mut body = json!({});

--- a/docs/src/app/providers/firecrawl/layout.tsx
+++ b/docs/src/app/providers/firecrawl/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("providers/firecrawl");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/providers/firecrawl/page.mdx
+++ b/docs/src/app/providers/firecrawl/page.mdx
@@ -1,0 +1,32 @@
+# Firecrawl
+
+[Firecrawl](https://firecrawl.dev) provides a managed cloud browser (proxies, anti-bot, persistent login profiles, live view) via its Browser Sandbox. Use it when running agent-browser in environments where a local browser isn't feasible, or when you want Firecrawl's infrastructure underneath agent-browser's automation.
+
+## Setup
+
+```bash
+export FIRECRAWL_API_KEY="fc-your-api-key"
+agent-browser -p firecrawl open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=firecrawl
+export FIRECRAWL_API_KEY="fc-your-api-key"
+agent-browser open https://example.com
+```
+
+The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
+
+When enabled, agent-browser creates a Firecrawl browser session (`POST /v2/browser`), connects to the returned CDP URL instead of launching a local browser, and deletes the session on close. All commands work identically.
+
+## Options
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FIRECRAWL_API_KEY` | — | Firecrawl API key (`fc-...`). Required. |
+| `FIRECRAWL_API_URL` | `https://api.firecrawl.dev` | Override for self-hosted Firecrawl. |
+| `FIRECRAWL_PROFILE_NAME` | — | Persistent profile to load (cookies/localStorage/login state), so you can log in once and reuse the session. |
+
+Get your API key from the [Firecrawl Dashboard](https://www.firecrawl.dev/app).

--- a/docs/src/app/providers/firecrawl/page.mdx
+++ b/docs/src/app/providers/firecrawl/page.mdx
@@ -19,7 +19,7 @@ agent-browser open https://example.com
 
 The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
 
-When enabled, agent-browser creates a Firecrawl browser session (`POST /v2/browser`), connects to the returned CDP URL instead of launching a local browser, and deletes the session on close. All commands work identically.
+When enabled, agent-browser creates a Firecrawl browser session (`POST /v2/interact`), connects to the returned CDP URL instead of launching a local browser, and deletes the session on close. All commands work identically.
 
 ## Options
 

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -57,6 +57,7 @@ export const navigation: NavSection[] = [
       { name: "Browser Use", href: "/providers/browser-use" },
       { name: "Browserbase", href: "/providers/browserbase" },
       { name: "Browserless", href: "/providers/browserless" },
+      { name: "Firecrawl", href: "/providers/firecrawl" },
       { name: "Kernel", href: "/providers/kernel" },
     ],
   },

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -31,6 +31,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "providers/browser-use": "Browser Use",
   "providers/browserbase": "Browserbase",
   "providers/browserless": "Browserless",
+  "providers/firecrawl": "Firecrawl",
   "providers/kernel": "Kernel",
   changelog: "Changelog",
 };


### PR DESCRIPTION
**Draft / RFC** — opening for discussion before polishing.

Adds [Firecrawl](https://firecrawl.dev) as a built-in `browser.provider`, alongside Browserbase / Browserless / Kernel / Browser Use / AgentCore. Firecrawl's Browser Sandbox returns a CDP WebSocket URL, so it slots into the existing provider model directly.

### What's here
- `cli/src/native/providers.rs` — `connect_firecrawl()`: `POST {FIRECRAWL_API_URL}/v2/browser` with `Authorization: Bearer $FIRECRAWL_API_KEY`, returns the response `cdpUrl`; optional `FIRECRAWL_PROFILE_NAME` for persistent login profiles. Session cleanup via `DELETE /v2/browser/{id}`. Wired into the provider match + the "unknown provider" message.
- `cli/src/doctor/providers.rs` — `FIRECRAWL_API_KEY` presence check.
- Docs — `providers/firecrawl` page, nav + page-title registration, README provider section.

Usage:
```bash
export FIRECRAWL_API_KEY=fc-...
agent-browser -p firecrawl open https://example.com
```

### Notes / open questions
- Mirrors the Browserbase/Kernel patterns (env-based config, `reqwest`, `ProviderSession` cleanup). No new deps.
- I have **not** been able to `cargo build`/`fmt` locally in my environment — relying on CI here; happy to adjust to match lint/test conventions.
- Dashboard provider icon (`packages/dashboard/public/providers/*.svg`) not included yet — can add if you'd like it in this PR.
- Context: there's also a standalone plugin (`firecrawl/agent-browser-plugin-firecrawl`) using the `browser.provider` + `command.run` plugin protocol; this PR is the in-core provider equivalent per the docs' "new providers can start as plugins, then graduate to core" guidance. Glad to keep it as a plugin instead if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)