### PR TITLE
Trim key chord parts

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3720,6 +3720,10 @@ fn parse_key_chord(input: &str) -> (String, Option<i32>) {
     let mut key_parts: Vec<&str> = Vec::new();
 
     for part in &parts {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
         match part.to_lowercase().as_str() {
             "alt" => modifiers |= 1,
             "control" | "ctrl" => modifiers |= 2,
@@ -11209,6 +11213,13 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
     #[test]
     fn test_parse_key_chord_control_shift_a() {
         let (key, mods) = parse_key_chord("Control+Shift+a");
+        assert_eq!(key, "a");
+        assert_eq!(mods, Some(2 | 8));
+    }
+
+    #[test]
+    fn test_parse_key_chord_trims_parts() {
+        let (key, mods) = parse_key_chord(" Control + Shift + a ");
         assert_eq!(key, "a");
         assert_eq!(mods, Some(2 | 8));
     }


### PR DESCRIPTION
## Summary
- Trim whitespace around key chord parts before matching modifier names.
- Preserve existing behavior for plain keys and bare plus keys.
- Add regression coverage for spaced key chords like `Control + Shift + a`.

## Validation
- git diff --check
- Attempted: cargo test test_parse_key_chord --manifest-path cli/Cargo.toml, but this environment does not have cargo on PATH.
- rustfmt was also unavailable on PATH.