### PR TITLE
Prepare v0.31.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # agent-browser
 
-## 0.30.1
+## 0.31.0
 
 <!-- release:start -->
+### New Features
+
+- **Restore workflow** - Added `--restore`, `--restore-save`, restore validation flags, worktree-scoped `session id`, `session info`, and `--namespace` so agent runs can use stable, isolated, automatically restored browser state without managing state files by hand (#1486)
+
+### Improvements
+
+- Hardened **session lifecycle handling** with explicit daemon and browser compatibility checks, lifecycle status output, MCP support for restore options, and safer auto-save behavior that avoids overwriting good state after a failed restore or failed validation (#1486)
+
+### Bug Fixes
+
+- Fixed **restore lifecycle edge cases** around switching restore keys with a live browser, daemon configuration startup races, launch mode validation, and clearing restore failures after an explicit state load (#1486)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.30.1
+
 ### Bug Fixes
 
 - Fixed **URL waits** so `wait --url` and `waitforurl` honor glob patterns such as `**/dashboard` against the full active URL (#1483)
@@ -10,7 +29,6 @@
 ### Contributors
 
 - @gaearon
-<!-- release:end -->
 
 ## 0.30.0
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.31.0
+
+<p className="text-[#888] text-sm">June 25, 2026</p>
+
+### New Features
+
+- **Restore workflow** - Added `--restore`, `--restore-save`, restore validation flags, worktree-scoped `session id`, `session info`, and `--namespace` so agent runs can use stable, isolated, automatically restored browser state without managing state files by hand (#1486)
+
+### Improvements
+
+- Hardened **session lifecycle handling** with explicit daemon and browser compatibility checks, lifecycle status output, MCP support for restore options, and safer auto-save behavior that avoids overwriting good state after a failed restore or failed validation (#1486)
+
+### Bug Fixes
+
+- Fixed **restore lifecycle edge cases** around switching restore keys with a live browser, daemon configuration startup races, launch mode validation, and clearing restore failures after an explicit state load (#1486)
+
+---
+
 ## v0.30.1
 
 <p className="text-[#888] text-sm">June 24, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.30.1";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.31.0";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bump agent-browser, CLI, dashboard, and sandbox package versions to 0.31.0.
- Add 0.31.0 release notes covering the restore workflow and session lifecycle hardening.
- Move release extraction markers to the new changelog entry.