### PR TITLE
Fix --cdp reconnect for existing daemon

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,6 +79,10 @@ fn apply_hide_scrollbars_launch_option(
     }
 }
 
+fn should_send_cdp_launch_command(cmd: &serde_json::Value) -> bool {
+    cmd.get("action").and_then(|v| v.as_str()) != Some("launch")
+}
+
 fn attach_plugins_to_command(cmd: &mut serde_json::Value, plugins: &[plugins::PluginConfig]) {
     cmd["plugins"] = json!(plugins);
 }
@@ -1080,7 +1084,6 @@ fn main() {
 
     // Connect via CDP if --cdp flag is set
     // Accepts either a port number (e.g., "9222") or a full URL (e.g., "ws://..." or "wss://...")
-    // Skip when daemon already running — it already holds the CDP connection.
     if let Some(ref cdp_value) = flags.cdp {
         // Validate CDP value eagerly (even when daemon is already running) so
         // the user gets an immediate error for bad input instead of a silent no-op.
@@ -1140,7 +1143,7 @@ fn main() {
             })
         };
 
-        if !daemon_result.already_running {
+        if should_send_cdp_launch_command(&cmd) {
             let mut launch_cmd = launch_cmd;
 
             if flags.ignore_https_errors {
@@ -1654,6 +1657,20 @@ mod tests {
         let mut cli_true_cmd = json!({ "action": "launch" });
         apply_hide_scrollbars_launch_option(&mut cli_true_cmd, true, true);
         assert_eq!(cli_true_cmd["hideScrollbars"], true);
+    }
+
+    #[test]
+    fn test_should_send_cdp_launch_command_for_regular_commands() {
+        let cmd = json!({ "action": "navigate", "url": "https://example.com" });
+
+        assert!(should_send_cdp_launch_command(&cmd));
+    }
+
+    #[test]
+    fn test_should_not_send_cdp_launch_command_for_launch_commands() {
+        let cmd = json!({ "action": "launch", "cdpPort": 9223 });
+
+        assert!(!should_send_cdp_launch_command(&cmd));
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2221,9 +2221,12 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     let needs_relaunch = if let Some(ref mut mgr) = state.browser {
         let is_external = cdp_url.is_some() || cdp_port.is_some() || auto_connect;
         let was_external = mgr.is_cdp_connection();
+        let external_cdp_target_changed = (cdp_url.is_some() || cdp_port.is_some())
+            && !mgr.matches_cdp_target(cdp_url, cdp_port).await;
         let hash_changed = !is_external && state.launch_hash != Some(new_hash);
         let storage_state_requires_clean_launch = storage_state_owned.is_some() && !is_external;
         is_external != was_external
+            || external_cdp_target_changed
             || hash_changed
             || storage_state_requires_clean_launch
             || mgr.has_process_exited()

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -861,6 +861,26 @@ impl BrowserManager {
         &self.ws_url
     }
 
+    pub async fn matches_cdp_target(&self, cdp_url: Option<&str>, cdp_port: Option<u64>) -> bool {
+        if let Some(port) = cdp_port {
+            return u16::try_from(port)
+                .ok()
+                .is_some_and(|port| self.matches_local_cdp_port(port));
+        }
+
+        if let Some(url) = cdp_url {
+            return resolve_cdp_url(url)
+                .await
+                .is_ok_and(|ws_url| self.ws_url == ws_url);
+        }
+
+        false
+    }
+
+    fn matches_local_cdp_port(&self, port: u16) -> bool {
+        cdp_ws_url_matches_local_port(&self.ws_url, port)
+    }
+
     /// Returns the Chrome debug server address as "host:port".
     pub fn chrome_host_port(&self) -> &str {
         let stripped = self
@@ -1717,6 +1737,28 @@ async fn resolve_cdp_url(input: &str) -> Result<String, String> {
     ))
 }
 
+fn is_loopback_cdp_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]"
+}
+
+fn cdp_ws_url_matches_local_port(ws_url: &str, port: u16) -> bool {
+    let Ok(parsed) = url::Url::parse(ws_url) else {
+        return false;
+    };
+    let Some(current_port) = parsed.port_or_known_default() else {
+        return false;
+    };
+    if current_port != port {
+        return false;
+    }
+    parsed
+        .host_str()
+        .is_some_and(|host| is_loopback_cdp_host(host))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1777,6 +1819,35 @@ mod tests {
         assert!(TabRef::parse("-docs").is_err());
         assert!(TabRef::parse("docs!").is_err());
         assert!(TabRef::parse("docs space").is_err());
+    }
+
+    #[test]
+    fn test_cdp_ws_url_matches_local_port_for_loopback_hosts() {
+        assert!(cdp_ws_url_matches_local_port(
+            "ws://127.0.0.1:9223/devtools/browser/abc",
+            9223,
+        ));
+        assert!(cdp_ws_url_matches_local_port(
+            "ws://localhost:9223/devtools/browser/abc",
+            9223,
+        ));
+        assert!(cdp_ws_url_matches_local_port(
+            "ws://[::1]:9223/devtools/browser/abc",
+            9223,
+        ));
+    }
+
+    #[test]
+    fn test_cdp_ws_url_matches_local_port_rejects_different_or_remote_targets() {
+        assert!(!cdp_ws_url_matches_local_port(
+            "ws://127.0.0.1:9222/devtools/browser/abc",
+            9223,
+        ));
+        assert!(!cdp_ws_url_matches_local_port(
+            "ws://192.168.0.5:9223/devtools/browser/abc",
+            9223,
+        ));
+        assert!(!cdp_ws_url_matches_local_port("not-a-url", 9223));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Send the global `--cdp` launch request even when the daemon is already running, so regular commands can update the daemon's external CDP target.
- Avoid double-sending the launch request for explicit `launch` / `connect` commands.
- Relaunch the daemon browser manager when the requested external CDP port or URL differs from the current connection.

## Tests

- `cargo fmt -- --check`
- `cargo test should_send_cdp_launch_command --manifest-path Cargo.toml`
- `cargo test should_not_send_cdp_launch_command --manifest-path Cargo.toml`
- `cargo test cdp_ws_url_matches_local_port --manifest-path Cargo.toml`

Note: I also tried a full `cargo test`, but it did not finish locally after `native::parity_tests::test_all_documented_actions_are_handled` kept running with no further output.
