### PR TITLE
Fix doctor hang during browser close

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -310,6 +310,7 @@ pub struct BrowserManager {
 const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const LIGHTPANDA_CDP_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(10);
+const BROWSER_CLOSE_CDP_TIMEOUT: Duration = Duration::from_secs(2);
 
 impl BrowserManager {
     pub async fn launch(options: LaunchOptions, engine: Option<&str>) -> Result<Self, String> {
@@ -806,12 +807,12 @@ impl BrowserManager {
             // without shutting down the user's browser.
             let _ = self
                 .client
-                .send_command_no_params("Browser.close", None)
+                .send_command_with_timeout("Browser.close", None, None, BROWSER_CLOSE_CDP_TIMEOUT)
                 .await;
         }
 
         if let Some(mut process) = self.browser_process.take() {
-            let timeout = std::time::Duration::from_secs(5);
+            let timeout = Duration::from_secs(5);
             let _ = tokio::task::spawn_blocking(move || {
                 process.wait_or_kill(timeout);
             })

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -16,6 +16,14 @@ pub struct ChromeProcess {
 
 impl ChromeProcess {
     pub fn kill(&mut self) {
+        #[cfg(windows)]
+        {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &self.child.id().to_string(), "/T", "/F"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
         let _ = self.child.kill();
         // On Unix, kill the entire process group to ensure Chrome helper
         // processes (GPU, renderer, utility, crashpad) are also terminated.

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
@@ -17,6 +18,7 @@ type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<CdpMessage>>>>;
 /// Interval between WebSocket ping frames sent to keep the connection alive
 /// through intermediate proxies (reverse proxies, load balancers, service meshes).
 const WS_KEEPALIVE_INTERVAL_SECS: u64 = 30;
+const DEFAULT_CDP_COMMAND_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Raw incoming CDP message (text) broadcast to all subscribers.
 /// Used by the inspect proxy to forward responses and events to DevTools.
@@ -209,6 +211,22 @@ impl CdpClient {
         params: Option<Value>,
         session_id: Option<&str>,
     ) -> Result<Value, String> {
+        self.send_command_with_timeout(
+            method,
+            params,
+            session_id,
+            DEFAULT_CDP_COMMAND_RESPONSE_TIMEOUT,
+        )
+        .await
+    }
+
+    pub async fn send_command_with_timeout(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        session_id: Option<&str>,
+        response_timeout: Duration,
+    ) -> Result<Value, String> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
 
         let cmd = CdpCommand {
@@ -236,7 +254,7 @@ impl CdpClient {
                 .map_err(|e| format!("Failed to send CDP command: {}", e))?;
         }
 
-        let response = match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
+        let response = match tokio::time::timeout(response_timeout, rx).await {
             Ok(Ok(resp)) => resp,
             Ok(Err(_)) => return Err("CDP response channel closed".to_string()),
             Err(_) => {
@@ -358,4 +376,53 @@ fn enable_tcp_keepalive(stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::T
     let keepalive = keepalive.with_interval(std::time::Duration::from_secs(10));
 
     let _ = sock.set_tcp_keepalive(&keepalive);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+    use tokio_tungstenite::tungstenite::Message;
+
+    #[tokio::test]
+    async fn send_command_with_timeout_cleans_pending_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (seen_tx, seen_rx) = oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            if let Some(Ok(Message::Text(text))) = ws.next().await {
+                let sent: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(sent["method"], "Browser.close");
+                let _ = seen_tx.send(());
+            }
+            std::future::pending::<()>().await
+        });
+
+        let client = CdpClient::connect(&format!("ws://{addr}/devtools/browser/test"))
+            .await
+            .unwrap();
+        let err = tokio::time::timeout(
+            Duration::from_secs(2),
+            client.send_command_with_timeout(
+                "Browser.close",
+                None,
+                None,
+                Duration::from_millis(100),
+            ),
+        )
+        .await
+        .expect("custom CDP timeout should fire before the outer timeout")
+        .unwrap_err();
+
+        assert_eq!(err, "CDP command timed out: Browser.close");
+        seen_rx.await.unwrap();
+        assert!(client.pending.lock().await.is_empty());
+
+        server.abort();
+    }
 }

--- a/cli/tests/doctor_cli.rs
+++ b/cli/tests/doctor_cli.rs
@@ -6,6 +6,10 @@
 //! inspects a throwaway directory and never touches the user's real state.
 
 use std::process::Command;
+#[cfg(windows)]
+use std::process::{Child, Output, Stdio};
+#[cfg(windows)]
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 const BIN: &str = env!("CARGO_BIN_EXE_agent-browser");
@@ -104,6 +108,108 @@ fn doctor_offline_quick_json_emits_valid_payload() {
             id,
             stdout
         );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn doctor_offline_json_live_launch_completes_on_windows() {
+    let tmp = TempDir::new().unwrap();
+    let socket_dir = tmp.path().join("sockets");
+
+    let child = build_doctor_cmd(&tmp, &["doctor", "--offline", "--json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to invoke agent-browser doctor");
+
+    let output = wait_with_timeout(child, Duration::from_secs(60), &socket_dir);
+    let code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        code == 0 || code == 1,
+        "unexpected exit code {}\nstdout:\n{}\nstderr:\n{}",
+        code,
+        stdout,
+        stderr,
+    );
+
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout was not JSON: {}\n---\n{}", e, stdout));
+    let checks = payload["checks"]
+        .as_array()
+        .expect("checks should be an array");
+    assert!(
+        checks.iter().any(|c| c["category"] == "Launch test")
+            || checks
+                .iter()
+                .any(|c| { c["id"].as_str().is_some_and(|id| id.starts_with("launch.")) }),
+        "doctor --offline --json should exercise the live launch check\n{}",
+        stdout
+    );
+}
+
+#[cfg(windows)]
+fn wait_with_timeout(mut child: Child, timeout: Duration, socket_dir: &std::path::Path) -> Output {
+    let started = Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .expect("failed to poll agent-browser doctor")
+            .is_some()
+        {
+            return child
+                .wait_with_output()
+                .expect("failed to collect agent-browser doctor output");
+        }
+
+        if started.elapsed() >= timeout {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &child.id().to_string(), "/T", "/F"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            let _ = child.kill();
+            kill_sidecar_daemons(socket_dir);
+            let output = child
+                .wait_with_output()
+                .expect("failed to collect timed-out agent-browser doctor output");
+            panic!(
+                "agent-browser doctor timed out after {:?}\nstdout:\n{}\nstderr:\n{}",
+                timeout,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(windows)]
+fn kill_sidecar_daemons(socket_dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(socket_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("pid") {
+            continue;
+        }
+        let Ok(pid) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let pid = pid.trim();
+        if pid.is_empty() {
+            continue;
+        }
+        let _ = Command::new("taskkill")
+            .args(["/PID", pid, "/T", "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
     }
 }
 


### PR DESCRIPTION
## Summary

- Bound the CDP `Browser.close` wait during locally launched browser cleanup so `agent-browser doctor` cannot sit on a stuck close response.
- Keep cleanup scoped to local browser launches; external `--cdp` / `--auto-connect` sessions still are not closed by `Browser.close`.
- Kill the full Chrome process tree on Windows when graceful close times out, matching the existing Unix process-group cleanup intent.
- Add a deterministic CDP timeout regression test plus a Windows-only `doctor --offline --json` smoke test for the live launch path.

Fixes #1461.

## Validation

- `cargo fmt -- --check`
- `cargo test --manifest-path cli/Cargo.toml send_command_with_timeout_cleans_pending_request`
- `cargo test doctor --manifest-path cli/Cargo.toml`
- `cargo test --test doctor_cli --manifest-path cli/Cargo.toml`
- `cargo test native::browser::tests --manifest-path cli/Cargo.toml`
- `cargo clippy --manifest-path cli/Cargo.toml`

Note: the Windows debug instance was not provisioned in this environment, so the Windows-only smoke test was added but not executed locally.
