### PR TITLE
fix(postinstall): verify sha256 of the downloaded native binary (#1422)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,9 @@ jobs:
           fi
           echo "All 7 platform binaries present and valid"
 
+      - name: Generate binary checksums
+        run: node scripts/generate-checksums.js
+
       - name: Publish to npm
         run: pnpm publish --provenance --no-git-checks
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "build:docker": "docker build --platform linux/amd64 -t agent-browser-builder -f docker/Dockerfile.build .",
     "release": "npm run version:sync && npm run build:all-platforms && npm publish",
     "postinstall": "node scripts/postinstall.js",
-    "build:dashboard": "cd packages/dashboard && pnpm build"
+    "build:dashboard": "cd packages/dashboard && pnpm build",
+    "test:scripts": "node --test scripts/"
   },
   "keywords": [
     "browser",

--- a/scripts/checksums.json
+++ b/scripts/checksums.json
@@ -1,0 +1,11 @@
+{
+  "0.31.1": {
+    "agent-browser-darwin-arm64": "fd7acd17b3071ff7f75a03c1ecd30501959d9c2d063bdaa05adb6f77abf2a7bf",
+    "agent-browser-darwin-x64": "05aa3e2ed3550e06fb3eb7423a1cef0d9d6031c4d6a8835b9dbe033baf83ef6d",
+    "agent-browser-linux-arm64": "5f80bff26b25e9a9f712be64dda1f8ea2b22213a1a07c0f97ea8f9f226c2894b",
+    "agent-browser-linux-musl-arm64": "1ca397f714820ca954c6b575e816c08acc937ffacea2b901f5cf6524fc4a6853",
+    "agent-browser-linux-musl-x64": "b7492a3e00e52790bffbd2900c399265e6a80598276f89fb8b2fbfa314cc8d22",
+    "agent-browser-linux-x64": "72c13bcfd2fd6b188325bdd23c646d06ca69a1a964a9cdaab37e4ff8f47aa5c6",
+    "agent-browser-win32-x64.exe": "0a355020b0ff2f9199fbb7385a0b8b7e16b548bb0d6df64498b456b76898adfa"
+  }
+}

--- a/scripts/generate-checksums.js
+++ b/scripts/generate-checksums.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Regenerate scripts/checksums.json from the built platform binaries in bin/.
+ *
+ * Run this in the release pipeline after the binaries have been placed in bin/
+ * and before publishing, so the checksums shipped inside the package match the
+ * exact artifacts uploaded to the GitHub release. Values are keyed by version.
+ * Install-time verification only needs the running version's entry; any other
+ * versions present are whatever is already committed in checksums.json (this
+ * script merges rather than overwrites, but it does not commit its output back).
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { createHash } from 'crypto';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const binDir = join(projectRoot, 'bin');
+const checksumsPath = join(__dirname, 'checksums.json');
+
+const version = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8')).version;
+
+if (!existsSync(binDir)) {
+  console.error(`No bin/ directory at ${binDir}; build the binaries first.`);
+  process.exit(1);
+}
+
+const entries = {};
+for (const name of readdirSync(binDir).sort()) {
+  // Only the downloadable native binaries (agent-browser-<platform>); the JS
+  // wrapper agent-browser.js and any dotfiles do not match this prefix.
+  if (!name.startsWith('agent-browser-')) continue;
+  entries[name] = createHash('sha256').update(readFileSync(join(binDir, name))).digest('hex');
+}
+
+if (Object.keys(entries).length === 0) {
+  console.error('No agent-browser-* binaries found in bin/; nothing to checksum.');
+  process.exit(1);
+}
+
+let all = {};
+if (existsSync(checksumsPath)) {
+  try {
+    all = JSON.parse(readFileSync(checksumsPath, 'utf8'));
+  } catch {
+    all = {};
+  }
+}
+all[version] = entries;
+writeFileSync(checksumsPath, JSON.stringify(all, null, 2) + '\n');
+console.log(`Wrote ${Object.keys(entries).length} checksum(s) for v${version} to ${checksumsPath}`);

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'url';
 import { platform, arch } from 'os';
 import { get } from 'https';
 import { execSync } from 'child_process';
+import { verifyChecksum } from './verify-checksum.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
@@ -140,6 +141,11 @@ async function main() {
   try {
     await downloadFile(DOWNLOAD_URL, binaryPath);
 
+    // Verify integrity before making the binary executable. A mismatch means the
+    // downloaded bytes are not what this package expects (corrupted download or a
+    // tampered release artifact), so bail out and leave no executable behind.
+    verifyChecksum(binaryPath, binaryName, version);
+
     // Make executable on Unix
     if (platform() !== 'win32') {
       chmodSync(binaryPath, 0o755);
@@ -147,6 +153,11 @@ async function main() {
 
     console.log(`✓ Downloaded native binary: ${binaryName}`);
   } catch (err) {
+    if (err.code === 'ERR_CHECKSUM_MISMATCH') {
+      // Integrity failure is a hard stop, not a soft "couldn't download".
+      console.error(`✗ ${err.message}`);
+      process.exit(1);
+    }
     console.log(`Could not download native binary: ${err.message}`);
     console.log('');
     console.log('To build the native binary locally:');

--- a/scripts/verify-checksum.js
+++ b/scripts/verify-checksum.js
@@ -1,0 +1,75 @@
+/**
+ * SHA-256 integrity verification for the downloaded native binary.
+ *
+ * Kept in its own module (no side effects on import) so postinstall.js can call
+ * it and the regression test can exercise it directly.
+ *
+ * Behaviour:
+ *   - A checksum is recorded for this version+binary -> verify, throw on mismatch.
+ *   - No checksum is recorded -> skip with a warning (do not block the install).
+ * This "verify when present" gate keeps installs working across version bumps
+ * (a checksums.json that hasn't been regenerated for a new version won't falsely
+ * reject it) while still catching a tampered/corrupted download when we do have a
+ * known-good value to compare against.
+ */
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { createHash } from 'crypto';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CHECKSUMS_PATH = join(__dirname, 'checksums.json');
+
+/**
+ * Return the recorded sha256 for a binary at a given version, or null if none.
+ */
+export function loadExpectedChecksum(binaryName, version, checksumsPath = DEFAULT_CHECKSUMS_PATH) {
+  if (!existsSync(checksumsPath)) return null;
+  try {
+    const all = JSON.parse(readFileSync(checksumsPath, 'utf8'));
+    const forVersion = all[version];
+    return (forVersion && forVersion[binaryName]) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify the file at `filePath` against the recorded checksum for
+ * `binaryName` at `version`.
+ *
+ * @returns {boolean} true if verified, false if verification was skipped
+ *   (no recorded checksum).
+ * @throws {Error} with code 'ERR_CHECKSUM_MISMATCH' if the file's sha256 does
+ *   not match the recorded value. The mismatched file is deleted before throwing.
+ */
+export function verifyChecksum(filePath, binaryName, version, opts = {}) {
+  const { checksumsPath, log = console } = opts;
+  const expected = loadExpectedChecksum(binaryName, version, checksumsPath);
+
+  if (!expected) {
+    log.warn(`⚠ Skipping integrity check: no recorded checksum for ${binaryName} at v${version}.`);
+    return false;
+  }
+
+  const actual = createHash('sha256').update(readFileSync(filePath)).digest('hex');
+  if (actual !== expected) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // best-effort cleanup; the throw below is what matters
+    }
+    const err = new Error(
+      `Checksum mismatch for ${binaryName} (v${version}).\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${actual}\n` +
+        `The downloaded binary does not match the checksum shipped with this package, ` +
+        `so it was deleted and NOT installed. This usually means a corrupted download ` +
+        `or a tampered release artifact.`
+    );
+    err.code = 'ERR_CHECKSUM_MISMATCH';
+    throw err;
+  }
+
+  return true;
+}

--- a/scripts/verify-checksum.test.js
+++ b/scripts/verify-checksum.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
+import { verifyChecksum } from './verify-checksum.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VERSION = '9.9.9-test';
+const BINARY = 'agent-browser-linux-x64';
+const silent = { warn: () => {} };
+
+// Write a temp checksums.json recording the sha256 of `realBytes` for BINARY@VERSION.
+function setup(realBytes) {
+  const dir = mkdtempSync(join(tmpdir(), 'ab-checksum-'));
+  const sha = createHash('sha256').update(realBytes).digest('hex');
+  const checksumsPath = join(dir, 'checksums.json');
+  writeFileSync(checksumsPath, JSON.stringify({ [VERSION]: { [BINARY]: sha } }));
+  return { dir, checksumsPath };
+}
+
+test('rejects a tampered binary and deletes it', () => {
+  const { dir, checksumsPath } = setup(Buffer.from('the real signed binary'));
+  const binPath = join(dir, BINARY);
+  writeFileSync(binPath, Buffer.from('MALICIOUS payload, not the real binary'));
+
+  assert.throws(
+    () => verifyChecksum(binPath, BINARY, VERSION, { checksumsPath, log: silent }),
+    (err) => err.code === 'ERR_CHECKSUM_MISMATCH'
+  );
+  assert.equal(existsSync(binPath), false, 'the tampered binary must be removed, not left executable');
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('accepts a binary whose checksum matches', () => {
+  const good = Buffer.from('the real signed binary');
+  const { dir, checksumsPath } = setup(good);
+  const binPath = join(dir, BINARY);
+  writeFileSync(binPath, good);
+
+  const result = verifyChecksum(binPath, BINARY, VERSION, { checksumsPath, log: silent });
+  assert.equal(result, true);
+  assert.equal(existsSync(binPath), true, 'a valid binary must be left in place');
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('skips (warns, does not throw) when no checksum is recorded', () => {
+  const { dir, checksumsPath } = setup(Buffer.from('whatever'));
+  const binPath = join(dir, BINARY);
+  writeFileSync(binPath, Buffer.from('unverifiable but allowed'));
+
+  let warned = false;
+  const result = verifyChecksum(binPath, 'agent-browser-unknown-plat', '0.0.0-absent', {
+    checksumsPath,
+    log: { warn: () => { warned = true; } },
+  });
+  assert.equal(result, false, 'a missing checksum is skipped, not enforced');
+  assert.equal(warned, true, 'the skip must be surfaced as a warning');
+  assert.equal(existsSync(binPath), true, 'the install proceeds when no checksum is recorded');
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// Guard against placeholder/fake hashes ever shipping. Kept decoupled from the
+// exact package.json version on purpose: checksums for a new version are only
+// regenerated in the release pipeline, so coupling to the current version would
+// make this fail in the window between a version bump and the release.
+test('checksums.json holds only real sha256 values (no placeholders)', () => {
+  const all = JSON.parse(readFileSync(join(__dirname, 'checksums.json'), 'utf8'));
+  const versions = Object.keys(all);
+  assert.ok(versions.length >= 1, 'checksums.json should record at least one version');
+  let count = 0;
+  for (const version of versions) {
+    for (const [name, hash] of Object.entries(all[version])) {
+      assert.match(hash, /^[a-f0-9]{64}$/, `${version}/${name} must be a real 64-char sha256, not a placeholder`);
+      count++;
+    }
+  }
+  assert.ok(count >= 1, 'expected at least one recorded checksum');
+});


### PR DESCRIPTION
## Summary

`scripts/postinstall.js` downloaded the platform binary from GitHub Releases and made it executable after checking only the HTTP status code, with no integrity check. This adds SHA-256 verification of the downloaded file before it is `chmod`'d.

## What changed

- **`scripts/verify-checksum.js`** (new): compares the downloaded file's sha256 against a known-good value shipped in the package. Enforced when a checksum is recorded for the version, skipped with a warning when it isn't (so a version bump can't break installs). On mismatch the file is deleted and an `Error` with code `ERR_CHECKSUM_MISMATCH` is thrown.
- **`scripts/postinstall.js`**: verifies between download and `chmod`. A mismatch aborts the install (`exit 1`) instead of leaving an executable behind. The offline / network-failure path is unchanged.
- **`scripts/checksums.json`** (new): sha256 for all seven v0.31.1 binaries, generated from the release artifacts.
- **`scripts/generate-checksums.js`** (new) plus a step in `release.yml`: regenerate checksums from the built binaries at release time so shipped values always match the uploaded artifacts.
- **`scripts/verify-checksum.test.js`** (new): regression tests (`node --test`).

## Scope

Verification runs on the freshly downloaded binary only. The download is a fallback path; a normal registry install uses the bundled, npm-integrity-checked binary. The pre-existing-binary path is intentionally not verified, because it also serves locally-built binaries (`npm run build:native`) whose hash differs from the release, so checking it there would false-reject local builds. This also avoids restructuring publishing into per-platform subpackages (esbuild's mechanism); it uses the committed-checksums approach from the issue.

## How I verified

- **Before:** ran the current download + `chmod` path against a local server returning arbitrary bytes. The bytes were written and `chmod`'d `0755` with no error, and the sha256 mismatch went undetected.
- **After:** `node --test scripts/verify-checksum.test.js` passes. A tampered file throws `ERR_CHECKSUM_MISMATCH` and is deleted, a matching file is accepted, and a missing checksum is skipped with a warning. The generator reproduces the committed checksums exactly.

Closes #1422.
