### PR TITLE
fix: keep active tab with sticky --profile sessions (#1211)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -330,6 +330,10 @@ pub struct DaemonState {
     pub stream_server: Option<Arc<StreamServer>>,
     /// Hash of launch options used for the current browser, for relaunch detection.
     launch_hash: Option<u64>,
+    /// Profile path/name used for the current browser. Sticky across commands:
+    /// headed re-launches omit `--profile` by default, and treating that as
+    /// "no profile" would relaunch into a blank temp profile (#1211).
+    current_profile: Option<String>,
     /// Browser engine name (e.g. "chrome", "lightpanda") for observability.
     pub engine: String,
     /// Default timeout for wait operations, from AGENT_BROWSER_DEFAULT_TIMEOUT env var.
@@ -407,6 +411,7 @@ impl DaemonState {
             stream_client: None,
             stream_server: None,
             launch_hash: None,
+            current_profile: None,
             engine: env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
             // README documents 25s, intentionally below the CLI's 30s IPC
             // read timeout so the daemon reports a proper timeout error
@@ -773,7 +778,7 @@ impl DaemonState {
                     }
 
                     let tab_id = mgr.assign_tab_id();
-                    mgr.add_page(super::browser::PageInfo {
+                    mgr.add_page_background(super::browser::PageInfo {
                         tab_id,
                         label: None,
                         target_id: te.target_info.target_id.clone(),
@@ -1480,6 +1485,7 @@ pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(),
 
     close_active_provider_session(state).await;
     state.launch_hash = None;
+    state.current_profile = None;
     state.screencasting = false;
     state.reset_input_state();
     state.update_stream_client().await;
@@ -2222,10 +2228,12 @@ async fn auto_launch(
         "local",
         None,
     );
+    let profile_for_state = options.profile.clone();
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
     state.browser = Some(mgr);
     state.launch_hash = Some(hash);
+    state.current_profile = profile_for_state;
     state.subscribe_to_browser_events();
     state.start_fetch_handler();
     state.start_dialog_handler();
@@ -2764,7 +2772,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         profile: cmd
             .get("profile")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(|s| s.to_string())
+            // Keep the session's profile when a headed re-launch omits --profile.
+            // Otherwise launch_hash changes and we wipe the open page for #1211.
+            .or_else(|| state.current_profile.clone()),
         allow_file_access: cmd
             .get("allowFileAccess")
             .and_then(|v| v.as_bool())
@@ -3013,9 +3024,11 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     state.engine = engine.as_deref().unwrap_or("chrome").to_string();
     write_engine_file(&state.session_id, &state.engine);
     write_extensions_file_from_paths(&state.session_id, launch_options.extensions.as_deref());
+    let profile_for_state = launch_options.profile.clone();
     state.reset_input_state();
     state.browser = Some(BrowserManager::launch(launch_options, engine.as_deref()).await?);
     state.launch_hash = Some(new_hash);
+    state.current_profile = profile_for_state;
     state.subscribe_to_browser_events();
     state.start_fetch_handler();
     state.start_dialog_handler();
@@ -10641,6 +10654,39 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
                 "local",
                 None
             )
+        );
+    }
+
+    #[test]
+    fn test_sticky_profile_keeps_launch_hash_stable() {
+        // Headed re-launches often omit --profile. Without sticky fill that
+        // would change launch_hash and wipe the open page (#1211).
+        let mut original = LaunchOptions {
+            headless: false,
+            profile: Some("/tmp/agent-browser-sticky-profile".to_string()),
+            ..Default::default()
+        };
+        let hash_with_profile =
+            launch_hash(&original, &[], &[], &[], Some("chrome"), "local", None);
+
+        let omitted = LaunchOptions {
+            headless: false,
+            profile: None,
+            ..Default::default()
+        };
+        assert_ne!(
+            hash_with_profile,
+            launch_hash(&omitted, &[], &[], &[], Some("chrome"), "local", None),
+            "omitting profile must change the hash (so sticky fill is load-bearing)"
+        );
+
+        // Same as handle_launch: fill from current_profile before hashing.
+        original.profile = Some("/tmp/agent-browser-sticky-profile".to_string());
+        let mut sticky = omitted;
+        sticky.profile = original.profile.clone();
+        assert_eq!(
+            hash_with_profile,
+            launch_hash(&sticky, &[], &[], &[], Some("chrome"), "local", None),
         );
     }
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -111,6 +111,20 @@ fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo)
     false
 }
 
+fn add_page_and_activate(pages: &mut Vec<PageInfo>, active_page_index: &mut usize, page: PageInfo) {
+    let index = pages.len();
+    pages.push(page);
+    *active_page_index = index;
+}
+
+fn add_page_preserving_active(
+    pages: &mut Vec<PageInfo>,
+    _active_page_index: &mut usize,
+    page: PageInfo,
+) {
+    pages.push(page);
+}
+
 fn active_page_index_after_removal(
     active_page_index: usize,
     removed_index: usize,
@@ -1427,9 +1441,13 @@ impl BrowserManager {
     }
 
     pub fn add_page(&mut self, page: PageInfo) {
-        let index = self.pages.len();
-        self.pages.push(page);
-        self.active_page_index = index;
+        add_page_and_activate(&mut self.pages, &mut self.active_page_index, page);
+    }
+
+    /// Register a page discovered in the background (e.g. `Target.targetCreated`)
+    /// without changing the active tab.
+    pub fn add_page_background(&mut self, page: PageInfo) {
+        add_page_preserving_active(&mut self.pages, &mut self.active_page_index, page);
     }
 
     pub fn update_page_target_info(&mut self, target: &TargetInfo) -> bool {
@@ -1842,6 +1860,71 @@ mod tests {
         assert!(update_page_target_info_in_pages(&mut pages, &target));
         assert_eq!(pages[0].url, "https://example.com/popup");
         assert_eq!(pages[0].title, "Popup");
+    }
+
+    #[test]
+    fn test_add_page_and_activate_switches_active_page() {
+        let mut pages = vec![PageInfo {
+            tab_id: 1,
+            label: None,
+            target_id: "existing".to_string(),
+            session_id: "session-existing".to_string(),
+            url: "https://example.com/".to_string(),
+            title: "Example".to_string(),
+            target_type: "page".to_string(),
+        }];
+        let mut active_page_index = 0;
+
+        add_page_and_activate(
+            &mut pages,
+            &mut active_page_index,
+            PageInfo {
+                tab_id: 2,
+                label: None,
+                target_id: "explicit-new-tab".to_string(),
+                session_id: "session-new".to_string(),
+                url: "https://vercel.com/".to_string(),
+                title: "Vercel".to_string(),
+                target_type: "page".to_string(),
+            },
+        );
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(active_page_index, 1);
+        assert_eq!(pages[active_page_index].target_id, "explicit-new-tab");
+    }
+
+    #[test]
+    fn test_add_page_preserving_active_keeps_existing_active_page() {
+        let mut pages = vec![PageInfo {
+            tab_id: 1,
+            label: None,
+            target_id: "navigated-page".to_string(),
+            session_id: "session-navigated".to_string(),
+            url: "https://example.com/".to_string(),
+            title: "Example".to_string(),
+            target_type: "page".to_string(),
+        }];
+        let mut active_page_index = 0;
+
+        add_page_preserving_active(
+            &mut pages,
+            &mut active_page_index,
+            PageInfo {
+                tab_id: 2,
+                label: None,
+                target_id: "late-about-blank".to_string(),
+                session_id: "session-about-blank".to_string(),
+                url: "about:blank".to_string(),
+                title: String::new(),
+                target_type: "page".to_string(),
+            },
+        );
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(active_page_index, 0);
+        assert_eq!(pages[active_page_index].target_id, "navigated-page");
+        assert_eq!(pages[active_page_index].url, "https://example.com/");
     }
 
     #[test]

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -159,6 +159,8 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         "--disable-popup-blocking".to_string(),
         "--disable-prompt-on-repost".to_string(),
         "--disable-sync".to_string(),
+        "--disable-session-crashed-bubble".to_string(),
+        "--hide-crash-restore-bubble".to_string(),
         "--disable-features=Translate".to_string(),
         "--enable-features=NetworkService,NetworkServiceInProcess".to_string(),
         "--metrics-recording-only".to_string(),
@@ -243,6 +245,10 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
 
     args.extend(options.args.iter().cloned());
 
+    if !has_startup_target_arg(&options.args) {
+        args.push("about:blank".to_string());
+    }
+
     if should_disable_sandbox(&args) {
         args.push("--no-sandbox".to_string());
     }
@@ -255,6 +261,16 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         args,
         user_data_dir,
         temp_user_data_dir,
+    })
+}
+
+fn has_startup_target_arg(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        let lower = arg.to_ascii_lowercase();
+        lower == "--app"
+            || lower.starts_with("--app=")
+            || lower == "--no-startup-window"
+            || !arg.starts_with('-')
     })
 }
 
@@ -1381,6 +1397,47 @@ mod tests {
     }
 
     #[test]
+    fn test_build_args_adds_default_startup_target() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result.args.iter().any(|a| a == "about:blank"));
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_preserves_custom_startup_target() {
+        let opts = LaunchOptions {
+            args: vec!["https://example.com".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert_eq!(
+            result.args.iter().filter(|a| *a == "about:blank").count(),
+            0
+        );
+        assert!(result.args.iter().any(|a| a == "https://example.com"));
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_skips_default_startup_target_for_app_mode() {
+        let opts = LaunchOptions {
+            args: vec!["--app=https://example.com".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert_eq!(
+            result.args.iter().filter(|a| *a == "about:blank").count(),
+            0
+        );
+        assert!(result.args.iter().any(|a| a == "--app=https://example.com"));
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn test_build_args_headed_no_headless_flag() {
         let opts = LaunchOptions {
             headless: false,
@@ -1483,6 +1540,23 @@ mod tests {
             .args
             .iter()
             .any(|a| a.contains("--disable-features") && a.contains("Translate")));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_hides_crash_restore_ui() {
+        let opts = LaunchOptions::default();
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--disable-session-crashed-bubble"));
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--hide-crash-restore-bubble"));
         if let Some(ref dir) = result.temp_user_data_dir {
             let _ = std::fs::remove_dir_all(dir);
         }


### PR DESCRIPTION
## Summary

Fixes [#1211](https://github.com/vercel-labs/agent-browser/issues/1211): with `--profile` (and especially when `AGENT_BROWSER_HEADED=1` / `--headed` is set on every command), a successful `open` is followed by `tab` / `get url` reporting `about:blank`.

### Root causes

1. **Sticky profile wipe (main bug)**  
   Headed commands re-send `launch`. Open with `--profile` sets a profile launch hash; a later command without `--profile` launches with `profile: None`, hash changes, Chrome relaunches into a blank temp profile.

2. **Background targets steal active tab** (also addressed in open PR #1258)  
   Persistent profiles create late startup targets; `add_page()` switched `active_page_index` to those (often `about:blank`).

### Changes

- Remember `current_profile` on the daemon and reuse it when a launch omits `--profile`
- Register background CDP targets with `add_page_background` so they do not become active
- Start Chrome with an explicit `about:blank` target and hide crash-restore UI when no startup target is provided
- Unit tests for sticky launch-hash stability and background page registration

Includes the approach from [#1258](https://github.com/vercel-labs/agent-browser/pull/1258) plus the sticky-profile fix required when profile is only passed on the first command.

### Verified

```bash
agent-browser --headed --profile ~/.agent-browser/repro open https://example.com
agent-browser --headed tab          # no --profile
agent-browser --headed get url      # → https://example.com/
```

## Test plan

- [x] Local A/B: profile only on open vs on every command; bare `tab` after open
- [x] Unit: `test_sticky_profile_keeps_launch_hash_stable`
- [x] Unit: `test_add_page_preserving_active_*` / startup-target chrome arg tests (from #1258)
- [ ] CI on this PR