### PR TITLE
fix: add sandbox package publish metadata

### DIFF
--- a/packages/@agent-browser/sandbox/README.md
+++ b/packages/@agent-browser/sandbox/README.md
@@ -60,7 +60,7 @@ Set `AGENT_BROWSER_SNAPSHOT_ID` to boot from a prebuilt Vercel Sandbox snapshot.
 By default, this package installs the matching `agent-browser` version:
 
 ```ts
-agent-browser@0.28.0
+agent-browser@0.29.0
 ```
 
 Pass `installSpec: "latest"` or another npm spec to override that default.

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -35,6 +35,18 @@
     "browser-automation"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/agent-browser",
+    "directory": "packages/@agent-browser/sandbox"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/agent-browser/issues"
+  },
+  "homepage": "https://agent-browser.dev",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@vercel/sandbox": ">=1.0.0"
   },


### PR DESCRIPTION
- Add repository metadata required by npm provenance validation
- Mark the scoped sandbox package as public in publishConfig
- Update the sandbox README version example