### PR TITLE
fix: pin npm install version to mitigate supply-chain risk

### DIFF
--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -9,7 +9,9 @@ hidden: true
 
 Fast browser automation CLI for AI agents. Chrome/Chromium via CDP with accessibility-tree snapshots and compact `@eN` element refs.
 
-Install: `npm i -g agent-browser && agent-browser install`
+Install: `npm i -g agent-browser@0.31.1 && agent-browser install`
+
+> **Security note:** Pin to a specific version to avoid silent upgrades from unreviewed releases. Verify the current release at [github.com/vercel-labs/agent-browser/releases](https://github.com/vercel-labs/agent-browser/releases) before installing. Unpinned global installs (`npm i -g agent-browser`) are convenient but accept whatever version the registry serves at install time.
 
 ## Start here
 


### PR DESCRIPTION
## Summary

- Pins the install command in `skills/agent-browser/SKILL.md` from `npm i -g agent-browser` to `npm i -g agent-browser@0.31.1`
- Adds a brief security note directing adopters to verify the release before installing

## Motivation

This was flagged as `LLM_SUPPLY_CHAIN_ATTACK · HIGH` by the [Cisco AI Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) against this skill's `SKILL.md`.

An unpinned global install (`npm i -g agent-browser`) silently receives whatever version the registry serves at install time. If a compromised version is published before an org installs or updates the package, they receive it with no visible signal.

This is particularly impactful here because `SKILL.md` is a stub that delegates **all** agent behavior to the CLI — a compromised npm package would give an attacker full browser automation and credential access. The SHA pin in a catalog entry only pins the stub, not the runtime behavior the CLI serves.

**Likelihood:** Low — elevates for orgs that run `npm update -g` routinely without reviewing the changelog.
**Impact:** Critical — this is the delivery mechanism for any supply-chain attack against this package.

References:
- [LLM03:2025](https://genai.owasp.org/llmrisk/llm032025-supply-chain/) — OWASP Top 10 for LLM Applications: Supply Chain
- [A03:2025](https://owasp.org/Top10/2025/A03_2025-Software_Supply_Chain_Failures/) — OWASP Top 10: Software Supply Chain Failures

## Maintenance note

The pinned version (`@0.31.1`) will need bumping with each release. I'd suggest adding it to the release checklist (alongside the version sync step already in `AGENTS.md`). Alternatively, a `scripts/` helper that reads from `package.json` and patches `SKILL.md` could automate this.

## Test plan

- [ ] `SKILL.md` renders correctly as Markdown (blockquote + code fence)
- [ ] No code changes — CI (Rust tests, version sync, dashboard build) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)