### PR TITLE
Prepare v0.29.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # agent-browser
 
-## 0.29.0
+## 0.29.1
 
 <!-- release:start -->
+### Improvements
+
+- Defaulted **sandbox system dependency installs** so the Eve and Vercel sandbox helpers install Chromium's required libraries unless explicitly disabled, making first-run sandbox setup simpler (#1469)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.29.0
+
 ### New Features
 
 - **Sandbox package** - Added `@agent-browser/sandbox` with shared, Eve, and Vercel Sandbox helpers, example projects, and docs for running agent-browser in hosted sandbox environments (#1465)
@@ -15,7 +26,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.28.0
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.29.1
+
+<p className="text-[#888] text-sm">June 20, 2026</p>
+
+### Improvements
+
+- Defaulted **sandbox system dependency installs** so the Eve and Vercel sandbox helpers install Chromium's required libraries unless explicitly disabled, making first-run sandbox setup simpler (#1469)
+
+---
+
 ## v0.29.0
 
 <p className="text-[#888] text-sm">June 20, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/sandbox/README.md
+++ b/packages/@agent-browser/sandbox/README.md
@@ -62,7 +62,7 @@ Set `AGENT_BROWSER_SNAPSHOT_ID` to boot from a prebuilt Vercel Sandbox snapshot.
 By default, this package installs the matching `agent-browser` version:
 
 ```ts
-agent-browser@0.29.0
+agent-browser@0.29.1
 ```
 
 Pass `installSpec: "latest"` or another npm spec to override that default.

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.29.0";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.29.1";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bump agent-browser packages and Cargo metadata to 0.29.1
- Add changelog entries for sandbox dependency install defaults
- Update sandbox package version pinning docs