### PR TITLE
fix(daemon): validate session name before path construction

### DIFF
--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -19,8 +19,14 @@ use super::cdp::client::CdpClient;
 use super::state;
 use super::stream::StreamServer;
 use crate::connection::INTERNAL_DAEMON_SHUTDOWN_ACTION;
+use crate::validation::{is_valid_session_name, session_name_error};
 
 pub async fn run_daemon(session: &str) {
+    if !is_valid_session_name(session) {
+        eprintln!("{} {}", crate::color::error_indicator(), session_name_error(session));
+        process::exit(1);
+    }
+
     let socket_dir = get_daemon_socket_dir();
     if !socket_dir.exists() {
         let _ = fs::create_dir_all(&socket_dir);

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -57,4 +57,12 @@ mod tests {
     fn sanitize_session_component_trims_separators() {
         assert_eq!(sanitize_session_component(" --Agent__ "), "agent");
     }
+
+    #[test]
+    fn is_valid_session_name_rejects_path_traversal() {
+        assert!(!is_valid_session_name("../../etc/foo"));
+        assert!(!is_valid_session_name("..\\..\\evil"));
+        assert!(is_valid_session_name("my-session"));
+        assert!(is_valid_session_name("work_123"));
+    }
 }


### PR DESCRIPTION
## Sanitize (reject) invalid session names in the native daemon to prevent path traversal

Fixes #1533.

### The problem

`run_daemon` in `cli/src/native/daemon.rs` builds a series of filesystem paths directly from the caller-supplied `session` string, with no validation:

```rust
let log_path     = socket_dir.join(format!("{}.log", session));
let pid_path     = socket_dir.join(format!("{}.pid", session));
let version_path = socket_dir.join(format!("{}.version", session));
let socket_path  = socket_dir.join(format!("{}.sock", session));
let stream_path  = socket_dir.join(format!("{}.stream", session));
// ...also .port, .engine, .provider, .extensions
```

The `session` value originates from the `--session <name>` CLI flag (via the `AGENT_BROWSER_SESSION` environment variable). Because it is never validated at this entry point, a value containing path separators — e.g. `--session '../../../../tmp/evil'` — causes the daemon to create/remove its `.pid`, `.log`, `.sock`, etc. files **outside** the intended daemon socket directory. This is an arbitrary-file-write / path-traversal hazard originally reported in #1533.

### The fix

The repository already ships the right helper — `is_valid_session_name` in `cli/src/validation.rs` — which is exactly what the CLI uses elsewhere to guard session names (see `main.rs`, `commands.rs`, `native/actions.rs`, `native/state.rs`). The daemon entry point was simply not calling it.

This change validates the session name at the very top of `run_daemon`, **before any path is constructed**, and rejects (rather than silently rewrites) an invalid name:

```rust
pub async fn run_daemon(session: &str) {
    if !is_valid_session_name(session) {
        eprintln!("{} {}", crate::color::error_indicator(), session_name_error(session));
        process::exit(1);
    }
    // ...existing path construction now runs only on a validated name
}
```

Rejecting rather than sanitizing is deliberate and matches the rest of the codebase: every other session-name call site uses `is_valid_session_name` + `session_name_error` and refuses invalid input. Silently sanitizing here would make the daemon operate under a different session identifier than the client used to address its socket/pid/log files, producing a confusing functional mismatch. `run_daemon` returns `()` and is invoked purely for side effects (`rt.block_on(native::daemon::run_daemon(&session))`), so `process::exit(1)` is the correct way to abort — mirroring how invalid session names are handled elsewhere.

No new sanitizer or abstraction is introduced; the fix reuses the crate's own validator.

### Test

Added a unit test in the existing `#[cfg(test)]` module of `cli/src/validation.rs`:

```rust
#[test]
fn is_valid_session_name_rejects_path_traversal() {
    assert!(!is_valid_session_name("../../etc/foo"));
    assert!(!is_valid_session_name("..\\..\\evil"));
    assert!(is_valid_session_name("my-session"));
    assert!(is_valid_session_name("work_123"));
}
```

This asserts traversal-style names are rejected and normal names pass, exercising the exact validator the daemon now calls.

### Severity note

This is **local input-validation hardening**, not a remotely exploitable vulnerability. The `session` value is supplied by the user running the local CLI/daemon, so the practical impact is that a locally-controlled flag could write files outside the daemon directory. It is worth fixing (defense-in-depth, matches the reporter's analysis in #1533), but it is not a remote CVE and needs no embargo.

### Verification

- Code review: confirmed `run_daemon` (`main.rs:897`) is the sole call site and the only place that reads `AGENT_BROWSER_SESSION`; confirmed every `format!(...)` path built from `session` — directly in `run_daemon` and in `run_socket_server`, which is only ever invoked from `run_daemon` with the already-validated value — occurs after the new guard. No other unsanitized intake of the daemon session name exists.
- Confirmed the fix reuses `validation::is_valid_session_name` / `validation::session_name_error`, the same helpers already used at every other session-name intake point (`main.rs:1116-1117`, `commands.rs:1777,1833,1838`, `native/actions.rs:1412-1413`, `native/state.rs:318-319,347-348,754`) — no new validation logic introduced.
- `cargo test is_valid_session_name_rejects_path_traversal` (and full `cargo test validation`) in `cli/`: **pass**. New unit test ok; existing validation tests ok.
- `git apply --check` of the exported patch against a clean `origin/main` worktree succeeds.

Thanks to @asmit25805 for the clear report and repro in #1533.