### PR TITLE
fix(emulation): give a mobile viewport a real touch + UA-CH environment

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4902,7 +4902,14 @@ async fn handle_viewport(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .get("deviceScaleFactor")
         .and_then(|v| v.as_f64())
         .unwrap_or(1.0);
-    let mobile = cmd.get("mobile").and_then(|v| v.as_bool()).unwrap_or(false);
+    // When the caller doesn't specify `mobile`, inherit the current session's
+    // mobile state rather than resetting to desktop. Otherwise a plain
+    // `set viewport 375 667` after `set device "iPhone 15"` would silently
+    // drop touch/mobile emulation and re-render the desktop layout branch.
+    let mobile = cmd
+        .get("mobile")
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| state.viewport.map(|(_, _, _, m)| m).unwrap_or(false));
 
     mgr.set_viewport(width, height, scale, mobile).await?;
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1173,6 +1173,24 @@ impl BrowserManager {
             )
             .await?;
 
+        // A mobile device metrics override alone does NOT give a page a real
+        // touch environment: navigator.maxTouchPoints stays 0, no touch events
+        // fire, and `(pointer: coarse)` stays false, so touch/pointer-gated
+        // layouts render their desktop branch (false positives in mobile QA).
+        // Enable/disable touch emulation to match the mobile flag.
+        self.client
+            .send_command(
+                "Emulation.setTouchEmulationEnabled",
+                Some(json!({
+                    "enabled": mobile,
+                    // CDP requires maxTouchPoints in 1..=16; it is ignored when
+                    // `enabled` is false, so keep it >= 1 even when disabling.
+                    "maxTouchPoints": if mobile { 5 } else { 1 },
+                })),
+                Some(session_id),
+            )
+            .await?;
+
         // Screencast captures the actual content area, not the emulated CSS
         // viewport, so resize the content area to match.
         if let Ok(target_id) = self.active_target_id() {
@@ -1210,10 +1228,46 @@ impl BrowserManager {
 
     pub async fn set_user_agent(&self, user_agent: &str) -> Result<(), String> {
         let session_id = self.active_session_id()?;
+        // Overriding only the UA string leaves navigator.userAgentData.mobile
+        // (User-Agent Client Hints) unchanged, so UA-CH-gated code still sees a
+        // desktop client. Derive the UA-CH metadata from the UA string and send
+        // it alongside, so a mobile UA yields userAgentData.mobile === true.
+        let is_iphone = user_agent.contains("iPhone");
+        let is_ipad = user_agent.contains("iPad");
+        let is_android = user_agent.contains("Android");
+        // Phones carry the "Mobile" token; tablets (iPad) do not.
+        let mobile = user_agent.contains("Mobile") || is_iphone || is_android;
+        let platform = if is_iphone || is_ipad {
+            "iOS"
+        } else if is_android {
+            "Android"
+        } else {
+            "macOS"
+        };
+        let model = if is_iphone {
+            "iPhone"
+        } else if is_ipad {
+            "iPad"
+        } else {
+            ""
+        };
         self.client
             .send_command(
                 "Emulation.setUserAgentOverride",
-                Some(json!({ "userAgent": user_agent })),
+                Some(json!({
+                    "userAgent": user_agent,
+                    "userAgentMetadata": {
+                        "brands": [],
+                        "fullVersionList": [],
+                        "platform": platform,
+                        "platformVersion": "",
+                        "architecture": "",
+                        "model": model,
+                        "mobile": mobile,
+                        "bitness": "",
+                        "wow64": false,
+                    },
+                })),
                 Some(session_id),
             )
             .await?;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1855,6 +1855,113 @@ async fn e2e_viewport_emulation() {
 }
 
 // ---------------------------------------------------------------------------
+// Mobile emulation: touch + UA-CH
+// ---------------------------------------------------------------------------
+
+// A mobile viewport must produce a real touch environment, not just a narrow
+// width: navigator.maxTouchPoints > 0 and (pointer: coarse) must be true, so
+// touch/pointer-gated layouts render their mobile branch. Also verifies that a
+// subsequent `viewport` without an explicit `mobile` flag inherits the current
+// mobile state instead of silently resetting to desktop.
+#[tokio::test]
+#[ignore]
+async fn e2e_mobile_touch_emulation() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Touch</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Mobile viewport -> touch enabled.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "viewport", "width": 375, "height": 667, "deviceScaleFactor": 2.0, "mobile": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "navigator.maxTouchPoints" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(
+        get_data(&resp)["result"].as_i64().unwrap() > 0,
+        "maxTouchPoints should be > 0 under a mobile viewport"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "matchMedia('(pointer: coarse)').matches" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        true,
+        "(pointer: coarse) should match under a mobile viewport"
+    );
+
+    // Resize without specifying `mobile` -> should INHERIT mobile (touch stays on).
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "viewport", "width": 390, "height": 844 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["mobile"],
+        true,
+        "viewport without explicit mobile should inherit the current mobile state"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "evaluate", "script": "navigator.maxTouchPoints" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(
+        get_data(&resp)["result"].as_i64().unwrap() > 0,
+        "touch should persist after a resize that omits the mobile flag"
+    );
+
+    // Explicit mobile:false -> touch disabled again.
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "viewport", "width": 1280, "height": 900, "mobile": false }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "evaluate", "script": "navigator.maxTouchPoints" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"].as_i64().unwrap(),
+        0,
+        "maxTouchPoints should be 0 after switching back to a desktop viewport"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+// ---------------------------------------------------------------------------
 // Hover, scroll, press
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`set device` and `set viewport { mobile: true }` produce a viewport that is *narrow* but not an actual mobile environment: `navigator.maxTouchPoints` stays `0`, no touch events fire, and `(pointer: coarse)` is `false`. Pages that branch on touch / pointer type (or on `navigator.userAgentData.mobile`) therefore render their **desktop** layout under mobile emulation, which defeats mobile UI testing.

Root cause: the only emulation call was `Emulation.setDeviceMetricsOverride`. Chrome also needs `Emulation.setTouchEmulationEnabled` for touch, and `userAgentMetadata` on `Emulation.setUserAgentOverride` for the UA Client Hints mobile bit — the same calls Playwright device descriptors / DevTools device-mode make.

## Changes

- **`set_viewport`** (`native/browser.rs`): also send `Emulation.setTouchEmulationEnabled { enabled: mobile, maxTouchPoints }`. `maxTouchPoints` is kept within CDP's required `1..=16` range even when disabling (CDP rejects `0`).
- **`set_user_agent`** (`native/browser.rs`): send `userAgentMetadata` derived from the UA string so `navigator.userAgentData.mobile` matches a mobile UA (a bare UA-string override leaves the UA-CH mobile bit unchanged). This now sends metadata for every UA override (desktop UAs get `mobile: false`) — happy to gate it behind a flag if you'd prefer.
- **`handle_viewport`** (`native/actions.rs`): when the `mobile` field is omitted, inherit the session's current mobile state instead of resetting to `false`, so `set viewport <w> <h>` after `set device "iPhone 15"` doesn't silently drop touch emulation.
- **e2e test** covering touch enable → inherit-on-resize → disable.

## Before / after

`set device "iPhone 15"`, then evaluate on a page:

| | before | after |
|---|---|---|
| `navigator.maxTouchPoints` | `0` | `5` |
| `matchMedia('(pointer: coarse)').matches` | `false` | `true` |
| `'ontouchstart' in window` | `false` | `true` |
| `navigator.userAgentData.mobile` | `false` | `true` |

## Testing

- New `e2e_mobile_touch_emulation` and existing `e2e_viewport_emulation` pass (`cargo test <name> -- --ignored`).
- `cargo fmt --check` and `cargo clippy` clean.
- The `userAgentData.mobile` behavior isn't covered by an e2e test because `navigator.userAgentData` is only exposed in secure contexts and the e2e suite navigates `data:` URLs; verified manually against a live `https` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
