### PR TITLE
fix(recording): suppress ffmpeg console window on Windows

### DIFF
--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -117,6 +117,17 @@ fn build_ffmpeg_command(output_path: &str) -> tokio::process::Command {
         .stderr(Stdio::piped())
         .kill_on_drop(true);
 
+    // ffmpeg is a console-subsystem app. The recording daemon is spawned
+    // DETACHED_PROCESS (no console to inherit), so on Windows a plain spawn makes
+    // the OS allocate a visible console window for ffmpeg that stays up for the
+    // whole recording. CREATE_NO_WINDOW suppresses it; the piped stdin/stderr are
+    // unaffected.
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
     cmd
 }
 


### PR DESCRIPTION
## Summary

On Windows, starting a recording pops a visible, empty console window that stays open for the whole recording. It is the console Windows allocates for the spawned `ffmpeg.exe`.

## Root cause

`build_ffmpeg_command` (`cli/src/native/recording.rs`) spawns ffmpeg with no Windows creation flags. The recording daemon is spawned `DETACHED_PROCESS` (no console of its own — see `cli/src/connection.rs` and `cli/src/main.rs`), so there is no console for the ffmpeg child to inherit and Windows allocates a fresh one and shows its window. ffmpeg's stdout is `Stdio::null()` and stderr is piped, so the window is empty; it closes on `record stop`.

## Fix

Add `CREATE_NO_WINDOW` (`0x08000000`) to the ffmpeg command on Windows, mirroring the `creation_flags` already used for the daemon spawns. This suppresses the console window without affecting the `image2pipe` stdin or the stderr capture. No effect on macOS/Linux (the code is `#[cfg(windows)]`).

## Testing

Not tested on Windows — I don't have a Rust Windows toolchain set up locally to compile the `#[cfg(windows)]` path, so this is unverified by build or run. The change is small and mirrors an existing pattern in the repo, so it seems straightforward, but a Windows build/CI is the real check. macOS/Linux are unaffected.

---

Authored by Opus 4.8 (via Claude Code) and @mutewinter.
