### PR TITLE
docs: document private network browser fallback

### DIFF
--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -402,6 +402,35 @@ EOF
 
 **Authentication expires mid-workflow** Use `--session <id> --restore` so your session survives browser restarts. Check `agent-browser session info --json` if restore fails. See [references/session-management.md](references/session-management.md) and [references/authentication.md](references/authentication.md).
 
+**Private network host fails with `ERR_ADDRESS_UNREACHABLE` on macOS** If `agent-browser open <url>` fails for an intranet or private-IP host, but terminal tools or the user's normal desktop Chrome can reach the same URL, do not report a product login, GitLab, or resource authorization failure. Treat it as a browser access mismatch: Chrome for Testing (`com.google.chrome.for.testing`) may not have the same Local Network/private-route permission as the user's desktop Chrome.
+
+Verify the split first:
+
+```bash
+dig +short <host>
+route -n get <private-ip>
+nc -vz -G 5 <host> 443
+curl -L -sS -o /tmp/page.html -w '%{http_code} %{url_effective} %{content_type}\n' <url>
+agent-browser --session private-net-check open <url>
+agent-browser --session private-net-check --headed open <url>
+```
+
+If terminal checks pass and Chrome for Testing still fails, use a visible, task-scoped desktop Chrome with a CDP port, approve any macOS "Local Network" prompt, then attach agent-browser to that browser:
+
+```bash
+open -na "/Applications/Google Chrome.app" --args \
+  --user-data-dir=/tmp/agent-browser-private-net \
+  --remote-debugging-port=9222 \
+  --no-first-run \
+  --no-default-browser-check \
+  --no-proxy-server \
+  "<url>"
+
+agent-browser --cdp 9222 snapshot -i
+```
+
+Use the attached browser for DOM, screenshot, login, and interaction evidence. Only call access blocked after the terminal checks fail too, or after a visible CDP-connected Chrome also cannot load the URL with the OS prompt handled.
+
 ## Global flags worth knowing
 
 ```bash


### PR DESCRIPTION
## Summary
- Document how to diagnose private-network `ERR_ADDRESS_UNREACHABLE` failures in the agent-browser core skill.
- Clarify that terminal/desktop Chrome reachability means this is a Chrome for Testing browser access mismatch, not product authorization.
- Add a CDP fallback using a visible desktop Chrome for DOM, screenshot, login, and interaction evidence.

## Prior art checked
- #1502 / #1503 are the closest related work: they identify the same macOS Chrome for Testing vs real Chrome identity class, but fix profile cookie/keychain reuse rather than private-network reachability.
- #941 is an adjacent bundled-Chrome network issue, but it reports Linux external-site timeouts, not macOS private-network / Local Network permission failures.
- #1004, #1201, and #1508 cover auto-connect / remote debugging diagnostics, which are relevant to the fallback path but do not cover Chrome for Testing failing to reach a private host while terminal and desktop Chrome succeed.
- GitHub search found no existing issue or PR for `ERR_ADDRESS_UNREACHABLE`, `ADDRESS_UNREACHABLE`, `Local Network`, `private network`, `com.google.chrome.for.testing`, or intranet/private-host reachability matching this failure shape.

## Verification
- Reproduced agent-browser default Chrome for Testing failure against a private-network host: `net::ERR_ADDRESS_UNREACHABLE`.
- Verified terminal network path with `dig`, `route`, `nc`, and `curl`.
- Verified `agent-browser --headed` still fails on the same host.
- Verified `agent-browser --cdp` can attach to a visible desktop Chrome on the same host and read the page DOM.
- Ran `git diff --check`.
