### PR TITLE
fix: clean up remote provider sessions when daemon is unreachable

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -153,6 +153,18 @@ fn get_config_path(session: &str) -> PathBuf {
     get_socket_dir().join(format!("{}.config", session))
 }
 
+fn get_provider_session_path(session: &str) -> PathBuf {
+    get_socket_dir().join(format!("{}.provider-session", session))
+}
+
+/// Read the provider session ID saved by the daemon for cleanup on crash.
+pub fn read_provider_session_id(session: &str) -> Option<String> {
+    fs::read_to_string(get_provider_session_path(session))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Clean up stale socket and PID files for a session
 pub fn cleanup_stale_files(session: &str) {
     let pid_path = get_pid_path(session);
@@ -163,6 +175,8 @@ pub fn cleanup_stale_files(session: &str) {
     let _ = fs::remove_file(&config_path);
     let stream_path = get_socket_dir().join(format!("{}.stream", session));
     let _ = fs::remove_file(&stream_path);
+    let provider_session_path = get_provider_session_path(session);
+    let _ = fs::remove_file(&provider_session_path);
 
     #[cfg(unix)]
     {
@@ -229,6 +243,7 @@ pub enum CleanReason {
 pub struct CleanedSession {
     pub name: String,
     pub reason: CleanReason,
+    pub provider_session_id: Option<String>,
 }
 
 /// Information about the standalone dashboard process, if any.
@@ -289,6 +304,7 @@ pub fn walk_daemons() -> DaemonInventory {
                         inventory.cleaned.push(CleanedSession {
                             name: "dashboard".to_string(),
                             reason: CleanReason::DashboardGone,
+                            provider_session_id: None,
                         });
                     }
                 }
@@ -307,20 +323,24 @@ pub fn walk_daemons() -> DaemonInventory {
         {
             Some(p) => p,
             None => {
+                let provider_session_id = read_provider_session_id(&session_name);
                 cleanup_stale_files(&session_name);
                 inventory.cleaned.push(CleanedSession {
                     name: session_name,
                     reason: CleanReason::UnreadablePidFile,
+                    provider_session_id,
                 });
                 continue;
             }
         };
 
         if !is_pid_alive(pid) {
+            let provider_session_id = read_provider_session_id(&session_name);
             cleanup_stale_files(&session_name);
             inventory.cleaned.push(CleanedSession {
                 name: session_name,
                 reason: CleanReason::ProcessGone,
+                provider_session_id,
             });
             continue;
         }
@@ -344,10 +364,12 @@ pub fn walk_daemons() -> DaemonInventory {
                 }
                 let pid_path = socket_dir.join(format!("{}.pid", session_name));
                 if !pid_path.exists() {
+                    let provider_session_id = read_provider_session_id(session_name);
                     cleanup_stale_files(session_name);
                     inventory.cleaned.push(CleanedSession {
                         name: session_name.to_string(),
                         reason: CleanReason::OrphanedSocket,
+                        provider_session_id,
                     });
                 }
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ use windows_sys::Win32::System::Threading::OpenProcess;
 use commands::{gen_id, parse_command, ParseError};
 use connection::{
     cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
-    send_command, walk_daemons, DaemonOptions, Response,
+    read_provider_session_id, send_command, walk_daemons, DaemonOptions, Response,
 };
 use flags::{clean_args, parse_flags, Flags};
 use install::run_install;
@@ -787,11 +787,95 @@ fn run_dashboard_stop(json_mode: bool) {
     }
 }
 
+fn read_provider_file(session: &str) -> Option<String> {
+    let path = get_socket_dir().join(format!("{}.provider", session));
+    fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Best-effort cleanup of a remote provider session when the local daemon is
+/// unreachable. This prevents orphaned cloud sessions (e.g. Browser Use) from
+/// counting against the plan's concurrent session limit.
+async fn cleanup_orphaned_provider_session(session: &str, provider_session_id: &str) {
+    let provider = match read_provider_file(session) {
+        Some(p) => p,
+        None => return,
+    };
+
+    let client = reqwest::Client::new();
+    match provider.as_str() {
+        "browser-use" | "browseruse" => {
+            if let Ok(api_key) = env::var("BROWSER_USE_API_KEY") {
+                let _ = client
+                    .patch(format!(
+                        "https://api.browser-use.com/api/v3/browsers/{}",
+                        provider_session_id
+                    ))
+                    .header("X-Browser-Use-API-Key", &api_key)
+                    .header("Content-Type", "application/json")
+                    .json(&json!({ "action": "stop" }))
+                    .send()
+                    .await;
+            }
+        }
+        "browserbase" => {
+            if let Ok(api_key) = env::var("BROWSERBASE_API_KEY") {
+                let _ = client
+                    .post(format!(
+                        "https://api.browserbase.com/v1/sessions/{}",
+                        provider_session_id
+                    ))
+                    .header("Content-Type", "application/json")
+                    .header("X-BB-API-Key", &api_key)
+                    .json(&serde_json::json!({ "status": "REQUEST_RELEASE" }))
+                    .send()
+                    .await;
+            }
+        }
+        "browserless" => {
+            let _ = client.delete(provider_session_id).send().await;
+        }
+        "kernel" => {
+            if let Ok(api_key) = env::var("KERNEL_API_KEY") {
+                let endpoint = env::var("KERNEL_ENDPOINT")
+                    .unwrap_or_else(|_| "https://api.onkernel.com".to_string());
+                let _ = client
+                    .delete(format!(
+                        "{}/browsers/{}",
+                        endpoint.trim_end_matches('/'),
+                        provider_session_id
+                    ))
+                    .header("Authorization", format!("Bearer {}", api_key))
+                    .send()
+                    .await;
+            }
+        }
+        _ => {}
+    }
+}
+
 fn run_close_all(flags: &Flags) {
     // walk_daemons auto-cleans stale .pid / .sock / .stream sidecar files and
     // separates out the standalone dashboard. We only want to send `close` to
     // real session daemons; the dashboard has its own `dashboard stop`.
     let inventory = walk_daemons();
+
+    // Clean up orphaned provider sessions for dead daemons that were already
+    // cleaned up by walk_daemons(). This prevents cloud sessions (e.g. Browser Use)
+    // from counting against the plan's concurrent session limit.
+    let rt = tokio::runtime::Runtime::new().ok();
+    for cleaned in &inventory.cleaned {
+        if let Some(ref session_id) = cleaned.provider_session_id {
+            if let Some(rt) = rt.as_ref() {
+                rt.block_on(cleanup_orphaned_provider_session(&cleaned.name, session_id));
+            }
+        }
+        // Also remove leftover .provider file
+        let _ = fs::remove_file(get_socket_dir().join(format!("{}.provider", cleaned.name)));
+    }
+
     let sessions: Vec<(String, u32)> = inventory
         .sessions
         .iter()
@@ -835,6 +919,14 @@ fn run_close_all(flags: &Flags) {
                     if handle != 0 {
                         windows_sys::Win32::System::Threading::TerminateProcess(handle, 1);
                         CloseHandle(handle);
+                    }
+                }
+                // Best-effort cleanup of remote provider session (e.g. Browser Use)
+                // so orphaned cloud sessions don't count against plan limits.
+                if let Some(provider_session_id) = read_provider_session_id(session) {
+                    let rt = tokio::runtime::Runtime::new().ok();
+                    if let Some(rt) = rt {
+                        rt.block_on(cleanup_orphaned_provider_session(session, &provider_session_id));
                     }
                 }
                 cleanup_stale_files(session);

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2180,6 +2180,9 @@ async fn auto_launch(
                     state.start_dialog_handler();
                     state.update_stream_client().await;
                     write_provider_file(&state.session_id, &p);
+                    if let Some(ref ps) = conn.session {
+                        write_provider_session_file(&state.session_id, &ps.session_id);
+                    }
                     apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
                     try_auto_restore_state(state).await;
                     try_load_storage_state(state, &storage_state_path).await;
@@ -2875,6 +2878,9 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.start_dialog_handler();
                         state.update_stream_client().await;
                         write_provider_file(&state.session_id, provider);
+                        if let Some(ref ps) = conn.session {
+                            write_provider_session_file(&state.session_id, &ps.session_id);
+                        }
                         apply_launch_init_scripts(state, &enable_features, &init_script_paths)
                             .await;
                         try_auto_restore_state(state).await;
@@ -6295,8 +6301,15 @@ fn write_provider_file(session_id: &str, provider: &str) {
     let _ = fs::write(provider_file_path(session_id), provider);
 }
 
+fn write_provider_session_file(session_id: &str, provider_session_id: &str) {
+    let path = get_socket_dir().join(format!("{}.provider-session", session_id));
+    let _ = fs::write(path, provider_session_id);
+}
+
 fn remove_provider_file(session_id: &str) {
     let _ = fs::remove_file(provider_file_path(session_id));
+    let path = get_socket_dir().join(format!("{}.provider-session", session_id));
+    let _ = fs::remove_file(path);
 }
 
 fn extensions_file_path(session_id: &str) -> PathBuf {

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -141,7 +141,7 @@ pub async fn close_provider_session_with_plugins(
             if let Ok(api_key) = env::var("BROWSER_USE_API_KEY") {
                 let _ = client
                     .patch(format!(
-                        "https://api.browser-use.com/api/v2/browsers/{}",
+                        "https://api.browser-use.com/api/v3/browsers/{}",
                         session.session_id
                     ))
                     .header("X-Browser-Use-API-Key", &api_key)
@@ -385,9 +385,88 @@ async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), Stri
     let api_key = env::var("BROWSER_USE_API_KEY")
         .map_err(|_| "BROWSER_USE_API_KEY environment variable is not set")?;
 
-    let ws_url = format!("wss://connect.browser-use.com?apiKey={}", api_key);
+    let client = reqwest::Client::new();
 
-    Ok((ws_url, None))
+    // Step 1: Create a browser session via v3 REST API
+    let response = client
+        .post("https://api.browser-use.com/api/v3/browsers")
+        .header("X-Browser-Use-API-Key", &api_key)
+        .header("Content-Type", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| format!("Browser Use request failed: {}", e))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Browser Use response: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "Browser Use API error ({}): {}",
+            status.as_u16(),
+            body
+        ));
+    }
+
+    let json: Value =
+        serde_json::from_str(&body).map_err(|e| format!("Invalid Browser Use response: {}", e))?;
+
+    let session_id = json
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let cdp_url = json
+        .get("cdpUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Browser Use response missing cdpUrl".to_string())?;
+
+    // Step 2: Get the WebSocket debugger URL from the CDP endpoint
+    let version_url = format!(
+        "{}/json/version",
+        cdp_url.trim_end_matches('/')
+    );
+    let version_response = client
+        .get(&version_url)
+        .send()
+        .await
+        .map_err(|e| format!("Browser Use CDP version request failed: {}", e))?;
+
+    let version_status = version_response.status();
+    let version_body = version_response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Browser Use CDP version response: {}", e))?;
+
+    if !version_status.is_success() {
+        return Err(format!(
+            "Browser Use CDP version error ({}): {}",
+            version_status.as_u16(),
+            version_body
+        ));
+    }
+
+    let version_json: Value = serde_json::from_str(&version_body)
+        .map_err(|e| format!("Invalid Browser Use CDP version response: {}", e))?;
+
+    let ws_url = version_json
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Browser Use CDP version response missing webSocketDebuggerUrl".to_string())?;
+
+    Ok((
+        ws_url,
+        Some(ProviderSession {
+            provider: "browser-use".to_string(),
+            session_id,
+        }),
+    ))
 }
 
 async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {


### PR DESCRIPTION
When `close --all` encounters an unreachable daemon, it now reads the provider session ID from disk and calls the cleanup API. Prevents orphaned Browser Use/Browserbase/Kernel sessions from counting against plan limits.

Verified locally: killed daemon, ran `close --all`, confirmed session status changed to `stopped` via API.