### PR TITLE
Fix Android npm wrapper platform detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ agent-browser install --with-deps
 
 This exits nonzero if the package manager cannot install every required browser library.
 
+### Termux / Android
+
+On Termux, install with npm as usual. The wrapper reuses the matching Linux native binary and launches it through `grun`, so no separate Android native package is needed.
+
 ### Updating
 
 Upgrade to the latest version:
@@ -1418,6 +1422,7 @@ The daemon starts automatically on first command and persists between commands f
 | Linux ARM64 | Native Rust |
 | Linux x64   | Native Rust |
 | Windows x64 | Native Rust |
+| Termux / Android | Linux binary via `grun` |
 
 ## Usage with AI Agents
 

--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -8,62 +8,14 @@
  * binary directly (zero overhead).
  */
 
-import { spawn, execSync } from 'child_process';
+import { spawn } from 'child_process';
 import { existsSync, accessSync, chmodSync, constants } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { platform, arch } from 'os';
+import { getBinaryName, getExecutableCommand } from '../scripts/platform.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-// Detect if the system uses musl libc (e.g. Alpine Linux)
-function isMusl() {
-  if (platform() !== 'linux') return false;
-  try {
-    const result = execSync('ldd --version 2>&1 || true', { encoding: 'utf8' });
-    return result.toLowerCase().includes('musl');
-  } catch {
-    return existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1');
-  }
-}
-
-// Map Node.js platform/arch to binary naming convention
-function getBinaryName() {
-  const os = platform();
-  const cpuArch = arch();
-
-  let osKey;
-  switch (os) {
-    case 'darwin':
-      osKey = 'darwin';
-      break;
-    case 'linux':
-      osKey = isMusl() ? 'linux-musl' : 'linux';
-      break;
-    case 'win32':
-      osKey = 'win32';
-      break;
-    default:
-      return null;
-  }
-
-  let archKey;
-  switch (cpuArch) {
-    case 'x64':
-    case 'x86_64':
-      archKey = 'x64';
-      break;
-    case 'arm64':
-    case 'aarch64':
-      archKey = 'arm64';
-      break;
-    default:
-      return null;
-  }
-
-  const ext = os === 'win32' ? '.exe' : '';
-  return `agent-browser-${osKey}-${archKey}${ext}`;
-}
 
 function main() {
   const binaryName = getBinaryName();
@@ -101,8 +53,10 @@ function main() {
     }
   }
 
+  const command = getExecutableCommand(binaryPath, process.argv.slice(2));
+
   // Spawn the native binary with inherited stdio
-  const child = spawn(binaryPath, process.argv.slice(2), {
+  const child = spawn(command.executable, command.args, {
     stdio: 'inherit',
     windowsHide: false,
   });

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -67,6 +67,10 @@ agent-browser install --with-deps
 
 This exits nonzero if the package manager cannot install every required browser library.
 
+## Termux / Android
+
+On Termux, install with npm as usual. The wrapper reuses the matching Linux native binary and launches it through `grun`, so no separate Android native package is needed.
+
 ## Updating
 
 Upgrade to the latest version:

--- a/docs/src/app/page.mdx
+++ b/docs/src/app/page.mdx
@@ -19,7 +19,7 @@ npx agent-browser open example.com
 - **Observable**: [Video recording](/recording), [streaming](/streaming), [debugging](/debugging), [profiler](/profiler), and [diffing](/diffing) tools are built in
 - **Modern apps**: [Network control](/network), [React & Web Vitals](/react), [init scripts](/init-scripts), and [Next.js + Vercel](/next) workflows have first-class docs
 - **Stateful**: [Sessions](/sessions), profiles, auth state, cookies, storage, proxy, and security controls support long-running agents
-- **Cross-platform**: macOS, Linux, Windows with native binaries
+- **Cross-platform**: macOS, Linux, Windows, and Termux/Android with native binaries
 
 ## Works with
 
@@ -62,4 +62,4 @@ Daemon starts automatically and persists between commands.
 
 ## Platforms
 
-Native Rust binaries for macOS (ARM64, x64), Linux (ARM64, x64), and Windows (x64).
+Native Rust binaries for macOS (ARM64, x64), Linux (ARM64, x64), and Windows (x64). Termux/Android npm installs reuse the matching Linux binary through `grun`.

--- a/scripts/platform.js
+++ b/scripts/platform.js
@@ -1,0 +1,84 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { arch as currentArch, platform as currentPlatform } from 'os';
+
+export function isMusl(os = currentPlatform(), deps = {}) {
+  if (os !== 'linux') return false;
+
+  const exec = deps.execSync ?? execSync;
+  const exists = deps.existsSync ?? existsSync;
+
+  try {
+    const result = exec('ldd --version 2>&1 || true', { encoding: 'utf8' });
+    return result.toLowerCase().includes('musl');
+  } catch {
+    return exists('/lib/ld-musl-x86_64.so.1') || exists('/lib/ld-musl-aarch64.so.1');
+  }
+}
+
+export function getOsKey(os = currentPlatform(), musl = isMusl(os)) {
+  switch (os) {
+    case 'darwin':
+      return 'darwin';
+    case 'linux':
+      return musl ? 'linux-musl' : 'linux';
+    case 'android':
+      return 'linux';
+    case 'win32':
+      return 'win32';
+    default:
+      return null;
+  }
+}
+
+export function getArchKey(cpuArch = currentArch(), options = {}) {
+  switch (cpuArch) {
+    case 'x64':
+    case 'x86_64':
+      return 'x64';
+    case 'arm64':
+    case 'aarch64':
+      return options.winArm64Fallback ? 'x64' : 'arm64';
+    default:
+      return null;
+  }
+}
+
+export function getPlatformKey(options = {}) {
+  const os = options.platform ?? currentPlatform();
+  const cpuArch = options.arch ?? currentArch();
+  const osKey = getOsKey(os, options.isMusl ?? isMusl(os));
+  const archKey = getArchKey(cpuArch, {
+    winArm64Fallback: os === 'win32' && options.winArm64Fallback === true,
+  });
+
+  if (!osKey || !archKey) return null;
+  return `${osKey}-${archKey}`;
+}
+
+export function getBinaryName(options = {}) {
+  const os = options.platform ?? currentPlatform();
+  const platformKey = getPlatformKey(options);
+  if (!platformKey) return null;
+
+  const ext = os === 'win32' ? '.exe' : '';
+  return `agent-browser-${platformKey}${ext}`;
+}
+
+export function getExecutableCommand(binaryPath, args, os = currentPlatform()) {
+  if (os === 'android') {
+    return {
+      executable: 'grun',
+      args: [binaryPath, ...args],
+    };
+  }
+
+  return {
+    executable: binaryPath,
+    args,
+  };
+}
+
+export function shouldOptimizeGlobalBin(os = currentPlatform()) {
+  return os !== 'android';
+}

--- a/scripts/platform.test.mjs
+++ b/scripts/platform.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getBinaryName,
+  getExecutableCommand,
+  getPlatformKey,
+  shouldOptimizeGlobalBin,
+} from './platform.js';
+
+test('maps Android to the Linux binary artifact', () => {
+  assert.equal(
+    getBinaryName({ platform: 'android', arch: 'arm64', isMusl: false }),
+    'agent-browser-linux-arm64'
+  );
+  assert.equal(
+    getBinaryName({ platform: 'android', arch: 'arm64', isMusl: false, winArm64Fallback: true }),
+    'agent-browser-linux-arm64'
+  );
+  assert.equal(
+    getPlatformKey({ platform: 'android', arch: 'aarch64', isMusl: false }),
+    'linux-arm64'
+  );
+});
+
+test('runs Android binaries through grun', () => {
+  assert.deepEqual(getExecutableCommand('/pkg/bin/agent-browser-linux-arm64', ['--version'], 'android'), {
+    executable: 'grun',
+    args: ['/pkg/bin/agent-browser-linux-arm64', '--version'],
+  });
+});
+
+test('keeps the JavaScript wrapper active on Android global installs', () => {
+  assert.equal(shouldOptimizeGlobalBin('android'), false);
+});
+
+test('preserves existing Linux and macOS naming', () => {
+  assert.equal(
+    getBinaryName({ platform: 'linux', arch: 'x64', isMusl: false }),
+    'agent-browser-linux-x64'
+  );
+  assert.equal(
+    getBinaryName({ platform: 'linux', arch: 'arm64', isMusl: true }),
+    'agent-browser-linux-musl-arm64'
+  );
+  assert.equal(
+    getBinaryName({ platform: 'darwin', arch: 'arm64', isMusl: false }),
+    'agent-browser-darwin-arm64'
+  );
+});
+
+test('preserves Windows ARM64 postinstall fallback behavior when requested', () => {
+  assert.equal(
+    getBinaryName({ platform: 'win32', arch: 'arm64', isMusl: false, winArm64Fallback: true }),
+    'agent-browser-win32-x64.exe'
+  );
+  assert.equal(
+    getBinaryName({ platform: 'win32', arch: 'arm64', isMusl: false }),
+    'agent-browser-win32-arm64.exe'
+  );
+});
+
+test('returns null for unsupported platforms and architectures', () => {
+  assert.equal(getBinaryName({ platform: 'freebsd', arch: 'x64', isMusl: false }), null);
+  assert.equal(getBinaryName({ platform: 'linux', arch: 'riscv64', isMusl: false }), null);
+});

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -15,31 +15,18 @@ import { fileURLToPath } from 'url';
 import { platform, arch } from 'os';
 import { get } from 'https';
 import { execSync } from 'child_process';
+import { getBinaryName, getPlatformKey, shouldOptimizeGlobalBin } from './platform.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
 const binDir = join(projectRoot, 'bin');
 
-// Detect if the system uses musl libc (e.g. Alpine Linux)
-function isMusl() {
-  if (platform() !== 'linux') return false;
-  try {
-    const result = execSync('ldd --version 2>&1 || true', { encoding: 'utf8' });
-    return result.toLowerCase().includes('musl');
-  } catch {
-    return existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1');
-  }
-}
-
 // Platform detection
-const osKey = platform() === 'linux' && isMusl() ? 'linux-musl' : platform();
 // Windows ARM64 falls back to x64 binary (no native ARM64 build available).
 // x64 binaries run via Windows' built-in emulation on ARM64.
-const effectiveArch = platform() === 'win32' && arch() === 'arm64' ? 'x64' : arch();
-const platformKey = `${osKey}-${effectiveArch}`;
-const ext = platform() === 'win32' ? '.exe' : '';
-const binaryName = `agent-browser-${platformKey}${ext}`;
-const binaryPath = join(binDir, binaryName);
+const platformKey = getPlatformKey({ winArm64Fallback: true });
+const binaryName = getBinaryName({ winArm64Fallback: true });
+const binaryPath = binaryName ? join(binDir, binaryName) : null;
 
 // Package info
 const packageJson = JSON.parse(
@@ -49,7 +36,15 @@ const version = packageJson.version;
 
 // GitHub release URL
 const GITHUB_REPO = 'vercel-labs/agent-browser';
-const DOWNLOAD_URL = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${binaryName}`;
+const DOWNLOAD_URL = binaryName
+  ? `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${binaryName}`
+  : null;
+
+function showLocalBuildInstructions() {
+  console.log('To build the native binary locally:');
+  console.log('  1. Install Rust: https://rustup.rs');
+  console.log('  2. Run: npm run build:native');
+}
 
 async function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
@@ -109,6 +104,15 @@ function writeInstallMethod() {
 }
 
 async function main() {
+  if (!platformKey || !binaryName || !binaryPath || !DOWNLOAD_URL) {
+    console.log(`No prebuilt native binary available for ${platform()}-${arch()}.`);
+    console.log('');
+    showLocalBuildInstructions();
+    writeInstallMethod();
+    showInstallReminder();
+    return;
+  }
+
   // Check if binary already exists
   if (existsSync(binaryPath)) {
     // Ensure binary is executable (npm doesn't preserve execute bit)
@@ -149,9 +153,7 @@ async function main() {
   } catch (err) {
     console.log(`Could not download native binary: ${err.message}`);
     console.log('');
-    console.log('To build the native binary locally:');
-    console.log('  1. Install Rust: https://rustup.rs');
-    console.log('  2. Run: npm run build:native');
+    showLocalBuildInstructions();
   }
 
   writeInstallMethod();
@@ -225,6 +227,10 @@ function showInstallReminder() {
  * This provides zero-overhead CLI execution for global installs.
  */
 async function fixGlobalInstallBin() {
+  if (!shouldOptimizeGlobalBin()) {
+    return;
+  }
+
   if (platform() === 'win32') {
     await fixWindowsShims();
   } else {
@@ -295,7 +301,12 @@ async function fixWindowsShims() {
 
   // Detect architecture so ARM64 Windows is handled correctly
   // (falls back to x64 binary — see platform detection above)
-  const cpuArch = effectiveArch;
+  const windowsPlatformKey = getPlatformKey({ winArm64Fallback: true });
+  if (!windowsPlatformKey) {
+    return;
+  }
+
+  const cpuArch = windowsPlatformKey.split('-').at(-1);
   const relativeBinaryPath = `node_modules\\agent-browser\\bin\\agent-browser-win32-${cpuArch}.exe`;
   const absoluteBinaryPath = join(npmBinDir, relativeBinaryPath);
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -30,6 +30,8 @@ npm i -g agent-browser && agent-browser install
 # Linux hosts can install required browser libraries too
 agent-browser install --with-deps
 
+# Termux/Android npm installs reuse the matching Linux binary through grun
+
 # Take a screenshot of a page
 agent-browser open https://example.com
 agent-browser screenshot home.png


### PR DESCRIPTION
## Summary

- Map Node's `android` platform to the existing Linux native binary artifacts for npm installs
- Run Android launches through `grun` and keep global Android installs on the JS wrapper so that dispatch is preserved
- Add focused platform-selection tests and document Termux/Android npm installs in README, docs, and core skill data

## Why

Fixes #1477.

On Termux, Node reports `process.platform === "android"`, so the wrapper previously treated `android-arm64` as unsupported and postinstall would look for an unpublished `android-*` artifact. The package already ships matching Linux binaries, and Termux can run the Linux ARM64 binary through `grun`.

## Tests

- `node --check scripts/platform.js`
- `node --check bin/agent-browser.js`
- `node --check scripts/postinstall.js`
- `node --test scripts/platform.test.mjs`
  - 6 tests passed, 0 failed
- `git diff --check`
- `rg -n "[ \t]+$" scripts/platform.js scripts/platform.test.mjs`
  - no output

## Scope

- npm wrapper/postinstall platform selection
- Termux/Android installation documentation
- Existing Linux, Linux musl, macOS, and Windows naming behavior
- Windows ARM64 postinstall fallback to the x64 binary

## Non-goals

- No separate Android native binary
- No Rust CLI, MCP, daemon, browser automation, or provider changes
- No local Android source-build naming changes

## Caveats

- I could not run a real Termux/Android smoke test in this environment. The coverage is a focused Node-level simulation of platform and architecture decisions.
