### PR TITLE
Add persistent session tab binding and --pin-tab strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ With `--pin-tab`:
 - `tab list`, `tab new`, and `tab <ref>` still work in that state, so an agent can recover by binding a new tab
 - Tabs opened by other sessions or the user never steal the pinned session's active tab
 
-The flag is sticky per session: pass it once and later commands and daemon restarts keep the strict semantics.
+The flag is sticky per session: pass it once and later commands and daemon restarts keep the strict semantics. Pass `--no-pin-tab` to explicitly turn the pin off again.
 
 ## Chrome Profile Reuse
 
@@ -929,6 +929,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--cdp <port\|url>` | Connect via Chrome DevTools Protocol (port or WebSocket URL) |
 | `--auto-connect` | Auto-discover and connect to running Chrome (or `AGENT_BROWSER_AUTO_CONNECT` env) |
 | `--pin-tab` | Pin the session to its bound tab; fail with `tab_gone` instead of falling back to another tab (or `AGENT_BROWSER_PIN_TAB` env) |
+| `--no-pin-tab` | Disable a sticky pin previously enabled with `--pin-tab` |
 | `--color-scheme <scheme>` | Color scheme: `dark`, `light`, `no-preference` (or `AGENT_BROWSER_COLOR_SCHEME` env) |
 | `--download-path <path>` | Default download directory (or `AGENT_BROWSER_DOWNLOAD_PATH` env) |
 | `--content-boundaries` | Wrap page output in boundary markers for LLM safety (or `AGENT_BROWSER_CONTENT_BOUNDARIES` env) |

--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ agent-browser click @e3              # click uses docs's refs
 agent-browser tab close docs         # close by label
 ```
 
+`tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts, so they're the right handle for scripts coordinating multiple sessions on one browser.
+
 ### Frames
 
 ```bash
@@ -626,6 +628,27 @@ Each session has its own:
 - Navigation history
 - Authentication state
 
+### Tab pinning
+
+When several sessions share one Chrome over `--cdp`, each session remembers which tab it is bound to (by CDP target id, persisted across daemon restarts). A restarted daemon reattaches to the session's own tab instead of adopting whatever tab happens to be active, which is usually another session's.
+
+By default, if the bound tab is closed the session falls back to a neighboring tab (legacy behavior). Pass `--pin-tab` (or set `AGENT_BROWSER_PIN_TAB=1`) to make the binding strict:
+
+```bash
+# Two agents sharing one Chrome, each pinned to its own tab
+agent-browser --session agent1 --cdp 9222 --pin-tab open site-a.com
+agent-browser --session agent2 --cdp 9222 --pin-tab open site-b.com
+```
+
+With `--pin-tab`:
+
+- Attaching with no binding opens a fresh tab instead of adopting an existing one
+- If the bound tab is closed, commands fail with a `tab_gone` error (exit code 1; `--json` responses carry `"code": "tab_gone"`) instead of silently acting on another tab
+- `tab list`, `tab new`, and `tab <ref>` still work in that state, so an agent can recover by binding a new tab
+- Tabs opened by other sessions or the user never steal the pinned session's active tab
+
+The flag is sticky per session: pass it once and later commands and daemon restarts keep the strict semantics.
+
 ## Chrome Profile Reuse
 
 The fastest way to use your existing login state: pass a Chrome profile name to `--profile`:
@@ -905,6 +928,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--headed` | Show browser window (not headless) (or `AGENT_BROWSER_HEADED` env) |
 | `--cdp <port\|url>` | Connect via Chrome DevTools Protocol (port or WebSocket URL) |
 | `--auto-connect` | Auto-discover and connect to running Chrome (or `AGENT_BROWSER_AUTO_CONNECT` env) |
+| `--pin-tab` | Pin the session to its bound tab; fail with `tab_gone` instead of falling back to another tab (or `AGENT_BROWSER_PIN_TAB` env) |
 | `--color-scheme <scheme>` | Color scheme: `dark`, `light`, `no-preference` (or `AGENT_BROWSER_COLOR_SCHEME` env) |
 | `--download-path <path>` | Default download directory (or `AGENT_BROWSER_DOWNLOAD_PATH` env) |
 | `--content-boundaries` | Wrap page output in boundary markers for LLM safety (or `AGENT_BROWSER_CONTENT_BOUNDARIES` env) |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3115,6 +3115,7 @@ mod tests {
             cli_download_path: false,
             cli_headed: false,
             cli_restore: false,
+            cli_pin_tab: false,
             annotate: false,
             color_scheme: None,
             download_path: None,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3090,6 +3090,7 @@ mod tests {
             hide_scrollbars: true,
             device: None,
             auto_connect: false,
+            pin_tab: false,
             session_name: None,
             restore: None,
             restore_save: None,

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -35,6 +35,10 @@ pub struct Response {
     pub success: bool,
     pub data: Option<Value>,
     pub error: Option<String>,
+    /// Machine-readable error code for select failures (e.g. `tab_gone`
+    /// when a pinned session's bound tab no longer exists).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
 }
@@ -457,6 +461,7 @@ pub struct DaemonOptions<'a> {
     pub confirm_actions: Option<&'a str>,
     pub engine: Option<&'a str>,
     pub auto_connect: bool,
+    pub pin_tab: bool,
     pub idle_timeout: Option<&'a str>,
     pub default_timeout: Option<u64>,
     pub cdp: Option<&'a str>,
@@ -558,6 +563,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if opts.auto_connect {
         cmd.env("AGENT_BROWSER_AUTO_CONNECT", "1");
+    }
+    if opts.pin_tab {
+        cmd.env("AGENT_BROWSER_PIN_TAB", "1");
     }
     if let Some(idle) = opts.idle_timeout {
         cmd.env("AGENT_BROWSER_IDLE_TIMEOUT_MS", idle);
@@ -1262,6 +1270,7 @@ mod tests {
             confirm_actions: None,
             engine: None,
             auto_connect: false,
+            pin_tab: false,
             idle_timeout,
             default_timeout: None,
             cdp: None,

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -81,6 +81,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         confirm_actions: None,
         engine: None,
         auto_connect: false,
+        pin_tab: false,
         idle_timeout: None,
         default_timeout: None,
         cdp: None,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -393,6 +393,10 @@ pub struct Flags {
     pub cli_download_path: bool,
     pub cli_headed: bool,
     pub cli_restore: bool,
+    /// True when --pin-tab / --no-pin-tab was passed on the command line, so
+    /// an explicit disable can be sent to the daemon (a bare `pin_tab: false`
+    /// just means "absent" and must not override a sticky pin).
+    pub cli_pin_tab: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -606,6 +610,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_download_path: false,
         cli_headed: false,
         cli_restore: false,
+        cli_pin_tab: false,
     };
 
     let mut i = 0;
@@ -848,6 +853,15 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--pin-tab" => {
                 let (val, consumed) = parse_bool_arg(args, i);
                 flags.pin_tab = val;
+                flags.cli_pin_tab = true;
+                if consumed {
+                    i += 1;
+                }
+            }
+            "--no-pin-tab" => {
+                let (val, consumed) = parse_bool_arg(args, i);
+                flags.pin_tab = !val;
+                flags.cli_pin_tab = true;
                 if consumed {
                     i += 1;
                 }
@@ -1014,6 +1028,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--hide-scrollbars",
         "--auto-connect",
         "--pin-tab",
+        "--no-pin-tab",
         "--annotate",
         "--content-boundaries",
         "--confirm-interactive",

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -82,6 +82,7 @@ pub struct Config {
     pub allow_file_access: Option<bool>,
     pub cdp: Option<String>,
     pub auto_connect: Option<bool>,
+    pub pin_tab: Option<bool>,
     pub headers: Option<String>,
     pub annotate: Option<bool>,
     pub color_scheme: Option<String>,
@@ -151,6 +152,7 @@ impl Config {
             allow_file_access: other.allow_file_access.or(self.allow_file_access),
             cdp: other.cdp.or(self.cdp),
             auto_connect: other.auto_connect.or(self.auto_connect),
+            pin_tab: other.pin_tab.or(self.pin_tab),
             headers: other.headers.or(self.headers),
             annotate: other.annotate.or(self.annotate),
             color_scheme: other.color_scheme.or(self.color_scheme),
@@ -350,6 +352,7 @@ pub struct Flags {
     pub hide_scrollbars: bool,
     pub device: Option<String>,
     pub auto_connect: bool,
+    pub pin_tab: bool,
     pub session_name: Option<String>,
     pub annotate: bool,
     pub color_scheme: Option<String>,
@@ -527,6 +530,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         device: env::var("AGENT_BROWSER_IOS_DEVICE").ok().or(config.device),
         auto_connect: env_var_is_truthy("AGENT_BROWSER_AUTO_CONNECT")
             || config.auto_connect.unwrap_or(false),
+        pin_tab: env_var_is_truthy("AGENT_BROWSER_PIN_TAB") || config.pin_tab.unwrap_or(false),
         session_name: env::var("AGENT_BROWSER_SESSION_NAME")
             .ok()
             .or(config.session_name),
@@ -841,6 +845,13 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--pin-tab" => {
+                let (val, consumed) = parse_bool_arg(args, i);
+                flags.pin_tab = val;
+                if consumed {
+                    i += 1;
+                }
+            }
             "--session-name" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.session_name = Some(s.clone());
@@ -1002,6 +1013,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--allow-file-access",
         "--hide-scrollbars",
         "--auto-connect",
+        "--pin-tab",
         "--annotate",
         "--content-boundaries",
         "--confirm-interactive",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1107,6 +1107,12 @@ fn main() {
     // current config without a restart. The daemon strips this from stream
     // broadcasts before observers see the command payload.
     attach_plugins_to_command(&mut cmd, &flags.plugins);
+
+    // Strict session-to-tab binding: sent with every command so an
+    // already-running daemon adopts it too (it is sticky once enabled).
+    if flags.pin_tab {
+        cmd["pinTab"] = json!(true);
+    }
     attach_restore_config_to_command(&mut cmd, &flags);
 
     let restore_key = restore_key_from_flags(&flags);
@@ -1149,12 +1155,14 @@ fn main() {
                 success: true,
                 data: Some(data),
                 error: None,
+                code: None,
                 warning: None,
             },
             Err(e) => connection::Response {
                 success: false,
                 data: None,
                 error: Some(e),
+                code: None,
                 warning: None,
             },
         };
@@ -1215,6 +1223,7 @@ fn main() {
         confirm_actions: flags.confirm_actions.as_deref(),
         engine: flags.engine.as_deref(),
         auto_connect: flags.auto_connect,
+        pin_tab: flags.pin_tab,
         idle_timeout: flags.idle_timeout.as_deref(),
         default_timeout: flags.default_timeout,
         cdp: flags.cdp.as_deref(),
@@ -2025,6 +2034,7 @@ mod tests {
     fn test_confirmation_prompt_from_response_finds_nested_confirm_result() {
         let resp = Response {
             success: true,
+            code: None,
             data: Some(json!({
                 "confirmed": true,
                 "action": "navigate",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1110,8 +1110,12 @@ fn main() {
 
     // Strict session-to-tab binding: sent with every command so an
     // already-running daemon adopts it too (it is sticky once enabled).
+    // An explicit --no-pin-tab sends false to disable a sticky pin; the
+    // field is omitted entirely when the user expressed no preference.
     if flags.pin_tab {
         cmd["pinTab"] = json!(true);
+    } else if flags.cli_pin_tab {
+        cmd["pinTab"] = json!(false);
     }
     attach_restore_config_to_command(&mut cmd, &flags);
 

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1593,10 +1593,10 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_CONNECT,
             "Connect CDP",
-            "Connect to a browser over CDP. With pinTab, the session is strictly bound to its own tab: it re-binds by target id after restarts and fails with a tab_gone error instead of adopting another tab.",
+            "Connect to a browser over CDP. With pinTab, the session is strictly bound to its own tab: it re-binds by target id after restarts and fails with a tab_gone error instead of adopting another tab. Pass pinTab: false to explicitly disable a sticky pin; omit it to keep the current state.",
             json!({
                 "target": { "type": "string", "description": "CDP port or URL." },
-                "pinTab": { "type": "boolean", "default": false, "description": "Strict session-to-tab binding (sticky for the session)." }
+                "pinTab": { "type": "boolean", "description": "Strict session-to-tab binding (sticky for the session). Explicit false disables a sticky pin; omitted leaves it unchanged." }
             }),
             &["target"],
         ),
@@ -2288,8 +2288,10 @@ fn call_one_string(arguments: &Value, command: &str, key: &str) -> Result<Value,
 fn call_connect(arguments: &Value) -> Result<Value, ProtocolError> {
     let mut args = vec!["connect".to_string()];
     args.push(required_string(arguments, "target")?);
-    if arguments.get("pinTab").and_then(|v| v.as_bool()) == Some(true) {
-        args.push("--pin-tab".to_string());
+    match arguments.get("pinTab").and_then(|v| v.as_bool()) {
+        Some(true) => args.push("--pin-tab".to_string()),
+        Some(false) => args.push("--no-pin-tab".to_string()),
+        None => {}
     }
     call_cli_tool(arguments, args, None)
 }

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1221,15 +1221,15 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_TAB_SWITCH,
             "Tab switch",
-            "Switch to a tab by id or label.",
-            json!({ "tab": { "type": "string" } }),
+            "Switch to a tab by id (t1), label, or CDP target id. Switching also binds the session to that tab.",
+            json!({ "tab": { "type": "string", "description": "Tab id (t1), label, or CDP target id." } }),
             &["tab"],
         ),
         tool(
             TOOL_TAB_CLOSE,
             "Tab close",
-            "Close a tab.",
-            json!({ "tab": { "type": "string" } }),
+            "Close a tab by id (t1), label, or CDP target id. Omit to close the current tab.",
+            json!({ "tab": { "type": "string", "description": "Tab id (t1), label, or CDP target id." } }),
             &[],
         ),
         tool(
@@ -1593,8 +1593,11 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_CONNECT,
             "Connect CDP",
-            "Connect to a browser over CDP.",
-            json!({ "target": { "type": "string", "description": "CDP port or URL." } }),
+            "Connect to a browser over CDP. With pinTab, the session is strictly bound to its own tab: it re-binds by target id after restarts and fails with a tab_gone error instead of adopting another tab.",
+            json!({
+                "target": { "type": "string", "description": "CDP port or URL." },
+                "pinTab": { "type": "boolean", "default": false, "description": "Strict session-to-tab binding (sticky for the session)." }
+            }),
             &["target"],
         ),
         tool(
@@ -2175,7 +2178,7 @@ fn call_tool(params: Option<&Value>, config: &McpConfig) -> Result<Value, Protoc
         TOOL_REMOVE_INIT_SCRIPT => call_one_string(arguments, "removeinitscript", "id"),
         TOOL_CONFIRM => call_one_string(arguments, "confirm", "id"),
         TOOL_DENY => call_one_string(arguments, "deny", "id"),
-        TOOL_CONNECT => call_one_string(arguments, "connect", "target"),
+        TOOL_CONNECT => call_connect(arguments),
         TOOL_STREAM_ENABLE => call_stream_enable(arguments),
         TOOL_STREAM_DISABLE => call_literal(arguments, &["stream", "disable"]),
         TOOL_STREAM_STATUS => call_literal(arguments, &["stream", "status"]),
@@ -2279,6 +2282,15 @@ fn call_literal(arguments: &Value, parts: &[&str]) -> Result<Value, ProtocolErro
 fn call_one_string(arguments: &Value, command: &str, key: &str) -> Result<Value, ProtocolError> {
     let mut args = command_parts(command);
     args.push(required_string(arguments, key)?);
+    call_cli_tool(arguments, args, None)
+}
+
+fn call_connect(arguments: &Value) -> Result<Value, ProtocolError> {
+    let mut args = vec!["connect".to_string()];
+    args.push(required_string(arguments, "target")?);
+    if arguments.get("pinTab").and_then(|v| v.as_bool()) == Some(true) {
+        args.push("--pin-tab".to_string());
+    }
     call_cli_tool(arguments, args, None)
 }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2158,6 +2158,15 @@ async fn apply_tab_binding_on_attach(state: &mut DaemonState) -> Result<bool, St
                 .as_mut()
                 .map(|mgr| mgr.restore_target_binding(&b.target_id, &b.url))
                 .unwrap_or(false);
+            if restored {
+                // Attach only enables the CDP domains on the first target;
+                // the restored tab needs them too (like tab_switch), or
+                // lifecycle-dependent commands such as navigate hang.
+                if let Some(ref mgr) = state.browser {
+                    let session_id = mgr.active_session_id()?.to_string();
+                    mgr.enable_domains_pub(&session_id).await?;
+                }
+            }
             if restored || pin {
                 // Restored, or entered the tab_gone state (the stale binding
                 // file is intentionally kept so the state is re-derived if

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -356,10 +356,15 @@ impl DaemonState {
     pub fn new() -> Self {
         let session_id =
             env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string());
+        // A corrupt binding file is surfaced later, on attach; it does not
+        // enable pinning here because its pinned state is unknowable.
         let pin_tab = matches!(
             env::var("AGENT_BROWSER_PIN_TAB").as_deref(),
             Ok("1" | "true" | "yes")
-        ) || tab_binding::load(&session_id).is_some_and(|b| b.pinned);
+        ) || tab_binding::load(&session_id)
+            .ok()
+            .flatten()
+            .is_some_and(|b| b.pinned);
         Self {
             browser: None,
             appium: None,
@@ -1665,15 +1670,30 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     super::element::set_active_frame(state.active_frame_id.as_deref());
 
     // `--pin-tab` from the client enables strict tab binding even when the
-    // daemon was started without the flag. Sticky: persisted with the
-    // binding, so the session keeps strict semantics from here on.
-    if cmd.get("pinTab").and_then(|v| v.as_bool()) == Some(true) && !state.pin_tab {
-        state.pin_tab = true;
-        if let Some(ref mut mgr) = state.browser {
-            mgr.set_pin_tab(true);
+    // daemon was started without the flag, and `--no-pin-tab` (pinTab: false)
+    // disables a sticky pin restored from disk or enabled earlier. Both are
+    // persisted with the binding so the setting survives daemon restarts;
+    // absence of the field leaves the current state untouched.
+    match cmd.get("pinTab").and_then(|v| v.as_bool()) {
+        Some(pin) if pin != state.pin_tab => {
+            state.pin_tab = pin;
+            if let Some(ref mut mgr) = state.browser {
+                mgr.set_pin_tab(pin);
+            }
+            // Rewrite the persisted pinned state immediately: relying on the
+            // next browser-touching command would lose the change if the
+            // daemon restarts first (there may be no browser at all, e.g.
+            // when disabling a pin to recover a stuck session).
+            if let Ok(Some(mut binding)) = tab_binding::load(&state.session_id) {
+                if binding.pinned != pin {
+                    binding.pinned = pin;
+                    let _ = tab_binding::save(&state.session_id, &binding);
+                }
+            }
+            // Force write-on-change to re-persist from the live snapshot.
+            state.last_persisted_binding = None;
         }
-        // Force a rewrite so the persisted binding records pinned=true.
-        state.last_persisted_binding = None;
+        _ => {}
     }
 
     let skip_launch = skip_launch_action(action);
@@ -2039,14 +2059,35 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // Persist the session-to-tab binding (write-on-change) so a fresh daemon
     // re-attaches to this session's tab instead of adopting the browser's
     // most recently active one.
-    if !skip_launch {
-        maybe_persist_tab_binding(state);
-    }
+    let persist_error = if !skip_launch {
+        maybe_persist_tab_binding(state)
+    } else {
+        None
+    };
 
     let mut resp = match result {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
     };
+
+    // A failed binding write is retried on the next command, but a pinned
+    // session must know its isolation may not survive a daemon restart.
+    if let Some(err) = persist_error {
+        if let Some(obj) = resp.as_object_mut() {
+            let hint = if state.pin_tab {
+                " --pin-tab isolation may not survive a daemon restart until the binding persists."
+            } else {
+                ""
+            };
+            obj.insert(
+                "warning".to_string(),
+                json!(format!(
+                    "Failed to persist the session tab binding: {}.{}",
+                    err, hint
+                )),
+            );
+        }
+    }
     inject_lifecycle(
         &mut resp,
         state,
@@ -2110,23 +2151,30 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 /// browser-touching command; skipped while the bound tab is gone so the
 /// stale binding (needed to re-derive the tab_gone state after a daemon
 /// restart) is not overwritten by the fallback tab.
-fn maybe_persist_tab_binding(state: &mut DaemonState) {
-    let Some(ref mgr) = state.browser else {
-        return;
-    };
-    let Some((target_id, url)) = mgr.binding_snapshot() else {
-        return;
-    };
+///
+/// Returns the write error, if any. `last_persisted_binding` is only updated
+/// after a successful durable write, so a transient failure is retried on
+/// the next command instead of being silently treated as persisted (which
+/// would let a daemon restart drop the binding and, for a pinned session,
+/// the strict isolation boundary with it).
+fn maybe_persist_tab_binding(state: &mut DaemonState) -> Option<String> {
+    let mgr = state.browser.as_ref()?;
+    let (target_id, url) = mgr.binding_snapshot()?;
     let binding = tab_binding::TabBinding {
         target_id,
-        url,
+        url: tab_binding::sanitize_url(&url),
         pinned: state.pin_tab,
     };
     if state.last_persisted_binding.as_ref() == Some(&binding) {
-        return;
+        return None;
     }
-    tab_binding::save(&state.session_id, &binding);
-    state.last_persisted_binding = Some(binding);
+    match tab_binding::save(&state.session_id, &binding) {
+        Ok(()) => {
+            state.last_persisted_binding = Some(binding);
+            None
+        }
+        Err(e) => Some(e),
+    }
 }
 
 /// Re-apply this session's persisted tab binding after attaching to a
@@ -2140,7 +2188,16 @@ fn maybe_persist_tab_binding(state: &mut DaemonState) {
 /// Returns false when no binding existed and the legacy selection stands.
 async fn apply_tab_binding_on_attach(state: &mut DaemonState) -> Result<bool, String> {
     let session = state.session_id.clone();
-    let binding = tab_binding::load(&session);
+    // A corrupt or unreadable binding file is a recovery error, not a
+    // first-time session: it may have carried pinned=true, and silently
+    // starting fresh would drop the strict isolation boundary.
+    let binding = tab_binding::load(&session).map_err(|e| {
+        format!(
+            "{} — delete the file to reset the session's tab binding \
+             (re-run with --pin-tab afterwards if the session was pinned)",
+            e
+        )
+    })?;
     if binding.as_ref().is_some_and(|b| b.pinned) {
         state.pin_tab = true;
     }
@@ -2194,7 +2251,17 @@ async fn apply_tab_binding_on_attach(state: &mut DaemonState) -> Result<bool, St
         }
     };
     if established {
-        maybe_persist_tab_binding(state);
+        if let Some(err) = maybe_persist_tab_binding(state) {
+            // Strict pinning is only as durable as the binding file: fail
+            // the attach instead of pretending the pin is in place.
+            if state.pin_tab {
+                return Err(format!(
+                    "cannot persist the pinned tab binding: {} — \
+                     --pin-tab requires a writable socket directory",
+                    err
+                ));
+            }
+        }
     }
     Ok(established)
 }
@@ -2215,7 +2282,8 @@ async fn open_fresh_tab_for_auto_connect(state: &mut DaemonState) -> Result<(), 
         .client
         .send_command("Page.bringToFront", None, Some(&session_id))
         .await;
-    maybe_persist_tab_binding(state);
+    // Best effort: a failed write is retried after the next command.
+    let _ = maybe_persist_tab_binding(state);
     Ok(())
 }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -36,6 +36,7 @@ use super::snapshot::{self, SnapshotOptions};
 use super::state;
 use super::storage;
 use super::stream::{self, StreamServer};
+use super::tab_binding;
 use super::tracing::{self as native_tracing, TracingState};
 use super::webdriver::appium::AppiumManager;
 use super::webdriver::backend::{BrowserBackend, WebDriverBackend, WEBDRIVER_UNSUPPORTED_ACTIONS};
@@ -343,10 +344,22 @@ pub struct DaemonState {
     active_provider_session: Option<ActiveProviderSession>,
     /// Actions already approved while replaying a confirmed command.
     confirmed_policy_actions: HashSet<String>,
+    /// Strict session-to-tab binding (`--pin-tab` / AGENT_BROWSER_PIN_TAB).
+    /// Sticky per session: persisted in the binding file so later commands
+    /// and daemon restarts keep the strict semantics.
+    pub pin_tab: bool,
+    /// Last binding written to disk, so persistence is write-on-change.
+    last_persisted_binding: Option<tab_binding::TabBinding>,
 }
 
 impl DaemonState {
     pub fn new() -> Self {
+        let session_id =
+            env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string());
+        let pin_tab = matches!(
+            env::var("AGENT_BROWSER_PIN_TAB").as_deref(),
+            Ok("1" | "true" | "yes")
+        ) || tab_binding::load(&session_id).is_some_and(|b| b.pinned);
         Self {
             browser: None,
             appium: None,
@@ -377,7 +390,7 @@ impl DaemonState {
             restore_saved_path: None,
             last_command_finished: None,
             last_autosave_attempt: None,
-            session_id: env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
+            session_id,
             tracing_state: TracingState::new(),
             recording_state: RecordingState::new(),
             event_rx: None,
@@ -419,6 +432,8 @@ impl DaemonState {
             plugin_init_scripts: Vec::new(),
             active_provider_session: None,
             confirmed_policy_actions: HashSet::new(),
+            pin_tab,
+            last_persisted_binding: None,
         }
     }
 
@@ -773,7 +788,7 @@ impl DaemonState {
                     }
 
                     let tab_id = mgr.assign_tab_id();
-                    mgr.add_page(super::browser::PageInfo {
+                    let page = super::browser::PageInfo {
                         tab_id,
                         label: None,
                         target_id: te.target_info.target_id.clone(),
@@ -781,7 +796,15 @@ impl DaemonState {
                         url: te.target_info.url.clone(),
                         title: te.target_info.title.clone(),
                         target_type: te.target_info.target_type.clone(),
-                    });
+                    };
+                    if mgr.pin_tab() {
+                        // In a shared browser a discovered target may belong
+                        // to another session; track it for `tab list` but do
+                        // not let it steal the active slot or the binding.
+                        mgr.add_page_background(page);
+                    } else {
+                        mgr.add_page(page);
+                    }
                 }
             }
         }
@@ -1610,6 +1633,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     if let Some(ref server) = state.stream_server {
         let mut broadcast_cmd;
         let has_internal_fields = cmd.get("plugins").is_some()
+            || cmd.get("pinTab").is_some()
             || cmd.get("restoreKey").is_some()
             || cmd.get("restoreSave").is_some()
             || cmd.get("restoreCheckUrl").is_some()
@@ -1619,6 +1643,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             broadcast_cmd = cmd.clone();
             if let Some(obj) = broadcast_cmd.as_object_mut() {
                 obj.remove("plugins");
+                obj.remove("pinTab");
                 obj.remove("restoreKey");
                 obj.remove("restoreSave");
                 obj.remove("restoreCheckUrl");
@@ -1638,6 +1663,18 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // Keep element resolution in sync with the `frame` selection (see
     // element::set_active_frame for why this is mirrored).
     super::element::set_active_frame(state.active_frame_id.as_deref());
+
+    // `--pin-tab` from the client enables strict tab binding even when the
+    // daemon was started without the flag. Sticky: persisted with the
+    // binding, so the session keeps strict semantics from here on.
+    if cmd.get("pinTab").and_then(|v| v.as_bool()) == Some(true) && !state.pin_tab {
+        state.pin_tab = true;
+        if let Some(ref mut mgr) = state.browser {
+            mgr.set_pin_tab(true);
+        }
+        // Force a rewrite so the persisted binding records pinned=true.
+        state.last_persisted_binding = None;
+    }
 
     let skip_launch = skip_launch_action(action);
     let restore_key_change_needs_launch = !skip_launch
@@ -1999,6 +2036,13 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         state.last_command_finished = Some(std::time::Instant::now());
     }
 
+    // Persist the session-to-tab binding (write-on-change) so a fresh daemon
+    // re-attaches to this session's tab instead of adopting the browser's
+    // most recently active one.
+    if !skip_launch {
+        maybe_persist_tab_binding(state);
+    }
+
     let mut resp = match result {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
@@ -2059,20 +2103,111 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 }
 
 // ---------------------------------------------------------------------------
+// Session-to-tab binding
+// ---------------------------------------------------------------------------
+
+/// Persist the session's tab binding when it changed. Called after every
+/// browser-touching command; skipped while the bound tab is gone so the
+/// stale binding (needed to re-derive the tab_gone state after a daemon
+/// restart) is not overwritten by the fallback tab.
+fn maybe_persist_tab_binding(state: &mut DaemonState) {
+    let Some(ref mgr) = state.browser else {
+        return;
+    };
+    let Some((target_id, url)) = mgr.binding_snapshot() else {
+        return;
+    };
+    let binding = tab_binding::TabBinding {
+        target_id,
+        url,
+        pinned: state.pin_tab,
+    };
+    if state.last_persisted_binding.as_ref() == Some(&binding) {
+        return;
+    }
+    tab_binding::save(&state.session_id, &binding);
+    state.last_persisted_binding = Some(binding);
+}
+
+/// Re-apply this session's persisted tab binding after attaching to a
+/// browser over CDP, instead of keeping the default selection (the first
+/// target returned by `Target.getTargets`, i.e. the browser's most recently
+/// active tab, which in a shared browser is usually another session's tab).
+///
+/// Returns true when the session ends up with an established selection:
+/// re-bound to the persisted target, entered the `tab_gone` state (pin-tab,
+/// bound tab dead), or bound to a fresh tab (pin-tab, no prior binding).
+/// Returns false when no binding existed and the legacy selection stands.
+async fn apply_tab_binding_on_attach(state: &mut DaemonState) -> Result<bool, String> {
+    let session = state.session_id.clone();
+    let binding = tab_binding::load(&session);
+    if binding.as_ref().is_some_and(|b| b.pinned) {
+        state.pin_tab = true;
+    }
+    let pin = state.pin_tab;
+    if state.browser.is_none() {
+        return Ok(false);
+    }
+    if let Some(ref mut mgr) = state.browser {
+        mgr.set_pin_tab(pin);
+    }
+    let established = match binding {
+        Some(b) => {
+            let restored = state
+                .browser
+                .as_mut()
+                .map(|mgr| mgr.restore_target_binding(&b.target_id, &b.url))
+                .unwrap_or(false);
+            if restored || pin {
+                // Restored, or entered the tab_gone state (the stale binding
+                // file is intentionally kept so the state is re-derived if
+                // the daemon restarts again before the agent re-binds).
+                true
+            } else {
+                // Legacy sessions fall back to the first target; drop the
+                // stale binding.
+                tab_binding::clear(&session);
+                state.last_persisted_binding = None;
+                false
+            }
+        }
+        None => {
+            if pin {
+                // A pinned session never implicitly adopts an existing tab:
+                // start it on a fresh one.
+                if let Some(ref mut mgr) = state.browser {
+                    mgr.tab_new(None, None).await?;
+                }
+                true
+            } else {
+                false
+            }
+        }
+    };
+    if established {
+        maybe_persist_tab_binding(state);
+    }
+    Ok(established)
+}
+
+// ---------------------------------------------------------------------------
 // Auto-launch
 // ---------------------------------------------------------------------------
 
-/// Connect to a running Chrome via auto-discovery and open a fresh tab so
-/// subsequent navigations don't hijack the user's existing tabs.
-async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
-    let mut mgr = BrowserManager::connect_auto().await?;
+/// Open a fresh tab so auto-connect navigations don't hijack the user's
+/// existing tabs. Used when no persisted binding re-established a tab.
+async fn open_fresh_tab_for_auto_connect(state: &mut DaemonState) -> Result<(), String> {
+    let Some(ref mut mgr) = state.browser else {
+        return Ok(());
+    };
     mgr.tab_new(None, None).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let _ = mgr
         .client
         .send_command("Page.bringToFront", None, Some(&session_id))
         .await;
-    Ok(mgr)
+    maybe_persist_tab_binding(state);
+    Ok(())
 }
 
 async fn auto_launch(
@@ -2125,6 +2260,7 @@ async fn auto_launch(
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
+        apply_tab_binding_on_attach(state).await?;
         state.update_stream_client().await;
         apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
         try_auto_restore_state(state).await;
@@ -2143,7 +2279,10 @@ async fn auto_launch(
             None,
         );
         state.reset_input_state();
-        state.browser = Some(connect_auto_with_fresh_tab().await?);
+        state.browser = Some(BrowserManager::connect_auto().await?);
+        if !apply_tab_binding_on_attach(state).await? {
+            open_fresh_tab_for_auto_connect(state).await?;
+        }
         state.launch_hash = Some(hash);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -2870,6 +3009,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
+        apply_tab_binding_on_attach(state).await?;
         state.update_stream_client().await;
         apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
         try_auto_restore_state(state).await;
@@ -2884,6 +3024,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
+        apply_tab_binding_on_attach(state).await?;
         state.update_stream_client().await;
         apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
         try_auto_restore_state(state).await;
@@ -2893,7 +3034,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if auto_connect {
         state.reset_input_state();
-        state.browser = Some(connect_auto_with_fresh_tab().await?);
+        state.browser = Some(BrowserManager::connect_auto().await?);
+        if !apply_tab_binding_on_attach(state).await? {
+            open_fresh_tab_for_auto_connect(state).await?;
+        }
         state.launch_hash = Some(new_hash);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
@@ -9474,11 +9618,17 @@ fn inject_lifecycle(
 }
 
 fn error_response(id: &str, error: &str) -> Value {
-    json!({
+    let mut resp = json!({
         "id": id,
         "success": false,
         "error": error,
-    })
+    });
+    // Machine-readable code for "the bound tab no longer exists" so scripts
+    // using --json can match on it instead of parsing the message.
+    if error.starts_with(super::browser::TAB_GONE_PREFIX) {
+        resp["code"] = json!("tab_gone");
+    }
+    resp
 }
 
 #[cfg(test)]
@@ -10479,6 +10629,22 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         assert_eq!(resp["id"], "cmd-2");
         assert_eq!(resp["success"], false);
         assert_eq!(resp["error"], "Something went wrong");
+        // Ordinary errors carry no machine-readable code.
+        assert!(resp.get("code").is_none());
+    }
+
+    #[test]
+    fn test_error_response_tab_gone_code() {
+        // Errors whose message starts with the tab-gone prefix get a
+        // top-level machine-readable `code` so `--json` consumers can match
+        // on it instead of parsing the message.
+        let err = format!(
+            "{} bound tab is gone (target ABC). Run `agent-browser tab new <url>`",
+            super::super::browser::TAB_GONE_PREFIX
+        );
+        let resp = error_response("cmd-3", &err);
+        assert_eq!(resp["success"], false);
+        assert_eq!(resp["code"], "tab_gone");
     }
 
     #[tokio::test]

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -180,11 +180,21 @@ pub fn format_tab_id(tab_id: u32) -> String {
 }
 
 /// A tab reference as parsed from CLI/JSON input. Either a stable id like
-/// `t2` or a user-assigned label like `docs`.
+/// `t2`, a user-assigned label like `docs`, or a CDP target id like
+/// `4A0B...C3`. Target ids are stable across daemon restarts, unlike `t<N>`
+/// ids which are per-daemon counters.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TabRef {
     Id(u32),
     Label(String),
+    Target(String),
+}
+
+/// Heuristic for CDP target ids: long hex strings (Chrome uses 32 uppercase
+/// hex chars). Only used for inputs that are not valid labels; label-shaped
+/// hex strings resolve label-first with a target-id fallback.
+fn looks_like_target_id(s: &str) -> bool {
+    s.len() >= 16 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 impl TabRef {
@@ -212,6 +222,9 @@ impl TabRef {
                 }
                 return Ok(TabRef::Id(id));
             }
+        }
+        if looks_like_target_id(input) && !is_valid_label(input) {
+            return Ok(TabRef::Target(input.to_string()));
         }
         if input.chars().all(|c| c.is_ascii_digit()) {
             return Err(format!(
@@ -305,6 +318,36 @@ pub struct BrowserManager {
     /// Origins visited during this session, used by save_state to collect cross-origin localStorage.
     visited_origins: HashSet<String>,
     next_tab_id: u32,
+    /// Strict session-to-tab binding (`--pin-tab`). When enabled, the session
+    /// never silently adopts another tab: if the bound tab goes away, page
+    /// commands fail with a `tab_gone` error until the agent re-binds via
+    /// `tab new` or `tab <ref>`.
+    pin_tab: bool,
+    /// CDP target id of the tab this session is bound to. Updated whenever
+    /// the session creates a tab or explicitly switches tabs; persisted by
+    /// the daemon so re-attach selects the same tab instead of index 0.
+    bound_target_id: Option<String>,
+    /// Set when `pin_tab` is enabled and the bound tab was destroyed
+    /// (externally, or found missing at attach time): `(target_id, last_url)`.
+    /// While set, commands that need the active page fail with `tab_gone`.
+    bound_target_gone: Option<(String, String)>,
+}
+
+/// Stable machine-readable prefix for "the bound tab no longer exists"
+/// errors, so scripts using `--json` can match on it.
+pub const TAB_GONE_PREFIX: &str = "tab_gone:";
+
+fn tab_gone_error(target_id: &str, last_url: &str) -> String {
+    let url_part = if last_url.is_empty() {
+        String::new()
+    } else {
+        format!(", last url {}", last_url)
+    };
+    format!(
+        "{} bound tab is gone (target {}{}). Run `agent-browser tab new <url>` to bind a new \
+         tab, or `agent-browser tab list` to pick an existing one",
+        TAB_GONE_PREFIX, target_id, url_part
+    )
 }
 
 const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -377,6 +420,9 @@ impl BrowserManager {
                 ignore_https_errors,
                 visited_origins: HashSet::new(),
                 next_tab_id: 1,
+                pin_tab: false,
+                bound_target_id: None,
+                bound_target_gone: None,
             };
             manager.discover_and_attach_targets().await?;
             manager
@@ -466,6 +512,9 @@ impl BrowserManager {
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
+            pin_tab: false,
+            bound_target_id: None,
+            bound_target_gone: None,
         };
 
         if direct_page {
@@ -549,6 +598,7 @@ impl BrowserManager {
                 target_type: "page".to_string(),
             });
             self.active_page_index = 0;
+            self.bind_active_target();
             self.enable_domains(&attach_result.session_id).await?;
         } else {
             for target in &page_targets {
@@ -643,10 +693,89 @@ impl BrowserManager {
     }
 
     pub fn active_session_id(&self) -> Result<&str, String> {
+        self.check_bound()?;
         self.pages
             .get(self.active_page_index)
             .map(|p| p.session_id.as_str())
             .ok_or_else(|| "No active page".to_string())
+    }
+
+    // -----------------------------------------------------------------------
+    // Session-to-tab binding
+    // -----------------------------------------------------------------------
+
+    /// Enable or disable strict pin-tab semantics for this session.
+    pub fn set_pin_tab(&mut self, pin: bool) {
+        self.pin_tab = pin;
+    }
+
+    pub fn pin_tab(&self) -> bool {
+        self.pin_tab
+    }
+
+    /// The target id this session is bound to, if any.
+    pub fn bound_target_id(&self) -> Option<&str> {
+        self.bound_target_id.as_deref()
+    }
+
+    /// Returns the `tab_gone` error when the bound tab no longer exists.
+    /// Commands that operate on the active page call this (via
+    /// `active_session_id` / `active_target_id`) so they fail loudly instead
+    /// of acting on a neighboring tab. Recovery commands (`tab list`,
+    /// `tab new`, `tab <ref>`) do not.
+    fn check_bound(&self) -> Result<(), String> {
+        match self.bound_target_gone {
+            Some((ref target_id, ref last_url)) => Err(tab_gone_error(target_id, last_url)),
+            None => Ok(()),
+        }
+    }
+
+    /// True when the bound tab is gone and the session needs an explicit
+    /// re-bind (`tab new` / `tab <ref>`) before page commands can proceed.
+    pub fn bound_target_is_gone(&self) -> bool {
+        self.bound_target_gone.is_some()
+    }
+
+    /// Bind this session to the currently active tab. Called whenever the
+    /// session creates a tab or explicitly switches tabs; clears any
+    /// `tab_gone` state.
+    fn bind_active_target(&mut self) {
+        self.bound_target_id = self
+            .pages
+            .get(self.active_page_index)
+            .map(|p| p.target_id.clone());
+        self.bound_target_gone = None;
+    }
+
+    /// Restore a persisted binding after (re)attach. If the bound target is
+    /// still alive, make it the active page and return `true`. If it is
+    /// gone, return `false`: with `pin_tab` the manager enters the `tab_gone`
+    /// state, otherwise the legacy selection (index 0) is kept unchanged.
+    pub fn restore_target_binding(&mut self, target_id: &str, last_url: &str) -> bool {
+        if let Some(index) = self.pages.iter().position(|p| p.target_id == target_id) {
+            self.active_page_index = index;
+            self.bound_target_id = Some(target_id.to_string());
+            self.bound_target_gone = None;
+            return true;
+        }
+        self.bound_target_id = None;
+        if self.pin_tab {
+            self.bound_target_gone = Some((target_id.to_string(), last_url.to_string()));
+        }
+        false
+    }
+
+    /// React to the bound tab disappearing (closed externally, or closed by
+    /// this session). With `pin_tab`, enter the `tab_gone` state so nothing
+    /// silently retargets; otherwise just drop the stale binding.
+    fn handle_bound_target_removed(&mut self, target_id: &str, last_url: &str) {
+        if self.bound_target_id.as_deref() != Some(target_id) {
+            return;
+        }
+        self.bound_target_id = None;
+        if self.pin_tab {
+            self.bound_target_gone = Some((target_id.to_string(), last_url.to_string()));
+        }
     }
 
     pub async fn navigate(&mut self, url: &str, wait_until: WaitUntil) -> Result<Value, String> {
@@ -693,7 +822,11 @@ impl BrowserManager {
             page.title = title.clone();
         }
 
-        Ok(json!({ "url": page_url, "title": title }))
+        let target_id = self
+            .pages
+            .get(self.active_page_index)
+            .map(|p| p.target_id.clone());
+        Ok(json!({ "url": page_url, "title": title, "targetId": target_id }))
     }
 
     async fn wait_for_lifecycle(
@@ -872,6 +1005,7 @@ impl BrowserManager {
     }
 
     pub fn active_target_id(&self) -> Result<&str, String> {
+        self.check_bound()?;
         self.pages
             .get(self.active_page_index)
             .map(|p| p.target_id.as_str())
@@ -925,6 +1059,7 @@ impl BrowserManager {
             target_type: "page".to_string(),
         });
         self.active_page_index = 0;
+        self.bind_active_target();
         self.enable_domains(&attach_result.session_id).await?;
 
         Ok(())
@@ -961,11 +1096,12 @@ impl BrowserManager {
             .map(|(i, p)| {
                 json!({
                     "tabId": format_tab_id(p.tab_id),
+                    "targetId": p.target_id,
                     "label": p.label,
                     "title": p.title,
                     "url": p.url,
                     "type": p.target_type,
-                    "active": i == self.active_page_index,
+                    "active": i == self.active_page_index && !self.bound_target_is_gone(),
                 })
             })
             .collect()
@@ -990,13 +1126,38 @@ impl BrowserManager {
                 .iter()
                 .find(|p| p.label.as_deref() == Some(name.as_str()))
                 .map(|p| p.tab_id)
+                // A label-shaped hex string may actually be a CDP target id
+                // (target ids can start with a letter); fall back to an
+                // exact target-id match before giving up.
+                .or_else(|| {
+                    if looks_like_target_id(name) {
+                        self.find_tab_id_by_target(name)
+                    } else {
+                        None
+                    }
+                })
                 .ok_or_else(|| {
                     format!(
                         "No tab with label `{}`; run `agent-browser tab` to list open tabs",
                         name
                     )
                 }),
+            TabRef::Target(target_id) => self.find_tab_id_by_target(target_id).ok_or_else(|| {
+                format!(
+                    "No tab with target id `{}`; run `agent-browser tab list --json` to \
+                         list open tabs with their target ids",
+                    target_id
+                )
+            }),
         }
+    }
+
+    /// Exact, case-insensitive match of a CDP target id to a stable tab id.
+    fn find_tab_id_by_target(&self, target_id: &str) -> Option<u32> {
+        self.pages
+            .iter()
+            .find(|p| p.target_id.eq_ignore_ascii_case(target_id))
+            .map(|p| p.tab_id)
     }
 
     /// Returns true iff a tab already carries the given label.
@@ -1057,6 +1218,7 @@ impl BrowserManager {
         self.next_tab_id += 1;
         let index = self.pages.len();
         let label = label.map(|s| s.to_string());
+        let target_id = result.target_id.clone();
         self.pages.push(PageInfo {
             tab_id,
             label: label.clone(),
@@ -1067,9 +1229,11 @@ impl BrowserManager {
             target_type: "page".to_string(),
         });
         self.active_page_index = index;
+        self.bind_active_target();
 
         Ok(json!({
             "tabId": format_tab_id(tab_id),
+            "targetId": target_id,
             "label": label,
             "url": target_url,
             "total": self.pages.len(),
@@ -1086,6 +1250,7 @@ impl BrowserManager {
         }
 
         self.active_page_index = index;
+        self.bind_active_target();
         let session_id = self.pages[index].session_id.clone();
         self.enable_domains(&session_id).await?;
 
@@ -1106,6 +1271,7 @@ impl BrowserManager {
         let page = &self.pages[index];
         Ok(json!({
             "tabId": format_tab_id(page.tab_id),
+            "targetId": page.target_id,
             "label": page.label,
             "url": url,
             "title": title,
@@ -1113,6 +1279,11 @@ impl BrowserManager {
     }
 
     pub async fn tab_close(&mut self, index: Option<usize>) -> Result<Value, String> {
+        if index.is_none() {
+            // "Close the current tab" must not silently close a fallback tab
+            // when the bound tab is already gone.
+            self.check_bound()?;
+        }
         let target_index = index.unwrap_or(self.active_page_index);
 
         if target_index >= self.pages.len() {
@@ -1127,6 +1298,8 @@ impl BrowserManager {
         self.update_active_page_after_removal(target_index);
         let closed_tab_id = page.tab_id;
         let closed_label = page.label.clone();
+        let closed_target_id = page.target_id.clone();
+        self.handle_bound_target_removed(&page.target_id, &page.url);
         let _ = self
             .client
             .send_command_typed::<_, Value>(
@@ -1138,11 +1311,17 @@ impl BrowserManager {
             )
             .await;
 
-        let session_id = self.pages[self.active_page_index].session_id.clone();
-        self.enable_domains(&session_id).await?;
+        // With pin-tab, closing the bound tab leaves the session unbound
+        // (page commands return `tab_gone` until an explicit re-bind), so
+        // don't touch the neighboring tab that inherited the active slot.
+        if !self.bound_target_is_gone() {
+            let session_id = self.pages[self.active_page_index].session_id.clone();
+            self.enable_domains(&session_id).await?;
+        }
 
         Ok(json!({
             "tabId": format_tab_id(closed_tab_id),
+            "targetId": closed_target_id,
             "label": closed_label,
             "closed": true,
         }))
@@ -1426,10 +1605,32 @@ impl BrowserManager {
         id
     }
 
+    /// Add a page created by this session and make it active (and bound).
     pub fn add_page(&mut self, page: PageInfo) {
         let index = self.pages.len();
         self.pages.push(page);
         self.active_page_index = index;
+        self.bind_active_target();
+    }
+
+    /// Track a page without activating it. Used for targets discovered via
+    /// `Target.targetCreated` when pin-tab is enabled: in a shared browser
+    /// those may belong to another session, so they must not steal the
+    /// active slot or the binding.
+    pub fn add_page_background(&mut self, page: PageInfo) {
+        self.pages.push(page);
+    }
+
+    /// The active page's `(target_id, url)` for binding persistence, or
+    /// `None` when there is no page or the bound tab is gone (a stale
+    /// binding must not be overwritten by the fallback tab).
+    pub fn binding_snapshot(&self) -> Option<(String, String)> {
+        if self.bound_target_is_gone() {
+            return None;
+        }
+        self.pages
+            .get(self.active_page_index)
+            .map(|p| (p.target_id.clone(), p.url.clone()))
     }
 
     pub fn update_page_target_info(&mut self, target: &TargetInfo) -> bool {
@@ -1438,8 +1639,12 @@ impl BrowserManager {
 
     pub fn remove_page_by_target_id(&mut self, target_id: &str) {
         if let Some(pos) = self.pages.iter().position(|p| p.target_id == target_id) {
-            self.pages.remove(pos);
+            let page = self.pages.remove(pos);
             self.update_active_page_after_removal(pos);
+            // If the destroyed target was the bound tab (closed externally,
+            // e.g. by another session sharing this browser), fail loudly
+            // under pin-tab instead of silently pointing at a neighbor.
+            self.handle_bound_target_removed(&page.target_id, &page.url);
         }
     }
 
@@ -1617,6 +1822,9 @@ async fn initialize_lightpanda_manager(
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
+            pin_tab: false,
+            bound_target_id: None,
+            bound_target_gone: None,
         };
 
         match discover_and_attach_lightpanda_targets(&mut manager, deadline).await {
@@ -2172,6 +2380,278 @@ mod tests {
             "should wait for idle after second request, got {:?}",
             elapsed
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Session-to-tab binding tests
+    // -----------------------------------------------------------------------
+
+    fn page(tab_id: u32, target_id: &str, url: &str) -> PageInfo {
+        PageInfo {
+            tab_id,
+            label: None,
+            target_id: target_id.to_string(),
+            session_id: format!("session-{}", tab_id),
+            url: url.to_string(),
+            title: String::new(),
+            target_type: "page".to_string(),
+        }
+    }
+
+    /// Build a `BrowserManager` backed by a dummy WebSocket server that
+    /// accepts the connection and then stays silent. Enough for the binding
+    /// logic, which never awaits a CDP response in these tests.
+    async fn test_manager(pages: Vec<PageInfo>) -> BrowserManager {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                if let Ok(_ws) = tokio_tungstenite::accept_async(stream).await {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                }
+            }
+        });
+        let client = CdpClient::connect(&format!("ws://{}", addr)).await.unwrap();
+        BrowserManager {
+            client: Arc::new(client),
+            browser_process: None,
+            ws_url: format!("ws://{}", addr),
+            pages,
+            active_page_index: 0,
+            default_timeout_ms: 25_000,
+            download_path: None,
+            ignore_https_errors: false,
+            visited_origins: HashSet::new(),
+            next_tab_id: 100,
+            pin_tab: false,
+            bound_target_id: None,
+            bound_target_gone: None,
+        }
+    }
+
+    const TARGET_A: &str = "AAAA0000BBBB1111CCCC2222DDDD3333";
+    const TARGET_B: &str = "4F0A1111BBBB2222CCCC3333DDDD4444";
+
+    #[tokio::test]
+    async fn test_restore_target_binding_selects_bound_target() {
+        let mut mgr = test_manager(vec![
+            page(1, TARGET_B, "https://other.example"),
+            page(2, TARGET_A, "https://mine.example"),
+        ])
+        .await;
+
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+        assert_eq!(mgr.active_target_id().unwrap(), TARGET_A);
+        assert_eq!(mgr.bound_target_id(), Some(TARGET_A));
+        assert!(!mgr.bound_target_is_gone());
+    }
+
+    #[tokio::test]
+    async fn test_restore_target_binding_missing_with_pin_enters_tab_gone() {
+        let mut mgr = test_manager(vec![page(1, TARGET_B, "https://other.example")]).await;
+        mgr.set_pin_tab(true);
+
+        assert!(!mgr.restore_target_binding(TARGET_A, "https://mine.example/checkout"));
+        assert!(mgr.bound_target_is_gone());
+
+        let err = mgr.active_session_id().unwrap_err();
+        assert!(
+            err.starts_with(TAB_GONE_PREFIX),
+            "unexpected error: {}",
+            err
+        );
+        assert!(err.contains(TARGET_A));
+        assert!(err.contains("https://mine.example/checkout"));
+        assert!(err.contains("tab new"));
+
+        // active_target_id is guarded the same way
+        assert!(mgr
+            .active_target_id()
+            .unwrap_err()
+            .starts_with(TAB_GONE_PREFIX));
+        // No tab is reported active while the binding is unresolved.
+        assert!(mgr.tab_list().iter().all(|t| t["active"] == false));
+    }
+
+    #[tokio::test]
+    async fn test_restore_target_binding_missing_without_pin_keeps_legacy_selection() {
+        let mut mgr = test_manager(vec![page(1, TARGET_B, "https://other.example")]).await;
+
+        assert!(!mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+        assert!(!mgr.bound_target_is_gone());
+        // Legacy behavior: first target stays selected and commands work.
+        assert_eq!(mgr.active_target_id().unwrap(), TARGET_B);
+    }
+
+    #[tokio::test]
+    async fn test_external_removal_of_bound_tab_with_pin_enters_tab_gone() {
+        let mut mgr = test_manager(vec![
+            page(1, TARGET_A, "https://mine.example"),
+            page(2, TARGET_B, "https://other.example"),
+        ])
+        .await;
+        mgr.set_pin_tab(true);
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+
+        mgr.remove_page_by_target_id(TARGET_A);
+
+        assert!(mgr.bound_target_is_gone());
+        let err = mgr.active_session_id().unwrap_err();
+        assert!(err.starts_with(TAB_GONE_PREFIX));
+        // Recovery data is intact: the other tab is still listed.
+        assert_eq!(mgr.tab_list().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_external_removal_of_bound_tab_without_pin_falls_back() {
+        let mut mgr = test_manager(vec![
+            page(1, TARGET_A, "https://mine.example"),
+            page(2, TARGET_B, "https://other.example"),
+        ])
+        .await;
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+
+        mgr.remove_page_by_target_id(TARGET_A);
+
+        assert!(!mgr.bound_target_is_gone());
+        assert_eq!(mgr.bound_target_id(), None);
+        assert_eq!(mgr.active_target_id().unwrap(), TARGET_B);
+    }
+
+    #[tokio::test]
+    async fn test_removal_of_other_tab_does_not_affect_binding() {
+        let mut mgr = test_manager(vec![
+            page(1, TARGET_B, "https://other.example"),
+            page(2, TARGET_A, "https://mine.example"),
+        ])
+        .await;
+        mgr.set_pin_tab(true);
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+
+        mgr.remove_page_by_target_id(TARGET_B);
+
+        assert!(!mgr.bound_target_is_gone());
+        assert_eq!(mgr.active_target_id().unwrap(), TARGET_A);
+        assert_eq!(mgr.bound_target_id(), Some(TARGET_A));
+    }
+
+    #[tokio::test]
+    async fn test_tab_close_current_in_tab_gone_state_errors() {
+        let mut mgr = test_manager(vec![
+            page(1, TARGET_A, "https://mine.example"),
+            page(2, TARGET_B, "https://other.example"),
+        ])
+        .await;
+        mgr.set_pin_tab(true);
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+        mgr.remove_page_by_target_id(TARGET_A);
+
+        // "Close the current tab" must not close the fallback neighbor.
+        let err = mgr.tab_close(None).await.unwrap_err();
+        assert!(err.starts_with(TAB_GONE_PREFIX));
+        assert_eq!(mgr.tab_list().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_binding_snapshot_reflects_active_page_and_gone_state() {
+        let mut mgr = test_manager(vec![
+            page(1, TARGET_A, "https://mine.example"),
+            page(2, TARGET_B, "https://other.example"),
+        ])
+        .await;
+        mgr.set_pin_tab(true);
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+        assert_eq!(
+            mgr.binding_snapshot(),
+            Some((TARGET_A.to_string(), "https://mine.example".to_string()))
+        );
+
+        mgr.remove_page_by_target_id(TARGET_A);
+        // A stale binding must not be overwritten by the fallback tab.
+        assert_eq!(mgr.binding_snapshot(), None);
+    }
+
+    #[tokio::test]
+    async fn test_add_page_background_does_not_steal_active_slot() {
+        let mut mgr = test_manager(vec![page(1, TARGET_A, "https://mine.example")]).await;
+        mgr.set_pin_tab(true);
+        assert!(mgr.restore_target_binding(TARGET_A, "https://mine.example"));
+
+        mgr.add_page_background(page(2, TARGET_B, "https://other.example"));
+
+        assert_eq!(mgr.active_target_id().unwrap(), TARGET_A);
+        assert_eq!(mgr.bound_target_id(), Some(TARGET_A));
+        assert_eq!(mgr.tab_list().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_add_page_activates_and_binds() {
+        let mut mgr = test_manager(vec![page(1, TARGET_A, "https://mine.example")]).await;
+        mgr.add_page(page(2, TARGET_B, "https://new.example"));
+
+        assert_eq!(mgr.active_target_id().unwrap(), TARGET_B);
+        assert_eq!(mgr.bound_target_id(), Some(TARGET_B));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tab_ref_by_target_id() {
+        let mgr = test_manager(vec![
+            page(1, TARGET_A, "https://mine.example"),
+            page(2, TARGET_B, "https://other.example"),
+        ])
+        .await;
+
+        // Digit-leading target ids parse as TabRef::Target.
+        let tab_ref = TabRef::parse(TARGET_B).unwrap();
+        assert_eq!(tab_ref, TabRef::Target(TARGET_B.to_string()));
+        assert_eq!(mgr.resolve_tab_ref(&tab_ref).unwrap(), 2);
+
+        // Letter-leading target ids parse as labels and fall back to a
+        // target-id match.
+        let tab_ref = TabRef::parse(TARGET_A).unwrap();
+        assert_eq!(mgr.resolve_tab_ref(&tab_ref).unwrap(), 1);
+
+        // Case-insensitive.
+        let lower = TARGET_B.to_lowercase();
+        assert_eq!(
+            mgr.resolve_tab_ref(&TabRef::parse(&lower).unwrap())
+                .unwrap(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tab_ref_unknown_target_id_errors() {
+        let mgr = test_manager(vec![page(1, TARGET_A, "https://mine.example")]).await;
+        let err = mgr
+            .resolve_tab_ref(&TabRef::Target("0123456789ABCDEF".to_string()))
+            .unwrap_err();
+        assert!(err.contains("target id"));
+    }
+
+    #[tokio::test]
+    async fn test_tab_list_includes_target_id() {
+        let mgr = test_manager(vec![page(1, TARGET_A, "https://mine.example")]).await;
+        let tabs = mgr.tab_list();
+        assert_eq!(tabs[0]["targetId"], TARGET_A);
+    }
+
+    #[test]
+    fn test_parse_tab_ref_short_hex_is_label_not_target() {
+        // Short hex strings stay labels (or errors), not target ids.
+        assert_eq!(
+            TabRef::parse("deadbeef"),
+            Ok(TabRef::Label("deadbeef".to_string()))
+        );
+        assert!(TabRef::parse("1234").is_err());
+    }
+
+    #[test]
+    fn test_tab_gone_error_without_url_omits_url_part() {
+        let err = tab_gone_error("ABCD", "");
+        assert!(err.starts_with(TAB_GONE_PREFIX));
+        assert!(err.contains("(target ABCD)"));
+        assert!(!err.contains("last url"));
     }
 
     /// When the overall timeout expires before idle is reached, the function

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -705,8 +705,14 @@ impl BrowserManager {
     // -----------------------------------------------------------------------
 
     /// Enable or disable strict pin-tab semantics for this session.
+    /// Disabling also clears a pending `tab_gone` state (which only exists
+    /// under pin semantics) so the session falls back to legacy selection
+    /// instead of staying stuck on errors for a pin it no longer has.
     pub fn set_pin_tab(&mut self, pin: bool) {
         self.pin_tab = pin;
+        if !pin {
+            self.bound_target_gone = None;
+        }
     }
 
     pub fn pin_tab(&self) -> bool {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6330,3 +6330,235 @@ async fn e2e_removeinitscript_roundtrip() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+// ---------------------------------------------------------------------------
+// Session-to-tab binding (--pin-tab): two sessions sharing one Chrome over
+// CDP must not hijack each other's tabs. A restarted daemon re-binds to its
+// persisted target instead of adopting the most recently active tab, and a
+// pinned session whose tab is closed gets a tab_gone error instead of
+// silently acting on another session's tab.
+// ---------------------------------------------------------------------------
+
+/// Environment guard for binding tests: isolated socket dir (so binding
+/// files cannot leak between test runs) plus per-session env vars.
+fn binding_test_env() -> (EnvGuard<'static>, tempfile::TempDir) {
+    let guard = EnvGuard::new(&[
+        "AGENT_BROWSER_SOCKET_DIR",
+        "XDG_RUNTIME_DIR",
+        "AGENT_BROWSER_NAMESPACE",
+        "AGENT_BROWSER_SESSION",
+        "AGENT_BROWSER_PIN_TAB",
+    ]);
+    let dir = tempfile::tempdir().unwrap();
+    guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().unwrap());
+    guard.remove("XDG_RUNTIME_DIR");
+    guard.remove("AGENT_BROWSER_NAMESPACE");
+    guard.remove("AGENT_BROWSER_PIN_TAB");
+    (guard, dir)
+}
+
+/// Launch a host Chrome and return (host_state, ws_url) for other sessions
+/// to attach to over CDP.
+async fn launch_binding_host(guard: &EnvGuard<'static>) -> (DaemonState, String) {
+    guard.set("AGENT_BROWSER_SESSION", "e2e-bind-host");
+    let mut host = DaemonState::new();
+    let resp = execute_command(
+        &json!({
+            "id": "host-1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut host,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "host-2", "action": "cdp_url" }), &mut host).await;
+    assert_success(&resp);
+    let ws_url = get_data(&resp)["cdpUrl"]
+        .as_str()
+        .expect("cdpUrl should be a string")
+        .to_string();
+    (host, ws_url)
+}
+
+/// Create a pinned session attached to the shared Chrome and navigate its
+/// bound tab to `url`. Returns the session's state.
+async fn attach_pinned_session(
+    guard: &EnvGuard<'static>,
+    session: &str,
+    ws_url: &str,
+    url: &str,
+) -> DaemonState {
+    guard.set("AGENT_BROWSER_SESSION", session);
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({
+            "id": format!("{}-launch", session),
+            "action": "launch",
+            "cdpUrl": ws_url,
+            "pinTab": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": format!("{}-nav", session), "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    state
+}
+
+async fn current_url(state: &mut DaemonState, id: &str) -> Value {
+    execute_command(&json!({ "id": id, "action": "url" }), state).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_pin_tab_rebinds_after_daemon_restart() {
+    use super::tab_binding;
+
+    let (guard, _dir) = binding_test_env();
+    let (mut host, ws_url) = launch_binding_host(&guard).await;
+
+    let url_a = "data:text/html,session-a-page";
+    let url_b = "data:text/html,session-b-page";
+
+    // Session A binds its own tab (pin mode creates a fresh tab on attach).
+    let state_a = attach_pinned_session(&guard, "e2e-bind-a", &ws_url, url_a).await;
+    let binding_a = tab_binding::load("e2e-bind-a").expect("session A binding should persist");
+    assert!(binding_a.pinned, "binding should record pinned=true");
+    assert_eq!(binding_a.url, url_a);
+
+    // Session B binds its own tab and navigates last, so B's tab is the most
+    // recently active one (the tab a naive re-attach would adopt).
+    let mut state_b = attach_pinned_session(&guard, "e2e-bind-b", &ws_url, url_b).await;
+    let binding_b = tab_binding::load("e2e-bind-b").expect("session B binding should persist");
+    assert_ne!(
+        binding_a.target_id, binding_b.target_id,
+        "sessions must bind distinct tabs"
+    );
+
+    // Simulate session A's daemon dying (idle timeout, crash, kill): drop the
+    // state without a clean close. The binding file survives.
+    drop(state_a);
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // A restarted daemon for session A must re-bind to A's original tab by
+    // targetId, not adopt B's (most recently active) tab.
+    guard.set("AGENT_BROWSER_SESSION", "e2e-bind-a");
+    let mut state_a2 = DaemonState::new();
+    assert!(
+        state_a2.pin_tab,
+        "pin-tab should be sticky via the persisted binding"
+    );
+    let resp = execute_command(
+        &json!({ "id": "a2-launch", "action": "launch", "cdpUrl": ws_url }),
+        &mut state_a2,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = current_url(&mut state_a2, "a2-url").await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["url"],
+        url_a,
+        "restarted session A must operate on A's original tab"
+    );
+    let binding_a2 = tab_binding::load("e2e-bind-a").expect("binding should still exist");
+    assert_eq!(
+        binding_a2.target_id, binding_a.target_id,
+        "re-attach must keep the original bound target"
+    );
+
+    // Session B is unaffected.
+    let resp = current_url(&mut state_b, "b-url").await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], url_b);
+
+    let resp = execute_command(&json!({ "id": "host-99", "action": "close" }), &mut host).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_pin_tab_gone_error_and_recovery() {
+    use super::tab_binding;
+
+    let (guard, _dir) = binding_test_env();
+    let (mut host, ws_url) = launch_binding_host(&guard).await;
+
+    let url_a = "data:text/html,gone-session-a";
+    let url_b = "data:text/html,gone-session-b";
+
+    let mut state_a = attach_pinned_session(&guard, "e2e-gone-a", &ws_url, url_a).await;
+    let binding_a = tab_binding::load("e2e-gone-a").expect("session A binding should persist");
+    let mut state_b = attach_pinned_session(&guard, "e2e-gone-b", &ws_url, url_b).await;
+
+    // Session B closes A's tab by targetId (targetIds are accepted anywhere a
+    // tab ref is accepted and are stable across daemons).
+    let resp = execute_command(
+        &json!({ "id": "b-close-a", "action": "tab_close", "tabId": binding_a.target_id }),
+        &mut state_b,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Session A must now fail loudly with a machine-readable tab_gone error
+    // instead of silently adopting a neighboring tab.
+    let resp = current_url(&mut state_a, "a-url-gone").await;
+    assert_eq!(resp["success"], false);
+    assert_eq!(
+        resp["code"],
+        "tab_gone",
+        "response should carry code=tab_gone, got: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let err = resp["error"].as_str().unwrap_or("");
+    assert!(
+        err.starts_with(super::browser::TAB_GONE_PREFIX),
+        "error should start with the tab_gone prefix, got: {}",
+        err
+    );
+
+    // Recovery commands still work in the gone state: tab_list is allowed,
+    // and tab_new binds a fresh tab.
+    let resp = execute_command(
+        &json!({ "id": "a-list", "action": "tab_list" }),
+        &mut state_a,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url_a2 = "data:text/html,recovered-session-a";
+    let resp = execute_command(
+        &json!({ "id": "a-new", "action": "tab_new", "url": url_a2 }),
+        &mut state_a,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = current_url(&mut state_a, "a-url-recovered").await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], url_a2);
+
+    let binding_a2 = tab_binding::load("e2e-gone-a").expect("binding should be rewritten");
+    assert_ne!(
+        binding_a2.target_id, binding_a.target_id,
+        "recovery must bind a new target"
+    );
+    assert!(binding_a2.pinned, "recovered binding stays pinned");
+
+    // Session B keeps working on its own tab throughout.
+    let resp = current_url(&mut state_b, "b-url-after").await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], url_b);
+
+    let resp = execute_command(&json!({ "id": "host-99", "action": "close" }), &mut host).await;
+    assert_success(&resp);
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6416,11 +6416,15 @@ async fn current_url(state: &mut DaemonState, id: &str) -> Value {
     execute_command(&json!({ "id": id, "action": "url" }), state).await
 }
 
+fn load_binding(session: &str, expect: &str) -> super::tab_binding::TabBinding {
+    super::tab_binding::load(session)
+        .expect("binding file should be readable")
+        .expect(expect)
+}
+
 #[tokio::test]
 #[ignore]
 async fn e2e_pin_tab_rebinds_after_daemon_restart() {
-    use super::tab_binding;
-
     let (guard, _dir) = binding_test_env();
     let (mut host, ws_url) = launch_binding_host(&guard).await;
 
@@ -6429,14 +6433,14 @@ async fn e2e_pin_tab_rebinds_after_daemon_restart() {
 
     // Session A binds its own tab (pin mode creates a fresh tab on attach).
     let state_a = attach_pinned_session(&guard, "e2e-bind-a", &ws_url, url_a).await;
-    let binding_a = tab_binding::load("e2e-bind-a").expect("session A binding should persist");
+    let binding_a = load_binding("e2e-bind-a", "session A binding should persist");
     assert!(binding_a.pinned, "binding should record pinned=true");
     assert_eq!(binding_a.url, url_a);
 
     // Session B binds its own tab and navigates last, so B's tab is the most
     // recently active one (the tab a naive re-attach would adopt).
     let mut state_b = attach_pinned_session(&guard, "e2e-bind-b", &ws_url, url_b).await;
-    let binding_b = tab_binding::load("e2e-bind-b").expect("session B binding should persist");
+    let binding_b = load_binding("e2e-bind-b", "session B binding should persist");
     assert_ne!(
         binding_a.target_id, binding_b.target_id,
         "sessions must bind distinct tabs"
@@ -6469,7 +6473,7 @@ async fn e2e_pin_tab_rebinds_after_daemon_restart() {
         url_a,
         "restarted session A must operate on A's original tab"
     );
-    let binding_a2 = tab_binding::load("e2e-bind-a").expect("binding should still exist");
+    let binding_a2 = load_binding("e2e-bind-a", "binding should still exist");
     assert_eq!(
         binding_a2.target_id, binding_a.target_id,
         "re-attach must keep the original bound target"
@@ -6504,8 +6508,6 @@ async fn e2e_pin_tab_rebinds_after_daemon_restart() {
 #[tokio::test]
 #[ignore]
 async fn e2e_pin_tab_gone_error_and_recovery() {
-    use super::tab_binding;
-
     let (guard, _dir) = binding_test_env();
     let (mut host, ws_url) = launch_binding_host(&guard).await;
 
@@ -6513,7 +6515,7 @@ async fn e2e_pin_tab_gone_error_and_recovery() {
     let url_b = "data:text/html,gone-session-b";
 
     let mut state_a = attach_pinned_session(&guard, "e2e-gone-a", &ws_url, url_a).await;
-    let binding_a = tab_binding::load("e2e-gone-a").expect("session A binding should persist");
+    let binding_a = load_binding("e2e-gone-a", "session A binding should persist");
     let mut state_b = attach_pinned_session(&guard, "e2e-gone-b", &ws_url, url_b).await;
 
     // Session B closes A's tab by targetId (targetIds are accepted anywhere a
@@ -6564,7 +6566,7 @@ async fn e2e_pin_tab_gone_error_and_recovery() {
     assert_success(&resp);
     assert_eq!(get_data(&resp)["url"], url_a2);
 
-    let binding_a2 = tab_binding::load("e2e-gone-a").expect("binding should be rewritten");
+    let binding_a2 = load_binding("e2e-gone-a", "binding should be rewritten");
     assert_ne!(
         binding_a2.target_id, binding_a.target_id,
         "recovery must bind a new target"

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6475,6 +6475,23 @@ async fn e2e_pin_tab_rebinds_after_daemon_restart() {
         "re-attach must keep the original bound target"
     );
 
+    // Lifecycle-dependent commands must work on the restored tab: attach
+    // only enables the CDP domains on the first target, so the restore path
+    // must enable them on the bound tab too or navigate hangs waiting for
+    // Page lifecycle events (timeout guards against the hang regression).
+    let url_a2 = "data:text/html,session-a-page-2";
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        execute_command(
+            &json!({ "id": "a2-nav", "action": "navigate", "url": url_a2 }),
+            &mut state_a2,
+        ),
+    )
+    .await
+    .expect("navigate on the restored tab must not hang");
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["targetId"], binding_a.target_id);
+
     // Session B is unaffected.
     let resp = current_url(&mut state_b, "b-url").await;
     assert_success(&resp);

--- a/cli/src/native/mod.rs
+++ b/cli/src/native/mod.rs
@@ -39,6 +39,8 @@ pub mod storage;
 #[allow(dead_code)]
 pub mod stream;
 #[allow(dead_code)]
+pub mod tab_binding;
+#[allow(dead_code)]
 pub mod tracing;
 #[allow(dead_code)]
 pub mod webdriver;

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -719,3 +719,81 @@ async fn test_state_find_auto_returns_none_for_nonexistent() {
     let result = state::find_auto_state_file("nonexistent-session-xyz");
     assert!(result.is_none());
 }
+
+// ---------------------------------------------------------------------------
+// 5. Session-to-tab binding (--pin-tab) parity
+// ---------------------------------------------------------------------------
+
+/// Set up an isolated socket dir and session so `DaemonState::new` and the
+/// binding helpers cannot pick up a stray binding file from the real runtime
+/// directory. Returns the env guard and the tempdir; keep both alive for the
+/// duration of the test (the tempdir is deleted on drop).
+fn pin_tab_env(session: &str) -> (crate::test_utils::EnvGuard<'static>, tempfile::TempDir) {
+    let guard = crate::test_utils::EnvGuard::new(&[
+        "AGENT_BROWSER_SOCKET_DIR",
+        "XDG_RUNTIME_DIR",
+        "AGENT_BROWSER_NAMESPACE",
+        "AGENT_BROWSER_SESSION",
+        "AGENT_BROWSER_PIN_TAB",
+    ]);
+    let dir = tempfile::tempdir().unwrap();
+    guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().unwrap());
+    guard.remove("XDG_RUNTIME_DIR");
+    guard.remove("AGENT_BROWSER_NAMESPACE");
+    guard.set("AGENT_BROWSER_SESSION", session);
+    guard.remove("AGENT_BROWSER_PIN_TAB");
+    (guard, dir)
+}
+
+#[tokio::test]
+async fn test_pin_tab_command_field_enables_strict_binding() {
+    let (_guard, _dir) = pin_tab_env("parity-pin-cmd");
+    // A skip-launch action (no browser needed) still runs the early pinTab
+    // hook, so this exercises the flag plumbing without Chrome.
+    let mut state = DaemonState::new();
+    assert!(!state.pin_tab, "pin_tab should default to false");
+
+    let cmd = json!({ "action": "state_list", "id": "pin-1", "pinTab": true });
+    let result = execute_command(&cmd, &mut state).await;
+    assert_eq!(result["success"], true);
+    assert!(state.pin_tab, "pinTab command field should enable pin_tab");
+}
+
+#[tokio::test]
+async fn test_daemon_state_new_defaults_pin_tab_false() {
+    let (_guard, _dir) = pin_tab_env("parity-pin-default");
+    let state = DaemonState::new();
+    assert!(!state.pin_tab);
+}
+
+#[tokio::test]
+async fn test_daemon_state_new_reads_pin_tab_env() {
+    let (guard, _dir) = pin_tab_env("parity-pin-env");
+    guard.set("AGENT_BROWSER_PIN_TAB", "1");
+    let state = DaemonState::new();
+    assert!(
+        state.pin_tab,
+        "AGENT_BROWSER_PIN_TAB=1 should enable pin_tab"
+    );
+}
+
+#[tokio::test]
+async fn test_daemon_state_new_reads_sticky_pinned_binding() {
+    use super::tab_binding::{save, TabBinding};
+    let (_guard, _dir) = pin_tab_env("parity-pin-sticky");
+    // A persisted binding with pinned=true makes --pin-tab sticky across
+    // restarts even when the env var is absent.
+    save(
+        "parity-pin-sticky",
+        &TabBinding {
+            target_id: "ABCDEF0123456789".to_string(),
+            url: "https://example.com".to_string(),
+            pinned: true,
+        },
+    );
+    let state = DaemonState::new();
+    assert!(
+        state.pin_tab,
+        "a persisted pinned binding should enable pin_tab"
+    );
+}

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -790,10 +790,93 @@ async fn test_daemon_state_new_reads_sticky_pinned_binding() {
             url: "https://example.com".to_string(),
             pinned: true,
         },
-    );
+    )
+    .unwrap();
     let state = DaemonState::new();
     assert!(
         state.pin_tab,
         "a persisted pinned binding should enable pin_tab"
     );
+}
+
+#[tokio::test]
+async fn test_pin_tab_false_disables_pin_in_running_daemon() {
+    let (_guard, _dir) = pin_tab_env("parity-pin-disable-live");
+    let mut state = DaemonState::new();
+
+    let cmd = json!({ "action": "state_list", "id": "pin-on", "pinTab": true });
+    let result = execute_command(&cmd, &mut state).await;
+    assert_eq!(result["success"], true);
+    assert!(state.pin_tab);
+
+    let cmd = json!({ "action": "state_list", "id": "pin-off", "pinTab": false });
+    let result = execute_command(&cmd, &mut state).await;
+    assert_eq!(result["success"], true);
+    assert!(
+        !state.pin_tab,
+        "pinTab: false should disable pin_tab in a running daemon"
+    );
+}
+
+#[tokio::test]
+async fn test_pin_tab_false_disables_persisted_pin_across_restart() {
+    use super::tab_binding::{load, save, TabBinding};
+    let (_guard, _dir) = pin_tab_env("parity-pin-disable-sticky");
+    // Simulate a prior pinned session.
+    save(
+        "parity-pin-disable-sticky",
+        &TabBinding {
+            target_id: "ABCDEF0123456789".to_string(),
+            url: "https://example.com".to_string(),
+            pinned: true,
+        },
+    )
+    .unwrap();
+
+    // Fresh daemon restores the sticky pin; an explicit pinTab: false must
+    // disable it and rewrite the persisted record even with no browser
+    // attached, so the disable survives another restart.
+    let mut state = DaemonState::new();
+    assert!(state.pin_tab, "sticky pin should be restored");
+    let cmd = json!({ "action": "state_list", "id": "pin-off", "pinTab": false });
+    let result = execute_command(&cmd, &mut state).await;
+    assert_eq!(result["success"], true);
+    assert!(!state.pin_tab);
+
+    let binding = load("parity-pin-disable-sticky")
+        .unwrap()
+        .expect("binding file should still exist");
+    assert!(
+        !binding.pinned,
+        "the persisted binding must record pinned=false"
+    );
+    let state = DaemonState::new();
+    assert!(!state.pin_tab, "the disable must survive a daemon restart");
+}
+
+#[tokio::test]
+async fn test_pin_tab_absent_keeps_current_state() {
+    let (_guard, _dir) = pin_tab_env("parity-pin-absent");
+    let mut state = DaemonState::new();
+    let cmd = json!({ "action": "state_list", "id": "pin-on", "pinTab": true });
+    execute_command(&cmd, &mut state).await;
+    assert!(state.pin_tab);
+
+    // A command without the pinTab field must not reset the sticky pin.
+    let cmd = json!({ "action": "state_list", "id": "no-field" });
+    let result = execute_command(&cmd, &mut state).await;
+    assert_eq!(result["success"], true);
+    assert!(state.pin_tab, "absent pinTab must leave the pin enabled");
+}
+
+#[tokio::test]
+async fn test_daemon_state_new_with_corrupt_binding_does_not_pin() {
+    let (_guard, _dir) = pin_tab_env("parity-pin-corrupt");
+    let path = super::tab_binding::binding_path("parity-pin-corrupt");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "{\"targetId\":\"AAAA\",\"pin").unwrap();
+    // A corrupt file must not silently enable (or crash) pinning here; the
+    // attach path reports it as a recovery error instead.
+    let state = DaemonState::new();
+    assert!(!state.pin_tab);
 }

--- a/cli/src/native/tab_binding.rs
+++ b/cli/src/native/tab_binding.rs
@@ -1,0 +1,134 @@
+//! Persistent session to tab binding.
+//!
+//! Each daemon session can be bound to a single CDP target (tab). The binding
+//! is written to `{session}.target` in the daemon socket directory as a small
+//! JSON document and, unlike the other per-session files (`.pid`, `.sock`,
+//! `.stream`, ...), it intentionally survives daemon restarts. On the next
+//! attach over CDP the daemon re-selects the bound target by `targetId`
+//! instead of adopting whatever tab happens to be first in
+//! `Target.getTargets` (the most recently active one, which in a shared
+//! browser is usually another session's tab).
+//!
+//! The `pinned` field makes `--pin-tab` sticky for the session: once a
+//! session is created with `--pin-tab`, subsequent commands and daemon
+//! restarts keep the strict semantics without repeating the flag.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// A persisted session to tab binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TabBinding {
+    /// CDP target id of the bound tab. Stable across daemon restarts (unlike
+    /// `t<N>` ids, which are per-daemon counters).
+    #[serde(rename = "targetId")]
+    pub target_id: String,
+    /// Last known URL of the bound tab, used for actionable error messages
+    /// when the tab is gone.
+    #[serde(default)]
+    pub url: String,
+    /// Whether strict pin-tab semantics are enabled for this session.
+    #[serde(default)]
+    pub pinned: bool,
+}
+
+/// Path of the binding file for a session: `{socket_dir}/{session}.target`.
+pub fn binding_path(session: &str) -> PathBuf {
+    crate::connection::get_socket_dir().join(format!("{}.target", session))
+}
+
+/// Load the persisted binding for a session, if any. Unreadable or invalid
+/// files are treated as no binding.
+pub fn load(session: &str) -> Option<TabBinding> {
+    let raw = fs::read_to_string(binding_path(session)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Persist the binding for a session (write-on-change is the caller's
+/// responsibility). Errors are ignored: a failed write degrades to the old
+/// re-attach behavior instead of failing the command.
+pub fn save(session: &str, binding: &TabBinding) {
+    let path = binding_path(session);
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    if let Ok(raw) = serde_json::to_string(binding) {
+        let _ = fs::write(path, raw);
+    }
+}
+
+/// Remove the persisted binding for a session.
+pub fn clear(session: &str) {
+    let _ = fs::remove_file(binding_path(session));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_socket_dir<F: FnOnce()>(f: F) {
+        let guard = crate::test_utils::EnvGuard::new(&[
+            "AGENT_BROWSER_SOCKET_DIR",
+            "XDG_RUNTIME_DIR",
+            "AGENT_BROWSER_NAMESPACE",
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().unwrap());
+        guard.remove("XDG_RUNTIME_DIR");
+        guard.remove("AGENT_BROWSER_NAMESPACE");
+        f();
+    }
+
+    #[test]
+    fn test_binding_round_trip() {
+        with_socket_dir(|| {
+            let binding = TabBinding {
+                target_id: "4A0B7C4E1F2D3A4B5C6D7E8F90A1B2C3".to_string(),
+                url: "https://example.com/checkout".to_string(),
+                pinned: true,
+            };
+            save("agent-1", &binding);
+            assert_eq!(load("agent-1"), Some(binding));
+            clear("agent-1");
+            assert_eq!(load("agent-1"), None);
+        });
+    }
+
+    #[test]
+    fn test_load_missing_returns_none() {
+        with_socket_dir(|| {
+            assert_eq!(load("no-such-session"), None);
+        });
+    }
+
+    #[test]
+    fn test_load_invalid_json_returns_none() {
+        with_socket_dir(|| {
+            let path = binding_path("bad");
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "not json").unwrap();
+            assert_eq!(load("bad"), None);
+        });
+    }
+
+    #[test]
+    fn test_bindings_are_per_session() {
+        with_socket_dir(|| {
+            let a = TabBinding {
+                target_id: "AAAA".to_string(),
+                url: String::new(),
+                pinned: false,
+            };
+            let b = TabBinding {
+                target_id: "BBBB".to_string(),
+                url: String::new(),
+                pinned: true,
+            };
+            save("session-a", &a);
+            save("session-b", &b);
+            assert_eq!(load("session-a"), Some(a));
+            assert_eq!(load("session-b"), Some(b));
+        });
+    }
+}

--- a/cli/src/native/tab_binding.rs
+++ b/cli/src/native/tab_binding.rs
@@ -11,10 +11,14 @@
 //!
 //! The `pinned` field makes `--pin-tab` sticky for the session: once a
 //! session is created with `--pin-tab`, subsequent commands and daemon
-//! restarts keep the strict semantics without repeating the flag.
+//! restarts keep the strict semantics without repeating the flag. Because a
+//! lost or corrupt binding silently drops that safety boundary, writes are
+//! atomic (temp file + rename), owner-only, and fsynced, and both `save` and
+//! `load` report failures instead of swallowing them.
 
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
 
 /// A persisted session to tab binding.
@@ -25,7 +29,8 @@ pub struct TabBinding {
     #[serde(rename = "targetId")]
     pub target_id: String,
     /// Last known URL of the bound tab, used for actionable error messages
-    /// when the tab is gone.
+    /// when the tab is gone. Sanitized before persistence: credentials,
+    /// query, and fragment are stripped (see [`sanitize_url`]).
     #[serde(default)]
     pub url: String,
     /// Whether strict pin-tab semantics are enabled for this session.
@@ -38,24 +43,96 @@ pub fn binding_path(session: &str) -> PathBuf {
     crate::connection::get_socket_dir().join(format!("{}.target", session))
 }
 
-/// Load the persisted binding for a session, if any. Unreadable or invalid
-/// files are treated as no binding.
-pub fn load(session: &str) -> Option<TabBinding> {
-    let raw = fs::read_to_string(binding_path(session)).ok()?;
-    serde_json::from_str(&raw).ok()
+/// Strip credentials, query parameters, and fragment from a URL before it is
+/// persisted. The binding file outlives the daemon, and the URL is only
+/// diagnostic (used in `tab_gone` error messages), so OAuth codes, signed
+/// query parameters, and tokens must not be written to disk. URLs that do
+/// not parse are dropped entirely.
+pub fn sanitize_url(raw: &str) -> String {
+    match url::Url::parse(raw) {
+        Ok(mut parsed) => {
+            let _ = parsed.set_username("");
+            let _ = parsed.set_password(None);
+            parsed.set_query(None);
+            parsed.set_fragment(None);
+            parsed.to_string()
+        }
+        Err(_) => String::new(),
+    }
+}
+
+/// Load the persisted binding for a session. `Ok(None)` means no binding
+/// exists; `Err` means a binding file is present but unreadable or corrupt.
+/// Callers must not treat `Err` as a first-time session: a corrupt file may
+/// have carried `pinned: true`, and silently dropping it would remove the
+/// strict isolation boundary.
+pub fn load(session: &str) -> Result<Option<TabBinding>, String> {
+    let path = binding_path(session);
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(format!(
+                "cannot read tab binding file {}: {}",
+                path.display(),
+                e
+            ))
+        }
+    };
+    match serde_json::from_str(&raw) {
+        Ok(binding) => Ok(Some(binding)),
+        Err(e) => Err(format!(
+            "corrupt tab binding file {}: {}",
+            path.display(),
+            e
+        )),
+    }
 }
 
 /// Persist the binding for a session (write-on-change is the caller's
-/// responsibility). Errors are ignored: a failed write degrades to the old
-/// re-attach behavior instead of failing the command.
-pub fn save(session: &str, binding: &TabBinding) {
+/// responsibility). The write is atomic: the JSON is serialized first, then
+/// written to an owner-only temp file in the same directory, fsynced, and
+/// renamed over the destination, so a crash never leaves a truncated or
+/// half-written binding. Errors are returned so callers can retry on the
+/// next command instead of silently losing the binding.
+pub fn save(session: &str, binding: &TabBinding) -> Result<(), String> {
     let path = binding_path(session);
+    let raw = serde_json::to_string(binding)
+        .map_err(|e| format!("cannot serialize tab binding: {}", e))?;
     if let Some(dir) = path.parent() {
-        let _ = fs::create_dir_all(dir);
+        fs::create_dir_all(dir)
+            .map_err(|e| format!("cannot create socket dir {}: {}", dir.display(), e))?;
     }
-    if let Ok(raw) = serde_json::to_string(binding) {
-        let _ = fs::write(path, raw);
+    let tmp = path.with_extension(format!("target.tmp.{}", std::process::id()));
+    let write_result = (|| -> Result<(), String> {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&tmp)
+            .map_err(|e| format!("cannot create tab binding file {}: {}", tmp.display(), e))?;
+        file.write_all(raw.as_bytes())
+            .map_err(|e| format!("cannot write tab binding file {}: {}", tmp.display(), e))?;
+        file.sync_all()
+            .map_err(|e| format!("cannot sync tab binding file {}: {}", tmp.display(), e))?;
+        drop(file);
+        fs::rename(&tmp, &path).map_err(|e| {
+            format!(
+                "cannot rename tab binding file {} to {}: {}",
+                tmp.display(),
+                path.display(),
+                e
+            )
+        })
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp);
     }
+    write_result
 }
 
 /// Remove the persisted binding for a session.
@@ -88,27 +165,103 @@ mod tests {
                 url: "https://example.com/checkout".to_string(),
                 pinned: true,
             };
-            save("agent-1", &binding);
-            assert_eq!(load("agent-1"), Some(binding));
+            save("agent-1", &binding).unwrap();
+            assert_eq!(load("agent-1"), Ok(Some(binding)));
             clear("agent-1");
-            assert_eq!(load("agent-1"), None);
+            assert_eq!(load("agent-1"), Ok(None));
         });
     }
 
     #[test]
     fn test_load_missing_returns_none() {
         with_socket_dir(|| {
-            assert_eq!(load("no-such-session"), None);
+            assert_eq!(load("no-such-session"), Ok(None));
         });
     }
 
     #[test]
-    fn test_load_invalid_json_returns_none() {
+    fn test_load_invalid_json_returns_error() {
         with_socket_dir(|| {
             let path = binding_path("bad");
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             fs::write(&path, "not json").unwrap();
-            assert_eq!(load("bad"), None);
+            let err = load("bad").unwrap_err();
+            assert!(err.contains("corrupt"), "unexpected error: {}", err);
+        });
+    }
+
+    #[test]
+    fn test_load_truncated_json_returns_error() {
+        with_socket_dir(|| {
+            let path = binding_path("truncated");
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            // A partial write of a valid document (e.g. a crash mid-write
+            // with a non-atomic writer).
+            fs::write(&path, "{\"targetId\":\"AAAA\",\"pin").unwrap();
+            assert!(load("truncated").is_err());
+        });
+    }
+
+    #[test]
+    fn test_save_unwritable_dir_returns_error() {
+        let guard = crate::test_utils::EnvGuard::new(&[
+            "AGENT_BROWSER_SOCKET_DIR",
+            "XDG_RUNTIME_DIR",
+            "AGENT_BROWSER_NAMESPACE",
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        // Point the socket dir below a regular file so create_dir_all fails.
+        let blocker = dir.path().join("blocker");
+        fs::write(&blocker, "x").unwrap();
+        guard.set(
+            "AGENT_BROWSER_SOCKET_DIR",
+            blocker.join("sub").to_str().unwrap(),
+        );
+        guard.remove("XDG_RUNTIME_DIR");
+        guard.remove("AGENT_BROWSER_NAMESPACE");
+        let binding = TabBinding {
+            target_id: "AAAA".to_string(),
+            url: String::new(),
+            pinned: true,
+        };
+        assert!(save("blocked", &binding).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        with_socket_dir(|| {
+            let binding = TabBinding {
+                target_id: "AAAA".to_string(),
+                url: String::new(),
+                pinned: false,
+            };
+            save("perms", &binding).unwrap();
+            let mode = fs::metadata(binding_path("perms"))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        });
+    }
+
+    #[test]
+    fn test_save_leaves_no_temp_file() {
+        with_socket_dir(|| {
+            let binding = TabBinding {
+                target_id: "AAAA".to_string(),
+                url: String::new(),
+                pinned: false,
+            };
+            save("tmpcheck", &binding).unwrap();
+            let dir = binding_path("tmpcheck").parent().unwrap().to_path_buf();
+            let leftovers: Vec<_> = fs::read_dir(dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+                .collect();
+            assert!(leftovers.is_empty(), "temp files left: {:?}", leftovers);
         });
     }
 
@@ -125,10 +278,29 @@ mod tests {
                 url: String::new(),
                 pinned: true,
             };
-            save("session-a", &a);
-            save("session-b", &b);
-            assert_eq!(load("session-a"), Some(a));
-            assert_eq!(load("session-b"), Some(b));
+            save("session-a", &a).unwrap();
+            save("session-b", &b).unwrap();
+            assert_eq!(load("session-a"), Ok(Some(a)));
+            assert_eq!(load("session-b"), Ok(Some(b)));
         });
+    }
+
+    #[test]
+    fn test_sanitize_url_strips_sensitive_components() {
+        assert_eq!(
+            sanitize_url("https://user:secret@example.com/reset?token=abc123#code=xyz"),
+            "https://example.com/reset"
+        );
+        assert_eq!(
+            sanitize_url("https://example.com/cb?code=4/0AX4XfWh&state=s"),
+            "https://example.com/cb"
+        );
+        assert_eq!(
+            sanitize_url("https://example.com/checkout"),
+            "https://example.com/checkout"
+        );
+        assert_eq!(sanitize_url("about:blank"), "about:blank");
+        assert_eq!(sanitize_url("not a url"), "");
+        assert_eq!(sanitize_url(""), "");
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2289,17 +2289,23 @@ Manage browser tabs in the current window. Stable tab ids look like `t1`,
 `t2`, `t3`. An id is never reused within a session, so scripts can keep
 referring to the same tab across commands. Optional user-assigned labels
 (e.g. `docs`, `app`) are interchangeable with ids everywhere a tab ref is
-accepted.
+accepted. CDP target ids (from `tab list --json`) are also accepted as tab
+refs; unlike `t<N>` ids they stay stable across daemon restarts.
+
+Each session remembers its active tab (bound by CDP target id) and returns
+to it after a daemon restart. With --pin-tab, commands fail with a
+`tab_gone` error instead of falling back to another tab when the bound tab
+is closed; recover with `tab new` or `tab list`.
 
 Operations:
   list                       List open tabs with their ids and labels (default)
   new [url]                  Open a new tab
   new --label <name> [url]   Open a new tab with a label like `docs` or `app`
-  close [t<N>|label]         Close a tab (current if no ref given)
-  <t<N>|label>               Switch to a tab by id or label
+  close [t<N>|label|target]  Close a tab (current if no ref given)
+  <t<N>|label|target>        Switch to a tab by id, label, or CDP target id
 
 Global Options:
-  --json               Output as JSON
+  --json               Output as JSON (includes each tab's targetId)
   --session <name>     Use specific session
 
 Examples:
@@ -2313,6 +2319,8 @@ Examples:
   agent-browser tab close
   agent-browser tab close t1
   agent-browser tab close docs
+  agent-browser tab list --json                        # Includes CDP target ids
+  agent-browser tab close 4A0B7C4E1F2D3A4B5C6D7E8F90A1B2C3  # Close by target id
 "##
         }
 
@@ -3524,6 +3532,9 @@ Options:
   --screenshot-format <fmt>  Screenshot format: png, jpeg (or AGENT_BROWSER_SCREENSHOT_FORMAT)
   --headed                   Show browser window (not headless) (or AGENT_BROWSER_HEADED env)
   --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
+  --pin-tab                  Pin the session to its bound tab (or AGENT_BROWSER_PIN_TAB env)
+                             Commands fail with a tab_gone error instead of falling back
+                             to another tab when the bound tab is closed. Sticky per session.
   --color-scheme <scheme>    Color scheme: dark, light, no-preference (or AGENT_BROWSER_COLOR_SCHEME)
   --download-path <path>     Default download directory (or AGENT_BROWSER_DOWNLOAD_PATH)
   --content-boundaries       Wrap page output in boundary markers (or AGENT_BROWSER_CONTENT_BOUNDARIES)
@@ -3588,6 +3599,7 @@ Environment:
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
+  AGENT_BROWSER_PIN_TAB          Pin the session to its bound tab (strict tab binding)
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_HIDE_SCROLLBARS  Hide scrollbars in headless Chromium screenshots (default: true)
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)
@@ -3636,6 +3648,7 @@ Examples:
   agent-browser screenshot --annotate    # Labeled screenshot for vision models
   agent-browser wait 2000               # Wait for slow pages to settle
   agent-browser --cdp 9222 snapshot      # Connect via CDP port
+  agent-browser --cdp 9222 --pin-tab open example.com  # Pin session to its own tab
   agent-browser --auto-connect snapshot  # Auto-discover running Chrome
   agent-browser stream enable            # Start runtime streaming on an auto-selected port
   agent-browser stream status            # Inspect runtime streaming state

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2295,7 +2295,8 @@ refs; unlike `t<N>` ids they stay stable across daemon restarts.
 Each session remembers its active tab (bound by CDP target id) and returns
 to it after a daemon restart. With --pin-tab, commands fail with a
 `tab_gone` error instead of falling back to another tab when the bound tab
-is closed; recover with `tab new` or `tab list`.
+is closed; recover with `tab new` or `tab list`. The pin is sticky per
+session; pass --no-pin-tab to turn it off again.
 
 Operations:
   list                       List open tabs with their ids and labels (default)
@@ -3535,6 +3536,7 @@ Options:
   --pin-tab                  Pin the session to its bound tab (or AGENT_BROWSER_PIN_TAB env)
                              Commands fail with a tab_gone error instead of falling back
                              to another tab when the bound tab is closed. Sticky per session.
+  --no-pin-tab               Disable a sticky pin previously enabled with --pin-tab
   --color-scheme <scheme>    Color scheme: dark, light, no-preference (or AGENT_BROWSER_COLOR_SCHEME)
   --download-path <path>     Default download directory (or AGENT_BROWSER_DOWNLOAD_PATH)
   --content-boundaries       Wrap page output in boundary markers (or AGENT_BROWSER_CONTENT_BOUNDARIES)

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -57,6 +57,27 @@ This is useful when:
 - You want a zero-configuration connection to your existing browser
 - You don't want to track which port Chrome is using
 
+## Tab pinning
+
+When several sessions share one browser over CDP, each session remembers which tab it is bound to (by CDP target id, persisted across daemon restarts). A restarted daemon reattaches to the session's own tab instead of adopting whatever tab is currently active, which in a shared browser is usually another session's.
+
+Pass `--pin-tab` (or set `AGENT_BROWSER_PIN_TAB=1`) to make the binding strict:
+
+```bash
+# Two agents sharing one Chrome, each pinned to its own tab
+agent-browser --session agent1 --cdp 9222 --pin-tab open https://site-a.com
+agent-browser --session agent2 --cdp 9222 --pin-tab open https://site-b.com
+```
+
+With `--pin-tab`:
+
+- Attaching with no binding opens a fresh tab instead of adopting an existing one
+- If the bound tab is closed, commands fail with a `tab_gone` error instead of silently acting on another tab; with `--json` the response carries <code>"code": "tab_gone"</code>
+- `tab list`, `tab new`, and `tab <ref>` still work in that state, so an agent can recover by binding a new tab
+- Tabs opened by other sessions or the user never steal the pinned session's active tab
+
+The flag is sticky per session: pass it once and later commands and daemon restarts keep the strict semantics. See [Sessions](/sessions) for the multi-session workflow and [Commands](/commands) for tab refs by CDP target id.
+
 ## Color scheme
 
 Use `--color-scheme` to set a persistent preference when connecting via CDP:
@@ -104,6 +125,7 @@ This enables control of:
     <tr><td><code>--headed</code></td><td>Show browser window</td></tr>
     <tr><td><code>{"--cdp <port|url>"}</code></td><td>CDP connection (port or WebSocket URL)</td></tr>
     <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to running Chrome</td></tr>
+    <tr><td><code>--pin-tab</code></td><td>Pin the session to its bound tab (strict tab binding)</td></tr>
     <tr><td><code>--color-scheme &lt;scheme&gt;</code></td><td>Persistent color scheme (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>--debug</code></td><td>Debug output</td></tr>
   </tbody>

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -76,7 +76,7 @@ With `--pin-tab`:
 - `tab list`, `tab new`, and `tab <ref>` still work in that state, so an agent can recover by binding a new tab
 - Tabs opened by other sessions or the user never steal the pinned session's active tab
 
-The flag is sticky per session: pass it once and later commands and daemon restarts keep the strict semantics. See [Sessions](/sessions) for the multi-session workflow and [Commands](/commands) for tab refs by CDP target id.
+The flag is sticky per session: pass it once and later commands and daemon restarts keep the strict semantics. Pass `--no-pin-tab` to explicitly turn the pin off again. See [Sessions](/sessions) for the multi-session workflow and [Commands](/commands) for tab refs by CDP target id.
 
 ## Color scheme
 
@@ -126,6 +126,7 @@ This enables control of:
     <tr><td><code>{"--cdp <port|url>"}</code></td><td>CDP connection (port or WebSocket URL)</td></tr>
     <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to running Chrome</td></tr>
     <tr><td><code>--pin-tab</code></td><td>Pin the session to its bound tab (strict tab binding)</td></tr>
+    <tr><td><code>--no-pin-tab</code></td><td>Disable a sticky pin previously enabled with <code>--pin-tab</code></td></tr>
     <tr><td><code>--color-scheme &lt;scheme&gt;</code></td><td>Persistent color scheme (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>--debug</code></td><td>Debug output</td></tr>
   </tbody>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -246,6 +246,8 @@ agent-browser tab close docs    # close by label
 
 Labels are never auto-generated and never rewritten on navigation — an agent that names a tab `docs` keeps that name until the tab is closed. Labels are unique within a session; creating a second tab with an existing label errors.
 
+`tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts. Each session is bound to its active tab by target id and returns to it after a daemon restart; with `--pin-tab` the binding is strict and a closed bound tab produces a `tab_gone` error instead of a silent fallback. See [CDP Mode](/cdp-mode) for the multi-session workflow.
+
 Refs (`@e1`, etc.) are scoped to the tab that was active when the snapshot ran, so switch tabs first, then snapshot and interact:
 
 ```bash

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -86,6 +86,7 @@ Global launch, output, provider, and chat options can be set in the config file 
     <tr><td><code>allowFileAccess</code></td><td><code>--allow-file-access</code></td><td>boolean</td></tr>
     <tr><td><code>cdp</code></td><td><code>--cdp</code></td><td>string</td></tr>
     <tr><td><code>autoConnect</code></td><td><code>--auto-connect</code></td><td>boolean</td></tr>
+    <tr><td><code>pinTab</code></td><td><code>--pin-tab</code></td><td>boolean</td></tr>
     <tr><td><code>annotate</code></td><td><code>--annotate</code></td><td>boolean</td></tr>
     <tr><td><code>colorScheme</code></td><td><code>--color-scheme</code></td><td>string (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>downloadPath</code></td><td><code>--download-path</code></td><td>string</td></tr>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -36,6 +36,19 @@ Each session has its own:
 - Navigation history
 - Authentication state
 
+## Tab pinning in a shared browser
+
+Full isolation applies when each session launches its own browser. When sessions instead share one Chrome over `--cdp`, only the tab selection separates them. Each session remembers which tab it is bound to (by CDP target id, persisted across daemon restarts), so a restarted daemon reattaches to the session's own tab instead of adopting the most recently active one.
+
+Add `--pin-tab` (or set `AGENT_BROWSER_PIN_TAB=1`) to make the binding strict:
+
+```bash
+agent-browser --session agent1 --cdp 9222 --pin-tab open https://site-a.com
+agent-browser --session agent2 --cdp 9222 --pin-tab open https://site-b.com
+```
+
+With `--pin-tab`, a session whose bound tab was closed gets a `tab_gone` error (with <code>"code": "tab_gone"</code> in `--json` output) instead of silently acting on another session's tab; run `tab new <url>` or pick a tab from `tab list` to recover. The flag is sticky per session. See [CDP Mode](/cdp-mode) for details.
+
 ## Chrome profile reuse
 
 The simplest way to reuse your existing login state: pass a Chrome profile name to `--profile`. agent-browser copies the profile to a temp directory (read-only snapshot) and launches Chrome with your existing cookies and sessions.
@@ -270,6 +283,7 @@ agent-browser set headers '{"X-Custom-Header": "value"}'
   <tbody>
     <tr><td><code>AGENT_BROWSER_SESSION</code></td><td>Browser session ID (default: "default")</td></tr>
     <tr><td><code>AGENT_BROWSER_NAMESPACE</code></td><td>Namespace for daemon sockets and restore-state directories</td></tr>
+    <tr><td><code>AGENT_BROWSER_PIN_TAB</code></td><td>Pin the session to its bound tab (strict tab binding)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE</code></td><td>Auto-save/load state persistence key</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_SAVE</code></td><td>Restore save policy: <code>auto</code>, <code>always</code>, or <code>never</code></td></tr>
     <tr><td><code>AGENT_BROWSER_AUTOSAVE_INTERVAL_MS</code></td><td>Minimum ms between periodic session autosaves (default: 30000, <code>0</code> disables)</td></tr>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -47,7 +47,7 @@ agent-browser --session agent1 --cdp 9222 --pin-tab open https://site-a.com
 agent-browser --session agent2 --cdp 9222 --pin-tab open https://site-b.com
 ```
 
-With `--pin-tab`, a session whose bound tab was closed gets a `tab_gone` error (with <code>"code": "tab_gone"</code> in `--json` output) instead of silently acting on another session's tab; run `tab new <url>` or pick a tab from `tab list` to recover. The flag is sticky per session. See [CDP Mode](/cdp-mode) for details.
+With `--pin-tab`, a session whose bound tab was closed gets a `tab_gone` error (with <code>"code": "tab_gone"</code> in `--json` output) instead of silently acting on another session's tab; run `tab new <url>` or pick a tab from `tab list` to recover. The flag is sticky per session; pass `--no-pin-tab` to turn it off again. See [CDP Mode](/cdp-mode) for details.
 
 ## Chrome profile reuse
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -295,7 +295,7 @@ agent-browser --session b fill @e1 "bob@test.com"
 
 `AGENT_BROWSER_SESSION=myapp` sets the default session for the current shell.
 
-When several sessions share one Chrome over `--cdp <port>`, add `--pin-tab` so each session sticks to its own tab. Every session remembers its bound tab across daemon restarts; with `--pin-tab` a command whose bound tab was closed fails with a `tab_gone` error (`"code": "tab_gone"` in `--json`) instead of acting on another session's tab. Recover with `tab new <url>` or pick a tab from `tab list`. The flag is sticky per session, so pass it once. See `references/session-management.md` for details.
+When several sessions share one Chrome over `--cdp <port>`, add `--pin-tab` so each session sticks to its own tab. Every session remembers its bound tab across daemon restarts; with `--pin-tab` a command whose bound tab was closed fails with a `tab_gone` error (`"code": "tab_gone"` in `--json`) instead of acting on another session's tab. Recover with `tab new <url>` or pick a tab from `tab list`. The flag is sticky per session, so pass it once (`--no-pin-tab` turns it off again). See `references/session-management.md` for details.
 
 ### Mock network requests
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -280,7 +280,7 @@ agent-browser tab t2                   # switch to tab t2
 agent-browser tab close t2             # close tab t2
 ```
 
-Stable `tabId`s mean `t2` points at the same tab across commands even when other tabs open or close. After switching, refs from a prior snapshot on a different tab no longer apply — re-snapshot.
+Stable `tabId`s mean `t2` points at the same tab across commands even when other tabs open or close. After switching, refs from a prior snapshot on a different tab no longer apply — re-snapshot. `tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted; target ids stay stable across daemon restarts, unlike `t<N>` ids.
 
 ### Run multiple browsers in parallel
 
@@ -294,6 +294,8 @@ agent-browser --session b fill @e1 "bob@test.com"
 ```
 
 `AGENT_BROWSER_SESSION=myapp` sets the default session for the current shell.
+
+When several sessions share one Chrome over `--cdp <port>`, add `--pin-tab` so each session sticks to its own tab. Every session remembers its bound tab across daemon restarts; with `--pin-tab` a command whose bound tab was closed fails with a `tab_gone` error (`"code": "tab_gone"` in `--json`) instead of acting on another session's tab. Recover with `tab new <url>` or pick a tab from `tab list`. The flag is sticky per session, so pass it once. See `references/session-management.md` for details.
 
 ### Mock network requests
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -223,6 +223,8 @@ agent-browser tab close docs             # close by label
 
 Labels are never auto-generated, never rewritten on navigation, and must be unique within a session. To interact with another tab, switch to it first: the daemon maintains a single active tab, so refs (`@eN`) belong to the tab that was active when the snapshot ran.
 
+`tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Target ids stay stable across daemon restarts, unlike `t<N>` ids, which are per-daemon counters. With `--pin-tab` the session is pinned to its bound tab: if that tab is closed, commands fail with a `tab_gone` error instead of falling back to another tab, and `tab new` or `tab list` recover.
+
 ## Frames
 
 ```bash
@@ -367,6 +369,7 @@ agent-browser --session <name> ...    # Isolated browser session
 agent-browser --json ...              # JSON output for parsing
 agent-browser --headed ...            # Show browser window (not headless)
 agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
+agent-browser --pin-tab ...           # Pin the session to its bound tab (strict tab binding)
 agent-browser -p <provider> ...       # Browser provider or configured provider plugin
 agent-browser --proxy <url> ...       # Use proxy server
 agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -370,6 +370,7 @@ agent-browser --json ...              # JSON output for parsing
 agent-browser --headed ...            # Show browser window (not headless)
 agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
 agent-browser --pin-tab ...           # Pin the session to its bound tab (strict tab binding)
+agent-browser --no-pin-tab ...        # Disable a sticky pin previously enabled with --pin-tab
 agent-browser -p <provider> ...       # Browser provider or configured provider plugin
 agent-browser --proxy <url> ...       # Use proxy server
 agent-browser --proxy-bypass <hosts>  # Hosts to bypass proxy

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -64,7 +64,7 @@ Every session remembers which tab it is bound to (by CDP target id, persisted in
 - Recovery commands still work in that state: run `tab new <url>` to bind a fresh tab, or `tab list` and switch to an existing one
 - Tabs opened by other sessions or the user never steal the pinned session's active tab
 
-The flag is sticky per session: pass it once at session creation and later commands and daemon restarts keep the strict semantics. Use each tab's `targetId` from `tab list --json` when one session needs to reference another session's tab; target ids stay stable across daemon restarts.
+The flag is sticky per session: pass it once at session creation and later commands and daemon restarts keep the strict semantics. Pass `--no-pin-tab` to explicitly turn the pin off again. Use each tab's `targetId` from `tab list --json` when one session needs to reference another session's tab; target ids stay stable across daemon restarts.
 
 ## Session State Persistence
 

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -8,6 +8,7 @@ Multiple isolated browser sessions with state persistence and concurrent browsin
 
 - [Named Sessions](#named-sessions)
 - [Session Isolation Properties](#session-isolation-properties)
+- [Tab Pinning in a Shared Browser](#tab-pinning-in-a-shared-browser)
 - [Session State Persistence](#session-state-persistence)
 - [Common Patterns](#common-patterns)
 - [Default Session](#default-session)
@@ -46,6 +47,24 @@ Each session has independent:
 - Cache
 - Browsing history
 - Open tabs
+
+## Tab Pinning in a Shared Browser
+
+Full isolation applies when each session launches its own browser. When sessions instead share one Chrome over `--cdp <port>`, cookies and storage are shared, and only the tab selection separates the sessions. Add `--pin-tab` so each session sticks to its own tab:
+
+```bash
+agent-browser --session agent1 --cdp 9222 --pin-tab open https://site-a.com
+agent-browser --session agent2 --cdp 9222 --pin-tab open https://site-b.com
+```
+
+Every session remembers which tab it is bound to (by CDP target id, persisted in the session's state directory), so a restarted daemon reattaches to the session's own tab instead of adopting the most recently active one. `--pin-tab` (env `AGENT_BROWSER_PIN_TAB=1`) additionally makes the binding strict:
+
+- Attaching with no binding opens a fresh tab instead of adopting an existing one
+- If the bound tab is closed, commands fail with a `tab_gone` error (`"code": "tab_gone"` in `--json` output) instead of silently acting on another tab
+- Recovery commands still work in that state: run `tab new <url>` to bind a fresh tab, or `tab list` and switch to an existing one
+- Tabs opened by other sessions or the user never steal the pinned session's active tab
+
+The flag is sticky per session: pass it once at session creation and later commands and daemon restarts keep the strict semantics. Use each tab's `targetId` from `tab list --json` when one session needs to reference another session's tab; target ids stay stable across daemon restarts.
 
 ## Session State Persistence
 


### PR DESCRIPTION
Fixes #1530.

## Problem

When multiple sessions share one Chrome over `--cdp`, a session's current tab is an in-memory index that silently re-resolves to another tab in two situations (details and a 10-session repro in #1530):

- **Daemon (re)attach**: `discover_and_attach_targets` sets `active_page_index = 0`, and `Target.getTargets` returns most-recently-active first, so a restarted daemon adopts whatever tab is currently active, typically another session's (`cli/src/native/browser.rs`).
- **Tab removal fallback**: `active_page_index_after_removal` and the clamp logic silently shift the pointer to a neighboring tab when the current tab is closed externally.

Related: #326, #896, #1219, #384, #1211, #1272, #1265 (implemented here), #1068 (out of scope).

## Design

**1. Persisted session-to-tab binding** (`cli/src/native/tab_binding.rs`). Each session records its bound tab's CDP target id in `{session}.target` next to the existing per-session files, written on tab create, explicit switch, and whenever the active tab changes (write-on-change). Unlike the other files it survives daemon restarts: on attach over CDP the daemon re-selects the bound target by id instead of adopting index 0. This part applies without any flag; nobody depends on a restarted daemon adopting a random tab, so it is treated as a pure bug fix.

**2. Strict mode behind `--pin-tab`** (env `AGENT_BROWSER_PIN_TAB`, config `pinTab`, sticky per session via the binding file). With the flag:

- Attaching with no binding opens a fresh tab instead of adopting an existing one.
- If the bound tab is gone (at attach or mid-session), commands fail with `tab_gone: bound tab is gone (target <id>, last url <url>). Run 'tab new <url>' ...`, non-zero exit, and `"code": "tab_gone"` at the top level of `--json` responses.
- Recovery commands (`tab list`, `tab new`, `tab switch`, session ops) still work in that state.
- Externally created tabs never steal the pinned session's active slot.

Without the flag, removal fallback behavior is unchanged. The strictness check is isolated (a single `pin_tab` flag consulted in `BrowserManager`), so flipping the default later is a one-line change. Maintainers may well prefer strict-by-default under `--cdp`; happy to make that change if you want it, and the opt-in flag is just the conservative starting point.

**3. targetId in the CLI surface** (subsumes #1265). `tab list --json` includes `targetId` per tab; `tab new` / `tab switch` / `tab close` / `navigate` results include it; and a target id is accepted anywhere a tab ref (`t<N>` / label) is accepted, e.g. `tab <targetId>` and `tab close <targetId>`. Target ids are stable across daemon restarts, unlike `t<N>` per-daemon counters.

**4. MCP parity and docs.** `connect` tool gained a `pinTab` param; tab tool descriptions mention target ids. All five doc locations updated per AGENTS.md (help text, README, core skill + references, docs site MDX, inline doc comments). No CHANGELOG.md changes (maintainer-owned).

## Tests

- 15 unit tests in `browser.rs` covering bound-target resolution on attach (present, absent + pin, absent + legacy), removal of the bound tab under both modes, gone-state guards, target-ref parsing, and background tab tracking; 4 binding persistence round-trip tests in `tab_binding.rs`.
- Parity tests for the `pinTab` command field, `AGENT_BROWSER_PIN_TAB`, sticky pinned binding, and the `tab_gone` response code.
- Two e2e tests (`e2e_pin_tab_rebinds_after_daemon_restart`, `e2e_pin_tab_gone_error_and_recovery`): one Chrome, two sessions; kill session A's daemon and assert the next A command lands on A's original tab (B's tab was most recently active); close A's tab from session B by target id and assert the `tab_gone` error plus recovery via `tab new`, with B unaffected throughout.
- Full suite: `cargo test` (931 tests), `cargo fmt --check`, `cargo clippy` clean (3 pre-existing warnings in untouched files left alone).
- Live smoke test against a throwaway Chrome (`--remote-debugging-port` + temp `--user-data-dir`): two pinned sessions, daemon kill + re-bind by target id verified, `tab_gone` + `"code":"tab_gone"` in `--json` verified, recovery verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
