### PR TITLE
fix: clean up remote provider sessions when daemon is unreachable

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,0 +1,48 @@
+name: Build Native Binary
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Linux x64 Binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install npm dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
+
+      - name: Build native binary
+        run: pnpm build:native
+
+      - name: Verify binary exists
+        run: |
+          ls -la bin/agent-browser-linux-x64
+          file bin/agent-browser-linux-x64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-browser-linux-x64
+          path: bin/agent-browser-linux-x64
+          if-no-files-found: error

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -153,6 +153,18 @@ fn get_config_path(session: &str) -> PathBuf {
     get_socket_dir().join(format!("{}.config", session))
 }
 
+fn get_provider_session_path(session: &str) -> PathBuf {
+    get_socket_dir().join(format!("{}.provider-session", session))
+}
+
+/// Read the provider session ID saved by the daemon for cleanup on crash.
+pub fn read_provider_session_id(session: &str) -> Option<String> {
+    fs::read_to_string(get_provider_session_path(session))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Clean up stale socket and PID files for a session
 pub fn cleanup_stale_files(session: &str) {
     let pid_path = get_pid_path(session);
@@ -163,6 +175,8 @@ pub fn cleanup_stale_files(session: &str) {
     let _ = fs::remove_file(&config_path);
     let stream_path = get_socket_dir().join(format!("{}.stream", session));
     let _ = fs::remove_file(&stream_path);
+    let provider_session_path = get_provider_session_path(session);
+    let _ = fs::remove_file(&provider_session_path);
 
     #[cfg(unix)]
     {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ use windows_sys::Win32::System::Threading::OpenProcess;
 use commands::{gen_id, parse_command, ParseError};
 use connection::{
     cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
-    send_command, walk_daemons, DaemonOptions, Response,
+    read_provider_session_id, send_command, walk_daemons, DaemonOptions, Response,
 };
 use flags::{clean_args, parse_flags, Flags};
 use install::run_install;
@@ -787,11 +787,97 @@ fn run_dashboard_stop(json_mode: bool) {
     }
 }
 
+fn read_provider_file(session: &str) -> Option<String> {
+    let path = get_socket_dir().join(format!("{}.provider", session));
+    fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Best-effort cleanup of a remote provider session when the local daemon is
+/// unreachable. This prevents orphaned cloud sessions (e.g. Browser Use) from
+/// counting against the plan's concurrent session limit.
+async fn cleanup_orphaned_provider_session(session: &str) {
+    let provider = match read_provider_file(session) {
+        Some(p) => p,
+        None => return,
+    };
+    let session_id = match read_provider_session_id(session) {
+        Some(id) => id,
+        None => return,
+    };
+
+    let client = reqwest::Client::new();
+    match provider.as_str() {
+        "browser-use" | "browseruse" => {
+            if let Ok(api_key) = env::var("BROWSER_USE_API_KEY") {
+                let _ = client
+                    .patch(format!(
+                        "https://api.browser-use.com/api/v3/browsers/{}",
+                        session_id
+                    ))
+                    .header("X-Browser-Use-API-Key", &api_key)
+                    .header("Content-Type", "application/json")
+                    .json(&json!({ "action": "stop" }))
+                    .send()
+                    .await;
+            }
+        }
+        "browserbase" => {
+            if let Ok(api_key) = env::var("BROWSERBASE_API_KEY") {
+                let _ = client
+                    .post(format!(
+                        "https://api.browserbase.com/v1/sessions/{}",
+                        session_id
+                    ))
+                    .header("Content-Type", "application/json")
+                    .header("X-BB-API-Key", &api_key)
+                    .json(&serde_json::json!({ "status": "REQUEST_RELEASE" }))
+                    .send()
+                    .await;
+            }
+        }
+        "browserless" => {
+            let _ = client.delete(&session_id).send().await;
+        }
+        "kernel" => {
+            if let Ok(api_key) = env::var("KERNEL_API_KEY") {
+                let endpoint = env::var("KERNEL_ENDPOINT")
+                    .unwrap_or_else(|_| "https://api.onkernel.com".to_string());
+                let _ = client
+                    .delete(format!(
+                        "{}/browsers/{}",
+                        endpoint.trim_end_matches('/'),
+                        session_id
+                    ))
+                    .header("Authorization", format!("Bearer {}", api_key))
+                    .send()
+                    .await;
+            }
+        }
+        _ => {}
+    }
+}
+
 fn run_close_all(flags: &Flags) {
     // walk_daemons auto-cleans stale .pid / .sock / .stream sidecar files and
     // separates out the standalone dashboard. We only want to send `close` to
     // real session daemons; the dashboard has its own `dashboard stop`.
     let inventory = walk_daemons();
+
+    // Clean up orphaned provider sessions for dead daemons that were already
+    // cleaned up by walk_daemons(). This prevents cloud sessions (e.g. Browser Use)
+    // from counting against the plan's concurrent session limit.
+    let rt = tokio::runtime::Runtime::new().ok();
+    for cleaned in &inventory.cleaned {
+        if let Some(rt) = rt.as_ref() {
+            rt.block_on(cleanup_orphaned_provider_session(&cleaned.name));
+        }
+        // Also remove leftover .provider file
+        let _ = fs::remove_file(get_socket_dir().join(format!("{}.provider", cleaned.name)));
+    }
+
     let sessions: Vec<(String, u32)> = inventory
         .sessions
         .iter()
@@ -836,6 +922,12 @@ fn run_close_all(flags: &Flags) {
                         windows_sys::Win32::System::Threading::TerminateProcess(handle, 1);
                         CloseHandle(handle);
                     }
+                }
+                // Best-effort cleanup of remote provider session (e.g. Browser Use)
+                // so orphaned cloud sessions don't count against plan limits.
+                let rt = tokio::runtime::Runtime::new().ok();
+                if let Some(rt) = rt {
+                    rt.block_on(cleanup_orphaned_provider_session(session));
                 }
                 cleanup_stale_files(session);
                 closed.push(session.clone());

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2180,6 +2180,9 @@ async fn auto_launch(
                     state.start_dialog_handler();
                     state.update_stream_client().await;
                     write_provider_file(&state.session_id, &p);
+                    if let Some(ref ps) = conn.session {
+                        write_provider_session_file(&state.session_id, &ps.session_id);
+                    }
                     apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
                     try_auto_restore_state(state).await;
                     try_load_storage_state(state, &storage_state_path).await;
@@ -2875,6 +2878,9 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.start_dialog_handler();
                         state.update_stream_client().await;
                         write_provider_file(&state.session_id, provider);
+                        if let Some(ref ps) = conn.session {
+                            write_provider_session_file(&state.session_id, &ps.session_id);
+                        }
                         apply_launch_init_scripts(state, &enable_features, &init_script_paths)
                             .await;
                         try_auto_restore_state(state).await;
@@ -6295,8 +6301,15 @@ fn write_provider_file(session_id: &str, provider: &str) {
     let _ = fs::write(provider_file_path(session_id), provider);
 }
 
+fn write_provider_session_file(session_id: &str, provider_session_id: &str) {
+    let path = get_socket_dir().join(format!("{}.provider-session", session_id));
+    let _ = fs::write(path, provider_session_id);
+}
+
 fn remove_provider_file(session_id: &str) {
     let _ = fs::remove_file(provider_file_path(session_id));
+    let path = get_socket_dir().join(format!("{}.provider-session", session_id));
+    let _ = fs::remove_file(path);
 }
 
 fn extensions_file_path(session_id: &str) -> PathBuf {


### PR DESCRIPTION
When `close --all` encounters an unreachable daemon, it never calls the provider cleanup API, leaving orphaned cloud sessions (e.g. Browser Use) counting against the plan limit.

This persists provider session IDs to `.provider-session` sidecar files and calls the cleanup API on unreachable daemons.

Supports: Browser Use, Browserbase, Browserless, Kernel.