### PR TITLE
fix(select): support custom ARIA combobox widgets (#1105)

### DIFF
--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -882,6 +882,155 @@ async fn e2e_form_interaction() {
     assert_success(&resp);
 }
 
+// Regression for #1105: `select` on a custom ARIA combobox (div-based, options
+// hidden until opened) must open it and click the matching option, and must
+// error (not silently succeed) on a value that does not exist.
+#[tokio::test]
+#[ignore]
+async fn e2e_select_aria_combobox() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let html = r#"<div role="combobox" id="cb" tabindex="0" aria-expanded="false" aria-controls="lb">Choose</div>
+<ul role="listbox" id="lb" style="display:none">
+<li role="option" data-value="apple">Apple</li>
+<li role="option" data-value="banana">Banana</li>
+</ul>
+<output id="result">none</output>
+<select id="native"><option value="">--</option><option value="x">Xylophone</option><option value="y">Yak</option></select>
+<ul role="listbox" id="multi" aria-multiselectable="true"><li role="option" data-value="m1">One</li><li role="option" data-value="m2">Two</li><li role="option" data-value="m3">Three</li></ul>
+<script>
+var cb=document.getElementById('cb'),lb=document.getElementById('lb'),r=document.getElementById('result');
+function setOpen(open){lb.style.display=open?'block':'none';cb.setAttribute('aria-expanded',String(open));}
+cb.addEventListener('click',function(){setOpen(lb.style.display==='none');});
+lb.querySelectorAll('[role=option]').forEach(function(o){o.addEventListener('click',function(){cb.textContent=o.textContent;o.setAttribute('aria-selected','true');r.textContent=o.getAttribute('data-value');setOpen(false);});});
+document.querySelectorAll('#multi [role=option]').forEach(function(o){o.addEventListener('click',function(){o.setAttribute('aria-selected',o.getAttribute('aria-selected')==='true'?'false':'true');});});
+</script>"#;
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // ARIA combobox: select opens the widget and clicks the matching option.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "select", "selector": "#cb", "values": ["Apple"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.getElementById('result').textContent" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "apple",
+        "combobox option should have been selected"
+    );
+
+    // Already-open combobox: select must not toggle it shut before matching.
+    let resp = execute_command(
+        &json!({ "id": "4b", "action": "evaluate", "script": "document.getElementById('cb').click(); document.getElementById('cb').getAttribute('aria-expanded')" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "true",
+        "combobox should be open going into the next step"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4c", "action": "select", "selector": "#cb", "values": ["Banana"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4d", "action": "evaluate", "script": "document.getElementById('result').textContent" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "banana",
+        "select on an already-open combobox must not close it"
+    );
+
+    // A value that does not exist must error, not silently succeed.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "select", "selector": "#cb", "values": ["Dragonfruit"] }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "an unknown combobox option must error, got: {}",
+        serde_json::to_string(&resp).unwrap_or_default()
+    );
+
+    // Native <select> path is unchanged.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "select", "selector": "#native", "values": ["Yak"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "evaluate", "script": "document.getElementById('native').value" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "y",
+        "native select should still work"
+    );
+
+    // role=listbox (multi-select): options are the listbox's own descendants, and
+    // every requested value is selected (mirroring native <select multiple>).
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "select", "selector": "#multi", "values": ["One", "Three"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "evaluate", "script": "Array.from(document.querySelectorAll('#multi [role=option][aria-selected=true]')).map(function(o){return o.getAttribute('data-value')}).join(',')" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "m1,m3",
+        "multi-select listbox should select every requested value"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // Navigation: back, forward, reload
 // ---------------------------------------------------------------------------

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -441,19 +441,94 @@ pub async fn select_option(
     // Matching nothing must be an error, not a silent success: an agent that
     // selects a misspelled option otherwise sees "Done", and only discovers
     // the page state is wrong after more commands. List what was available.
-    let js = r#"function(vals) {
-            const options = Array.from(this.options);
-            let matched = 0;
-            for (const opt of options) {
-                opt.selected = vals.includes(opt.value) || vals.includes(opt.textContent.trim());
-                if (opt.selected) matched += 1;
+    //
+    // Native <select> is handled inline. For a div-based ARIA combobox/listbox
+    // (Radix, Headless UI, etc.) there is no `this.options`, so emulate a human:
+    // open the widget, wait for its role=option items, and click the match.
+    let js = r#"async function(vals) {
+            const norm = (s) => (s || '').trim();
+
+            // Native <select>: unchanged behavior.
+            if (this instanceof HTMLSelectElement) {
+                const options = Array.from(this.options);
+                let matched = 0;
+                for (const opt of options) {
+                    opt.selected = vals.includes(opt.value) || vals.includes(norm(opt.textContent));
+                    if (opt.selected) matched += 1;
+                }
+                if (matched === 0) {
+                    const available = options.map(o => o.value + ' ("' + norm(o.textContent) + '")').join(', ');
+                    return { error: 'No option matched ' + JSON.stringify(vals) + '. Available options: ' + available };
+                }
+                this.dispatchEvent(new Event('change', { bubbles: true }));
+                return { matched };
             }
-            if (matched === 0) {
-                const available = options.map(o => o.value + ' ("' + o.textContent.trim() + '")').join(', ');
+
+            // Custom ARIA combobox/listbox widget.
+            const role = this.getAttribute('role');
+            if (role !== 'combobox' && role !== 'listbox') {
+                return { error: 'select target <' + this.tagName.toLowerCase() + '> is not a <select> or a role=combobox/listbox element' };
+            }
+
+            const realClick = (el) => {
+                const r = el.getBoundingClientRect();
+                const o = { bubbles: true, cancelable: true, composed: true,
+                            clientX: r.left + r.width / 2, clientY: r.top + r.height / 2,
+                            button: 0, pointerId: 1, isPrimary: true };
+                el.dispatchEvent(new PointerEvent('pointerdown', o));
+                el.dispatchEvent(new MouseEvent('mousedown', o));
+                el.dispatchEvent(new PointerEvent('pointerup', o));
+                el.dispatchEvent(new MouseEvent('mouseup', o));
+                el.dispatchEvent(new MouseEvent('click', o));
+            };
+
+            // Open the listbox, unless it is already open: clicking an open
+            // combobox toggles it shut. A role=listbox target is already open.
+            if (role === 'combobox' && this.getAttribute('aria-expanded') !== 'true') {
+                realClick(this);
+            }
+
+            const collect = () => {
+                // A role=listbox holds its own options; a combobox points at them
+                // via aria-controls, or portals them (then fall back to the document).
+                let scope = role === 'listbox' ? this : null;
+                if (!scope) {
+                    const controls = this.getAttribute('aria-controls');
+                    if (controls) { const byId = document.getElementById(controls); if (byId) scope = byId; }
+                }
+                const nodes = Array.from((scope || document).querySelectorAll('[role=option]'));
+                return nodes.filter(o => o.getClientRects().length > 0);
+            };
+
+            // Options may be injected or shown asynchronously after opening.
+            let options = collect();
+            for (let i = 0; i < 40 && options.length === 0; i++) {
+                await new Promise((r) => setTimeout(r, 50));
+                options = collect();
+            }
+            if (options.length === 0) {
+                return { error: 'combobox opened but no visible role=option elements were found' };
+            }
+
+            // Exact match on the option's accessible name (aria-label or trimmed text)
+            // or an explicit value attribute, mirroring the native path's semantics.
+            // Select every requested value, like the native <select multiple> path,
+            // and error only if none match (no silent partial success).
+            const wanted = options.filter((o) => {
+                const name = norm(o.getAttribute('aria-label')) || norm(o.textContent);
+                const val = norm(o.getAttribute('data-value')) || norm(o.getAttribute('value'));
+                return vals.includes(name) || (val && vals.includes(val));
+            });
+            if (wanted.length === 0) {
+                const available = options.map((o) => '"' + norm(o.textContent) + '"').join(', ');
                 return { error: 'No option matched ' + JSON.stringify(vals) + '. Available options: ' + available };
             }
-            this.dispatchEvent(new Event('change', { bubbles: true }));
-            return { matched };
+
+            for (const opt of wanted) {
+                opt.scrollIntoView({ block: 'nearest' });
+                realClick(opt);
+            }
+            return { matched: wanted.length };
         }"#
     .to_string();
 
@@ -468,11 +543,24 @@ pub async fn select_option(
                     object_id: None,
                 }]),
                 return_by_value: Some(true),
-                await_promise: Some(false),
+                await_promise: Some(true),
             },
             Some(&effective_session_id),
         )
         .await?;
+
+    // A thrown script error must surface, not silently succeed. Previously a
+    // non-<select> element hit `Array.from(this.options)`, threw, and the
+    // exception was ignored, so the caller saw "Done" while nothing happened.
+    if let Some(exc) = result.get("exceptionDetails") {
+        let msg = exc
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .or_else(|| exc.get("text").and_then(|t| t.as_str()))
+            .unwrap_or("select failed: script error");
+        return Err(msg.to_string());
+    }
 
     if let Some(error) = result
         .get("result")


### PR DESCRIPTION
## Summary

`select` worked on native `<select>` but silently did nothing on div-based ARIA comboboxes (Radix, Headless UI, etc.). `select_option` ran `Array.from(this.options)`, which only exists on a real `<select>`; on a `role="combobox"` div it threw, and the exception was swallowed (only a `value.error` was checked), so the caller saw "Done" while nothing was selected. Even a nonexistent value "succeeded".

## Reproduction (before)

Local Radix/Headless-style combobox (options `display:none` until the combobox is clicked):

- `select "#cb" "Apple"` returns "Done", but the widget is unchanged.
- `select "#cb" "Dragonfruit"` (nonexistent) also returns "Done".
- `document.querySelector('#cb').options` is `undefined`.

(The report describes "Element not found / not visible"; on current main it is actually a silent no-op.)

## What changed

- Native `<select>` path is unchanged (guarded by `this instanceof HTMLSelectElement`).
- For a `role=combobox/listbox` element, `select` now emulates a human: open the widget (only when it is not already expanded, so an open combobox is not toggled shut), wait for its visible `role=option` items (scoped to the listbox itself for a `role=listbox`, or via `aria-controls`/the document for a combobox), and click every option whose accessible name (`aria-label`/trimmed text) or value matches (mirroring native `<select multiple>`).
- No match after opening returns a clear error listing the available options.
- Runtime exceptions are surfaced instead of swallowed, so a thrown script error can no longer masquerade as success.

Match semantics: exact, case-sensitive, on the option's accessible name or value attribute, mirroring the native path.

## After

- `select "#cb" "Apple"` selects the option (verified via the committed value / `aria-selected` / visible label).
- A nonexistent value errors with the available options.
- An already-open combobox is not toggled shut, and a multi-select `role=listbox` selects every requested value.
- Native `<select>` still works.
- Test: `e2e_select_aria_combobox` (real Chrome, `#[ignore]`) covers all of the above; fails before the fix (combobox result stays "none"), passes after.

Closes #1105.
