### PR TITLE
fix: preserve storage in recording context

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5178,6 +5178,29 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
                 .unwrap_or_else(|_| "about:blank".to_string())
         };
 
+        // Capture the current browser state before creating the recording context.
+        // `record start` promises to preserve cookies and localStorage, but the
+        // recording target lives in a fresh browser context. Reuse the same
+        // storage-state path as `state save/load` so cookies, localStorage, and
+        // sessionStorage stay in sync with the rest of the CLI.
+        let temp_state_arg = std::env::temp_dir()
+            .join(format!(
+                "agent-browser-recording-state-{}.json",
+                uuid::Uuid::new_v4()
+            ))
+            .to_string_lossy()
+            .to_string();
+        let saved_storage_state = state::save_state(
+            &mgr.client,
+            &old_session_id,
+            Some(&temp_state_arg),
+            state.session_name.as_deref(),
+            &state.session_id,
+            mgr.visited_origins(),
+        )
+        .await
+        .ok();
+
         // Capture current cookies
         let cookies_result = mgr
             .client
@@ -5267,6 +5290,12 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
                         .await;
                 }
             }
+        }
+
+        // Transfer localStorage/sessionStorage to the new recording context.
+        if let Some(ref storage_path) = saved_storage_state {
+            let _ = state::load_state(&mgr.client, &new_session_id, storage_path).await;
+            let _ = fs::remove_file(storage_path);
         }
 
         // Add page and switch to it

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -4881,6 +4881,85 @@ async fn e2e_recording_inherits_viewport() {
     assert_success(&resp);
 }
 
+/// Verify that `recording_start` preserves storage from the current page when
+/// it creates the fresh recording context. The CLI help promises cookies and
+/// localStorage survive recording; authenticated SPAs often depend on this.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_preserves_storage() {
+    let (base_url, _server) = start_echo_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": base_url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "localStorage.setItem('ab_record_local', 'from-current-context'); sessionStorage.setItem('ab_record_session', 'from-current-context'); 'ok'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "ok");
+
+    let rec_path =
+        std::env::temp_dir().join(format!("ab-e2e-rec-storage-{}.webm", std::process::id()));
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "evaluate",
+            "script": "({ local: localStorage.getItem('ab_record_local'), session: sessionStorage.getItem('ab_record_session') })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"]["local"],
+        "from-current-context",
+        "recording context should inherit localStorage"
+    );
+    assert_eq!(
+        get_data(&resp)["result"]["session"],
+        "from-current-context",
+        "recording context should inherit sessionStorage"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let _ = std::fs::remove_file(&rec_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // --state / storageState flag: cookies should be loaded at launch time
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`agent-browser record start` creates a fresh browser context for recording and the help text says it preserves cookies and localStorage. In practice the recording path only copied cookies into the fresh context, so authenticated SPAs that store auth/session state in web storage were recorded in a logged-out or otherwise reset state.

This change reuses the existing `state save/load` storage-state implementation when starting a recording:

- save the current page's cookies, localStorage, and sessionStorage before creating the recording context
- create and attach the recording target as before
- load the saved storage state into the recording target before navigating it to the recording URL
- remove the temporary state file immediately after loading

The existing explicit cookie transfer remains as a best-effort compatibility path, but web storage now follows the same semantics as `state save/load`.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo build`
- `cargo test native::recording`
- `cargo test native::state`
- `cargo test e2e_recording_preserves_storage -- --ignored --test-threads=1`
- `cargo test native::e2e_tests::e2e_recording_inherits_viewport -- --ignored --test-threads=1`
