### PR TITLE
fix(kernel): send profile as object so KERNEL_PROFILE_NAME works

### DIFF
--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -390,6 +390,14 @@ async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), Stri
     Ok((ws_url, None))
 }
 
+fn kernel_profile_from_env() -> Option<Value> {
+    let profile = env::var("KERNEL_PROFILE_NAME").ok()?;
+    if profile.is_empty() {
+        return None;
+    }
+    Some(json!({ "name": profile, "save_changes": true }))
+}
+
 async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {
     let api_key = env::var("KERNEL_API_KEY").ok();
     let endpoint =
@@ -414,12 +422,10 @@ async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {
         "timeout_seconds": timeout_seconds,
     });
 
-    if let Ok(profile) = env::var("KERNEL_PROFILE_NAME") {
-        if !profile.is_empty() {
-            body.as_object_mut()
-                .unwrap()
-                .insert("profile".to_string(), json!(profile));
-        }
+    if let Some(profile) = kernel_profile_from_env() {
+        body.as_object_mut()
+            .unwrap()
+            .insert("profile".to_string(), profile);
     }
 
     let client = reqwest::Client::new();
@@ -878,6 +884,27 @@ mod tests {
         let result = rt.block_on(connect_provider("unknown-provider"));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Unknown provider"));
+    }
+
+    #[test]
+    fn test_kernel_profile_from_env_unset_or_empty() {
+        let guard = EnvGuard::new(&["KERNEL_PROFILE_NAME"]);
+        guard.remove("KERNEL_PROFILE_NAME");
+        assert_eq!(kernel_profile_from_env(), None);
+
+        guard.set("KERNEL_PROFILE_NAME", "");
+        assert_eq!(kernel_profile_from_env(), None);
+    }
+
+    #[test]
+    fn test_kernel_profile_from_env_is_object_not_string() {
+        let guard = EnvGuard::new(&["KERNEL_PROFILE_NAME"]);
+        guard.set("KERNEL_PROFILE_NAME", "my-profile");
+
+        assert_eq!(
+            kernel_profile_from_env(),
+            Some(json!({ "name": "my-profile", "save_changes": true })),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1473

## Summary

- `connect_kernel()` sent the create-browser `profile` field as a bare string; Kernel's API expects an object (`{ name, save_changes }`), so every open with `KERNEL_PROFILE_NAME` set failed with a 400 at JSON-decode time.
- Send `{ name, save_changes: true }` instead. `save_changes` defaults to `true` so cookies/logins persist across sessions, matching the documented profile behavior (the SDK default is `false`, which would load the profile but silently never persist).
- Extract a small `kernel_profile_from_env()` helper and add unit tests for the object shape and the unset/empty cases.

## Why

With `KERNEL_PROFILE_NAME` set, `agent-browser open` always failed:

```
✗ Kernel API error (400): can't decode JSON body: json: cannot unmarshal
  string into Go struct field BrowserRequest.profile of type map[string]json.RawMessage
```

The API expects the `@onkernel/sdk` `BrowserProfile` shape (`{ id?, name?, save_changes? }`), not a string. Posting to `POST /browsers` directly with the **same pre-existing profile**, varying only the `profile` field:

| `profile` value | Status |
|---|---|
| `"my-profile"` (string, old behavior) | **400** `cannot unmarshal string into ... profile` |
| `{ "name": "my-profile", "save_changes": true }` (this PR) | **200**, browser created |

So the string is rejected at decode time regardless of whether the profile exists — purely a serialization mismatch.

## Test plan

- [x] `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- [x] `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings` (clean)
- [x] `cargo test --manifest-path cli/Cargo.toml` — new unit tests pass:
  - `test_kernel_profile_from_env_is_object_not_string`
  - `test_kernel_profile_from_env_unset_or_empty`
- [x] End-to-end against a real Kernel account with a pre-created profile:
  - `KERNEL_PROFILE_NAME=<profile> agent-browser open …` now returns 200 (was 400)
  - Wrote `localStorage` in session A, closed, reopened the same profile in session B → value persisted (confirms `save_changes: true`)
