### PR TITLE
fix(cdp): drain Chrome stderr so a full pipe can't freeze the browser

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -420,6 +420,25 @@ fn try_launch_chrome(chrome_path: &Path, options: &LaunchOptions) -> Result<Chro
         }
     };
 
+    // Drain Chrome's stderr forever on a detached thread. The pipe is only
+    // consumed by the stderr-scrape FALLBACK above; on the happy path
+    // (DevToolsActivePort found) it was previously never read and never
+    // closed, so once Chrome had logged ~64KB the kernel pipe buffer filled
+    // and Chrome's next stderr write BLOCKED — freezing the entire browser
+    // (observed on a long-lived macOS session: CrBrowserMain stuck in
+    // write(2) for hours, UI beachball + CDP unresponsive, recurring every
+    // 1-2 days). On the fallback path stderr was already taken and its
+    // reader dropped (read end closed → Chrome's writes fail fast with
+    // EPIPE, which Chrome tolerates), so take() returning None is fine.
+    if let Some(stderr) = child.stderr.take() {
+        let _ = std::thread::Builder::new()
+            .name("chrome-stderr-drain".into())
+            .spawn(move || {
+                let mut stderr = stderr;
+                let _ = std::io::copy(&mut stderr, &mut std::io::sink());
+            });
+    }
+
     #[cfg(unix)]
     let pgid = {
         let pid = child.id() as i32;


### PR DESCRIPTION
## Problem

Chrome is spawned with `stderr(Stdio::piped())` (`cli/src/native/cdp/chrome.rs`), but the pipe is only ever read on the **DevToolsActivePort fallback path** (scraping `DevTools listening on …`). On the normal happy path the pipe is never read and never closed — it just sits in `ChromeProcess.child` for the browser's lifetime.

On a long-lived session Chrome steadily writes log lines to stderr. Once ~64KB accumulates, the kernel pipe buffer is full and Chrome's **next stderr write blocks forever**.

Observed live on macOS (long-running headed session, reproducing every 1–2 days):

- The browser UI beachballs and CDP goes completely dead — even `GET /json/version` on the DevTools port hangs (25s+, zero bytes) while the TCP socket still accepts.
- A thread sample showed **`CrBrowserMain` 100% blocked in `write(2)`** at the bottom of a CFRunLoop source dispatch.
- `lsof` correlation: Chrome fd 2 = 64KB PIPE whose read end was an fd in the spawning daemon, unread since launch.
- Closing the pipe's read end instantly unfroze the browser (the blocked `write` returns `EPIPE`, which Chrome tolerates).

## Fix

After launch, hand the stderr pipe to a detached `chrome-stderr-drain` thread that copies it to `io::sink()` until EOF.

The fallback path is unaffected: it already `take()`s stderr and drops the reader on return, which closes the read end and makes Chrome's subsequent stderr writes fail fast with `EPIPE` — so `child.stderr.take()` returning `None` there is fine.

## Testing

- `cargo check`, `cargo fmt --check`, `cargo clippy` clean; `cargo test` in `cli/`: 904 passed, 0 failed.
- Rebuilt binary run against the previously-freezing daily workload; the frozen state was reproduced live with the old binary and diagnosed via `sample`/`lsof` as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)