### PR TITLE
Add periodic restore state autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ agent-browser --session "$SESSION" --restore open twitter.com
 agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open twitter.com
 ```
 
-State is saved when the browser closes (explicit `close`, idle timeout, or daemon shutdown) and also periodically while the browser is open, so a browser window you close by hand still leaves a recent save behind. Periodic autosave runs after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` (default 30000; set to `0` to save only on close). It respects the `--restore-save` policy.
+State is saved when the browser closes (explicit `close`, idle timeout, or daemon shutdown) and also periodically while the browser is open, so a browser window you close by hand still leaves a recent save behind. Periodic autosave waits for commands to settle, then saves at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` (default 30000; set to `0` to save only on close). Idle sessions keep saving on the same interval, so changes the page makes on its own (token refreshes, background requests) are captured too. It respects the `--restore-save` policy.
 
 ### State Encryption
 

--- a/README.md
+++ b/README.md
@@ -689,6 +689,8 @@ agent-browser --session "$SESSION" --restore open twitter.com
 agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open twitter.com
 ```
 
+State is saved when the browser closes (explicit `close`, idle timeout, or daemon shutdown) and also periodically while the browser is open, so a browser window you close by hand still leaves a recent save behind. Periodic autosave runs after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` (default 30000; set to `0` to save only on close). It respects the `--restore-save` policy.
+
 ### State Encryption
 
 Encrypt saved session data at rest with AES-256-GCM:
@@ -705,6 +707,7 @@ agent-browser --session secure --restore open example.com
 | --------------------------------- | -------------------------------------------------- |
 | `AGENT_BROWSER_RESTORE`           | Auto-save/load state persistence name              |
 | `AGENT_BROWSER_RESTORE_SAVE`      | Restore save policy: `auto`, `always`, or `never`  |
+| `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` | Min ms between periodic autosaves (default: 30000, 0 disables) |
 | `AGENT_BROWSER_NAMESPACE`         | Namespace for daemon sockets and restore state     |
 | `AGENT_BROWSER_SESSION_NAME`      | Legacy auto-save/load state persistence name       |
 | `AGENT_BROWSER_ENCRYPTION_KEY`    | 64-char hex key for AES-256-GCM encryption         |

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -276,15 +276,12 @@ pub struct DaemonState {
     pub restore_validation_pending: bool,
     pub restore_save_status: String,
     pub restore_saved_path: Option<String>,
-    /// True when a browser-touching command has run since the last successful
-    /// session save; drives the daemon's periodic autosave tick.
-    pub autosave_pending: bool,
     /// When the most recent browser-touching command finished. Periodic
     /// autosaves wait for a quiet period after this so a multi-second save
     /// never lands in the middle of an active command burst.
     pub last_command_finished: Option<std::time::Instant>,
-    /// When the last periodic autosave was attempted (success or failure),
-    /// used to enforce the minimum interval between attempts.
+    /// When session state was last saved or a periodic autosave last failed,
+    /// used to enforce the minimum interval between periodic saves.
     pub last_autosave_attempt: Option<std::time::Instant>,
     pub session_id: String,
     pub tracing_state: TracingState,
@@ -378,7 +375,6 @@ impl DaemonState {
             restore_validation_pending: false,
             restore_save_status: "not_attempted".to_string(),
             restore_saved_path: None,
-            autosave_pending: false,
             last_command_finished: None,
             last_autosave_attempt: None,
             session_id: env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
@@ -1996,12 +1992,10 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         validate_restore_if_pending(state).await;
     }
 
-    // Any command that touches the browser may have changed cookies or
-    // storage (page JS can mutate them even during "read" interactions), so
-    // treat it as making the session eligible for the next periodic autosave.
-    // Marked even on error: a failed click can still have navigated.
+    // Stamp browser-touching commands so periodic autosave waits for an
+    // active command burst to settle before collecting state. Stamped even on
+    // error: a failed click can still have navigated.
     if !skip_launch {
-        state.autosave_pending = true;
         state.last_command_finished = Some(std::time::Instant::now());
     }
 
@@ -2536,10 +2530,10 @@ const AUTOSAVE_QUIET_PERIOD_MS: u64 = 2_000;
 
 /// Whether the daemon's periodic tick should attempt an autosave right now.
 ///
-/// Cheap pre-checks only; the full policy matrix (restore key, save policy,
-/// restore-failed skip) lives in `auto_save_restore_state`, which this gates.
+/// Timing and dialog pre-checks only; restore-key, save-policy, and browser
+/// gating live in `maybe_autosave_restore_state` and `auto_save_restore_state`.
 fn autosave_due(state: &DaemonState, interval_ms: u64) -> bool {
-    if interval_ms == 0 || !state.autosave_pending {
+    if interval_ms == 0 {
         return false;
     }
     // A JS dialog blocks the renderer's main thread, so the storage-collection
@@ -2561,25 +2555,25 @@ fn autosave_due(state: &DaemonState, interval_ms: u64) -> bool {
     true
 }
 
-/// Periodically persist session state while the browser is alive, so a
-/// browser the user closes by hand (which kills CDP and makes save-on-close
-/// impossible) loses at most `interval_ms` of state.
+/// Periodically persist session state while a browser is open with a restore
+/// key configured, so a browser the user closes by hand (which kills CDP and
+/// makes save-on-close impossible) loses at most roughly `interval_ms` of
+/// state. Saves stay eligible even without new commands: the page itself can
+/// mutate cookies and storage while idle (token refreshes, background
+/// requests), so idle sessions are re-saved on every interval too.
 ///
 /// Called from the daemon's background tick. Failures are expected while a
-/// page is mid-navigation; the pending flag stays set so the next interval
-/// retries, and `auto_save_restore_state` records the status either way.
+/// page is mid-navigation; the next interval retries, and
+/// `auto_save_restore_state` records the status either way.
 pub(crate) async fn maybe_autosave_restore_state(state: &mut DaemonState, interval_ms: u64) {
     if !autosave_due(state, interval_ms) {
         return;
     }
-    // Sessions without a restore key, or with saving disabled, can never
-    // autosave; clear the flag so the tick stays a no-op for them.
+    // Sessions without a restore key, or with saving disabled, never autosave.
     if state.session_name.is_none() || state.restore_save == "never" {
-        state.autosave_pending = false;
         return;
     }
-    // No browser means nothing to collect from; keep the flag so a save can
-    // still happen if a relaunch path picks the session back up.
+    // No browser means nothing to collect from.
     if state.browser.is_none() {
         return;
     }
@@ -2639,7 +2633,9 @@ pub(crate) async fn auto_save_restore_state(
         Ok(path) => {
             state.restore_save_status = "saved".to_string();
             state.restore_saved_path = Some(path.clone());
-            state.autosave_pending = false;
+            // Saves from any path (close, relaunch, restore-key change) reset
+            // the periodic interval so the tick doesn't immediately re-save.
+            state.last_autosave_attempt = Some(std::time::Instant::now());
             Ok(Some(path))
         }
         Err(err) => {
@@ -9543,19 +9539,18 @@ mod tests {
     }
 
     #[test]
-    fn test_autosave_due_requires_pending_flag_and_interval() {
-        let mut state = DaemonState::new();
-        assert!(!autosave_due(&state, 30_000), "clean session is never due");
-
-        state.autosave_pending = true;
-        assert!(autosave_due(&state, 30_000));
+    fn test_autosave_due_requires_interval() {
+        let state = DaemonState::new();
+        assert!(
+            autosave_due(&state, 30_000),
+            "idle sessions stay eligible so page-driven mutations get saved"
+        );
         assert!(!autosave_due(&state, 0), "interval 0 disables autosave");
     }
 
     #[test]
     fn test_autosave_waits_for_quiet_period_after_command() {
         let mut state = DaemonState::new();
-        state.autosave_pending = true;
 
         state.last_command_finished = Some(std::time::Instant::now());
         assert!(!autosave_due(&state, 30_000));
@@ -9570,7 +9565,6 @@ mod tests {
     #[test]
     fn test_autosave_enforces_min_interval_between_attempts() {
         let mut state = DaemonState::new();
-        state.autosave_pending = true;
 
         state.last_autosave_attempt = Some(std::time::Instant::now());
         assert!(!autosave_due(&state, 30_000));
@@ -9584,7 +9578,6 @@ mod tests {
     #[test]
     fn test_autosave_blocked_while_dialog_open() {
         let mut state = DaemonState::new();
-        state.autosave_pending = true;
         state.pending_dialog = Some(PendingDialog {
             dialog_type: "confirm".to_string(),
             message: "Are you sure?".to_string(),
@@ -9596,13 +9589,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_autosave_clears_pending_when_it_can_never_apply() {
-        // No restore key: the flag is dropped so the tick stays a no-op.
+    async fn test_autosave_skips_sessions_it_can_never_apply_to() {
+        // No restore key: the tick is a no-op.
         let mut state = DaemonState::new();
         state.session_name = None;
-        state.autosave_pending = true;
         maybe_autosave_restore_state(&mut state, 30_000).await;
-        assert!(!state.autosave_pending);
         assert!(state.last_autosave_attempt.is_none());
         assert_eq!(state.restore_save_status, "not_attempted");
 
@@ -9610,24 +9601,17 @@ mod tests {
         let mut state = DaemonState::new();
         state.session_name = Some("my-session".to_string());
         state.restore_save = "never".to_string();
-        state.autosave_pending = true;
         maybe_autosave_restore_state(&mut state, 30_000).await;
-        assert!(!state.autosave_pending);
         assert!(state.last_autosave_attempt.is_none());
         assert_eq!(state.restore_save_status, "not_attempted");
     }
 
     #[tokio::test]
-    async fn test_autosave_keeps_pending_without_browser() {
+    async fn test_autosave_skips_without_browser() {
         let mut state = DaemonState::new();
         state.session_name = Some("my-session".to_string());
         state.restore_save = "auto".to_string();
-        state.autosave_pending = true;
         maybe_autosave_restore_state(&mut state, 30_000).await;
-        assert!(
-            state.autosave_pending,
-            "flag survives until a browser exists to save from"
-        );
         assert!(state.last_autosave_attempt.is_none());
         assert_eq!(state.restore_save_status, "not_attempted");
     }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -276,6 +276,16 @@ pub struct DaemonState {
     pub restore_validation_pending: bool,
     pub restore_save_status: String,
     pub restore_saved_path: Option<String>,
+    /// True when a browser-touching command has run since the last successful
+    /// session save; drives the daemon's periodic autosave tick.
+    pub autosave_pending: bool,
+    /// When the most recent browser-touching command finished. Periodic
+    /// autosaves wait for a quiet period after this so a multi-second save
+    /// never lands in the middle of an active command burst.
+    pub last_command_finished: Option<std::time::Instant>,
+    /// When the last periodic autosave was attempted (success or failure),
+    /// used to enforce the minimum interval between attempts.
+    pub last_autosave_attempt: Option<std::time::Instant>,
     pub session_id: String,
     pub tracing_state: TracingState,
     pub recording_state: RecordingState,
@@ -368,6 +378,9 @@ impl DaemonState {
             restore_validation_pending: false,
             restore_save_status: "not_attempted".to_string(),
             restore_saved_path: None,
+            autosave_pending: false,
+            last_command_finished: None,
+            last_autosave_attempt: None,
             session_id: env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
             tracing_state: TracingState::new(),
             recording_state: RecordingState::new(),
@@ -1983,6 +1996,15 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         validate_restore_if_pending(state).await;
     }
 
+    // Any command that touches the browser may have changed cookies or
+    // storage (page JS can mutate them even during "read" interactions), so
+    // treat it as making the session eligible for the next periodic autosave.
+    // Marked even on error: a failed click can still have navigated.
+    if !skip_launch {
+        state.autosave_pending = true;
+        state.last_command_finished = Some(std::time::Instant::now());
+    }
+
     let mut resp = match result {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
@@ -2508,6 +2530,63 @@ fn mark_explicit_storage_state_loaded(state: &mut DaemonState, path: &str) {
     state.restore_saved_path = None;
 }
 
+/// Quiet time required after the last command before a periodic autosave may
+/// run, so a multi-second save never stalls an active command burst.
+const AUTOSAVE_QUIET_PERIOD_MS: u64 = 2_000;
+
+/// Whether the daemon's periodic tick should attempt an autosave right now.
+///
+/// Cheap pre-checks only; the full policy matrix (restore key, save policy,
+/// restore-failed skip) lives in `auto_save_restore_state`, which this gates.
+fn autosave_due(state: &DaemonState, interval_ms: u64) -> bool {
+    if interval_ms == 0 || !state.autosave_pending {
+        return false;
+    }
+    // A JS dialog blocks the renderer's main thread, so the storage-collection
+    // evaluate would hang until its CDP timeout. Wait for the dialog instead.
+    if state.pending_dialog.is_some() {
+        return false;
+    }
+    let now = std::time::Instant::now();
+    if let Some(t) = state.last_command_finished {
+        if now.duration_since(t) < std::time::Duration::from_millis(AUTOSAVE_QUIET_PERIOD_MS) {
+            return false;
+        }
+    }
+    if let Some(t) = state.last_autosave_attempt {
+        if now.duration_since(t) < std::time::Duration::from_millis(interval_ms) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Periodically persist session state while the browser is alive, so a
+/// browser the user closes by hand (which kills CDP and makes save-on-close
+/// impossible) loses at most `interval_ms` of state.
+///
+/// Called from the daemon's background tick. Failures are expected while a
+/// page is mid-navigation; the pending flag stays set so the next interval
+/// retries, and `auto_save_restore_state` records the status either way.
+pub(crate) async fn maybe_autosave_restore_state(state: &mut DaemonState, interval_ms: u64) {
+    if !autosave_due(state, interval_ms) {
+        return;
+    }
+    // Sessions without a restore key, or with saving disabled, can never
+    // autosave; clear the flag so the tick stays a no-op for them.
+    if state.session_name.is_none() || state.restore_save == "never" {
+        state.autosave_pending = false;
+        return;
+    }
+    // No browser means nothing to collect from; keep the flag so a save can
+    // still happen if a relaunch path picks the session back up.
+    if state.browser.is_none() {
+        return;
+    }
+    state.last_autosave_attempt = Some(std::time::Instant::now());
+    let _ = auto_save_restore_state(state).await;
+}
+
 pub(crate) async fn auto_save_restore_state(
     state: &mut DaemonState,
 ) -> Result<Option<String>, String> {
@@ -2560,6 +2639,7 @@ pub(crate) async fn auto_save_restore_state(
         Ok(path) => {
             state.restore_save_status = "saved".to_string();
             state.restore_saved_path = Some(path.clone());
+            state.autosave_pending = false;
             Ok(Some(path))
         }
         Err(err) => {
@@ -9460,6 +9540,96 @@ mod tests {
         assert!(!should_validate_restore_after_action("launch"));
         assert!(should_validate_restore_after_action("navigate"));
         assert!(should_validate_restore_after_action("click"));
+    }
+
+    #[test]
+    fn test_autosave_due_requires_pending_flag_and_interval() {
+        let mut state = DaemonState::new();
+        assert!(!autosave_due(&state, 30_000), "clean session is never due");
+
+        state.autosave_pending = true;
+        assert!(autosave_due(&state, 30_000));
+        assert!(!autosave_due(&state, 0), "interval 0 disables autosave");
+    }
+
+    #[test]
+    fn test_autosave_waits_for_quiet_period_after_command() {
+        let mut state = DaemonState::new();
+        state.autosave_pending = true;
+
+        state.last_command_finished = Some(std::time::Instant::now());
+        assert!(!autosave_due(&state, 30_000));
+
+        state.last_command_finished = std::time::Instant::now().checked_sub(
+            std::time::Duration::from_millis(AUTOSAVE_QUIET_PERIOD_MS + 1_000),
+        );
+        assert!(state.last_command_finished.is_some());
+        assert!(autosave_due(&state, 30_000));
+    }
+
+    #[test]
+    fn test_autosave_enforces_min_interval_between_attempts() {
+        let mut state = DaemonState::new();
+        state.autosave_pending = true;
+
+        state.last_autosave_attempt = Some(std::time::Instant::now());
+        assert!(!autosave_due(&state, 30_000));
+
+        state.last_autosave_attempt =
+            std::time::Instant::now().checked_sub(std::time::Duration::from_secs(31));
+        assert!(state.last_autosave_attempt.is_some());
+        assert!(autosave_due(&state, 30_000));
+    }
+
+    #[test]
+    fn test_autosave_blocked_while_dialog_open() {
+        let mut state = DaemonState::new();
+        state.autosave_pending = true;
+        state.pending_dialog = Some(PendingDialog {
+            dialog_type: "confirm".to_string(),
+            message: "Are you sure?".to_string(),
+            url: "https://example.com".to_string(),
+            default_prompt: None,
+            session_id: None,
+        });
+        assert!(!autosave_due(&state, 30_000));
+    }
+
+    #[tokio::test]
+    async fn test_autosave_clears_pending_when_it_can_never_apply() {
+        // No restore key: the flag is dropped so the tick stays a no-op.
+        let mut state = DaemonState::new();
+        state.session_name = None;
+        state.autosave_pending = true;
+        maybe_autosave_restore_state(&mut state, 30_000).await;
+        assert!(!state.autosave_pending);
+        assert!(state.last_autosave_attempt.is_none());
+        assert_eq!(state.restore_save_status, "not_attempted");
+
+        // Saving disabled by policy: same treatment.
+        let mut state = DaemonState::new();
+        state.session_name = Some("my-session".to_string());
+        state.restore_save = "never".to_string();
+        state.autosave_pending = true;
+        maybe_autosave_restore_state(&mut state, 30_000).await;
+        assert!(!state.autosave_pending);
+        assert!(state.last_autosave_attempt.is_none());
+        assert_eq!(state.restore_save_status, "not_attempted");
+    }
+
+    #[tokio::test]
+    async fn test_autosave_keeps_pending_without_browser() {
+        let mut state = DaemonState::new();
+        state.session_name = Some("my-session".to_string());
+        state.restore_save = "auto".to_string();
+        state.autosave_pending = true;
+        maybe_autosave_restore_state(&mut state, 30_000).await;
+        assert!(
+            state.autosave_pending,
+            "flag survives until a browser exists to save from"
+        );
+        assert!(state.last_autosave_attempt.is_none());
+        assert_eq!(state.restore_save_status, "not_attempted");
     }
 
     #[test]

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -12,7 +12,8 @@ use tokio::signal;
 use tokio::sync::{mpsc, Notify, RwLock};
 
 use super::actions::{
-    auto_save_restore_state, close_current_browser, execute_command, DaemonState,
+    auto_save_restore_state, close_current_browser, execute_command, maybe_autosave_restore_state,
+    DaemonState,
 };
 use super::cdp::client::CdpClient;
 use super::state;
@@ -122,12 +123,15 @@ pub async fn run_daemon(session: &str) {
         .and_then(|s| s.parse::<u64>().ok())
         .filter(|&ms| ms > 0);
 
+    let autosave_interval_ms = autosave_interval_ms_from_env();
+
     let result = run_socket_server(
         &socket_path,
         session,
         stream_client,
         stream_server_instance,
         idle_timeout_ms,
+        autosave_interval_ms,
     )
     .await;
 
@@ -152,6 +156,15 @@ pub async fn run_daemon(session: &str) {
     }
 }
 
+/// Minimum ms between periodic session autosaves while the browser is open.
+/// Defaults to 30s; 0 disables periodic autosave (save-on-close still runs).
+fn autosave_interval_ms_from_env() -> u64 {
+    env::var("AGENT_BROWSER_AUTOSAVE_INTERVAL_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(30_000)
+}
+
 #[cfg(unix)]
 async fn run_socket_server(
     socket_path: &PathBuf,
@@ -159,6 +172,7 @@ async fn run_socket_server(
     stream_client: Option<Arc<RwLock<Option<Arc<CdpClient>>>>>,
     stream_server: Option<Arc<StreamServer>>,
     idle_timeout_ms: Option<u64>,
+    autosave_interval_ms: u64,
 ) -> Result<(), String> {
     use tokio::net::UnixListener;
 
@@ -219,6 +233,7 @@ async fn run_socket_server(
                     let _ = close_current_browser(&mut s).await;
                 } else if s.browser.is_some() {
                     s.drain_cdp_events_background().await;
+                    maybe_autosave_restore_state(&mut s, autosave_interval_ms).await;
                 }
             }
             _ = async {
@@ -262,6 +277,7 @@ async fn run_socket_server(
     stream_client: Option<Arc<RwLock<Option<Arc<CdpClient>>>>>,
     stream_server: Option<Arc<StreamServer>>,
     idle_timeout_ms: Option<u64>,
+    autosave_interval_ms: u64,
 ) -> Result<(), String> {
     use tokio::net::TcpListener;
 
@@ -301,6 +317,10 @@ async fn run_socket_server(
     let idle_sleep = idle_timeout_ms.map(|ms| tokio::time::sleep(Duration::from_millis(ms)));
     let mut idle_sleep_pin = idle_sleep.map(Box::pin);
 
+    // The Windows loop has no CDP drain tick, so give autosave its own tick.
+    let mut autosave_tick = tokio::time::interval(Duration::from_millis(1_000));
+    autosave_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     loop {
         tokio::select! {
             accept_result = listener.accept() => {
@@ -318,6 +338,10 @@ async fn run_socket_server(
                         let _ = writeln!(std::io::stderr(), "Accept error: {}", e);
                     }
                 }
+            }
+            _ = autosave_tick.tick() => {
+                let mut s = state.lock().await;
+                maybe_autosave_restore_state(&mut s, autosave_interval_ms).await;
             }
             _ = async {
                 match idle_sleep_pin {

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -317,9 +317,11 @@ async fn run_socket_server(
     let idle_sleep = idle_timeout_ms.map(|ms| tokio::time::sleep(Duration::from_millis(ms)));
     let mut idle_sleep_pin = idle_sleep.map(Box::pin);
 
-    // The Windows loop has no CDP drain tick, so give autosave its own tick.
-    let mut autosave_tick = tokio::time::interval(Duration::from_millis(1_000));
-    autosave_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Mirror the unix loop's background tick: reap a browser the user closed
+    // by hand, and drain CDP events (dialog state in particular) before
+    // autosave so a save never runs against a dialog-blocked renderer.
+    let mut drain_interval = tokio::time::interval(Duration::from_millis(100));
+    drain_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         tokio::select! {
@@ -339,9 +341,19 @@ async fn run_socket_server(
                     }
                 }
             }
-            _ = autosave_tick.tick() => {
+            _ = drain_interval.tick() => {
                 let mut s = state.lock().await;
-                maybe_autosave_restore_state(&mut s, autosave_interval_ms).await;
+                let process_exited = s
+                    .browser
+                    .as_mut()
+                    .map(|mgr| mgr.has_process_exited())
+                    .unwrap_or(false);
+                if process_exited {
+                    let _ = close_current_browser(&mut s).await;
+                } else if s.browser.is_some() {
+                    s.drain_cdp_events_background().await;
+                    maybe_autosave_restore_state(&mut s, autosave_interval_ms).await;
+                }
             }
             _ = async {
                 match idle_sleep_pin {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -14,7 +14,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::test_utils::EnvGuard;
 
-use super::actions::{execute_command, DaemonState};
+use super::actions::{
+    close_current_browser, execute_command, maybe_autosave_restore_state, DaemonState,
+};
 
 fn assert_success(resp: &Value) {
     assert_eq!(
@@ -5434,6 +5436,159 @@ async fn e2e_restore_loads_during_explicit_launch_before_navigation() {
         assert!(
             found,
             "Cookie should be restored by explicit launch before first navigation. Cookies found: {:?}",
+            cookies
+                .iter()
+                .map(|c| c["name"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+
+        let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+        assert_success(&resp);
+    }
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(format!("{}.previous", path));
+}
+
+/// Verify that periodic autosave persists session state while the browser is
+/// open, so state survives the browser dying WITHOUT the daemon's
+/// save-on-close path running (e.g. the user closes the window by hand).
+#[tokio::test]
+#[ignore]
+async fn e2e_periodic_autosave_survives_abrupt_browser_exit() {
+    let restore_key = format!(
+        "e2e-autosave-abrupt-{}",
+        &uuid::Uuid::new_v4().to_string()[..8]
+    );
+    let env = EnvGuard::new(&[
+        "AGENT_BROWSER_SESSION_NAME",
+        "AGENT_BROWSER_RESTORE_SAVE",
+        "AGENT_BROWSER_STATE",
+        "AGENT_BROWSER_ENCRYPTION_KEY",
+    ]);
+    env.remove("AGENT_BROWSER_SESSION_NAME");
+    env.remove("AGENT_BROWSER_RESTORE_SAVE");
+    env.remove("AGENT_BROWSER_STATE");
+    env.remove("AGENT_BROWSER_ENCRYPTION_KEY");
+
+    {
+        let mut state = DaemonState::new();
+        let resp = execute_command(
+            &json!({
+                "id": "1",
+                "action": "launch",
+                "headless": true,
+                "restoreKey": restore_key
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp = execute_command(
+            &json!({
+                "id": "3",
+                "action": "cookies_set",
+                "name": "autosave_test",
+                "value": "saved_by_tick",
+                "domain": ".example.com",
+                "path": "/",
+                "expires": 2000000000
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        assert!(
+            state.autosave_pending,
+            "browser-touching commands should mark the session dirty"
+        );
+
+        // The command just finished, so the quiet period must block the tick.
+        maybe_autosave_restore_state(&mut state, 30_000).await;
+        assert_eq!(state.restore_save_status, "not_attempted");
+        assert!(
+            super::state::find_auto_state_file(&restore_key).is_none(),
+            "autosave must not fire inside the post-command quiet period"
+        );
+
+        // Simulate the quiet period having elapsed, then run the tick again.
+        state.last_command_finished =
+            std::time::Instant::now().checked_sub(std::time::Duration::from_secs(10));
+        maybe_autosave_restore_state(&mut state, 30_000).await;
+        assert_eq!(state.restore_save_status, "saved");
+        assert!(!state.autosave_pending);
+        assert!(
+            super::state::find_auto_state_file(&restore_key).is_some(),
+            "periodic autosave should write the session state file"
+        );
+
+        // Kill the browser out from under the daemon, the way a user closing
+        // the window does: the process exits and CDP dies, so no further save
+        // is possible. Then mimic the daemon drain tick, which only closes.
+        let mgr = state.browser.as_mut().expect("browser should be running");
+        let _ = mgr
+            .client
+            .send_command_no_params("Browser.close", None)
+            .await;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !mgr.has_process_exited() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(
+            state
+                .browser
+                .as_mut()
+                .expect("browser manager should still be present")
+                .has_process_exited(),
+            "browser process should have exited after Browser.close"
+        );
+        let _ = close_current_browser(&mut state).await;
+    }
+
+    let path = super::state::find_auto_state_file(&restore_key)
+        .expect("autosaved state should survive the abrupt browser exit");
+
+    {
+        let mut state = DaemonState::new();
+        let resp = execute_command(
+            &json!({
+                "id": "10",
+                "action": "launch",
+                "headless": true,
+                "restoreKey": restore_key
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        assert_eq!(get_data(&resp)["lifecycle"]["restoreStatus"], "loaded");
+
+        let resp = execute_command(
+            &json!({ "id": "11", "action": "navigate", "url": "https://example.com" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let resp =
+            execute_command(&json!({ "id": "12", "action": "cookies_get" }), &mut state).await;
+        assert_success(&resp);
+        let cookies = get_data(&resp)["cookies"].as_array().unwrap();
+        let found = cookies
+            .iter()
+            .any(|c| c["name"] == "autosave_test" && c["value"] == "saved_by_tick");
+        assert!(
+            found,
+            "Cookie saved only by periodic autosave should be restored after the browser was killed without a graceful close. Cookies found: {:?}",
             cookies
                 .iter()
                 .map(|c| c["name"].as_str().unwrap_or("?"))

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5507,11 +5507,6 @@ async fn e2e_periodic_autosave_survives_abrupt_browser_exit() {
         .await;
         assert_success(&resp);
 
-        assert!(
-            state.autosave_pending,
-            "browser-touching commands should mark the session dirty"
-        );
-
         // The command just finished, so the quiet period must block the tick.
         maybe_autosave_restore_state(&mut state, 30_000).await;
         assert_eq!(state.restore_save_status, "not_attempted");
@@ -5525,10 +5520,24 @@ async fn e2e_periodic_autosave_survives_abrupt_browser_exit() {
             std::time::Instant::now().checked_sub(std::time::Duration::from_secs(10));
         maybe_autosave_restore_state(&mut state, 30_000).await;
         assert_eq!(state.restore_save_status, "saved");
-        assert!(!state.autosave_pending);
+        assert!(
+            state.last_autosave_attempt.is_some(),
+            "successful save should reset the periodic interval"
+        );
         assert!(
             super::state::find_auto_state_file(&restore_key).is_some(),
             "periodic autosave should write the session state file"
+        );
+
+        // An idle session stays eligible: once the interval elapses again the
+        // tick re-saves, capturing page-driven mutations like token refreshes.
+        state.last_autosave_attempt =
+            std::time::Instant::now().checked_sub(std::time::Duration::from_secs(31));
+        state.restore_save_status = "not_attempted".to_string();
+        maybe_autosave_restore_state(&mut state, 30_000).await;
+        assert_eq!(
+            state.restore_save_status, "saved",
+            "idle session should be re-saved on the next interval without new commands"
         );
 
         // Kill the browser out from under the daemon, the way a user closing

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3570,6 +3570,7 @@ Environment:
   AGENT_BROWSER_NAMESPACE        Namespace for daemon sockets and restore state
   AGENT_BROWSER_RESTORE          Auto-save/restore persistence key
   AGENT_BROWSER_RESTORE_SAVE     Restore save policy: auto, always, never
+  AGENT_BROWSER_AUTOSAVE_INTERVAL_MS Min ms between periodic session autosaves (default: 30000, 0 disables)
   AGENT_BROWSER_RESTORE_CHECK_URL URL pattern restored state must match
   AGENT_BROWSER_RESTORE_CHECK_TEXT Page text restored state must contain
   AGENT_BROWSER_RESTORE_CHECK_FN JS expression restored state must satisfy

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -259,6 +259,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_NAMESPACE</code></td><td>Namespace for daemon sockets and restore-state directories.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE</code></td><td>Auto-save/load state persistence key.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_SAVE</code></td><td>Restore save policy: <code>auto</code>, <code>always</code>, or <code>never</code>.</td><td><code>auto</code></td></tr>
+    <tr><td><code>AGENT_BROWSER_AUTOSAVE_INTERVAL_MS</code></td><td>Minimum ms between periodic session autosaves while the browser is open. <code>0</code> saves only on close.</td><td><code>30000</code></td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_CHECK_URL</code></td><td>URL pattern restored state must match.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_CHECK_TEXT</code></td><td>Page text restored state must contain.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_CHECK_FN</code></td><td>JavaScript expression restored state must satisfy.</td><td>(none)</td></tr>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -154,6 +154,8 @@ agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open
 
 State files are stored in `~/.agent-browser/sessions/` and automatically loaded before navigation. With the default `--restore-save auto` policy, failed restore or failed validation skips auto-save.
 
+State is saved when the browser closes (explicit `close`, idle timeout, or daemon shutdown) and also periodically while the browser is open, so a browser window you close by hand still leaves a recent save behind. Periodic autosave runs after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` (default 30000; set to `0` to save only on close), and respects the `--restore-save` policy.
+
 ### Restore key rules
 
 Session and restore names must contain only alphanumeric characters, hyphens, and underscores. Use `agent-browser session id` to generate a valid key:
@@ -270,6 +272,7 @@ agent-browser set headers '{"X-Custom-Header": "value"}'
     <tr><td><code>AGENT_BROWSER_NAMESPACE</code></td><td>Namespace for daemon sockets and restore-state directories</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE</code></td><td>Auto-save/load state persistence key</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_SAVE</code></td><td>Restore save policy: <code>auto</code>, <code>always</code>, or <code>never</code></td></tr>
+    <tr><td><code>AGENT_BROWSER_AUTOSAVE_INTERVAL_MS</code></td><td>Minimum ms between periodic session autosaves (default: 30000, <code>0</code> disables)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_CHECK_URL</code></td><td>URL pattern restored state must match</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_CHECK_TEXT</code></td><td>Page text restored state must contain</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_CHECK_FN</code></td><td>JavaScript expression restored state must satisfy</td></tr>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -154,7 +154,7 @@ agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open
 
 State files are stored in `~/.agent-browser/sessions/` and automatically loaded before navigation. With the default `--restore-save auto` policy, failed restore or failed validation skips auto-save.
 
-State is saved when the browser closes (explicit `close`, idle timeout, or daemon shutdown) and also periodically while the browser is open, so a browser window you close by hand still leaves a recent save behind. Periodic autosave runs after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` (default 30000; set to `0` to save only on close), and respects the `--restore-save` policy.
+State is saved when the browser closes (explicit `close`, idle timeout, or daemon shutdown) and also periodically while the browser is open, so a browser window you close by hand still leaves a recent save behind. Periodic autosave waits for commands to settle, then saves at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS` (default 30000; set to `0` to save only on close). Idle sessions keep saving on the same interval, so changes the page makes on its own (token refreshes, background requests) are captured too. It respects the `--restore-save` policy.
 
 ### Restore key rules
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -228,7 +228,7 @@ SESSION="$(agent-browser session id --scope worktree --prefix my-app)"
 agent-browser --session "$SESSION" --restore open https://app.example.com
 ```
 
-`--restore` with no value uses the current `--session` as the persistence key. Agent skills should prefer this over hand-built state file paths. Use `--restore-save auto` by default so a failed restore does not overwrite the previous known-good state.
+`--restore` with no value uses the current `--session` as the persistence key. Agent skills should prefer this over hand-built state file paths. Use `--restore-save auto` by default so a failed restore does not overwrite the previous known-good state. State is saved on close and also periodically while the browser is open (at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS`, default 30000), so state survives even if the user closes the browser window by hand.
 
 ```bash
 agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open https://app.example.com

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -57,7 +57,7 @@ SESSION="$(agent-browser session id --scope worktree --prefix next-dev-loop)"
 agent-browser --session "$SESSION" --restore open https://app.example.com/dashboard
 ```
 
-State is loaded before navigation and saved on close, daemon shutdown, idle timeout, and compatible relaunch. It is also saved periodically while the browser is open (after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS`, default 30000; set to `0` to save only on close), so a browser window the user closes by hand still leaves a recent save behind. The default save policy is `--restore-save auto`, which skips auto-save if restore failed or validation failed; `never` disables periodic autosave too.
+State is loaded before navigation and saved on close, daemon shutdown, idle timeout, and compatible relaunch. It is also saved periodically while the browser is open (after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS`, default 30000; set to `0` to save only on close), so a browser window the user closes by hand still leaves a recent save behind. Idle sessions keep saving on the same interval, capturing changes the page makes on its own such as token refreshes. The default save policy is `--restore-save auto`, which skips auto-save if restore failed or validation failed; `never` disables periodic autosave too.
 
 ```bash
 agent-browser --session "$SESSION" --restore --restore-check-url "**/dashboard" open https://app.example.com/dashboard

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -57,7 +57,7 @@ SESSION="$(agent-browser session id --scope worktree --prefix next-dev-loop)"
 agent-browser --session "$SESSION" --restore open https://app.example.com/dashboard
 ```
 
-State is loaded before navigation and saved on close, daemon shutdown, idle timeout, and compatible relaunch. The default save policy is `--restore-save auto`, which skips auto-save if restore failed or validation failed.
+State is loaded before navigation and saved on close, daemon shutdown, idle timeout, and compatible relaunch. It is also saved periodically while the browser is open (after commands settle, at most once per `AGENT_BROWSER_AUTOSAVE_INTERVAL_MS`, default 30000; set to `0` to save only on close), so a browser window the user closes by hand still leaves a recent save behind. The default save policy is `--restore-save auto`, which skips auto-save if restore failed or validation failed; `never` disables periodic autosave too.
 
 ```bash
 agent-browser --session "$SESSION" --restore --restore-check-url "**/dashboard" open https://app.example.com/dashboard


### PR DESCRIPTION
* Save restore state periodically after browser-touching commands, honoring the quiet period and restore-save policy.
* Add the AGENT_BROWSER_AUTOSAVE_INTERVAL_MS control and cross-platform daemon ticks.
* Document autosave behavior across CLI help, README, docs, and core skill references.