### PR TITLE
feat(cli): expose the addinitscript command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -144,6 +144,7 @@ pub fn is_top_level_command(value: &str) -> bool {
             | "vitals"
             | "web-vitals"
             | "pushstate"
+            | "addinitscript"
             | "removeinitscript"
             | "session"
             | "mcp"
@@ -1938,6 +1939,20 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             Ok(json!({ "id": id, "action": "pushstate", "url": url }))
         }
 
+        // === Add init script ===
+        "addinitscript" => {
+            // Whole tail is the source, so scripts with spaces work quoted or
+            // not (like `eval`).
+            let script = rest.join(" ");
+            if script.is_empty() {
+                return Err(ParseError::MissingArguments {
+                    context: "addinitscript".to_string(),
+                    usage: "addinitscript <script>",
+                });
+            }
+            Ok(json!({ "id": id, "action": "addinitscript", "script": script }))
+        }
+
         // === Remove init script ===
         "removeinitscript" => {
             let identifier = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -3347,6 +3362,22 @@ mod tests {
         let cmd = parse_command(&args("pushstate /foo"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "pushstate");
         assert_eq!(cmd["url"], "/foo");
+    }
+
+    #[test]
+    fn test_addinitscript_command() {
+        let cmd = parse_command(
+            &args("addinitscript window.__testMode = true"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "addinitscript");
+        assert_eq!(cmd["script"], "window.__testMode = true");
+    }
+
+    #[test]
+    fn test_addinitscript_requires_script() {
+        assert!(parse_command(&args("addinitscript"), &default_flags()).is_err());
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3417,6 +3417,7 @@ SPA:
                              history.pushState + popstate/navigate events for other frameworks
 
 Init scripts:
+  addinitscript <script>     Register a script to run before page JS on future navigations
   removeinitscript <id>      Remove a script registered via --init-script or addinitscript
 
 Batch:


### PR DESCRIPTION
## Summary

`agent-browser addinitscript "<script>"` is documented as a runtime command in `docs/src/app/init-scripts/page.mdx`, the daemon action (`addinitscript`) has existed since the native rewrite, and it is covered by e2e/parity tests — but the CLI parser never wired the command up, so running it fails:

```
$ agent-browser addinitscript "window.__testMode = true"
Unknown command: addinitscript
```

Only `--init-script` (launch-time) and `removeinitscript` were reachable from the CLI, leaving the "add at runtime" path the docs already promise unreachable.

## Changes

- Parse `addinitscript <script>` in `commands.rs` into the existing `{"action":"addinitscript","script":…}` daemon action. The whole argument tail is joined into the source (like `eval`) so inline scripts containing spaces work whether or not the shell quotes them.
- Register `addinitscript` in `is_top_level_command()`.
- List `addinitscript <script>` in the init-scripts help block (`output.rs`).
- Unit tests for the happy path and the missing-argument error.

## Verification

Unit tests plus an end-to-end run against a debug build:

```
$ agent-browser --session s open "data:text/html,<h1>hi</h1>"
$ agent-browser --session s addinitscript "window.__testMode = true"
✓ Done
$ agent-browser --session s reload
$ agent-browser --session s eval "window.__testMode === true"
true
$ agent-browser --session s addinitscript          # missing arg
Usage: agent-browser addinitscript <script>
```

`removeinitscript <id>` round-trips (the script stops running after removal), and multiple `addinitscript` calls stack (each returns its own identifier).

## Scope

This exposes the existing behavior only: the script is registered on the active tab and applies to its future documents. Propagating init scripts to newly opened tabs/popups is a separate concern (#1521) and intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
