### PR TITLE
fix(snapshot): truncate long link urls in --urls output

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -7,6 +7,7 @@ use super::cdp::types::{
     AXNode, AXProperty, AXValue, EvaluateParams, EvaluateResult, GetFullAXTreeResult,
 };
 use super::element::{resolve_ax_session, RefMap};
+use crate::output::truncate_field;
 
 const INTERACTIVE_ROLES: &[&str] = &[
     "button",
@@ -73,6 +74,10 @@ const INVISIBLE_CHARS: &[char] = &[
     '\u{2060}', // Word Joiner
     '\u{00A0}', // Non-Breaking Space (&nbsp;)
 ];
+
+// Link hrefs longer than this are truncated in `--urls` output so long redirect
+// targets don't dominate the snapshot; the full URL stays reachable via `get attr`.
+const MAX_URL_CHARS: usize = 200;
 
 #[derive(Default)]
 pub struct SnapshotOptions {
@@ -1156,7 +1161,7 @@ fn render_tree(
     }
 
     if let Some(ref url) = node.url {
-        attrs.push(format!("url={}", url));
+        attrs.push(format!("url={}", truncate_field(url, MAX_URL_CHARS)));
     }
 
     if !attrs.is_empty() {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -204,7 +204,7 @@ fn format_compact_number(value: f64) -> String {
     }
 }
 
-fn truncate_field(value: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_field(value: &str, max_chars: usize) -> String {
     if value.chars().count() <= max_chars {
         return value.to_string();
     }
@@ -3753,6 +3753,18 @@ mod tests {
         OutputOptions,
     };
     use serde_json::json;
+
+    #[test]
+    fn test_truncate_field_caps_long_values() {
+        let short = "https://example.com/page";
+        assert_eq!(super::truncate_field(short, 96), short);
+
+        let long = format!("https://example.com/{}", "a".repeat(500));
+        let out = super::truncate_field(&long, 96);
+        assert_eq!(out.chars().count(), 96);
+        assert!(out.starts_with("https://example.com/"));
+        assert!(out.ends_with("..."));
+    }
 
     #[test]
     fn test_format_stream_status_text_for_enabled_stream() {

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -72,6 +72,8 @@ agent-browser snapshot -s "#main"         # scope to a CSS selector
 agent-browser snapshot -i --json          # machine-readable output
 ```
 
+With `-u`, very long link targets are truncated in the `url=` field; fetch the full href with `get attr @<ref> href`.
+
 Snapshot output looks like:
 
 ```


### PR DESCRIPTION
## Summary

`snapshot --urls` inlines each link's `href` verbatim. On link-dense pages, redirect/tracking targets (ad click-throughs, signed URLs) are frequently multi-kilobyte blobs that dominate the snapshot and can blow past an agent harness's tool-output limits, crowding out the actual page structure.

This truncates the inlined `url=` value to 200 characters, keeping a boundary-safe prefix and appending `...`. The full href stays available via `get attr @<ref> href`.

Refines the `--urls` output added in #1160.

## Why truncate (and why 200)

Truncating long fields is already the norm in this codebase — `truncate_field` truncates the vitals LCP asset URL to 96 chars, and `--max-output` / `truncate_if_needed` bound command output. This reuses `truncate_field` rather than adding a parallel helper.

200 is well above real-world URL lengths: typical URLs run ~40-80 chars and even dynamic, parameter-heavy URLs average ~77, so organic links pass through untouched. What exceeds 200 is overwhelmingly tracking/redirect cruft, and the navigable prefix (origin + path + any `/dp/<id>`-style slug) survives the cap.

## Changes

- `cli/src/native/snapshot.rs`: cap the rendered `url=` value via `truncate_field(url, MAX_URL_CHARS)` (`MAX_URL_CHARS = 200`).
- `cli/src/output.rs`: make `truncate_field` `pub(crate)`; add a unit test (it had none).
- `skill-data/core/SKILL.md`: note that `-u` truncates long link targets and to use `get attr` for the full href.

## Testing

`cargo test --bin agent-browser truncate_field` and the snapshot tests pass.

---

_Written with Opus 4.8._
