### PR TITLE
Skip launch reconfigure when the daemon is already running

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1231,6 +1231,18 @@ fn main() {
         && flags.cdp.is_none()
         && flags.provider.is_none()
         && !flags.auto_connect
+        // Skip when the daemon was already running. It already holds a
+        // configured browser, and these launch-time options are reported as
+        // ignored above (see the `already_running` warning). Re-sending a
+        // `launch` command here carries this invocation's options (e.g. an
+        // empty `args` list when `--args` was only passed to the original
+        // `open`), which differs from the running browser's launch hash and
+        // forces a needless close + relaunch. On hosts that require specific
+        // launch flags to start Chrome at all (e.g. `--no-sandbox` on headless
+        // Linux/containers), that relaunch starts Chrome without them and
+        // wedges the daemon. Mirrors the same guard on the --auto-connect,
+        // --cdp, and --provider launch paths (#962).
+        && !daemon_result.already_running
     {
         let mut launch_cmd = json!({
             "id": gen_id(),


### PR DESCRIPTION
## Summary

When the daemon is already running, any command that does **not** repeat the original `open`'s launch options (the normal case — you pass `--args`/`--executable-path`/etc. once to `open`, then run bare `snapshot`/`get`/`click`) silently triggers a **close + relaunch** of Chrome. If the host requires specific flags to start Chrome at all (e.g. `--no-sandbox` on headless Linux, containers, or CI), the relaunch starts Chrome **without** them, the launch never completes, and the daemon wedges — so every subsequent command hangs indefinitely.

## Root cause

Every non-trivial command first sends an implicit `launch` command to the daemon. `handle_launch` compares a hash of *this invocation's* `LaunchOptions` against the running browser's stored hash (`cli/src/native/actions.rs`):

```rust
let hash_changed = !is_external && state.launch_hash != Some(new_hash);
// ...
if needs_relaunch { close_current_browser(state).await?; /* then relaunch */ }
```

The three other launch paths in `main.rs` — `--auto-connect`, `--cdp`, and `--provider` — are already guarded with `&& !daemon_result.already_running` (#962). The **local-browser** launch/configure path was not. So when a follow-up command reaches that block (it fires whenever e.g. `--executable-path` is set, including via `AGENT_BROWSER_EXECUTABLE_PATH`), it re-sends a `launch` carrying this invocation's options. With `--args` omitted, `args` is `[]`, the hash differs from the browser launched with `[--no-sandbox]`, and the daemon kills the healthy Chrome and relaunches it without `--no-sandbox`.

This also contradicts what the CLI already prints one block earlier:

```
⚠ --args ignored: daemon already running. Use 'agent-browser close' first to restart with new options.
```

The flags are reported as *ignored*, yet they were still driving a relaunch.

## Reproduction (headless Linux aarch64, external Chromium)

```bash
export AGENT_BROWSER_EXECUTABLE_PATH=/path/to/chromium   # arm64 has no Chrome for Testing build
agent-browser open https://example.com --args "--no-sandbox"   # ✓ works
agent-browser get url                                          # hangs forever (before this PR)
```

On the wedged daemon: the daemon→Chrome CDP socket goes to `CLOSE-WAIT`, Chrome's debug port stops listening, and the daemon never recovers.

<details>
<summary>Daemon log with temporary instrumentation (AGENT_BROWSER_DEBUG=1), paths redacted</summary>

```
[daemon] Debug logging started for session: default
# --- agent-browser open https://example.com --args "--no-sandbox" ---
[DIAG] action=launch    skip_launch=true  needs_launch=false
[DIAG] action=navigate  has_process_exited=false is_connection_alive=true
[DIAG] action=navigate  skip_launch=false needs_launch=false
# open succeeds; browser + CDP port healthy

# --- agent-browser get url   (no --args this time) ---
[DIAG] action=launch    skip_launch=true  needs_launch=false
[DIAG handle_launch] new_hash=9936...560 stored_hash=Some(10229...914) hash_changed=true cmd_args=[] -> needs_relaunch=true
[DIAG handle_launch] closing browser then relaunching with args=[]
[cdp] WebSocket Error: WebSocket protocol error: Connection reset without closing handshake
# Chrome was just relaunched WITHOUT --no-sandbox -> never comes up -> daemon wedged -> command hangs
```

(`[DIAG ...]` lines are temporary `eprintln!`s added only to diagnose this; they are **not** part of the patch. `stored_hash` is the hash of the running browser launched with `args=[--no-sandbox]`; `new_hash` is from the bare `get url` invocation with `cmd_args=[]`.)

</details>

## Fix

Add `&& !daemon_result.already_running` to the local-browser launch/configure condition in `main.rs`, mirroring the guard already used on the `--auto-connect`, `--cdp`, and `--provider` paths. When the daemon is already running it keeps its existing browser and the launch-time options are ignored — exactly what the `already_running` warning already promises. The actual command still runs, and `execute_command`'s connection-liveness check (`has_process_exited() || !is_connection_alive()`) still relaunches when the browser genuinely died.

## Why it's safe

- Matches the documented "options ignored when daemon already running" behavior.
- Identical guard pattern to the three sibling launch paths (#962).
- A genuinely dead/exited browser is still relaunched via the existing liveness check in `execute_command`.
- Session reuse is preserved (verified: page/URL persists across commands instead of resetting to `about:blank`).

## MCP parity

The MCP server (`cli/src/mcp.rs`) executes every tool by spawning the CLI binary itself (`run_cli` → `env::current_exe()`), so it delegates through this same `main()` path and inherits the fix with no separate change. No new flags, commands, or output were added, so no `--help`/README/SKILL/docs updates are required.

## Testing

- `cargo fmt -- --check` and `cargo clippy -- -D warnings`: clean.
- `cargo test --bin agent-browser`: **800 passed, 0 failed.** The remaining browser-launching unit/parity tests (`native::actions::tests`, `native::parity_tests`) exercise a real Chrome launch and could not complete on the headless aarch64 host I tested on — Chrome cannot start there in their default configuration, so they retry and stall ("has been running for over 60 seconds"). That is an environment limitation independent of this one-line change (it touches only the CLI launch-skip condition, not those code paths); CI runs the full matrix on a working Chrome.
- Manual end-to-end on headless aarch64 (Ubuntu 20.04) with external Chromium: before the fix, `get url`/`snapshot`/`screenshot` after `open --args "--no-sandbox"` hang; after the fix the full `open → snapshot (refs) → screenshot` loop works and the browser is reused across commands.

## Related issues

Likely the same root failure (daemon wedges after the first command):
- #1437 — screenshot hangs at `Page.captureScreenshot`, then the daemon is wedged for subsequent commands (arm64)
- #1049 — CLI hangs / `os error 11` on Ubuntu VM
- #248 — ARM64: Chromium not available (why arm64 users must use `--executable-path`, which is what surfaces this bug)
