### PR TITLE
fix(stream): forward CDP commands and always send text on keyDown (#1453)

### DIFF
--- a/cli/src/native/stream/websocket.rs
+++ b/cli/src/native/stream/websocket.rs
@@ -307,14 +307,7 @@ async fn handle_client_message(msg: &str, client: &CdpClient, session_id: Option
             let _ = client
                 .send_command(
                     "Input.dispatchKeyEvent",
-                    Some(json!({
-                        "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("keyDown"),
-                        "key": parsed.get("key"),
-                        "code": parsed.get("code"),
-                        "text": parsed.get("text"),
-                        "windowsVirtualKeyCode": parsed.get("windowsVirtualKeyCode").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "modifiers": parsed.get("modifiers").and_then(|v| v.as_i64()).unwrap_or(0),
-                    })),
+                    Some(build_key_event_params(&parsed)),
                     session_id,
                 )
                 .await;
@@ -334,5 +327,63 @@ async fn handle_client_message(msg: &str, client: &CdpClient, session_id: Option
         }
         "status" => {}
         _ => {}
+    }
+}
+
+/// Build the `Input.dispatchKeyEvent` params from a parsed `input_keyboard` message.
+fn build_key_event_params(parsed: &Value) -> Value {
+    let mut params = json!({
+        "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("keyDown"),
+        "key": parsed.get("key"),
+        "code": parsed.get("code"),
+        "text": parsed.get("text"),
+        "windowsVirtualKeyCode": parsed.get("windowsVirtualKeyCode").and_then(|v| v.as_i64()).unwrap_or(0),
+        "modifiers": parsed.get("modifiers").and_then(|v| v.as_i64()).unwrap_or(0),
+    });
+    // CDP types `commands` as array<string>; forward only a well-formed array so
+    // a malformed value can't make CDP reject the whole keystroke (the result is
+    // discarded by the caller, so the failure would be silent).
+    if let Some(commands) = parsed
+        .get("commands")
+        .filter(|v| v.as_array().is_some_and(|a| a.iter().all(Value::is_string)))
+    {
+        params["commands"] = commands.clone();
+    }
+    params
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forwards_commands_to_cdp() {
+        let parsed = json!({
+            "eventType": "keyDown", "key": "a", "code": "KeyA",
+            "windowsVirtualKeyCode": 65, "modifiers": 4,
+            "commands": ["selectAll"]
+        });
+        let params = build_key_event_params(&parsed);
+        assert_eq!(params.get("commands"), Some(&json!(["selectAll"])));
+    }
+
+    #[test]
+    fn omits_commands_when_absent() {
+        let parsed = json!({ "eventType": "keyDown", "key": "a", "code": "KeyA" });
+        let params = build_key_event_params(&parsed);
+        assert!(params.get("commands").is_none());
+    }
+
+    #[test]
+    fn drops_malformed_commands() {
+        // Non-array, or array with a non-string element: dropped so the keystroke
+        // still dispatches instead of CDP rejecting the whole event.
+        for bad in [json!([1]), json!("selectAll"), json!([["nested"]])] {
+            let parsed = json!({ "eventType": "keyDown", "key": "a", "commands": bad });
+            assert!(
+                build_key_event_params(&parsed).get("commands").is_none(),
+                "should drop {bad}"
+            );
+        }
     }
 }

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -387,8 +387,10 @@ export function Viewport() {
       // CDP only processes a keyDown (navigation, editing commands, even arrow keys)
       // when a `text` field is present — omitting it makes CDP drop the event. So a
       // keyDown always carries text: the printable char, or "" for non-printable
-      // keys (arrows, Home, …) and for Ctrl/Meta chords where the char must not type.
-      const suppressText = e.ctrlKey || e.metaKey;
+      // keys (arrows, Home, …) and for Meta chords where the char must not type.
+      // Scoped to Meta (matches macKeyCommands): blanking text for Ctrl chords on
+      // Windows/Linux would strip the printable char without supplying a command.
+      const suppressText = e.metaKey;
       const text = eventType !== "keyDown"
         ? undefined
         : suppressText

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -45,6 +45,30 @@ import { activeSessionNameAtom, activePortAtom } from "@/store/sessions";
 
 const SCREENCAST_ENGINES = new Set(["chrome"]);
 
+// macOS routes Cmd-chord editing/navigation through native key bindings, which
+// CDP exposes via Input.dispatchKeyEvent's `commands`. A bare keyDown with the
+// Meta modifier is not enough for this command class (see issue #1453).
+function macKeyCommands(e: KeyboardEvent): string[] | undefined {
+  if (!e.metaKey) return undefined;
+  const shift = e.shiftKey;
+  // Shift and CapsLock uppercase a single-char `key` ("Z", "A"); named keys
+  // ("ArrowLeft", "Backspace") must stay as-is, so only fold single chars.
+  const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+  switch (key) {
+    case "a": return ["selectAll"];
+    case "c": return ["copy"];
+    case "x": return ["cut"];
+    case "v": return ["paste"];
+    case "z": return shift ? ["redo"] : ["undo"];
+    case "ArrowLeft": return [shift ? "moveToBeginningOfLineAndModifySelection" : "moveToBeginningOfLine"];
+    case "ArrowRight": return [shift ? "moveToEndOfLineAndModifySelection" : "moveToEndOfLine"];
+    case "ArrowUp": return [shift ? "moveToBeginningOfDocumentAndModifySelection" : "moveToBeginningOfDocument"];
+    case "ArrowDown": return [shift ? "moveToEndOfDocumentAndModifySelection" : "moveToEndOfDocument"];
+    case "Backspace": return ["deleteToBeginningOfLine"];
+    default: return undefined;
+  }
+}
+
 function cdpModifiers(e: React.MouseEvent | React.WheelEvent): number {
   let m = 0;
   if (e.altKey) m |= 1;
@@ -360,15 +384,23 @@ export function Viewport() {
   const dispatchKey = useCallback(
     (e: KeyboardEvent, eventType: string) => {
       const info = KEY_INFO[e.key];
-      const text = eventType === "keyDown"
-        ? (info?.text ?? (e.key.length === 1 ? e.key : undefined))
-        : undefined;
+      // CDP only processes a keyDown (navigation, editing commands, even arrow keys)
+      // when a `text` field is present — omitting it makes CDP drop the event. So a
+      // keyDown always carries text: the printable char, or "" for non-printable
+      // keys (arrows, Home, …) and for Ctrl/Meta chords where the char must not type.
+      const suppressText = e.ctrlKey || e.metaKey;
+      const text = eventType !== "keyDown"
+        ? undefined
+        : suppressText
+          ? ""
+          : (info?.text ?? (e.key.length === 1 ? e.key : ""));
       const keyCode = info?.keyCode ?? (e.key.length === 1 ? e.key.charCodeAt(0) : 0);
       let m = 0;
       if (e.altKey) m |= 1;
       if (e.ctrlKey) m |= 2;
       if (e.metaKey) m |= 4;
       if (e.shiftKey) m |= 8;
+      const commands = eventType === "keyDown" ? macKeyCommands(e) : undefined;
       sendInput({
         type: "input_keyboard",
         eventType,
@@ -377,6 +409,7 @@ export function Viewport() {
         text,
         windowsVirtualKeyCode: keyCode,
         modifiers: m,
+        ...(commands ? { commands } : {}),
       });
     },
     [sendInput],


### PR DESCRIPTION


Fixes #1453


The stream `input_keyboard` path couldn't trigger macOS native key bindings(Cmd+A/C/V/Z, line/doc navigation) — CDP applies these via the `commands` array, but the message dropped it. CDP also only processes a `keyDown` when `text` is present, so even plain arrow keys were no-ops in the viewport.


https://github.com/user-attachments/assets/48a76963-26df-4091-8ce5-ab1dcd40bc55



