### PR TITLE
fix: color additions and removals in snapshot diff output

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3528,6 +3528,32 @@ iOS Simulator (requires Xcode and Appium):
     );
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum DiffLineStyle {
+    Addition,
+    Removal,
+    Meta,
+    Context,
+}
+
+/// Classify a unified-diff line for coloring.
+///
+/// `similar::TextDiff::unified_diff()` emits change lines as `+line` / `-line`
+/// with no space after the sign, file headers as `+++`/`---`, and hunk headers
+/// as `@@`. Matching on `"+ "` / `"- "` (sign plus a space) therefore never
+/// matched a change line, so additions and removals rendered dim like context.
+fn classify_diff_line(line: &str) -> DiffLineStyle {
+    if line.starts_with("+++") || line.starts_with("---") || line.starts_with("@@") {
+        DiffLineStyle::Meta
+    } else if line.starts_with('+') {
+        DiffLineStyle::Addition
+    } else if line.starts_with('-') {
+        DiffLineStyle::Removal
+    } else {
+        DiffLineStyle::Context
+    }
+}
+
 fn print_snapshot_diff(data: &serde_json::Map<String, serde_json::Value>) {
     let changed = data
         .get("changed")
@@ -3539,12 +3565,12 @@ fn print_snapshot_diff(data: &serde_json::Map<String, serde_json::Value>) {
     }
     if let Some(diff) = data.get("diff").and_then(|v| v.as_str()) {
         for line in diff.lines() {
-            if line.starts_with("+ ") {
-                println!("{}", color::green(line));
-            } else if line.starts_with("- ") {
-                println!("{}", color::red(line));
-            } else {
-                println!("{}", color::dim(line));
+            match classify_diff_line(line) {
+                DiffLineStyle::Addition => println!("{}", color::green(line)),
+                DiffLineStyle::Removal => println!("{}", color::red(line)),
+                DiffLineStyle::Meta | DiffLineStyle::Context => {
+                    println!("{}", color::dim(line))
+                }
             }
         }
         let additions = data.get("additions").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -3610,8 +3636,20 @@ pub fn print_version() {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_storage_text, format_vitals_text};
+    use super::{classify_diff_line, format_storage_text, format_vitals_text, DiffLineStyle};
     use serde_json::json;
+
+    #[test]
+    fn classify_diff_line_handles_similar_unified_prefixes() {
+        // Prefixes as emitted by similar::TextDiff::unified_diff(): change lines
+        // carry the sign with no trailing space, headers use +++/---/@@.
+        assert_eq!(classify_diff_line("+DELTA"), DiffLineStyle::Addition);
+        assert_eq!(classify_diff_line("-beta"), DiffLineStyle::Removal);
+        assert_eq!(classify_diff_line(" alpha"), DiffLineStyle::Context);
+        assert_eq!(classify_diff_line("+++ after"), DiffLineStyle::Meta);
+        assert_eq!(classify_diff_line("--- before"), DiffLineStyle::Meta);
+        assert_eq!(classify_diff_line("@@ -1,3 +1,3 @@"), DiffLineStyle::Meta);
+    }
 
     #[test]
     fn test_format_stream_status_text_for_enabled_stream() {


### PR DESCRIPTION
## Summary

`snapshot --diff` (and `diff`) print additions and removals in the same dim gray as unchanged context lines, so changes are not visually distinguishable in the diff body.

## Current vs expected

For a one-line change, the unified diff is printed but every line renders dim, including the `+`/`-` change lines. Additions should be green and removals red, matching the trailing summary the command already prints (`N additions, N removals, N unchanged`).

## Root cause

`print_snapshot_diff` colored a line green when it started with `"+ "` and red when it started with `"- "` (the sign followed by a space). The diff string comes from `similar::TextDiff::unified_diff()`, which emits:

```
--- before
+++ after
@@ -1,3 +1,3 @@
 alpha
-beta
+DELTA
 gamma
```

Change lines carry the sign with no trailing space (`+DELTA`, `-beta`) and file headers use `+++`/`---`, so no line ever matched `"+ "` / `"- "` and everything fell through to the dim branch. I confirmed the exact prefixes by printing the raw `unified_diff()` output.

## Fix

Classify each line by the prefix `similar` actually emits: lines starting with `+` are additions (green) and `-` are removals (red), while the `+++`/`---`/`@@` headers and context lines stay dim. The classification is extracted into a pure `classify_diff_line` helper so the prefix rules are testable in isolation.

## Tests

A unit test pins the classifier against the exact prefixes from `unified_diff()` output (`+DELTA`, `-beta`, ` alpha`, `+++ after`, `--- before`, `@@ ... @@`), so a future change to the diff format that breaks coloring is caught. `cargo test --profile ci` passes.

## Notes

This is unrelated to #1394 ("diff always only displays additions"), which is about `diff snapshot` using an empty baseline when `--baseline` is not supplied. This PR only corrects how diff lines are colored; the same prefix rules apply whether a line is a real change or part of an all-additions diff.
