### PR TITLE
feat(network): capture response bodies in HAR and network request

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -98,7 +98,20 @@ pub struct HarEntry {
     /// Monotonic timestamp (seconds) from `Network.loadingFinished`; used to
     /// compute the `receive` timing phase.
     pub loading_finished_timestamp: Option<f64>,
+    /// Decoded response body, fetched via `Network.getResponseBody` after
+    /// `Network.loadingFinished`. `None` when no body was captured (no-body
+    /// status, redirect, evicted buffer, or over the size cap). Holds a base64
+    /// string when `response_body_base64` is true.
+    pub response_body: Option<String>,
+    /// True when `response_body` holds base64-encoded bytes (binary / non-UTF-8
+    /// response). Surfaces as HAR `content.encoding = "base64"`.
+    pub response_body_base64: bool,
 }
+
+/// Maximum decoded response-body size (bytes) stored on a HAR entry. Larger
+/// bodies keep their `size`/`mimeType` metadata but omit `text`, so one big
+/// download can't bloat the HAR. Not yet configurable via CLI.
+const MAX_HAR_BODY_BYTES: i64 = 10 * 1024 * 1024;
 
 pub struct RouteEntry {
     pub url_pattern: String,
@@ -180,6 +193,9 @@ struct DrainedEvents {
     attached_iframe_sessions: Vec<(String, String)>,
     /// Session IDs from Target.detachedFromTarget.
     detached_iframe_sessions: Vec<String>,
+    /// (requestId, sessionId) pairs from `Network.loadingFinished` during HAR
+    /// recording whose response body should be fetched in the async drain phase.
+    har_bodies_to_fetch: Vec<(String, Option<String>)>,
 }
 
 /// Compute a hash of the [`LaunchOptions`] fields that require a browser
@@ -794,6 +810,46 @@ impl DaemonState {
                 mgr.update_page_target_info(&te.target_info);
             }
         }
+
+        // Fetch response bodies for finished HAR requests. Response bodies are
+        // not pushed through CDP events, so each must be pulled explicitly with
+        // Network.getResponseBody while it is still buffered (buffers are
+        // enlarged in handle_har_start so they survive the drain gap). This is
+        // best-effort: any failure (no-body status, redirect, evicted buffer)
+        // simply leaves the entry without a `text` field.
+        if !drained.har_bodies_to_fetch.is_empty() {
+            if let Some(client) = self.browser.as_ref().map(|m| m.client.clone()) {
+                for (request_id, session_id) in &drained.har_bodies_to_fetch {
+                    let res = client
+                        .send_command(
+                            "Network.getResponseBody",
+                            Some(json!({ "requestId": request_id })),
+                            session_id.as_deref(),
+                        )
+                        .await;
+                    let Ok(res) = res else { continue };
+                    let base64 = res
+                        .get("base64Encoded")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let Some(body) = res.get("body").and_then(|v| v.as_str()) else {
+                        continue;
+                    };
+                    if body.len() as i64 > MAX_HAR_BODY_BYTES {
+                        continue;
+                    }
+                    if let Some(entry) = self
+                        .har_entries
+                        .iter_mut()
+                        .rev()
+                        .find(|e| &e.request_id == request_id)
+                    {
+                        entry.response_body = Some(body.to_string());
+                        entry.response_body_base64 = base64;
+                    }
+                }
+            }
+        }
     }
 
     fn drain_cdp_events(&mut self) -> DrainedEvents {
@@ -803,6 +859,7 @@ impl DaemonState {
         };
 
         let mut pending_acks: Vec<i64> = Vec::new();
+        let mut har_bodies_to_fetch: Vec<(String, Option<String>)> = Vec::new();
         let mut new_targets: Vec<TargetCreatedEvent> = Vec::new();
         let mut new_target_ids: HashSet<String> = HashSet::new();
         let mut changed_targets: Vec<TargetInfoChangedEvent> = Vec::new();
@@ -1022,6 +1079,8 @@ impl DaemonState {
                                         response_body_size: -1,
                                         cdp_timing: None,
                                         loading_finished_timestamp: None,
+                                        response_body: None,
+                                        response_body_base64: false,
                                     });
                                 }
                                 if self.request_tracking {
@@ -1151,6 +1210,10 @@ impl DaemonState {
                                     entry.response_body_size = len;
                                 }
                             }
+                            // Queue this finished request for a body fetch in the
+                            // async drain phase (bodies aren't in the event itself).
+                            har_bodies_to_fetch
+                                .push((request_id.to_string(), event.session_id.clone()));
                         }
                         "Network.loadingFailed" if self.har_recording => {
                             let request_id = event
@@ -1241,6 +1304,7 @@ impl DaemonState {
             destroyed_targets,
             attached_iframe_sessions,
             detached_iframe_sessions,
+            har_bodies_to_fetch,
         }
     }
 }
@@ -7720,15 +7784,30 @@ async fn handle_video_stop(state: &mut DaemonState) -> Result<Value, String> {
 async fn handle_har_start(state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
+    // Enlarge the CDP network buffers so response bodies survive until we fetch
+    // them. Bodies are pulled during the async drain, which can run a little
+    // after loadingFinished; Chrome's ~10 MB/resource default evicts them fast.
+    let enable_params = json!({
+        "maxTotalBufferSize": 200_000_000_i64,
+        "maxResourceBufferSize": 100_000_000_i64,
+    });
     mgr.client
-        .send_command_no_params("Network.enable", Some(&session_id))
+        .send_command(
+            "Network.enable",
+            Some(enable_params.clone()),
+            Some(&session_id),
+        )
         .await?;
     // Also enable Network on cross-origin iframe sessions so their
     // requests are captured in the HAR output.
     for iframe_sid in state.iframe_sessions.values() {
         let _ = mgr
             .client
-            .send_command_no_params("Network.enable", Some(iframe_sid.as_str()))
+            .send_command(
+                "Network.enable",
+                Some(enable_params.clone()),
+                Some(iframe_sid.as_str()),
+            )
             .await;
     }
     state.har_recording = true;
@@ -7839,6 +7918,20 @@ fn har_entry_to_json(e: HarEntry) -> Value {
         request["postData"] = json!({ "mimeType": post_content_type, "text": body });
     }
 
+    // Response body content object: always carry `size` + `mimeType`, and add
+    // the decoded body as `text` when one was captured. Per the HAR 1.2 spec, a
+    // binary / non-UTF-8 body is base64 and tagged with `encoding: "base64"`.
+    let mut content = json!({
+        "size": e.response_body_size,
+        "mimeType": mime_type,
+    });
+    if let Some(body) = e.response_body {
+        content["text"] = Value::String(body);
+        if e.response_body_base64 {
+            content["encoding"] = Value::String("base64".to_string());
+        }
+    }
+
     json!({
         "startedDateTime": started_date_time,
         "time": total_time,
@@ -7849,10 +7942,7 @@ fn har_entry_to_json(e: HarEntry) -> Value {
             "httpVersion": e.http_version,
             "cookies": resp_cookies,
             "headers": resp_headers,
-            "content": {
-                "size": e.response_body_size,
-                "mimeType": mime_type,
-            },
+            "content": content,
             "redirectURL": e.redirect_url,
             "headersSize": -1,
             "bodySize": e.response_body_size,
@@ -8596,10 +8686,10 @@ async fn handle_request_detail(cmd: &Value, state: &mut DaemonState) -> Result<V
                     .get("body")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                result["responseBody"] = json!(body);
                 if base64_encoded {
-                    result["responseBody"] = json!(format!("[base64, {} chars]", body.len()));
-                } else {
-                    result["responseBody"] = json!(body);
+                    // Binary / non-UTF-8 body: `responseBody` holds base64.
+                    result["responseBodyEncoding"] = json!("base64");
                 }
             }
         }
@@ -10900,6 +10990,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             response_body_size: 42,
             cdp_timing: None,
             loading_finished_timestamp: None,
+            response_body: None,
+            response_body_base64: false,
         };
 
         let har = har_entry_to_json(entry);
@@ -10923,6 +11015,61 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         assert_eq!(har["response"]["cookies"][0]["name"], "token");
         assert_eq!(har["response"]["cookies"][0]["value"], "xyz");
         assert_eq!(har["_resourceType"], "XHR");
+    }
+
+    fn har_entry_with_body(body: Option<&str>, base64: bool) -> HarEntry {
+        HarEntry {
+            request_id: "body-req".to_string(),
+            wall_time: 1773576000.0,
+            method: "GET".to_string(),
+            url: "https://api.example.com/data".to_string(),
+            request_headers: vec![],
+            post_data: None,
+            request_body_size: 0,
+            resource_type: "XHR".to_string(),
+            status: Some(200),
+            status_text: "OK".to_string(),
+            http_version: "HTTP/2.0".to_string(),
+            response_headers: vec![],
+            mime_type: "application/json".to_string(),
+            redirect_url: String::new(),
+            response_body_size: 11,
+            cdp_timing: None,
+            loading_finished_timestamp: None,
+            response_body: body.map(String::from),
+            response_body_base64: base64,
+        }
+    }
+
+    #[test]
+    fn test_har_entry_emits_text_response_body() {
+        let har = har_entry_to_json(har_entry_with_body(Some(r#"{"ok":true}"#), false));
+        assert_eq!(har["response"]["content"]["text"], r#"{"ok":true}"#);
+        assert!(
+            har["response"]["content"].get("encoding").is_none(),
+            "a UTF-8 text body must not carry a base64 encoding marker"
+        );
+        // Pre-existing content fields stay intact.
+        assert_eq!(har["response"]["content"]["mimeType"], "application/json");
+        assert_eq!(har["response"]["content"]["size"], 11);
+    }
+
+    #[test]
+    fn test_har_entry_emits_base64_body_with_encoding() {
+        let har = har_entry_to_json(har_entry_with_body(Some("iVBORw0KGgo="), true));
+        assert_eq!(har["response"]["content"]["text"], "iVBORw0KGgo=");
+        assert_eq!(har["response"]["content"]["encoding"], "base64");
+    }
+
+    #[test]
+    fn test_har_entry_without_body_omits_text() {
+        let har = har_entry_to_json(har_entry_with_body(None, false));
+        assert!(
+            har["response"]["content"].get("text").is_none(),
+            "no captured body -> no text key (preserves prior behaviour)"
+        );
+        assert!(har["response"]["content"].get("encoding").is_none());
+        assert_eq!(har["response"]["content"]["size"], 11);
     }
 
     #[test]
@@ -10982,6 +11129,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             response_body_size: 0,
             cdp_timing: None,
             loading_finished_timestamp: None,
+            response_body: None,
+            response_body_base64: false,
         };
         let har = har_entry_to_json(entry);
         assert_eq!(har["response"]["cookies"][0]["name"], "token");
@@ -11037,6 +11186,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             response_body_size: 128,
             cdp_timing: None,
             loading_finished_timestamp: None,
+            response_body: None,
+            response_body_base64: false,
         });
 
         let result = handle_har_stop(&json!({ "action": "har_stop" }), &mut state)
@@ -11084,6 +11235,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             response_body_size: 64,
             cdp_timing: None,
             loading_finished_timestamp: None,
+            response_body: None,
+            response_body_base64: false,
         });
 
         let result = execute_command(

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3957,6 +3957,78 @@ async fn e2e_headers_persist_same_origin_fetch() {
     assert_success(&resp);
 }
 
+/// HAR export captures the decoded response body as `content.text`.
+#[tokio::test]
+#[ignore]
+async fn e2e_har_captures_response_body() {
+    let (base_url, _server) = start_echo_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Start HAR recording, then navigate to the JSON endpoint. The document
+    // response body is the echo server's `{"headers":{...}}` payload.
+    let resp = execute_command(&json!({ "id": "2", "action": "har_start" }), &mut state).await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "navigate", "url": format!("{}/data", base_url) }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Any subsequent command drains CDP events, which triggers the
+    // loadingFinished -> getResponseBody body fetch before we stop recording.
+    let resp = execute_command(&json!({ "id": "4", "action": "requests" }), &mut state).await;
+    assert_success(&resp);
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let har_path = std::env::temp_dir().join(format!("agent-browser-e2e-har-body-{nanos}.har"));
+    let resp = execute_command(
+        &json!({
+            "id": "5", "action": "har_stop",
+            "path": har_path.to_string_lossy().to_string(),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let har: Value = serde_json::from_str(&std::fs::read_to_string(&har_path).unwrap()).unwrap();
+    let entries = har["log"]["entries"].as_array().expect("HAR entries array");
+    let doc = entries
+        .iter()
+        .find(|e| {
+            e["request"]["url"]
+                .as_str()
+                .map(|u| u.ends_with("/data"))
+                .unwrap_or(false)
+        })
+        .expect("HAR should contain the /data document request");
+    let text = doc["response"]["content"]["text"]
+        .as_str()
+        .expect("content.text must be populated with the response body");
+    let parsed: Value =
+        serde_json::from_str(text).expect("content.text should be the exact JSON body");
+    assert!(
+        parsed.get("headers").is_some(),
+        "captured body should be the echo JSON, got: {text}"
+    );
+
+    let _ = std::fs::remove_file(&har_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// Headers set via --headers do NOT leak to a different origin.
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
## Summary

HAR export (`network har stop`) and `network request <id>` previously surfaced only request/response **metadata** — `response.content.text` was always absent, so a captured HAR could not be used to inspect JSON/API payloads.

Response bodies are **not** delivered through CDP `Network.*` events; each one must be pulled explicitly with `Network.getResponseBody` *while it is still in Chrome's per-request buffer*. This PR does that at the right moment and threads the body into the HAR.

## What changed

- **Eager body capture.** When HAR recording is on, each `Network.loadingFinished` queues its `(requestId, sessionId)`; the async event-drain then calls `Network.getResponseBody` and caches the result on the `HarEntry`. Fetching right after `loadingFinished` (rather than lazily at export time) avoids the "buffer already evicted" failures.
- **Enlarged CDP buffers.** `har start` now enables `Network` with `maxTotalBufferSize` / `maxResourceBufferSize` raised (200 MB / 100 MB) so bodies survive until they're fetched. (Chrome's ~10 MB/resource default evicts them quickly.)
- **HAR emission.** `har_entry_to_json` now writes `content.text`, and for binary / non-UTF-8 responses `content.encoding: "base64"` (per the HAR 1.2 spec). The existing `size` / `mimeType` fields are unchanged.
- **`network request <id>` fix.** It already fetched the body on demand, but stored a useless `"[base64, N chars]"` placeholder for binary responses. It now returns the real base64 string and a `responseBodyEncoding: "base64"` marker.

All changes are confined to `cli/src/native/actions.rs` (plus a test in `e2e_tests.rs`).

## Behaviour / edge cases

- **Binary bodies** → `content.text` is base64 with `content.encoding: "base64"`.
- **Bodies over 10 MB** (`MAX_HAR_BODY_BYTES`) keep their `size` / `mimeType` but omit `text`, so one large download can't bloat the HAR.
- **No-body responses** (204/304, redirects, `loadingFailed`, evicted buffers) → `getResponseBody` errors are swallowed; the entry simply has no `text`. Never breaks the HAR.
- **Cross-origin iframe requests** → fetched on the event's own `sessionId`.
- Bodies are captured for all resource types (matching DevTools HAR completeness), bounded by the size cap.

## Testing

- **Unit tests** (`har_entry_to_json`): text body → `content.text` set with no `encoding`; base64 body → `content.text` + `content.encoding: "base64"`; no body → no `text` key (prior output preserved).
- **E2E** (`e2e_har_captures_response_body`, `#[ignore]`): records a HAR against a local server and asserts `content.text` is the exact JSON body.
- **Manual** against real traffic with a release build:
  - JSON document and in-page `fetch`/XHR → `content.text` = decoded JSON.
  - PNG → `content.text` = base64 decoding back to valid PNG bytes.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full test suite all pass.

## Possible follow-ups (intentionally out of scope here)

- A `--no-bodies` opt-out and/or a `--max-body-size` flag (currently on-by-default with a hard-coded cap, to keep this change small).
- A MIME allowlist if capturing media bodies proves undesirable by default.
