### PR TITLE
Default sandbox system dependency installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,8 @@ const result = await withAgentBrowserSandbox(async (sandbox) => {
 
 Install `@agent-browser/sandbox` and `@vercel/sandbox` in the consuming app. See the [sandbox helper example](examples/sandbox/) for minimal Eve and Vercel Sandbox usage, or the [environments example](examples/environments/) for a full UI demo with a deploy-to-Vercel button.
 
+Fresh Vercel and Eve sandboxes install Chromium system dependencies by default. Pass `installSystemDependencies: false` only when your sandbox image already includes those libraries.
+
 ### Serverless (AWS Lambda)
 
 ```typescript

--- a/docs/src/app/next/page.mdx
+++ b/docs/src/app/next/page.mdx
@@ -10,7 +10,7 @@ pnpm add @agent-browser/sandbox @vercel/sandbox
 
 ## Server action
 
-The Vercel Sandbox runs Amazon Linux. Chromium requires system libraries that are not installed by default, so fresh sandboxes need a `dnf install` step before agent-browser can launch Chrome. Use a sandbox snapshot (below) to skip this entirely in production. The `@agent-browser/sandbox` helper handles the bootstrap and command execution.
+The Vercel Sandbox runs Amazon Linux. Chromium requires system libraries that are not installed by default, so fresh sandboxes need a `dnf install` step before agent-browser can launch Chrome. Use a sandbox snapshot (below) to skip this entirely in production. The `@agent-browser/sandbox` helper installs those system dependencies by default and handles command execution.
 
 ```ts
 "use server";

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -19,7 +19,7 @@ vercel env pull .env.local --yes
 pnpm run dev
 ```
 
-The app follows the project shape created by `eve init --channel-web-nextjs`. Its `agent/sandbox.ts` bootstrap installs `agent-browser` and Chrome once into the sandbox template. The `browser_snapshot` tool opens a URL and returns an accessibility snapshot to the agent.
+The app follows the project shape created by `eve init --channel-web-nextjs`. Its `agent/sandbox.ts` bootstrap installs Chromium system dependencies, `agent-browser`, and Chrome once into the sandbox template. The `browser_snapshot` tool opens a URL and returns an accessibility snapshot to the agent.
 
 ## Vercel Sandbox
 

--- a/examples/sandbox/eve/README.md
+++ b/examples/sandbox/eve/README.md
@@ -17,4 +17,4 @@ Open the local Next.js URL and ask the agent to inspect a page, for example:
 Inspect https://example.com and summarize what is visible.
 ```
 
-The sandbox bootstrap installs `agent-browser` and Chrome into the Vercel Sandbox template. The tool runs `agent-browser open` and `agent-browser snapshot` inside that sandbox, not in the Next.js runtime.
+The sandbox bootstrap installs Chromium system dependencies, `agent-browser`, and Chrome into the Vercel Sandbox template. The tool runs `agent-browser open` and `agent-browser snapshot` inside that sandbox, not in the Next.js runtime.

--- a/examples/sandbox/eve/agent/sandbox.ts
+++ b/examples/sandbox/eve/agent/sandbox.ts
@@ -4,9 +4,9 @@ import { vercel } from "eve/sandbox/vercel";
 
 export default defineSandbox({
   backend: vercel({ runtime: "node24", resources: { vcpus: 2 } }),
-  revalidationKey: () => agentBrowserRevalidationKey({ installSystemDependencies: true }),
+  revalidationKey: () => agentBrowserRevalidationKey(),
   async bootstrap({ use }) {
     const sandbox = await use();
-    await installAgentBrowser(sandbox, { installSystemDependencies: true });
+    await installAgentBrowser(sandbox);
   },
 });

--- a/packages/@agent-browser/sandbox/README.md
+++ b/packages/@agent-browser/sandbox/README.md
@@ -13,10 +13,10 @@ import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser
 
 export default defineSandbox({
   backend: vercel({ runtime: "node24", resources: { vcpus: 2 } }),
-  revalidationKey: () => agentBrowserRevalidationKey({ installSystemDependencies: true }),
+  revalidationKey: () => agentBrowserRevalidationKey(),
   async bootstrap({ use }) {
     const sandbox = await use();
-    await installAgentBrowser(sandbox, { installSystemDependencies: true });
+    await installAgentBrowser(sandbox);
   },
 });
 ```
@@ -52,6 +52,8 @@ const snapshot = await withAgentBrowserSandbox(async (sandbox) => {
   return result.stdout;
 });
 ```
+
+The Eve and Vercel helpers install browser system dependencies by default. Pass `installSystemDependencies: false` only when the sandbox image already provides Chromium's required libraries.
 
 Set `AGENT_BROWSER_SNAPSHOT_ID` to boot from a prebuilt Vercel Sandbox snapshot. Without a snapshot, the helper installs system dependencies, `agent-browser`, and Chrome on first boot.
 

--- a/packages/@agent-browser/sandbox/src/eve.ts
+++ b/packages/@agent-browser/sandbox/src/eve.ts
@@ -123,7 +123,7 @@ export function agentBrowserRevalidationKey(options: AgentBrowserInstallOptions 
     `bootstrap-${EVE_BOOTSTRAP_REVISION}`,
     resolveAgentBrowserInstallSpec(options),
     options.installBrowser === false ? "no-browser" : "browser",
-    options.installSystemDependencies === true ? "system-deps" : "no-system-deps",
+    options.installSystemDependencies === false ? "no-system-deps" : "system-deps",
   ].join(":");
 }
 
@@ -135,7 +135,7 @@ export async function installAgentBrowser(
   const installSpec = resolveAgentBrowserInstallSpec(options);
   const commands = [];
 
-  if (options.installSystemDependencies === true) {
+  if (options.installSystemDependencies !== false) {
     commands.push(buildLinuxSystemDependenciesCommand());
   }
 

--- a/packages/@agent-browser/sandbox/src/shared.ts
+++ b/packages/@agent-browser/sandbox/src/shared.ts
@@ -7,6 +7,7 @@ export type AgentBrowserArgs = readonly string[];
 export interface AgentBrowserInstallOptions {
   readonly installBrowser?: boolean;
   readonly installSpec?: string;
+  /** Install Chromium system libraries before installing agent-browser. Defaults to true. */
   readonly installSystemDependencies?: boolean;
 }
 

--- a/packages/@agent-browser/sandbox/test/eve.test.mjs
+++ b/packages/@agent-browser/sandbox/test/eve.test.mjs
@@ -10,8 +10,12 @@ import {
 
 test("builds Eve revalidation key from install options", () => {
   assert.equal(
-    agentBrowserRevalidationKey({ installSpec: "agent-browser@1.2.3", installSystemDependencies: true }),
+    agentBrowserRevalidationKey({ installSpec: "agent-browser@1.2.3" }),
     "agent-browser:bootstrap-3:agent-browser@1.2.3:browser:system-deps",
+  );
+  assert.equal(
+    agentBrowserRevalidationKey({ installSpec: "agent-browser@1.2.3", installSystemDependencies: false }),
+    "agent-browser:bootstrap-3:agent-browser@1.2.3:browser:no-system-deps",
   );
 });
 
@@ -32,7 +36,7 @@ test("installs agent-browser in an Eve sandbox", async () => {
     },
   };
 
-  await installAgentBrowser(sandbox, { installSpec: "agent-browser@1.2.3", installSystemDependencies: true });
+  await installAgentBrowser(sandbox, { installSpec: "agent-browser@1.2.3" });
 
   assert.equal(commands.length, 3);
   assert.match(commands[0], /^if command -v apt-get/);
@@ -43,6 +47,24 @@ test("installs agent-browser in an Eve sandbox", async () => {
   assert.match(commands[0], /sudo dnf install -y --skip-broken -- glib2 nss/);
   assert.equal(commands[1], "npm install -g agent-browser@1.2.3");
   assert.equal(commands[2], "agent-browser install");
+});
+
+test("skips Eve system dependencies when explicitly disabled", async () => {
+  const commands = [];
+  const sandbox = {
+    id: "sandbox-1",
+    async run({ command }) {
+      commands.push(command);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+
+  await installAgentBrowser(sandbox, {
+    installSpec: "agent-browser@1.2.3",
+    installSystemDependencies: false,
+  });
+
+  assert.deepEqual(commands, ["npm install -g agent-browser@1.2.3", "agent-browser install"]);
 });
 
 test("runs agent-browser through ctx.getSandbox", async () => {

--- a/packages/@agent-browser/sandbox/test/vercel.test.mjs
+++ b/packages/@agent-browser/sandbox/test/vercel.test.mjs
@@ -94,6 +94,26 @@ test("creates and bootstraps a fresh Vercel sandbox", async () => {
   assert.deepEqual(calls[3], ["agent-browser", ["install"]]);
 });
 
+test("skips Vercel system dependencies when explicitly disabled", async () => {
+  const calls = [];
+  const sandbox = {
+    async runCommand(command, args) {
+      calls.push([command, args]);
+      return commandResult();
+    },
+  };
+
+  await installAgentBrowserInVercelSandbox(sandbox, {
+    installSpec: "agent-browser@1.2.3",
+    installSystemDependencies: false,
+  });
+
+  assert.deepEqual(calls, [
+    ["npm", ["install", "-g", "agent-browser@1.2.3"]],
+    ["agent-browser", ["install"]],
+  ]);
+});
+
 test("rejects invalid Vercel system dependency names", async () => {
   const calls = [];
   const sandbox = {

--- a/skill-data/vercel-sandbox/SKILL.md
+++ b/skill-data/vercel-sandbox/SKILL.md
@@ -13,7 +13,7 @@ Run agent-browser + headless Chrome inside ephemeral Vercel Sandbox microVMs. A 
 pnpm add @agent-browser/sandbox @vercel/sandbox
 ```
 
-The sandbox VM needs system dependencies for Chromium plus agent-browser itself. The `@agent-browser/sandbox` helpers install them for fresh sandboxes and use sandbox snapshots (below) for sub-second startup.
+The sandbox VM needs system dependencies for Chromium plus agent-browser itself. The `@agent-browser/sandbox` helpers install them by default for fresh sandboxes and use sandbox snapshots (below) for sub-second startup. Pass `installSystemDependencies: false` only when the sandbox image already provides Chromium's required libraries.
 
 ## Core Pattern
 


### PR DESCRIPTION
- Default Eve installs to include Chromium system deps unless disabled
- Keep Vercel opt-out behavior covered by tests
- Update sandbox docs and examples for simpler setup