### PR TITLE
fix(daemon): reconcile ignore_https_errors on daemon reuse (#1359)

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -585,6 +585,10 @@ fn daemon_config_fingerprint(opts: &DaemonOptions) -> String {
     opts.idle_timeout.hash(&mut hasher);
     opts.default_timeout.hash(&mut hasher);
     opts.no_auto_dialog.hash(&mut hasher);
+    // ignore_https_errors is baked into the browser context at launch, so a changed
+    // value must restart the daemon instead of being silently kept from the first
+    // spawn (a reused daemon otherwise ignores the new value with no warning) (#1359).
+    opts.ignore_https_errors.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
 
@@ -1289,6 +1293,27 @@ mod tests {
         assert_ne!(
             daemon_config_fingerprint(&base),
             daemon_config_fingerprint(&domains_changed)
+        );
+    }
+
+    #[test]
+    fn test_daemon_config_fingerprint_tracks_ignore_https_errors() {
+        // Regression for #1359: ignore_https_errors is applied at browser launch, so a
+        // changed value must change the fingerprint (which triggers a daemon restart)
+        // instead of being silently kept from the first spawn.
+        let off = test_daemon_options(None, false, None);
+        let on = DaemonOptions {
+            ignore_https_errors: true,
+            ..test_daemon_options(None, false, None)
+        };
+        assert_ne!(
+            daemon_config_fingerprint(&off),
+            daemon_config_fingerprint(&on)
+        );
+        // Same value still reuses silently (no spurious restart, no warning).
+        assert_eq!(
+            daemon_config_fingerprint(&off),
+            daemon_config_fingerprint(&test_daemon_options(None, false, None))
         );
     }
 


### PR DESCRIPTION
## Summary

`ensure_daemon` reconciles daemon reuse with a config fingerprint: a matching config reuses the running daemon, a different one restarts it. `daemon_config_fingerprint` left out `ignore_https_errors`, so a call that changed the flag reused the daemon unchanged and the new value was silently dropped, with no restart and no warning.

## Reproduction (before)

Against `https://self-signed.badssl.com/`:

1. Start a session without the flag: navigation fails with `net::ERR_CERT_AUTHORITY_INVALID`.
2. Run the same session with `--ignore-https-errors`: still fails, and the daemon PID is unchanged (no restart). The flag is ignored.

A fresh daemon started with the flag loads the page fine, so the flag works; it is specifically dropped on daemon reuse. (The "ignored: daemon already running" warning from the original report is already gone on current main; this is the remaining silent drop.)

## What changed

- Added `ignore_https_errors` to `daemon_config_fingerprint`. A changed value now produces a different fingerprint, so `ensure_daemon` restarts the daemon and applies it; an unchanged value still reuses silently.

## After

- The reuse call with `--ignore-https-errors` restarts the daemon and loads the self-signed page (exit 0).
- Test: `test_daemon_config_fingerprint_tracks_ignore_https_errors` (fingerprints differ when the flag differs, match when equal).

## Note

The same fingerprint omission affects other launch-baked options (`user_agent`, `proxy*`, `executable_path`, `hide_scrollbars`, `extensions`, `init_scripts`, `enable`, `args`, `device`, `engine`, `allow_file_access`): reusing a session with a changed value for any of them silently keeps the first spawn's value. This PR is scoped to `ignore_https_errors` (the issue's subject); the broader set is worth a separate look, since each option needs a deliberate call on whether a change should force a daemon restart.

Closes #1359.
