### PR TITLE
fix: --auto-connect prompts twice and times out after 2s

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--headed` | Show browser window (not headless) (or `AGENT_BROWSER_HEADED` env) |
 | `--cdp <port\|url>` | Connect via Chrome DevTools Protocol (port or WebSocket URL) |
 | `--auto-connect` | Auto-discover and connect to running Chrome (or `AGENT_BROWSER_AUTO_CONNECT` env) |
+| `autoConnectTimeout` | Config/env only: auto-connect discovery timeout in ms (or `AGENT_BROWSER_AUTO_CONNECT_TIMEOUT` env, default: 10000) |
 | `--color-scheme <scheme>` | Color scheme: `dark`, `light`, `no-preference` (or `AGENT_BROWSER_COLOR_SCHEME` env) |
 | `--download-path <path>` | Default download directory (or `AGENT_BROWSER_DOWNLOAD_PATH` env) |
 | `--content-boundaries` | Wrap page output in boundary markers for LLM safety (or `AGENT_BROWSER_CONTENT_BOUNDARIES` env) |
@@ -990,6 +991,7 @@ Create an `agent-browser.json` file to set persistent defaults instead of repeat
   "userAgent": "my-agent/1.0",
   "hideScrollbars": false,
   "ignoreHttpsErrors": true,
+  "autoConnectTimeout": 25000,
   "plugins": [
     {
       "name": "vault",
@@ -1303,6 +1305,8 @@ agent-browser --auto-connect snapshot
 # Or via environment variable
 AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
 ```
+
+Chrome 144+ may show a remote-debugging approval prompt. Auto-connect waits up to 10000ms by default for discovery and approval. Set `autoConnectTimeout` in config or `AGENT_BROWSER_AUTO_CONNECT_TIMEOUT` in the environment to give yourself a longer approval window, such as 30000ms.
 
 Auto-connect discovers Chrome by:
 

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -128,6 +128,12 @@
       "type": "boolean",
       "description": "Auto-discover and connect to a running Chrome instance."
     },
+    "autoConnectTimeout": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "Auto-connect discovery timeout in milliseconds, including Chrome remote-debugging approval prompts."
+    },
     "annotate": {
       "type": "boolean",
       "description": "Annotated screenshot with numbered element labels."

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3090,6 +3090,7 @@ mod tests {
             hide_scrollbars: true,
             device: None,
             auto_connect: false,
+            auto_connect_timeout: None,
             session_name: None,
             restore: None,
             restore_save: None,

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -459,6 +459,7 @@ pub struct DaemonOptions<'a> {
     pub auto_connect: bool,
     pub idle_timeout: Option<&'a str>,
     pub default_timeout: Option<u64>,
+    pub auto_connect_timeout: Option<u64>,
     pub cdp: Option<&'a str>,
     pub no_auto_dialog: bool,
     pub plugins: Option<&'a str>,
@@ -565,6 +566,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     if let Some(timeout) = opts.default_timeout {
         cmd.env("AGENT_BROWSER_DEFAULT_TIMEOUT", timeout.to_string());
     }
+    if let Some(timeout) = opts.auto_connect_timeout {
+        cmd.env("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT", timeout.to_string());
+    }
     if let Some(cdp) = opts.cdp {
         cmd.env("AGENT_BROWSER_CDP", cdp);
     }
@@ -584,6 +588,7 @@ fn daemon_config_fingerprint(opts: &DaemonOptions) -> String {
     opts.allowed_domains.hash(&mut hasher);
     opts.idle_timeout.hash(&mut hasher);
     opts.default_timeout.hash(&mut hasher);
+    opts.auto_connect_timeout.hash(&mut hasher);
     opts.no_auto_dialog.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
@@ -1084,7 +1089,11 @@ fn has_os_error(error: &str, code: u32) -> bool {
 /// the extended budget, and that field is set client-side per invocation,
 /// avoiding the daemon's spawn-time env snapshot drifting from the client.
 fn read_timeout_for(cmd: &Value) -> Duration {
-    let op_ms = cmd.get("timeout").and_then(|v| v.as_u64()).unwrap_or(0);
+    let op_ms = cmd
+        .get("timeout")
+        .or_else(|| cmd.get("autoConnectTimeout"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
     Duration::from_millis(op_ms.saturating_add(10_000).max(30_000))
 }
 
@@ -1228,6 +1237,7 @@ mod tests {
 
     fn test_daemon_options<'a>(
         idle_timeout: Option<&'a str>,
+        auto_connect_timeout: Option<u64>,
         no_auto_dialog: bool,
         allowed_domains: Option<&'a [String]>,
     ) -> DaemonOptions<'a> {
@@ -1264,6 +1274,7 @@ mod tests {
             auto_connect: false,
             idle_timeout,
             default_timeout: None,
+            auto_connect_timeout,
             cdp: None,
             no_auto_dialog,
             plugins: None,
@@ -1271,16 +1282,32 @@ mod tests {
     }
 
     #[test]
+    fn test_read_timeout_tracks_auto_connect_timeout() {
+        let cmd = json!({
+            "action": "launch",
+            "autoConnect": true,
+            "autoConnectTimeout": 45000
+        });
+
+        assert_eq!(read_timeout_for(&cmd), Duration::from_millis(55_000));
+    }
+
+    #[test]
     fn test_daemon_config_fingerprint_tracks_daemon_owned_options() {
         let domains = vec!["example.com".to_string()];
-        let base = test_daemon_options(None, false, None);
-        let idle_changed = test_daemon_options(Some("1000"), false, None);
-        let dialog_changed = test_daemon_options(None, true, None);
-        let domains_changed = test_daemon_options(None, false, Some(&domains));
+        let base = test_daemon_options(None, None, false, None);
+        let idle_changed = test_daemon_options(Some("1000"), None, false, None);
+        let auto_connect_timeout_changed = test_daemon_options(None, Some(12000), false, None);
+        let dialog_changed = test_daemon_options(None, None, true, None);
+        let domains_changed = test_daemon_options(None, None, false, Some(&domains));
 
         assert_ne!(
             daemon_config_fingerprint(&base),
             daemon_config_fingerprint(&idle_changed)
+        );
+        assert_ne!(
+            daemon_config_fingerprint(&base),
+            daemon_config_fingerprint(&auto_connect_timeout_changed)
         );
         assert_ne!(
             daemon_config_fingerprint(&base),
@@ -1300,8 +1327,8 @@ mod tests {
         guard.remove("AGENT_BROWSER_NAMESPACE");
 
         let session = "race-config";
-        let winner_opts = test_daemon_options(Some("1000"), false, None);
-        let loser_opts = test_daemon_options(Some("2000"), false, None);
+        let winner_opts = test_daemon_options(Some("1000"), None, false, None);
+        let loser_opts = test_daemon_options(Some("2000"), None, false, None);
 
         fs::create_dir_all(get_socket_dir()).unwrap();
         fs::write(get_pid_path(session), "12345").unwrap();
@@ -1322,7 +1349,7 @@ mod tests {
         guard.remove("AGENT_BROWSER_NAMESPACE");
 
         let session = "race-config-match";
-        let opts = test_daemon_options(Some("1000"), false, None);
+        let opts = test_daemon_options(Some("1000"), None, false, None);
 
         fs::create_dir_all(get_socket_dir()).unwrap();
         fs::write(get_pid_path(session), "12345").unwrap();
@@ -1344,7 +1371,7 @@ mod tests {
         guard.remove("AGENT_BROWSER_NAMESPACE");
 
         let session = "startup-config";
-        let opts = test_daemon_options(Some("1000"), false, None);
+        let opts = test_daemon_options(Some("1000"), None, false, None);
         fs::create_dir_all(get_socket_dir()).unwrap();
 
         let config_path = get_config_path(session);
@@ -1371,7 +1398,7 @@ mod tests {
         guard.remove("AGENT_BROWSER_NAMESPACE");
 
         let session = "race-config-owner";
-        let opts = test_daemon_options(Some("1000"), false, None);
+        let opts = test_daemon_options(Some("1000"), None, false, None);
         let spawned_pid = 67890;
 
         fs::create_dir_all(get_socket_dir()).unwrap();

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -83,6 +83,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         auto_connect: false,
         idle_timeout: None,
         default_timeout: None,
+        auto_connect_timeout: None,
         cdp: None,
         no_auto_dialog: false,
         plugins: None,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -82,6 +82,7 @@ pub struct Config {
     pub allow_file_access: Option<bool>,
     pub cdp: Option<String>,
     pub auto_connect: Option<bool>,
+    pub auto_connect_timeout: Option<u64>,
     pub headers: Option<String>,
     pub annotate: Option<bool>,
     pub color_scheme: Option<String>,
@@ -151,6 +152,7 @@ impl Config {
             allow_file_access: other.allow_file_access.or(self.allow_file_access),
             cdp: other.cdp.or(self.cdp),
             auto_connect: other.auto_connect.or(self.auto_connect),
+            auto_connect_timeout: other.auto_connect_timeout.or(self.auto_connect_timeout),
             headers: other.headers.or(self.headers),
             annotate: other.annotate.or(self.annotate),
             color_scheme: other.color_scheme.or(self.color_scheme),
@@ -350,6 +352,7 @@ pub struct Flags {
     pub hide_scrollbars: bool,
     pub device: Option<String>,
     pub auto_connect: bool,
+    pub auto_connect_timeout: Option<u64>,
     pub session_name: Option<String>,
     pub annotate: bool,
     pub color_scheme: Option<String>,
@@ -527,6 +530,10 @@ pub fn parse_flags(args: &[String]) -> Flags {
         device: env::var("AGENT_BROWSER_IOS_DEVICE").ok().or(config.device),
         auto_connect: env_var_is_truthy("AGENT_BROWSER_AUTO_CONNECT")
             || config.auto_connect.unwrap_or(false),
+        auto_connect_timeout: env::var("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or(config.auto_connect_timeout),
         session_name: env::var("AGENT_BROWSER_SESSION_NAME")
             .ok()
             .or(config.session_name),
@@ -1432,6 +1439,7 @@ mod tests {
             "allowFileAccess": true,
             "cdp": "9222",
             "autoConnect": true,
+            "autoConnectTimeout": 12000,
             "headers": "{\"Auth\":\"token\"}",
             "plugins": [
                 {
@@ -1466,6 +1474,7 @@ mod tests {
         assert_eq!(config.allow_file_access, Some(true));
         assert_eq!(config.cdp.as_deref(), Some("9222"));
         assert_eq!(config.auto_connect, Some(true));
+        assert_eq!(config.auto_connect_timeout, Some(12000));
         assert_eq!(config.headers.as_deref(), Some("{\"Auth\":\"token\"}"));
         let plugin = &config.plugins.as_ref().unwrap()[0];
         assert_eq!(plugin.name, "onepassword");
@@ -1754,6 +1763,32 @@ mod tests {
     fn test_auto_connect_false() {
         let flags = parse_flags(&args("--auto-connect false open"));
         assert!(!flags.auto_connect);
+    }
+
+    #[test]
+    fn test_auto_connect_timeout_from_env() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_AUTO_CONNECT_TIMEOUT"]);
+        guard.set("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT", "12000");
+
+        let flags = parse_flags(&args("snapshot"));
+
+        assert_eq!(flags.auto_connect_timeout, Some(12000));
+    }
+
+    #[test]
+    fn test_config_merge_auto_connect_timeout_project_overrides_user() {
+        let user = Config {
+            auto_connect_timeout: Some(10000),
+            ..Config::default()
+        };
+        let project = Config {
+            auto_connect_timeout: Some(25000),
+            ..Config::default()
+        };
+
+        let merged = user.merge(project);
+
+        assert_eq!(merged.auto_connect_timeout, Some(25000));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1217,6 +1217,7 @@ fn main() {
         auto_connect: flags.auto_connect,
         idle_timeout: flags.idle_timeout.as_deref(),
         default_timeout: flags.default_timeout,
+        auto_connect_timeout: flags.auto_connect_timeout,
         cdp: flags.cdp.as_deref(),
         no_auto_dialog: flags.no_auto_dialog,
         plugins: Some(plugin_registry_json.as_str()),
@@ -1258,6 +1259,10 @@ fn main() {
         if let Some(ref dp) = flags.download_path {
             launch_cmd["downloadPath"] = json!(dp);
         }
+
+        launch_cmd["autoConnectTimeout"] = json!(flags
+            .auto_connect_timeout
+            .unwrap_or(crate::native::cdp::chrome::DEFAULT_AUTO_CONNECT_TIMEOUT_MS));
 
         let err = match send_command(launch_cmd, &flags.session) {
             Ok(resp) if resp.success => None,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -14,7 +14,7 @@ use crate::validation::{is_valid_session_name, session_name_error};
 
 use super::auth;
 use super::browser::{should_track_target, BrowserManager, WaitUntil};
-use super::cdp::chrome::LaunchOptions;
+use super::cdp::chrome::{LaunchOptions, DEFAULT_AUTO_CONNECT_TIMEOUT_MS};
 use super::cdp::client::CdpClient;
 use super::cdp::types::{
     AttachToTargetParams, AttachToTargetResult, CdpEvent, CreateTargetResult,
@@ -2046,10 +2046,36 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 // Auto-launch
 // ---------------------------------------------------------------------------
 
+fn auto_connect_timeout_from_ms(ms: Option<u64>) -> tokio::time::Duration {
+    tokio::time::Duration::from_millis(ms.unwrap_or(DEFAULT_AUTO_CONNECT_TIMEOUT_MS))
+}
+
+fn auto_connect_timeout_from_env() -> tokio::time::Duration {
+    auto_connect_timeout_from_ms(
+        env::var("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok()),
+    )
+}
+
+fn auto_connect_timeout_from_command_or_env(cmd: &Value) -> tokio::time::Duration {
+    auto_connect_timeout_from_ms(
+        cmd.get("autoConnectTimeout")
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                env::var("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+            }),
+    )
+}
+
 /// Connect to a running Chrome via auto-discovery and open a fresh tab so
 /// subsequent navigations don't hijack the user's existing tabs.
-async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
-    let mut mgr = BrowserManager::connect_auto().await?;
+async fn connect_auto_with_fresh_tab(
+    timeout: tokio::time::Duration,
+) -> Result<BrowserManager, String> {
+    let mut mgr = BrowserManager::connect_auto(timeout).await?;
     mgr.tab_new(None, None).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let _ = mgr
@@ -2127,7 +2153,7 @@ async fn auto_launch(
             None,
         );
         state.reset_input_state();
-        state.browser = Some(connect_auto_with_fresh_tab().await?);
+        state.browser = Some(connect_auto_with_fresh_tab(auto_connect_timeout_from_env()).await?);
         state.launch_hash = Some(hash);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -2817,7 +2843,8 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if auto_connect {
         state.reset_input_state();
-        state.browser = Some(connect_auto_with_fresh_tab().await?);
+        state.browser =
+            Some(connect_auto_with_fresh_tab(auto_connect_timeout_from_command_or_env(cmd)).await?);
         state.launch_hash = Some(new_hash);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -10875,6 +10902,40 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         env.remove("AGENT_BROWSER_DEFAULT_TIMEOUT");
         let state = DaemonState::new();
         assert_eq!(state.default_timeout_ms, 25_000);
+    }
+
+    #[test]
+    fn test_auto_connect_timeout_from_env() {
+        let env = EnvGuard::new(&["AGENT_BROWSER_AUTO_CONNECT_TIMEOUT"]);
+        env.set("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT", "12000");
+
+        assert_eq!(
+            auto_connect_timeout_from_env(),
+            tokio::time::Duration::from_millis(12_000)
+        );
+    }
+
+    #[test]
+    fn test_auto_connect_timeout_from_command_overrides_env() {
+        let env = EnvGuard::new(&["AGENT_BROWSER_AUTO_CONNECT_TIMEOUT"]);
+        env.set("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT", "12000");
+        let cmd = json!({ "autoConnectTimeout": 25000 });
+
+        assert_eq!(
+            auto_connect_timeout_from_command_or_env(&cmd),
+            tokio::time::Duration::from_millis(25_000)
+        );
+    }
+
+    #[test]
+    fn test_auto_connect_timeout_default() {
+        let env = EnvGuard::new(&["AGENT_BROWSER_AUTO_CONNECT_TIMEOUT"]);
+        env.remove("AGENT_BROWSER_AUTO_CONNECT_TIMEOUT");
+
+        assert_eq!(
+            auto_connect_timeout_from_env(),
+            tokio::time::Duration::from_millis(DEFAULT_AUTO_CONNECT_TIMEOUT_MS)
+        );
     }
 
     #[tokio::test]

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, Mutex};
 
-use super::cdp::chrome::{auto_connect_cdp, launch_chrome, ChromeProcess, LaunchOptions};
+use super::cdp::chrome::{
+    auto_connect_candidates, launch_chrome, AutoConnectCandidate, ChromeProcess, LaunchOptions,
+};
 use super::cdp::client::CdpClient;
 use super::cdp::discovery::discover_cdp_url;
 use super::cdp::lightpanda::{launch_lightpanda, LightpandaLaunchOptions, LightpandaProcess};
@@ -109,6 +111,26 @@ fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo)
         return true;
     }
     false
+}
+
+/// Distinguishes why a CDP connection attempt failed, so auto-connect can
+/// decide whether to try the next candidate or stop.
+enum CdpConnectError {
+    /// No listener / transport refused at the WebSocket endpoint. Safe to move
+    /// on to the next candidate (and prune a stale DevToolsActivePort file).
+    Unreachable(String),
+    /// Reached the endpoint but a CDP setup command failed, or approval did not
+    /// arrive within the configured timeout. Terminal: another connection to
+    /// the same live endpoint would only re-trigger Chrome's approval prompt.
+    Other(String),
+}
+
+impl CdpConnectError {
+    fn message(&self) -> &str {
+        match self {
+            CdpConnectError::Unreachable(m) | CdpConnectError::Other(m) => m,
+        }
+    }
 }
 
 fn active_page_index_after_removal(
@@ -432,29 +454,41 @@ impl BrowserManager {
     }
 
     pub async fn connect_cdp(url: &str) -> Result<Self, String> {
-        Self::connect_cdp_inner(url, false, None).await
+        Self::connect_cdp_inner(url, false, None)
+            .await
+            .map_err(|e| e.message().to_string())
     }
 
     /// Connect to a provider CDP proxy where the WebSocket IS the page session.
     /// Skips browser-level Target.* commands that most proxies don't support.
     pub async fn connect_cdp_direct(url: &str) -> Result<Self, String> {
-        Self::connect_cdp_inner(url, true, None).await
+        Self::connect_cdp_inner(url, true, None)
+            .await
+            .map_err(|e| e.message().to_string())
     }
 
     pub async fn connect_cdp_with_headers(
         url: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Result<Self, String> {
-        Self::connect_cdp_inner(url, false, headers).await
+        Self::connect_cdp_inner(url, false, headers)
+            .await
+            .map_err(|e| e.message().to_string())
     }
 
     async fn connect_cdp_inner(
         url: &str,
         direct_page: bool,
         headers: Option<Vec<(String, String)>>,
-    ) -> Result<Self, String> {
-        let ws_url = resolve_cdp_url(url).await?;
-        let client = Arc::new(CdpClient::connect_with_headers(&ws_url, headers).await?);
+    ) -> Result<Self, CdpConnectError> {
+        let ws_url = resolve_cdp_url(url)
+            .await
+            .map_err(CdpConnectError::Unreachable)?;
+        let client = Arc::new(
+            CdpClient::connect_with_headers(&ws_url, headers)
+                .await
+                .map_err(CdpConnectError::Unreachable)?,
+        );
         let mut manager = Self {
             client,
             browser_process: None,
@@ -480,16 +514,66 @@ impl BrowserManager {
                 target_type: "page".to_string(),
             });
             manager.active_page_index = 0;
-            manager.enable_domains_direct().await?;
+            manager
+                .enable_domains_direct()
+                .await
+                .map_err(CdpConnectError::Other)?;
         } else {
-            manager.discover_and_attach_targets().await?;
+            manager
+                .discover_and_attach_targets()
+                .await
+                .map_err(CdpConnectError::Other)?;
         }
         Ok(manager)
     }
 
-    pub async fn connect_auto() -> Result<Self, String> {
-        let ws_url = auto_connect_cdp().await?;
-        Self::connect_cdp(&ws_url).await
+    pub async fn connect_auto(timeout: std::time::Duration) -> Result<Self, String> {
+        let candidates = auto_connect_candidates(timeout).await;
+        Self::connect_auto_from_candidates(candidates, timeout).await
+    }
+
+    /// Try each discovered candidate in order. Each candidate gets at most one
+    /// real CDP connection, bounded by `timeout`; there is no throwaway probe,
+    /// so a live Chrome instance is prompted at most once per `--auto-connect`.
+    ///
+    /// A transport-level refusal (`Unreachable`) prunes any stale
+    /// `DevToolsActivePort` file and moves on. A setup failure or approval
+    /// timeout (`Other`) is terminal: retrying the same live endpoint would
+    /// only produce another approval prompt.
+    async fn connect_auto_from_candidates(
+        candidates: Vec<AutoConnectCandidate>,
+        timeout: std::time::Duration,
+    ) -> Result<Self, String> {
+        for candidate in candidates {
+            let attempt = tokio::time::timeout(
+                timeout,
+                Self::connect_cdp_inner(&candidate.ws_url, false, None),
+            )
+            .await;
+            match attempt {
+                Ok(Ok(mgr)) => return Ok(mgr),
+                Ok(Err(CdpConnectError::Unreachable(_))) => {
+                    if let Some(stale) = candidate.stale_devtools_file {
+                        let _ = std::fs::remove_file(&stale);
+                    }
+                    continue;
+                }
+                Ok(Err(CdpConnectError::Other(msg))) => return Err(msg),
+                Err(_) => {
+                    return Err(format!(
+                        "Auto-connect timed out after {}ms waiting for Chrome's \
+                         remote-debugging approval. Increase `autoConnectTimeout` or \
+                         launch Chrome with `--remote-debugging-port`.",
+                        timeout.as_millis()
+                    ));
+                }
+            }
+        }
+
+        Err(
+            "No running Chrome instance found. Launch Chrome with --remote-debugging-port or use --cdp."
+                .to_string(),
+        )
     }
 
     async fn discover_and_attach_targets(&mut self) -> Result<(), String> {
@@ -590,19 +674,18 @@ impl BrowserManager {
     }
 
     async fn enable_domains(&self, session_id: &str) -> Result<(), String> {
+        // Resume first: Chrome 144+ real browser sessions can pause targets
+        // after attach, and domain enable commands may hang until resumed.
+        let _ = self
+            .client
+            .send_command_no_params("Runtime.runIfWaitingForDebugger", Some(session_id))
+            .await;
         self.client
             .send_command_no_params("Page.enable", Some(session_id))
             .await?;
         self.client
             .send_command_no_params("Runtime.enable", Some(session_id))
             .await?;
-        // Resume the target if it is paused waiting for the debugger.
-        // This is needed for real browser sessions (Chrome 144+) where targets
-        // are paused after attach until explicitly resumed. No-op otherwise.
-        let _ = self
-            .client
-            .send_command_no_params("Runtime.runIfWaitingForDebugger", Some(session_id))
-            .await;
         self.client
             .send_command_no_params("Network.enable", Some(session_id))
             .await?;
@@ -626,16 +709,16 @@ impl BrowserManager {
 
     /// Enable domains on a direct page connection (no session_id needed).
     async fn enable_domains_direct(&self) -> Result<(), String> {
+        let _ = self
+            .client
+            .send_command_no_params("Runtime.runIfWaitingForDebugger", None)
+            .await;
         self.client
             .send_command_no_params("Page.enable", None)
             .await?;
         self.client
             .send_command_no_params("Runtime.enable", None)
             .await?;
-        let _ = self
-            .client
-            .send_command_no_params("Runtime.runIfWaitingForDebugger", None)
-            .await;
         self.client
             .send_command_no_params("Network.enable", None)
             .await?;
@@ -1726,6 +1809,98 @@ mod tests {
     fn test_format_tab_id() {
         assert_eq!(format_tab_id(1), "t1");
         assert_eq!(format_tab_id(42), "t42");
+    }
+
+    #[tokio::test]
+    async fn test_auto_connect_keeps_first_devtools_active_port_websocket() {
+        use futures_util::{SinkExt, StreamExt};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio_tungstenite::tungstenite::Message as WsMsg;
+
+        // One candidate derived from a DevToolsActivePort file pointing at a
+        // live WebSocket server. The candidate carries no prior probe, so the
+        // server should see exactly one WebSocket connection (the real one).
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let profile_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            profile_dir.path().join("DevToolsActivePort"),
+            format!("{}\n/devtools/browser/test-browser\n", port),
+        )
+        .unwrap();
+
+        let connections = Arc::new(AtomicUsize::new(0));
+        let server_connections = Arc::clone(&connections);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            server_connections.fetch_add(1, Ordering::SeqCst);
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            while let Some(Ok(WsMsg::Text(text))) = ws.next().await {
+                let req: Value = serde_json::from_str(&text).unwrap();
+                let id = req.get("id").cloned().unwrap_or_else(|| json!(0));
+                let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+                let result = match method {
+                    "Target.getTargets" => json!({
+                        "targetInfos": [{
+                            "targetId": "page-1",
+                            "type": "page",
+                            "title": "",
+                            "url": "about:blank",
+                            "attached": false
+                        }]
+                    }),
+                    "Target.attachToTarget" => json!({ "sessionId": "session-1" }),
+                    _ => json!({}),
+                };
+                ws.send(WsMsg::Text(
+                    json!({ "id": id, "result": result }).to_string(),
+                ))
+                .await
+                .unwrap();
+            }
+        });
+
+        let candidates = vec![AutoConnectCandidate {
+            ws_url: format!("ws://127.0.0.1:{}/devtools/browser/test-browser", port),
+            host: "127.0.0.1".to_string(),
+            port,
+            stale_devtools_file: Some(profile_dir.path().join("DevToolsActivePort")),
+        }];
+        let manager =
+            BrowserManager::connect_auto_from_candidates(candidates, Duration::from_secs(5))
+                .await
+                .expect("auto-connect should keep the first DevToolsActivePort WebSocket");
+
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+        assert_eq!(manager.pages.len(), 1);
+        drop(manager);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_auto_connect_skips_dead_candidate_without_prompting() {
+        // A candidate pointing at a port with no listener is skipped via the TCP
+        // reachability check. Its stale DevToolsActivePort file is removed, and
+        // no WebSocket connection is attempted.
+        let profile_dir = tempfile::tempdir().unwrap();
+        let stale = profile_dir.path().join("DevToolsActivePort");
+        std::fs::write(&stale, "65500\n/devtools/browser/dead\n").unwrap();
+
+        let candidates = vec![AutoConnectCandidate {
+            ws_url: "ws://127.0.0.1:65500/devtools/browser/dead".to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 65500,
+            stale_devtools_file: Some(stale.clone()),
+        }];
+        let result =
+            BrowserManager::connect_auto_from_candidates(candidates, Duration::from_secs(5)).await;
+
+        assert!(result.is_err(), "no live candidate should error");
+        assert!(
+            !stale.exists(),
+            "stale DevToolsActivePort should be pruned after an unreachable candidate"
+        );
     }
 
     #[test]

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -3,7 +3,12 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-use super::discovery::discover_cdp_url;
+use super::discovery::discover_cdp_url_http_with_timeout;
+
+/// Default auto-connect discovery timeout. Long enough to approve Chrome's
+/// remote-debugging prompt in most cases; raise it with `autoConnectTimeout` or
+/// `AGENT_BROWSER_AUTO_CONNECT_TIMEOUT` for slower workflows.
+pub const DEFAULT_AUTO_CONNECT_TIMEOUT_MS: u64 = 10_000;
 
 pub struct ChromeProcess {
     child: Child,
@@ -660,78 +665,83 @@ pub fn read_devtools_active_port(user_data_dir: &Path) -> Option<(u16, String)> 
     Some((port, ws_path))
 }
 
-pub async fn auto_connect_cdp() -> Result<String, String> {
-    let user_data_dirs = get_chrome_user_data_dirs();
-
-    for dir in &user_data_dirs {
-        if let Some((port, ws_path)) = read_devtools_active_port(dir) {
-            if let Ok(ws_url) = resolve_cdp_from_active_port(port, &ws_path).await {
-                return Ok(ws_url);
-            }
-            // Port is dead — remove the stale file so future runs skip it.
-            let stale = dir.join("DevToolsActivePort");
-            let _ = std::fs::remove_file(&stale);
-        }
-    }
-
-    // Fallback: probe common ports
-    for port in [9222u16, 9229] {
-        if let Ok(ws_url) = discover_cdp_url("127.0.0.1", port, None).await {
-            return Ok(ws_url);
-        }
-    }
-
-    Err("No running Chrome instance found. Launch Chrome with --remote-debugging-port or use --cdp.".to_string())
-}
-
-/// Resolve a CDP WebSocket URL from a DevToolsActivePort entry.
+/// A candidate CDP endpoint discovered for `--auto-connect`.
 ///
-/// Tries the exact WebSocket path from DevToolsActivePort first (single
-/// prompt on M144+), then falls back to legacy HTTP discovery for older
-/// Chrome versions. This order avoids triggering duplicate remote-debugging
-/// permission prompts (#1210, #1206).
-async fn resolve_cdp_from_active_port(port: u16, ws_path: &str) -> Result<String, String> {
-    let ws_url = format!("ws://127.0.0.1:{}{}", port, ws_path);
-    if verify_ws_endpoint(&ws_url).await {
-        return Ok(ws_url);
-    }
-
-    // Pre-M144 fallback: HTTP endpoints (/json/version, /json/list, etc.)
-    if let Ok(ws_url) = discover_cdp_url("127.0.0.1", port, None).await {
-        return Ok(ws_url);
-    }
-
-    Err(format!(
-        "Cannot connect to Chrome on port {}: both direct WebSocket and HTTP discovery failed",
-        port
-    ))
+/// Discovery resolves URLs *without* opening a WebSocket, so it never triggers
+/// Chrome's remote-debugging approval prompt. The caller opens a single real
+/// connection to a reachable candidate.
+#[derive(Debug, Clone)]
+pub struct AutoConnectCandidate {
+    /// Fully-formed `ws://host:port/path` URL to connect to.
+    pub ws_url: String,
+    /// Host used for the reachability pre-check (e.g. `127.0.0.1`).
+    pub host: String,
+    /// Port used for the reachability pre-check.
+    pub port: u16,
+    /// `DevToolsActivePort` file that should be removed if the port is dead.
+    pub stale_devtools_file: Option<PathBuf>,
 }
 
-/// Verify that a WebSocket endpoint is a live CDP server by sending
-/// `Browser.getVersion` and checking for a valid response.
-async fn verify_ws_endpoint(ws_url: &str) -> bool {
-    use futures_util::{SinkExt, StreamExt};
-    use tokio_tungstenite::tungstenite::Message;
+/// Resolve ordered auto-connect candidate endpoints without opening any
+/// WebSocket connection.
+///
+/// Order, deduplicated by port so a single Chrome instance is only contacted
+/// once:
+/// 1. Exact `DevToolsActivePort` URLs from known Chrome/Chromium/Brave
+///    user-data directories (Chrome 144+ UI remote debugging writes these with
+///    a dynamic port and the exact browser WebSocket path).
+/// 2. HTTP discovery (`/json/version`, `/json/list`) on common fixed
+///    remote-debugging ports. Plain HTTP never triggers the approval prompt.
+/// 3. Generic `/devtools/browser` fallback for common ports, used when Chrome
+///    136+ exposes CDP over WebSocket but serves no HTTP discovery endpoints.
+pub async fn auto_connect_candidates(discovery_timeout: Duration) -> Vec<AutoConnectCandidate> {
+    let mut candidates: Vec<AutoConnectCandidate> = Vec::new();
+    let mut seen_ports: std::collections::HashSet<u16> = std::collections::HashSet::new();
 
-    let timeout = Duration::from_secs(2);
-    let result = tokio::time::timeout(timeout, async {
-        let (mut ws, _) = tokio_tungstenite::connect_async(ws_url).await.ok()?;
-        let cmd = r#"{"id":1,"method":"Browser.getVersion"}"#;
-        ws.send(Message::Text(cmd.into())).await.ok()?;
-        while let Some(Ok(msg)) = ws.next().await {
-            if let Message::Text(text) = msg {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-                    if v.get("id").and_then(|id| id.as_u64()) == Some(1) {
-                        let _ = ws.close(None).await;
-                        return Some(());
-                    }
-                }
+    for dir in get_chrome_user_data_dirs() {
+        if let Some((port, ws_path)) = read_devtools_active_port(&dir) {
+            if seen_ports.insert(port) {
+                candidates.push(AutoConnectCandidate {
+                    ws_url: format!("ws://127.0.0.1:{}{}", port, ws_path),
+                    host: "127.0.0.1".to_string(),
+                    port,
+                    stale_devtools_file: Some(dir.join("DevToolsActivePort")),
+                });
             }
         }
-        None
-    })
-    .await;
-    matches!(result, Ok(Some(())))
+    }
+
+    for port in [9222u16, 9229] {
+        if seen_ports.contains(&port) {
+            continue;
+        }
+        // HTTP discovery is plain HTTP: it does not trigger Chrome's approval
+        // prompt and returns the exact browser WebSocket URL when available.
+        if let Ok(ws_url) =
+            discover_cdp_url_http_with_timeout("127.0.0.1", port, None, discovery_timeout).await
+        {
+            seen_ports.insert(port);
+            candidates.push(AutoConnectCandidate {
+                ws_url,
+                host: "127.0.0.1".to_string(),
+                port,
+                stale_devtools_file: None,
+            });
+        }
+        if seen_ports.contains(&port) {
+            continue;
+        }
+        // Final fallback: a generic WebSocket URL for Chrome 136+ UI remote
+        // debugging, which exposes CDP over WebSocket without HTTP endpoints.
+        candidates.push(AutoConnectCandidate {
+            ws_url: format!("ws://127.0.0.1:{}/devtools/browser", port),
+            host: "127.0.0.1".to_string(),
+            port,
+            stale_devtools_file: None,
+        });
+    }
+
+    candidates
 }
 
 /// Returns the default Chrome user-data directory paths for the current platform.
@@ -1894,101 +1904,5 @@ mod tests {
             result.args.iter().any(|a| a == "--password-store=basic"),
             "profile path should keep keychain flags"
         );
-    }
-
-    // -------------------------------------------------------------------
-    // auto_connect_cdp discovery-order tests (#1210, #1206)
-    // -------------------------------------------------------------------
-
-    /// When DevToolsActivePort provides a ws_path and the port is reachable,
-    /// `resolve_cdp_from_active_port` should return the exact ws_path URL
-    /// WITHOUT calling HTTP discovery first.
-    #[tokio::test]
-    async fn test_resolve_cdp_from_active_port_prefers_ws_path() {
-        use futures_util::{SinkExt, StreamExt};
-        use tokio_tungstenite::tungstenite::Message as WsMsg;
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let ws_path = "/devtools/browser/test-uuid-1234".to_string();
-
-        let server = tokio::spawn(async move {
-            // accept: verify_ws_endpoint() WebSocket handshake
-            let (stream, _) = listener.accept().await.unwrap();
-            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
-            if let Some(Ok(WsMsg::Text(text))) = ws.next().await {
-                let req: serde_json::Value = serde_json::from_str(&text).unwrap();
-                let id = req.get("id").unwrap();
-                let reply = format!(
-                    r#"{{"id":{},"result":{{"protocolVersion":"1.3","product":"Chrome/147"}}}}"#,
-                    id
-                );
-                ws.send(WsMsg::Text(reply)).await.unwrap();
-            }
-            let _ = ws.close(None).await;
-        });
-
-        let result = resolve_cdp_from_active_port(port, &ws_path).await;
-        assert!(result.is_ok(), "should succeed: {:?}", result);
-        let url = result.unwrap();
-        assert!(
-            url.contains("test-uuid-1234"),
-            "should use exact ws_path from DevToolsActivePort, got: {}",
-            url
-        );
-        assert_eq!(url, format!("ws://127.0.0.1:{}{}", port, ws_path));
-        server.await.unwrap();
-    }
-
-    /// When the exact ws_path connection fails, `resolve_cdp_from_active_port`
-    /// should fall back to HTTP discovery.
-    #[tokio::test]
-    async fn test_resolve_cdp_from_active_port_falls_back_to_http_discovery() {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        let server = tokio::spawn(async move {
-            // 1st accept: verify_ws_endpoint() ws_path probe — reject (just close)
-            let (s1, _) = listener.accept().await.unwrap();
-            drop(s1);
-
-            // 2nd accept: HTTP /json/version from discover_cdp_url()
-            let (mut s2, _) = listener.accept().await.unwrap();
-            let mut buf = [0u8; 2048];
-            let _ = s2.read(&mut buf).await;
-            let body = format!(
-                r#"{{"webSocketDebuggerUrl":"ws://127.0.0.1:{}/devtools/browser/fallback-uuid"}}"#,
-                port
-            );
-            let resp = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            s2.write_all(resp.as_bytes()).await.unwrap();
-        });
-
-        let result = resolve_cdp_from_active_port(port, "/devtools/browser/nonexistent-uuid").await;
-        assert!(result.is_ok(), "should fall back to HTTP: {:?}", result);
-        let url = result.unwrap();
-        assert!(
-            url.contains("fallback-uuid"),
-            "should use HTTP discovery fallback, got: {}",
-            url
-        );
-        server.await.unwrap();
-    }
-
-    /// When neither ws_path nor HTTP discovery works, return an error.
-    #[tokio::test]
-    async fn test_resolve_cdp_from_active_port_both_fail() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-
-        let result = resolve_cdp_from_active_port(port, "/devtools/browser/dead").await;
-        assert!(result.is_err(), "should fail when nothing is listening");
     }
 }

--- a/cli/src/native/cdp/discovery.rs
+++ b/cli/src/native/cdp/discovery.rs
@@ -32,7 +32,33 @@ pub async fn discover_cdp_url_with_timeout(
     query: Option<&str>,
     timeout: Duration,
 ) -> Result<String, String> {
-    // Primary: /json/version (standard path)
+    match discover_cdp_url_http_with_timeout(host, port, query, timeout).await {
+        Ok(ws_url) => Ok(ws_url),
+        Err((version_err, list_err)) => {
+            // Final fallback: direct WebSocket at /devtools/browser.
+            // Chrome 136+ with UI-based remote debugging (chrome://inspect) exposes
+            // CDP over WebSocket but does not serve HTTP discovery endpoints.
+            match discover_cdp_ws(host, port, timeout).await {
+                Ok(ws_url) => Ok(append_query(&ws_url, query)),
+                Err(ws_err) => Err(format!(
+                    "All CDP discovery methods failed for {}:{}: /json/version: {}; /json/list: {}; WebSocket: {}",
+                    host, port, version_err, list_err, ws_err
+                )),
+            }
+        }
+    }
+}
+
+/// Discover a CDP WebSocket URL using HTTP endpoints only.
+///
+/// This avoids opening a throwaway WebSocket when the caller intends to keep
+/// the first WebSocket connection, which matters for Chrome approval prompts.
+pub async fn discover_cdp_url_http_with_timeout(
+    host: &str,
+    port: u16,
+    query: Option<&str>,
+    timeout: Duration,
+) -> Result<String, (String, String)> {
     let version_err = match fetch_cdp_info(host, port, timeout).await {
         Ok(info) => {
             if let Some(ws_url) = info.web_socket_debugger_url {
@@ -46,22 +72,12 @@ pub async fn discover_cdp_url_with_timeout(
         Err(e) => e,
     };
 
-    // Fallback: /json/list (returns target list; look for the browser target)
     let list_err = match fetch_cdp_list(host, port, timeout).await {
         Ok(ws_url) => return Ok(append_query(&rewrite_ws_host(&ws_url, host, port), query)),
         Err(e) => e,
     };
 
-    // Final fallback: direct WebSocket at /devtools/browser.
-    // Chrome 136+ with UI-based remote debugging (chrome://inspect) exposes
-    // CDP over WebSocket but does not serve HTTP discovery endpoints.
-    match discover_cdp_ws(host, port, timeout).await {
-        Ok(ws_url) => Ok(append_query(&ws_url, query)),
-        Err(ws_err) => Err(format!(
-            "All CDP discovery methods failed for {}:{}: /json/version: {}; /json/list: {}; WebSocket: {}",
-            host, port, version_err, list_err, ws_err
-        )),
-    }
+    Err((version_err, list_err))
 }
 
 /// Bracket an IPv6 address for use in URLs. No-op for IPv4 or already-bracketed addresses.

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3559,7 +3559,7 @@ Configuration:
   Extensions from user and project configs are merged (not replaced).
 
   Example agent-browser.json:
-    {{"headed": true, "hideScrollbars": false, "proxy": "http://localhost:8080"}}
+    {{"headed": true, "hideScrollbars": false, "autoConnectTimeout": 25000, "proxy": "http://localhost:8080"}}
 
   Plugin example:
     {{"plugins":[{{"name":"vault","command":"agent-browser-plugin-vault","capabilities":["credential.read"]}},{{"name":"stealth","command":"agent-browser-plugin-stealth","capabilities":["launch.mutate"]}}]}}
@@ -3587,6 +3587,7 @@ Environment:
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
+  AGENT_BROWSER_AUTO_CONNECT_TIMEOUT Auto-connect discovery timeout in ms (default: 10000)
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_HIDE_SCROLLBARS  Hide scrollbars in headless Chromium screenshots (default: true)
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -128,6 +128,12 @@
       "type": "boolean",
       "description": "Auto-discover and connect to a running Chrome instance."
     },
+    "autoConnectTimeout": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "Auto-connect discovery timeout in milliseconds, including Chrome remote-debugging approval prompts."
+    },
     "annotate": {
       "type": "boolean",
       "description": "Annotated screenshot with numbered element labels."

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -45,6 +45,8 @@ agent-browser --auto-connect snapshot
 AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
 ```
 
+Chrome 144+ may show a remote-debugging approval prompt. Auto-connect waits up to 10000ms by default for discovery and approval. Set `autoConnectTimeout` in config or `AGENT_BROWSER_AUTO_CONNECT_TIMEOUT` in the environment to give yourself a longer approval window, such as 30000ms.
+
 Auto-connect discovers Chrome by:
 
 1. Reading Chrome's `DevToolsActivePort` file from the default user data directory
@@ -104,6 +106,7 @@ This enables control of:
     <tr><td><code>--headed</code></td><td>Show browser window</td></tr>
     <tr><td><code>{"--cdp <port|url>"}</code></td><td>CDP connection (port or WebSocket URL)</td></tr>
     <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to running Chrome</td></tr>
+    <tr><td><code>autoConnectTimeout</code></td><td>Config/env only auto-connect discovery timeout in ms</td></tr>
     <tr><td><code>--color-scheme &lt;scheme&gt;</code></td><td>Persistent color scheme (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>--debug</code></td><td>Debug output</td></tr>
   </tbody>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -554,6 +554,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --headed                 # Show browser window (not headless)
 --cdp <port|url>         # Connect via Chrome DevTools Protocol (port or WebSocket URL)
 --auto-connect           # Auto-discover and connect to running Chrome
+# autoConnectTimeout / AGENT_BROWSER_AUTO_CONNECT_TIMEOUT adjusts auto-connect discovery wait (default 10000ms)
 --color-scheme <scheme>  # Color scheme: dark, light, no-preference
 --download-path <path>   # Default download directory
 --content-boundaries     # Wrap page output in boundary markers for LLM safety

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -36,7 +36,8 @@ AGENT_BROWSER_CONFIG=./ci-config.json agent-browser open example.com
   "profile": "./browser-data",
   "userAgent": "my-agent/1.0",
   "hideScrollbars": false,
-  "ignoreHttpsErrors": true
+  "ignoreHttpsErrors": true,
+  "autoConnectTimeout": 25000
 }
 ```
 
@@ -86,6 +87,7 @@ Global launch, output, provider, and chat options can be set in the config file 
     <tr><td><code>allowFileAccess</code></td><td><code>--allow-file-access</code></td><td>boolean</td></tr>
     <tr><td><code>cdp</code></td><td><code>--cdp</code></td><td>string</td></tr>
     <tr><td><code>autoConnect</code></td><td><code>--auto-connect</code></td><td>boolean</td></tr>
+    <tr><td><code>autoConnectTimeout</code></td><td>(config/env only)</td><td>number, milliseconds</td></tr>
     <tr><td><code>annotate</code></td><td><code>--annotate</code></td><td>boolean</td></tr>
     <tr><td><code>colorScheme</code></td><td><code>--color-scheme</code></td><td>string (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>downloadPath</code></td><td><code>--download-path</code></td><td>string</td></tr>
@@ -239,6 +241,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_CONFIG</code></td><td>Path to an explicit config file.</td><td>(default discovery)</td></tr>
     <tr><td><code>AGENT_BROWSER_SESSION</code></td><td>Isolated browser session name.</td><td><code>default</code></td></tr>
     <tr><td><code>AGENT_BROWSER_AUTO_CONNECT</code></td><td>Auto-discover and connect to a running Chrome instance.</td><td>(disabled)</td></tr>
+    <tr><td><code>AGENT_BROWSER_AUTO_CONNECT_TIMEOUT</code></td><td>Auto-connect discovery timeout in ms, including Chrome remote-debugging approval prompts.</td><td><code>10000</code></td></tr>
     <tr><td><code>AGENT_BROWSER_ALLOW_FILE_ACCESS</code></td><td>Allow <code>file://</code> URLs to access local files.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_EXECUTABLE_PATH</code></td><td>Custom browser executable path.</td><td>(auto-discover)</td></tr>
     <tr><td><code>AGENT_BROWSER_PROFILE</code></td><td>Chrome profile name or persistent profile directory.</td><td>(none)</td></tr>

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -409,6 +409,7 @@ EOF
 --json                  # JSON output (for machine parsing)
 --headed                # show the window (default is headless)
 --auto-connect          # connect to an already-running Chrome
+# autoConnectTimeout / AGENT_BROWSER_AUTO_CONNECT_TIMEOUT adjusts auto-connect approval/discovery wait (default 10000ms)
 --cdp <port>            # connect to a specific CDP port
 --profile <name|path>   # use a Chrome profile (login state survives)
 --headers <json>        # HTTP headers scoped to the URL's origin

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -453,5 +453,6 @@ AGENT_BROWSER_PROVIDER="browserbase"         # Browser provider or configured pr
 AGENT_BROWSER_STREAM_PORT="9223"             # Override WebSocket streaming port (default: OS-assigned)
 AGENT_BROWSER_CONFIG="./agent-browser.json"  # Custom config file
 AGENT_BROWSER_CDP="9222"                     # Connect daemon to CDP port or WebSocket URL
+AGENT_BROWSER_AUTO_CONNECT_TIMEOUT="25000"   # Auto-connect discovery and approval timeout in ms
 AGENT_BROWSER_PLUGINS='[{"name":"vault","command":"agent-browser-plugin-vault","capabilities":["credential.read"]},{"name":"stealth","command":"agent-browser-plugin-stealth","capabilities":["launch.mutate"]}]'
 ```


### PR DESCRIPTION
Auto-connect kept asking me to approve the remote-debugging prompt twice in a row, and I only had about two seconds to click before it gave up.

Discovery was opening a throwaway WebSocket to verify the endpoint with `Browser.getVersion`, closing it, then opening the real CDP connection. Chrome shows the approval prompt once per WebSocket, so auto-connect fired two of them. The verify step also had a hardcoded 2s timeout (#1365).

This change makes discovery resolve candidate URLs without touching a WebSocket: `DevToolsActivePort` files first, then HTTP `/json/version` on the common ports, then a generic `/devtools/browser` fallback. The caller opens one real connection per candidate and keeps it. Dead ports are skipped and stale `DevToolsActivePort` files pruned, classified by a typed error rather than string-matching on messages.

Adds `autoConnectTimeout` (config) and `AGENT_BROWSER_AUTO_CONNECT_TIMEOUT` (env), defaulting to 10s. People who need longer to click can raise it.

One adjacent fix: `Runtime.runIfWaitingForDebugger` now runs before `Page.enable`. Chrome 144+ pauses targets after attach, so `Page.enable` was hanging on real browser sessions until the target got resumed.

Tested against Chrome 144+ over the `chrome://inspect` UI toggle: one prompt, click allow, connected, drove real tabs. Unit and e2e suites pass.

Fixes #1365.
Refs #1206, #1210, #1218.
