### PR TITLE
feat(dashboard): add System theme option and default to system

### DIFF
--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn("font-sans antialiased", geist.variable)} suppressHydrationWarning>
       <body>
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <JotaiProvider>
             <TooltipProvider>{children}</TooltipProvider>
           </JotaiProvider>

--- a/packages/dashboard/src/components/theme-toggle.tsx
+++ b/packages/dashboard/src/components/theme-toggle.tsx
@@ -1,23 +1,63 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
-import { Moon, Sun } from "lucide-react";
+import { Monitor, Moon, Sun } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+const THEMES = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+] as const;
 
 export function ThemeToggle() {
-  const { resolvedTheme, setTheme } = useTheme();
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // next-themes resolves the theme on the client, so wait until mounted to
+  // render the active-state icon and avoid a hydration mismatch.
+  useEffect(() => setMounted(true), []);
+
+  // Reflect the user's selection: the monitor icon when following the system
+  // preference, otherwise the icon for the currently resolved theme.
+  const TriggerIcon =
+    !mounted || theme === "system"
+      ? Monitor
+      : resolvedTheme === "dark"
+        ? Moon
+        : Sun;
 
   return (
-    <button
-      type="button"
-      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-      className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-      title={resolvedTheme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-    >
-      {resolvedTheme === "dark" ? (
-        <Sun className="size-3" />
-      ) : (
-        <Moon className="size-3" />
-      )}
-    </button>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        type="button"
+        className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none"
+        title="Change theme"
+      >
+        <TriggerIcon className="size-3" />
+        <span className="sr-only">Change theme</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-32">
+        <DropdownMenuRadioGroup
+          value={mounted ? theme : undefined}
+          onValueChange={setTheme}
+        >
+          {THEMES.map(({ value, label, icon: Icon }) => (
+            <DropdownMenuRadioItem key={value} value={value}>
+              <Icon className="size-3.5" />
+              {label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Summary

Two related changes to the dashboard's color theme (this is about the **dashboard management UI**, not the automated/controlled browser):

1. **Add a System option** to the theme switcher so the UI can follow the OS color scheme — alongside the existing Light and Dark.
2. **Default to `system`** instead of forcing dark, so a fresh install respects `prefers-color-scheme`.

The two are in separate commits so the additive change (1) can be taken independently of the default change (2).

## Problem

`ThemeProvider` was already configured with `enableSystem` (and `defaultTheme="dark"`) in `src/app/layout.tsx`, so `next-themes` fully supported a `system` theme. However, the toggle never exposed it:

```tsx
// before — src/components/theme-toggle.tsx
const { resolvedTheme, setTheme } = useTheme();
// ...
onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
```

Because the button always wrote an explicit `light`/`dark` value derived from `resolvedTheme`, a user could never select — or get back to — the `system` setting. The capability existed in the provider but had no UI affordance, and the default forced dark regardless of the OS preference.

## Changes

**Commit 1 — add the System option** (`theme-toggle.tsx`)

Replace the binary toggle button with a small **Light / Dark / System** dropdown, built on the dashboard's existing `DropdownMenu` UI primitives (`DropdownMenuRadioGroup` / `DropdownMenuRadioItem`):

- The trigger keeps the same compact icon-button styling and placement in the session-tree header.
- The trigger icon reflects the current selection: the **Monitor** icon when following the system preference, otherwise the **Sun**/**Moon** icon for the currently resolved theme.
- A `mounted` guard is used because `next-themes` only resolves the theme on the client — this avoids a hydration mismatch on the active-state icon and the radio selection.

**Commit 2 — default theme to `system`** (`layout.tsx`)

`defaultTheme="dark"` → `defaultTheme="system"`. Light is already a first-class theme here (a full token set in `globals.css`, a light Shiki theme, and light JSON-syntax variants), so following the OS by default won't drop anyone into an unfinished UI.

### Behavior change

Commit 2 is a behavior change, not purely additive: users who never explicitly picked a theme will switch from forced-dark to following their OS. Anyone who has chosen Light or Dark in the switcher keeps their choice (next-themes persists explicit selections). If you'd rather keep dark as the default, commit 1 stands on its own.

## Testing

- `tsc --noEmit` — passes
- `next build` — compiles successfully and prerenders pages without errors
- Manual (inception 🙂): ran the dashboard locally and drove it with **agent-browser itself** (built from this repo's Rust CLI) to exercise the switcher — opening the menu and selecting each option. Light, Dark, and System are all selectable; selecting System tracks the OS scheme and the trigger icon updates accordingly. The accessibility tree exposes the three options as `menuitemradio` with correct `checked` state.

## Screenshots

**The new switcher across all three states** — the trigger icon (Moon / Sun / Monitor) and the checkmark both follow the selection:

<img width="1278" height="330" alt="theme-dropdown" src="https://github.com/user-attachments/assets/0503c0a3-2d8f-4609-ae9d-cb1bb9dc1d5e" />

**The dashboard management UI with the theme applied** — System resolved to dark here, following the OS:

<img width="1324" height="341" alt="theme-applied" src="https://github.com/user-attachments/assets/bb7bda55-96fd-4908-8bfb-84234032603b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
