### PR TITLE
fix(native): match implicit ARIA roles and accessible names in find role

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ agent-browser find nth <n> <sel> <action> [value]     # Nth match
 
 ```bash
 agent-browser find role button click --name "Submit"
-agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, top-level <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find first ".item" click

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ agent-browser find nth <n> <sel> <action> [value]     # Nth match
 
 **Actions:** `click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`
 
-**Options:** `--name <name>` (filter role by accessible name), `--exact` (require exact text match)
+**Options:** `--name <name>` (filter role by accessible name), `--exact` (exact accessible-name match, case-sensitive; without it, matching is a case-insensitive substring)
 
 **Examples:**
 
 ```bash
-agent-browser find role button click --name "Submit"
+agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find first ".item" click

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ agent-browser find nth <n> <sel> <action> [value]     # Nth match
 
 **Actions:** `click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`
 
-**Options:** `--name <name>` (filter role by accessible name), `--exact` (exact accessible-name match, case-sensitive; without it, matching is a case-insensitive substring)
+**Options:** `--name <name>` (filter role by accessible name), `--exact` (exact, case-sensitive match; for `role` it applies to the accessible name, whose default is a case-insensitive substring)
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ agent-browser find nth <n> <sel> <action> [value]     # Nth match
 **Examples:**
 
 ```bash
-agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
+agent-browser find role button click --name "Submit"
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find first ".item" click

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ agent-browser find last <sel> <action> [value]        # Last match
 agent-browser find nth <n> <sel> <action> [value]     # Nth match
 ```
 
-**Actions:** `click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`
+**Actions:** `click`, `fill`, `check`, `hover`, `text`
 
 **Options:** `--name <name>` (filter role by accessible name), `--exact` (exact, case-sensitive match; for `role` it applies to the accessible name, whose default is a case-insensitive substring)
 

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1039,7 +1039,7 @@ fn parity_tools() -> Vec<Value> {
                 "text": { "type": "string", "description": "Optional text/value for fill or type actions." },
                 "index": { "type": "integer", "description": "Index for nth locator." },
                 "name": { "type": "string", "description": "Accessible name filter for role locator." },
-                "exact": { "type": "boolean", "default": false }
+                "exact": { "type": "boolean", "description": "Exact, case-sensitive whole-string match. Default is substring matching; role accessible names also match case-insensitively.", "default": false }
             }),
             &["locator", "value"],
         ),

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1039,7 +1039,7 @@ fn parity_tools() -> Vec<Value> {
                 "text": { "type": "string", "description": "Optional text/value for fill or type actions." },
                 "index": { "type": "integer", "description": "Index for nth locator." },
                 "name": { "type": "string", "description": "Accessible name filter for role locator." },
-                "exact": { "type": "boolean", "description": "Exact, case-sensitive accessible-name match. Default is case-insensitive substring matching. The role value itself always matches case-insensitively, with or without exact.", "default": false }
+                "exact": { "type": "boolean", "description": "Exact, case-sensitive match. For the role locator it applies to the accessible name, whose default is a case-insensitive substring. The role value itself always matches case-insensitively, with or without exact.", "default": false }
             }),
             &["locator", "value"],
         ),

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1039,7 +1039,7 @@ fn parity_tools() -> Vec<Value> {
                 "text": { "type": "string", "description": "Optional text/value for fill or type actions." },
                 "index": { "type": "integer", "description": "Index for nth locator." },
                 "name": { "type": "string", "description": "Accessible name filter for role locator." },
-                "exact": { "type": "boolean", "description": "Exact, case-sensitive whole-string match. Default is substring matching; role accessible names also match case-insensitively.", "default": false }
+                "exact": { "type": "boolean", "description": "Exact, case-sensitive accessible-name match. Default is case-insensitive substring matching. The role value itself always matches case-insensitively, with or without exact.", "default": false }
             }),
             &["locator", "value"],
         ),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7849,9 +7849,12 @@ async fn handle_presentational_getbyrole(
     };
 
     let role_json = serde_json::to_string(&role.to_ascii_lowercase()).unwrap_or_default();
+    // ARIA roles Playwright recognizes (WAI-ARIA 1.2). The operative role is the
+    // first token that is a defined role, so omitting one (e.g. `mark`) lets a
+    // later presentational token wrongly win.
     let query = format!(
         r#"(() => {{
-            const VALID_ROLES = new Set(['alert','alertdialog','application','article','banner','blockquote','button','caption','cell','checkbox','code','columnheader','combobox','complementary','contentinfo','definition','deletion','dialog','directory','document','emphasis','feed','figure','form','generic','grid','gridcell','group','heading','img','insertion','link','list','listbox','listitem','log','main','marquee','math','meter','menu','menubar','menuitem','menuitemcheckbox','menuitemradio','navigation','none','note','option','paragraph','presentation','progressbar','radio','radiogroup','region','row','rowgroup','rowheader','scrollbar','search','searchbox','separator','slider','spinbutton','status','strong','subscript','superscript','switch','tab','table','tablist','tabpanel','term','textbox','time','timer','toolbar','tooltip','tree','treegrid','treeitem']);
+            const VALID_ROLES = new Set(['alert','alertdialog','application','article','banner','blockquote','button','caption','cell','checkbox','code','columnheader','combobox','complementary','contentinfo','definition','deletion','dialog','directory','document','emphasis','feed','figure','form','generic','grid','gridcell','group','heading','img','insertion','link','list','listbox','listitem','log','main','mark','marquee','math','meter','menu','menubar','menuitem','menuitemcheckbox','menuitemradio','navigation','none','note','option','paragraph','presentation','progressbar','radio','radiogroup','region','row','rowgroup','rowheader','scrollbar','search','searchbox','separator','slider','spinbutton','status','strong','subscript','superscript','switch','tab','table','tablist','tabpanel','term','textbox','time','timer','toolbar','tooltip','tree','treegrid','treeitem']);
             const norm = s => (s || '').replace(/\s+/g, ' ').trim();
             const nameOf = el => {{
                 const lb = el.getAttribute('aria-labelledby');
@@ -7929,9 +7932,10 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     let name = cmd.get("name").and_then(|v| v.as_str());
     let exact = cmd.get("exact").and_then(|v| v.as_bool()).unwrap_or(false);
 
-    // Presentational roles never appear in the AX tree (their whole point
-    // is removal from it), so they get a syntactic DOM match instead.
-    if is_presentational_role(role) {
+    // The AX tree cannot answer these, so they fall back to a DOM match on the
+    // explicit `role` attribute: none/presentation are pruned from the tree, and
+    // Chrome collapses `directory` into `list` (only the attribute tells them apart).
+    if is_presentational_role(role) || role.eq_ignore_ascii_case("directory") {
         return handle_presentational_getbyrole(cmd, state, role, name, exact).await;
     }
 
@@ -7972,10 +7976,10 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     result
 }
 
-/// Map a Chrome AX tree role to its public ARIA role name. The AX tree
-/// mostly uses ARIA names already; the known divergence is `image`, which
-/// ARIA (and Playwright) call `img`. Queries are normalized through the
-/// same table, so both spellings match either way.
+/// Map a Chrome AX tree role to its ARIA name. The only divergence is `image`,
+/// which ARIA and Playwright call `img`; queries pass through the same table so
+/// both spellings match. `directory` is not mapped here (Chrome collapses it
+/// into `list`); it is matched on the DOM attribute instead, see handle_getbyrole.
 fn normalize_ax_role(role: &str) -> String {
     let lower = role.to_ascii_lowercase();
     match lower.as_str() {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7865,6 +7865,7 @@ fn find_ax_node_by_role(
 ) -> Result<(i64, String), String> {
     let mut matched_without_backend_id = false;
     let mut names_seen: Vec<String> = Vec::new();
+    let mut role_match_count: usize = 0;
 
     for node in nodes {
         if node.ignored.unwrap_or(false) {
@@ -7886,8 +7887,11 @@ fn find_ax_node_by_role(
         };
 
         if !matches {
-            if name.is_some() && !names_seen.contains(&node_name) {
-                names_seen.push(node_name);
+            if name.is_some() {
+                role_match_count += 1;
+                if !names_seen.contains(&node_name) {
+                    names_seen.push(node_name);
+                }
             }
             continue;
         }
@@ -7923,14 +7927,14 @@ fn find_ax_node_by_role(
                 .map(|n| format!("\"{}\"", n))
                 .collect();
             let more = if names_seen.len() > 5 { ", ..." } else { "" };
-            let (plural, verb) = if names_seen.len() == 1 {
+            let (plural, verb) = if role_match_count == 1 {
                 ("", "has")
             } else {
                 ("s", "have")
             };
             return Err(format!(
                 "{count} element{plural} {verb} role \"{role}\", but none match name \"{target_name}\". Names seen: {shown}{more}",
-                count = names_seen.len(),
+                count = role_match_count,
                 plural = plural,
                 verb = verb,
                 role = role,
@@ -10619,6 +10623,29 @@ mod tests {
         assert!(err.contains("Nope"));
         assert!(err.contains("\"Skills\""));
         assert!(err.contains("\"Experience\""));
+    }
+
+    #[test]
+    fn find_ax_node_by_role_name_miss_count_is_elements_not_unique_names() {
+        let nodes = vec![
+            ax_node("heading", "Skills", Some(43), false),
+            ax_node("heading", "Skills", Some(44), false),
+            ax_node("heading", "Skills", Some(45), false),
+        ];
+
+        let err = find_ax_node_by_role(&nodes, "heading", Some("Nope"), false)
+            .expect_err("no node should match an unrelated name");
+        // 3 elements share the same name, so names_seen dedupes to 1 entry --
+        // the element count must still say 3, not 1.
+        assert!(
+            err.contains("3 elements have role \"heading\""),
+            "expected element count 3, got: {err}"
+        );
+        assert_eq!(
+            err.matches("\"Skills\"").count(),
+            1,
+            "names_seen must dedupe the display list: {err}"
+        );
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7831,9 +7831,6 @@ async fn handle_presentational_getbyrole(
     name: Option<&str>,
     exact: bool,
 ) -> Result<Value, String> {
-    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-    let session_id = mgr.active_session_id()?.to_string();
-
     let name_check = match name {
         Some(n) => {
             let name_json = serde_json::to_string(n).unwrap_or_default();
@@ -7852,15 +7849,17 @@ async fn handle_presentational_getbyrole(
     // ARIA roles Playwright recognizes (WAI-ARIA 1.2). The operative role is the
     // first token that is a defined role, so omitting one (e.g. `mark`) lets a
     // later presentational token wrongly win.
-    let query = format!(
-        r#"(() => {{
+    // A function of `root` (the document to search), so it can run against the
+    // top document or a selected frame's document, not just the global one.
+    let locate_body = format!(
+        r#"(root) => {{
             const VALID_ROLES = new Set(['alert','alertdialog','application','article','banner','blockquote','button','caption','cell','checkbox','code','columnheader','combobox','complementary','contentinfo','definition','deletion','dialog','directory','document','emphasis','feed','figure','form','generic','grid','gridcell','group','heading','img','insertion','link','list','listbox','listitem','log','main','mark','marquee','math','meter','menu','menubar','menuitem','menuitemcheckbox','menuitemradio','navigation','none','note','option','paragraph','presentation','progressbar','radio','radiogroup','region','row','rowgroup','rowheader','scrollbar','search','searchbox','separator','slider','spinbutton','status','strong','subscript','superscript','switch','tab','table','tablist','tabpanel','term','textbox','time','timer','toolbar','tooltip','tree','treegrid','treeitem']);
             const norm = s => (s || '').replace(/\s+/g, ' ').trim();
             const nameOf = el => {{
                 const lb = el.getAttribute('aria-labelledby');
                 if (lb) {{
                     const t = lb.trim().split(/\s+/)
-                        .map(id => {{ const r = document.getElementById(id); return r ? r.textContent : ''; }})
+                        .map(id => {{ const r = root.getElementById(id); return r ? r.textContent : ''; }})
                         .join(' ');
                     if (norm(t)) return t;
                 }}
@@ -7869,7 +7868,7 @@ async fn handle_presentational_getbyrole(
                 return el.textContent || '';
             }};
             const role = {role_json};
-            for (const el of document.querySelectorAll('[role]')) {{
+            for (const el of root.querySelectorAll('[role]')) {{
                 const tokens = (el.getAttribute('role') || '').trim().toLowerCase().split(/\s+/);
                 const operative = tokens.find(t => VALID_ROLES.has(t));
                 if (operative !== role) continue;
@@ -7878,29 +7877,23 @@ async fn handle_presentational_getbyrole(
                 return true;
             }}
             return false;
-        }})()"#
+        }}"#
     );
 
-    let result: super::cdp::types::EvaluateResult = mgr
-        .client
-        .send_command_typed(
-            "Runtime.evaluate",
-            &super::cdp::types::EvaluateParams {
-                expression: query,
-                return_by_value: Some(true),
-                await_promise: Some(false),
-            },
-            Some(&session_id),
+    let located = {
+        let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+        let top_session = mgr.active_session_id()?.to_string();
+        eval_body_in_active_frame(
+            mgr,
+            state.active_frame_id.as_deref(),
+            &top_session,
+            &state.iframe_sessions,
+            &locate_body,
         )
-        .await?;
+        .await?
+    };
 
-    if !result
-        .result
-        .value
-        .as_ref()
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
+    if !located.as_bool().unwrap_or(false) {
         return Err(format!(
             "No element found: {}",
             build_role_selector(role, name, exact)
@@ -7910,16 +7903,81 @@ async fn handle_presentational_getbyrole(
     let selector = "[data-agent-browser-located='true']";
     let action_result = execute_subaction(cmd, state, selector).await;
 
-    if let Some(ref browser) = state.browser {
-        let _ = browser
-            .evaluate(
-                "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
-                None,
+    // Clean up the marker in whichever document it was set in.
+    if let Some(mgr) = state.browser.as_ref() {
+        if let Ok(top_session) = mgr.active_session_id() {
+            let top_session = top_session.to_string();
+            let _ = eval_body_in_active_frame(
+                mgr,
+                state.active_frame_id.as_deref(),
+                &top_session,
+                &state.iframe_sessions,
+                "(root) => { root.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located'); }",
             )
             .await;
+        }
     }
 
     action_result
+}
+
+/// Evaluate a `(root) => {...}` body against the active frame's document, or the
+/// top document when no frame is selected. Runtime.evaluate cannot target a
+/// same-origin child frame, so that case runs the body against the frame owner's
+/// contentDocument (as element resolution does); an OOPIF has its own session
+/// where `document` is already the frame document.
+async fn eval_body_in_active_frame(
+    mgr: &BrowserManager,
+    frame_id: Option<&str>,
+    top_session: &str,
+    iframe_sessions: &HashMap<String, String>,
+    body: &str,
+) -> Result<Value, String> {
+    match frame_id {
+        Some(fid) if !iframe_sessions.contains_key(fid) => {
+            let owner =
+                super::element::frame_owner_object_id(&mgr.client, top_session, fid).await?;
+            let func = format!(
+                "function() {{ const d = this.contentDocument; if (!d) return null; return ({body})(d); }}"
+            );
+            let res = mgr
+                .client
+                .send_command(
+                    "Runtime.callFunctionOn",
+                    Some(serde_json::json!({
+                        "objectId": owner,
+                        "functionDeclaration": func,
+                        "returnByValue": true,
+                    })),
+                    Some(top_session),
+                )
+                .await?;
+            Ok(res
+                .get("result")
+                .and_then(|r| r.get("value"))
+                .cloned()
+                .unwrap_or(Value::Null))
+        }
+        _ => {
+            let session = frame_id
+                .and_then(|f| iframe_sessions.get(f))
+                .map(|s| s.as_str())
+                .unwrap_or(top_session);
+            let res: super::cdp::types::EvaluateResult = mgr
+                .client
+                .send_command_typed(
+                    "Runtime.evaluate",
+                    &super::cdp::types::EvaluateParams {
+                        expression: format!("({body})(document)"),
+                        return_by_value: Some(true),
+                        await_promise: Some(false),
+                    },
+                    Some(session),
+                )
+                .await?;
+            Ok(res.result.value.unwrap_or(Value::Null))
+        }
+    }
 }
 
 async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7805,6 +7805,107 @@ fn build_role_selector(role: &str, name: Option<&str>, exact: bool) -> String {
     }
 }
 
+/// role="none" and role="presentation" (ARIA synonyms) exist to strip an
+/// element's semantics, so Chrome prunes such elements from the AX tree
+/// entirely (divs, lists, imgs) or keeps them only as ignored nodes
+/// (tables). The accessibility tree can never answer a query for them.
+fn is_presentational_role(role: &str) -> bool {
+    role.eq_ignore_ascii_case("none") || role.eq_ignore_ascii_case("presentation")
+}
+
+/// Match presentational roles against the explicit `role` attribute in the
+/// DOM, the only place the author's intent survives (see
+/// `is_presentational_role`). Matching is literal per synonym — a query
+/// for "none" only matches role="none" — mirroring both the old CSS path
+/// and Playwright's literal role comparison. Name matching mirrors the AX
+/// path: non-exact is a case-insensitive substring check against
+/// aria-label or textContent, exact is case-sensitive after trimming.
+async fn handle_presentational_getbyrole(
+    cmd: &Value,
+    state: &mut DaemonState,
+    role: &str,
+    name: Option<&str>,
+    exact: bool,
+) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let name_check = match name {
+        Some(n) => {
+            let name_json = serde_json::to_string(n).unwrap_or_default();
+            if exact {
+                format!(
+                    "const target = {name_json};
+                    if ((el.getAttribute('aria-label') || '').trim() !== target.trim()
+                        && (el.textContent || '').trim() !== target.trim()) continue;"
+                )
+            } else {
+                format!(
+                    "const target = {name_json}.toLowerCase();
+                    if (!(el.getAttribute('aria-label') || '').toLowerCase().includes(target)
+                        && !(el.textContent || '').toLowerCase().includes(target)) continue;"
+                )
+            }
+        }
+        None => String::new(),
+    };
+
+    let role_json = serde_json::to_string(&role.to_ascii_lowercase()).unwrap_or_default();
+    let query = format!(
+        r#"(() => {{
+            const role = {role_json};
+            for (const el of document.querySelectorAll('[role]')) {{
+                const tokens = (el.getAttribute('role') || '').trim().toLowerCase().split(/\s+/);
+                if (!tokens.includes(role)) continue;
+                {name_check}
+                el.setAttribute('data-agent-browser-located', 'true');
+                return true;
+            }}
+            return false;
+        }})()"#
+    );
+
+    let result: super::cdp::types::EvaluateResult = mgr
+        .client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &super::cdp::types::EvaluateParams {
+                expression: query,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(&session_id),
+        )
+        .await?;
+
+    if !result
+        .result
+        .value
+        .as_ref()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Err(format!(
+            "No element found: {}",
+            build_role_selector(role, name, exact)
+        ));
+    }
+
+    let selector = "[data-agent-browser-located='true']";
+    let action_result = execute_subaction(cmd, state, selector).await;
+
+    if let Some(ref browser) = state.browser {
+        let _ = browser
+            .evaluate(
+                "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
+                None,
+            )
+            .await;
+    }
+
+    action_result
+}
+
 async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
@@ -7814,6 +7915,12 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         .ok_or("Missing 'role' parameter")?;
     let name = cmd.get("name").and_then(|v| v.as_str());
     let exact = cmd.get("exact").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    // Presentational roles never appear in the AX tree (their whole point
+    // is removal from it), so they get a syntactic DOM match instead.
+    if is_presentational_role(role) {
+        return handle_presentational_getbyrole(cmd, state, role, name, exact).await;
+    }
 
     // Query the accessibility tree via CDP: the browser engine is the
     // authoritative source for implicit roles (e.g. <h2> -> "heading",
@@ -10656,6 +10763,66 @@ mod tests {
             .expect_err("no node has this role at all");
         assert!(err.contains("getByRole('heading'"));
         assert!(err.contains("Nope"));
+    }
+
+    #[test]
+    fn presentational_roles_are_detected_case_insensitively() {
+        assert!(is_presentational_role("none"));
+        assert!(is_presentational_role("presentation"));
+        assert!(is_presentational_role("None"));
+        assert!(is_presentational_role("PRESENTATION"));
+        assert!(!is_presentational_role("heading"));
+        assert!(!is_presentational_role("generic"));
+    }
+
+    /// Chrome prunes role="none"/"presentation" elements from the AX tree
+    /// (divs, uls, imgs vanish; tables survive only as ignored nodes), so
+    /// these queries must resolve through the DOM-attribute fallback, not
+    /// `find_ax_node_by_role`. Regression test for the review finding on
+    /// #1552: the AX rewrite broke `find role none` / `find role
+    /// presentation`, which the old CSS path matched.
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_presentational_roles_resolve_through_dom_fallback() {
+        let mut state = DaemonState::new();
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert!(resp.get("success").and_then(|v| v.as_bool()) == Some(true));
+
+        let resp = execute_command(
+            &json!({
+                "id": "2",
+                "action": "navigate",
+                "url": "data:text/html,<div role='none'>alpha</div><div role='presentation'>beta</div><h2>gamma</h2>"
+            }),
+            &mut state,
+        )
+        .await;
+        assert!(resp.get("success").and_then(|v| v.as_bool()) == Some(true));
+
+        for (role, expected) in [("none", "alpha"), ("presentation", "beta"), ("heading", "gamma")]
+        {
+            let resp = execute_command(
+                &json!({ "id": "3", "action": "getbyrole", "role": role, "subaction": "text" }),
+                &mut state,
+            )
+            .await;
+            assert!(
+                resp.get("success").and_then(|v| v.as_bool()) == Some(true),
+                "find role {role} text must succeed: {resp}"
+            );
+            let text = resp
+                .get("data")
+                .and_then(|d| d.get("text"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+            assert_eq!(text, expected, "find role {role} text");
+        }
+
+        let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     }
 
     async fn start_webdriver_response_server(

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7868,10 +7868,20 @@ async fn handle_presentational_getbyrole(
                 return el.textContent || '';
             }};
             const role = {role_json};
+            const isPresentational = role === 'none' || role === 'presentation';
+            // Global ARIA states/properties (WAI-ARIA 1.2); their presence, not any
+            // aria-* attribute, triggers presentational-roles conflict resolution.
+            const GLOBAL_ARIA = new Set(['aria-atomic','aria-busy','aria-controls','aria-current','aria-describedby','aria-description','aria-details','aria-disabled','aria-dropeffect','aria-errormessage','aria-flowto','aria-grabbed','aria-haspopup','aria-hidden','aria-invalid','aria-keyshortcuts','aria-label','aria-labelledby','aria-live','aria-owns','aria-relevant','aria-roledescription']);
+            const isFocusable = el => el.tabIndex >= 0 || el.hasAttribute('tabindex');
             for (const el of root.querySelectorAll('[role]')) {{
                 const tokens = (el.getAttribute('role') || '').trim().toLowerCase().split(/\s+/);
                 const operative = tokens.find(t => VALID_ROLES.has(t));
                 if (operative !== role) continue;
+                // ARIA presentational-roles conflict resolution: none/presentation
+                // is ignored on a focusable element or one carrying global ARIA
+                // states/properties, so it keeps its implicit role and must not
+                // answer a query for none/presentation.
+                if (isPresentational && (isFocusable(el) || el.getAttributeNames().some(a => GLOBAL_ARIA.has(a)))) continue;
                 {name_check}
                 el.setAttribute('data-agent-browser-located', 'true');
                 return true;
@@ -8034,14 +8044,16 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     result
 }
 
-/// Map a Chrome AX tree role to its ARIA name. The only divergence is `image`,
-/// which ARIA and Playwright call `img`; queries pass through the same table so
-/// both spellings match. `directory` is not mapped here (Chrome collapses it
-/// into `list`); it is matched on the DOM attribute instead, see handle_getbyrole.
+/// Map a Chrome AX tree role to its ARIA name. Divergences: `image` -> `img`
+/// and `RootWebArea` -> `document` (Chrome's names for what ARIA/Playwright call
+/// `img` and `document`); queries pass through the same table so both spellings
+/// match. `directory` is not mapped here (Chrome collapses it into `list`); it is
+/// matched on the DOM attribute instead, see handle_getbyrole.
 fn normalize_ax_role(role: &str) -> String {
     let lower = role.to_ascii_lowercase();
     match lower.as_str() {
         "image" => "img".to_string(),
+        "rootwebarea" => "document".to_string(),
         _ => lower,
     }
 }
@@ -8067,7 +8079,11 @@ fn find_ax_node_by_role(
     exact: bool,
 ) -> Result<(i64, String), String> {
     let mut matched_without_backend_id = false;
+    // `names_seen` keeps first-seen order for the error message; `names_set` makes
+    // the dedup check O(1) so a failed name query is linear, not quadratic, in the
+    // number of role matches.
     let mut names_seen: Vec<String> = Vec::new();
+    let mut names_set: HashSet<String> = HashSet::new();
     let mut role_match_count: usize = 0;
     let target_role = normalize_ax_role(role);
 
@@ -8093,7 +8109,7 @@ fn find_ax_node_by_role(
         if !matches {
             if name.is_some() {
                 role_match_count += 1;
-                if !names_seen.contains(&node_name) {
+                if names_set.insert(node_name.clone()) {
                     names_seen.push(node_name);
                 }
             }
@@ -10716,6 +10732,15 @@ mod tests {
             backend_d_o_m_node_id: backend_node_id,
             ignored: Some(ignored),
         }
+    }
+
+    #[test]
+    fn normalize_ax_role_maps_rootwebarea_to_document() {
+        // Chrome's AX root is `RootWebArea`; ARIA and Playwright call it
+        // `document`. Force-red: drop the mapping and `find role document` misses
+        // the root. `image` is pre-existing and covered elsewhere.
+        assert_eq!(normalize_ax_role("RootWebArea"), "document");
+        assert_eq!(normalize_ax_role("document"), "document");
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7815,11 +7815,15 @@ fn is_presentational_role(role: &str) -> bool {
 
 /// Match presentational roles against the explicit `role` attribute in the
 /// DOM, the only place the author's intent survives (see
-/// `is_presentational_role`). Matching is literal per synonym — a query
-/// for "none" only matches role="none" — mirroring both the old CSS path
-/// and Playwright's literal role comparison. Name matching mirrors the AX
-/// path: non-exact is a case-insensitive substring check against
-/// aria-label or textContent, exact is case-sensitive after trimming.
+/// `is_presentational_role`). ARIA treats the role attribute as an ordered
+/// fallback list whose first supported token is the operative role, so
+/// `role="button none"` is a button and must not answer a query for "none",
+/// while `role="none button"` must. Matching is literal per synonym: a query
+/// for "none" only matches an operative "none", mirroring Playwright's
+/// literal role comparison. Name matching approximates accessible-name
+/// precedence (aria-labelledby, then aria-label, then text content) with
+/// whitespace normalized; non-exact is a case-insensitive substring check,
+/// exact is a case-sensitive whole-name comparison.
 async fn handle_presentational_getbyrole(
     cmd: &Value,
     state: &mut DaemonState,
@@ -7834,16 +7838,10 @@ async fn handle_presentational_getbyrole(
         Some(n) => {
             let name_json = serde_json::to_string(n).unwrap_or_default();
             if exact {
-                format!(
-                    "const target = {name_json};
-                    if ((el.getAttribute('aria-label') || '').trim() !== target.trim()
-                        && (el.textContent || '').trim() !== target.trim()) continue;"
-                )
+                format!("if (norm(nameOf(el)) !== norm({name_json})) continue;")
             } else {
                 format!(
-                    "const target = {name_json}.toLowerCase();
-                    if (!(el.getAttribute('aria-label') || '').toLowerCase().includes(target)
-                        && !(el.textContent || '').toLowerCase().includes(target)) continue;"
+                    "if (!norm(nameOf(el)).toLowerCase().includes(norm({name_json}).toLowerCase())) continue;"
                 )
             }
         }
@@ -7853,10 +7851,25 @@ async fn handle_presentational_getbyrole(
     let role_json = serde_json::to_string(&role.to_ascii_lowercase()).unwrap_or_default();
     let query = format!(
         r#"(() => {{
+            const VALID_ROLES = new Set(['alert','alertdialog','application','article','banner','blockquote','button','caption','cell','checkbox','code','columnheader','combobox','complementary','contentinfo','definition','deletion','dialog','directory','document','emphasis','feed','figure','form','generic','grid','gridcell','group','heading','img','insertion','link','list','listbox','listitem','log','main','marquee','math','meter','menu','menubar','menuitem','menuitemcheckbox','menuitemradio','navigation','none','note','option','paragraph','presentation','progressbar','radio','radiogroup','region','row','rowgroup','rowheader','scrollbar','search','searchbox','separator','slider','spinbutton','status','strong','subscript','superscript','switch','tab','table','tablist','tabpanel','term','textbox','time','timer','toolbar','tooltip','tree','treegrid','treeitem']);
+            const norm = s => (s || '').replace(/\s+/g, ' ').trim();
+            const nameOf = el => {{
+                const lb = el.getAttribute('aria-labelledby');
+                if (lb) {{
+                    const t = lb.trim().split(/\s+/)
+                        .map(id => {{ const r = document.getElementById(id); return r ? r.textContent : ''; }})
+                        .join(' ');
+                    if (norm(t)) return t;
+                }}
+                const al = el.getAttribute('aria-label');
+                if (al !== null && norm(al)) return al;
+                return el.textContent || '';
+            }};
             const role = {role_json};
             for (const el of document.querySelectorAll('[role]')) {{
                 const tokens = (el.getAttribute('role') || '').trim().toLowerCase().split(/\s+/);
-                if (!tokens.includes(role)) continue;
+                const operative = tokens.find(t => VALID_ROLES.has(t));
+                if (operative !== role) continue;
                 {name_check}
                 el.setAttribute('data-agent-browser-located', 'true');
                 return true;
@@ -7959,11 +7972,32 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     result
 }
 
+/// Map a Chrome AX tree role to its public ARIA role name. The AX tree
+/// mostly uses ARIA names already; the known divergence is `image`, which
+/// ARIA (and Playwright) call `img`. Queries are normalized through the
+/// same table, so both spellings match either way.
+fn normalize_ax_role(role: &str) -> String {
+    let lower = role.to_ascii_lowercase();
+    match lower.as_str() {
+        "image" => "img".to_string(),
+        _ => lower,
+    }
+}
+
+/// Collapse internal whitespace runs to single spaces and trim, mirroring
+/// Playwright's accessible-name normalization: `"Save   changes"` and
+/// `"Save changes"` are the same accessible name.
+fn normalize_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// Match a role and (optional) accessible name against the AX tree, mirroring
-/// Playwright's getByRole semantics: non-exact name matching is a
-/// case-insensitive substring check, exact matching is case-sensitive after
-/// trimming. Continues past AX nodes without a backendDOMNodeId (virtual
-/// nodes) so a later actionable match still wins.
+/// Playwright's getByRole semantics: role values are compared case-insensitively
+/// after AX-to-ARIA normalization; accessible names are whitespace-normalized on
+/// both sides, then non-exact matching is a case-insensitive substring check and
+/// exact matching is a case-sensitive whole-name comparison. Continues past AX
+/// nodes without a backendDOMNodeId (virtual nodes) so a later actionable match
+/// still wins.
 fn find_ax_node_by_role(
     nodes: &[super::cdp::types::AXNode],
     role: &str,
@@ -7973,6 +8007,7 @@ fn find_ax_node_by_role(
     let mut matched_without_backend_id = false;
     let mut names_seen: Vec<String> = Vec::new();
     let mut role_match_count: usize = 0;
+    let target_role = normalize_ax_role(role);
 
     for node in nodes {
         if node.ignored.unwrap_or(false) {
@@ -7980,16 +8015,16 @@ fn find_ax_node_by_role(
         }
 
         let node_role = super::element::extract_ax_string(&node.role);
-        if !node_role.eq_ignore_ascii_case(role) {
+        if normalize_ax_role(&node_role) != target_role {
             continue;
         }
 
         let node_name = super::element::extract_ax_string(&node.name);
         let matches = match name {
-            Some(target_name) if exact => node_name.trim() == target_name.trim(),
-            Some(target_name) => node_name
+            Some(target_name) if exact => normalize_ws(&node_name) == normalize_ws(target_name),
+            Some(target_name) => normalize_ws(&node_name)
                 .to_lowercase()
-                .contains(&target_name.to_lowercase()),
+                .contains(&normalize_ws(target_name).to_lowercase()),
             None => true,
         };
 
@@ -10676,6 +10711,36 @@ mod tests {
         assert_eq!(backend_id, 43);
     }
 
+    /// Chrome's AX tree reports `<img>` as role "image" while ARIA (and
+    /// Playwright queries) call it "img"; both spellings must find the node.
+    #[test]
+    fn find_ax_node_by_role_normalizes_ax_role_synonyms() {
+        let nodes = vec![ax_node("image", "Logo", Some(51), false)];
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "img", Some("Logo"), false)
+            .expect("the ARIA role name must match Chrome's AX role");
+        assert_eq!(backend_id, 51);
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "image", Some("Logo"), false)
+            .expect("the AX spelling keeps matching after normalization");
+        assert_eq!(backend_id, 51);
+    }
+
+    /// Accessible names are whitespace-normalized on both sides, so a name
+    /// rendered with a collapsed run of spaces still matches exactly.
+    #[test]
+    fn find_ax_node_by_role_normalizes_whitespace_in_names() {
+        let nodes = vec![ax_node("button", "Save   changes", Some(52), false)];
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "button", Some("Save changes"), true)
+            .expect("exact matching must normalize internal whitespace");
+        assert_eq!(backend_id, 52);
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "button", Some("save  changes"), false)
+            .expect("substring matching must normalize internal whitespace");
+        assert_eq!(backend_id, 52);
+    }
+
     #[test]
     fn find_ax_node_by_role_supports_substring_matching() {
         let nodes = vec![ax_node("button", "Submit form", Some(7), false)];
@@ -10742,7 +10807,7 @@ mod tests {
 
         let err = find_ax_node_by_role(&nodes, "heading", Some("Nope"), false)
             .expect_err("no node should match an unrelated name");
-        // 3 elements share the same name, so names_seen dedupes to 1 entry --
+        // 3 elements share the same name, so names_seen dedupes to 1 entry;
         // the element count must still say 3, not 1.
         assert!(
             err.contains("3 elements have role \"heading\""),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -18,8 +18,9 @@ use super::cdp::chrome::LaunchOptions;
 use super::cdp::client::CdpClient;
 use super::cdp::types::{
     AttachToTargetParams, AttachToTargetResult, CdpEvent, CreateTargetResult,
-    DispatchMouseEventParams, ExceptionThrownEvent, JavascriptDialogOpeningEvent,
-    TargetCreatedEvent, TargetDestroyedEvent, TargetInfo, TargetInfoChangedEvent,
+    DispatchMouseEventParams, ExceptionThrownEvent, GetFullAXTreeResult,
+    JavascriptDialogOpeningEvent, TargetCreatedEvent, TargetDestroyedEvent, TargetInfo,
+    TargetInfoChangedEvent,
 };
 use super::cookies;
 use super::diff;
@@ -7814,78 +7815,98 @@ async fn handle_getbyrole(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     let name = cmd.get("name").and_then(|v| v.as_str());
     let exact = cmd.get("exact").and_then(|v| v.as_bool()).unwrap_or(false);
 
-    let name_match = name
-        .map(|n| {
-            if exact {
-                format!(
-                    "el.getAttribute('aria-label') === {} || el.textContent.trim() === {}",
-                    serde_json::to_string(n).unwrap_or_default(),
-                    serde_json::to_string(n).unwrap_or_default()
-                )
-            } else {
-                format!(
-                    "(el.getAttribute('aria-label') || '').includes({n}) || el.textContent.includes({n})",
-                    n = serde_json::to_string(n).unwrap_or_default()
-                )
-            }
-        })
-        .unwrap_or_else(|| "true".to_string());
-
-    let js = format!(
-        r#"(() => {{
-            const els = document.querySelectorAll('[role="{role}"], {role}');
-            for (const el of els) {{
-                if ({name_match}) {{
-                    el.setAttribute('data-agent-browser-located', 'true');
-                    return true;
-                }}
-            }}
-            return false;
-        }})()"#,
-        role = role,
-        name_match = name_match,
+    // Query the accessibility tree via CDP: the browser engine is the
+    // authoritative source for implicit roles (e.g. <h2> -> "heading",
+    // <a href> -> "link"), which a CSS selector cannot approximate.
+    let (ax_params, effective_session_id) = super::element::resolve_ax_session(
+        state.active_frame_id.as_deref(),
+        &session_id,
+        &state.iframe_sessions,
     );
 
-    let result: super::cdp::types::EvaluateResult = mgr
+    let ax_tree: GetFullAXTreeResult = mgr
         .client
         .send_command_typed(
-            "Runtime.evaluate",
-            &super::cdp::types::EvaluateParams {
-                expression: js,
-                return_by_value: Some(true),
-                await_promise: Some(false),
-            },
-            Some(&session_id),
+            "Accessibility.getFullAXTree",
+            &ax_params,
+            Some(effective_session_id),
         )
         .await?;
 
-    if !result
-        .result
-        .value
-        .as_ref()
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        let desc = build_role_selector(role, name, exact);
-        return Err(format!("No element found: {}", desc));
-    }
+    let (backend_node_id, actual_name) = find_ax_node_by_role(&ax_tree.nodes, role, name, exact)?;
 
-    let selector = "[data-agent-browser-located='true']";
-    let result = execute_subaction(cmd, state, selector).await;
+    let ref_num = state.ref_map.next_ref_num();
+    let temp_ref = format!("e{}", ref_num);
+    state.ref_map.add_with_frame(
+        temp_ref.clone(),
+        Some(backend_node_id),
+        role,
+        &actual_name,
+        None,
+        state.active_frame_id.as_deref(),
+    );
+    state.ref_map.set_next_ref_num(ref_num + 1);
 
-    // Clean up the marker attribute
-    if let Some(ref browser) = state.browser {
-        if browser.active_session_id().is_ok() {
-            let _ = browser
-                .evaluate(
-                    "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
-                    None,
-                )
-                .await;
-        }
-    }
-
+    let result = execute_subaction(cmd, state, &format!("@{}", temp_ref)).await;
+    state.ref_map.remove(&temp_ref);
     result
+}
+
+/// Match a role and (optional) accessible name against the AX tree, mirroring
+/// Playwright's getByRole semantics: non-exact name matching is a
+/// case-insensitive substring check, exact matching is case-sensitive after
+/// trimming. Continues past AX nodes without a backendDOMNodeId (virtual
+/// nodes) so a later actionable match still wins.
+fn find_ax_node_by_role(
+    nodes: &[super::cdp::types::AXNode],
+    role: &str,
+    name: Option<&str>,
+    exact: bool,
+) -> Result<(i64, String), String> {
+    let mut matched_without_backend_id = false;
+
+    for node in nodes {
+        if node.ignored.unwrap_or(false) {
+            continue;
+        }
+
+        let node_role = super::element::extract_ax_string(&node.role);
+        if node_role != role {
+            continue;
+        }
+
+        let node_name = super::element::extract_ax_string(&node.name);
+        let matches = match name {
+            Some(target_name) if exact => node_name.trim() == target_name.trim(),
+            Some(target_name) => node_name
+                .to_lowercase()
+                .contains(&target_name.to_lowercase()),
+            None => true,
+        };
+
+        if !matches {
+            continue;
+        }
+
+        if let Some(id) = node.backend_d_o_m_node_id {
+            return Ok((id, node_name));
+        }
+
+        matched_without_backend_id = true;
+    }
+
+    if matched_without_backend_id {
+        return Err(match name {
+            Some(target_name) => format!(
+                "AX node has no backendDOMNodeId for role={} name={}",
+                role, target_name
+            ),
+            None => format!("AX node has no backendDOMNodeId for role={}", role),
+        });
+    }
+
+    let desc = build_role_selector(role, name, exact);
+    Err(format!("No element found: {}", desc))
 }
 
 async fn handle_semantic_locator(
@@ -10425,11 +10446,130 @@ fn error_response(id: &str, error: &str) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use super::super::cdp::types::{AXNode, AXValue};
     use super::*;
     use crate::test_utils::EnvGuard;
     use std::fs;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    fn ax_value(value: &str) -> AXValue {
+        AXValue {
+            value_type: "string".to_string(),
+            value: Some(Value::String(value.to_string())),
+        }
+    }
+
+    fn ax_node(role: &str, name: &str, backend_node_id: Option<i64>, ignored: bool) -> AXNode {
+        AXNode {
+            node_id: format!("node-{}", name),
+            role: Some(ax_value(role)),
+            name: Some(ax_value(name)),
+            value: None,
+            description: None,
+            properties: None,
+            child_ids: None,
+            backend_d_o_m_node_id: backend_node_id,
+            ignored: Some(ignored),
+        }
+    }
+
+    #[test]
+    fn find_ax_node_by_role_matches_browser_computed_implicit_roles() {
+        let nodes = vec![
+            ax_node("RootWebArea", "Fixture", Some(1), false),
+            ax_node("link", "Services", Some(42), false),
+            ax_node("heading", "Skills", Some(43), false),
+        ];
+
+        let (backend_id, actual_name) =
+            find_ax_node_by_role(&nodes, "link", Some("Services"), true)
+                .expect("computed AX link role should match the anchor");
+        assert_eq!(backend_id, 42);
+        assert_eq!(actual_name, "Services");
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "heading", None, false)
+            .expect("role-only lookup should match the implicit heading");
+        assert_eq!(backend_id, 43);
+    }
+
+    #[test]
+    fn find_ax_node_by_role_non_exact_name_is_case_insensitive() {
+        let nodes = vec![ax_node("heading", "SKILLS", Some(43), false)];
+
+        for query in ["Skills", "skills", "SKILLS", "kill"] {
+            let (backend_id, actual_name) =
+                find_ax_node_by_role(&nodes, "heading", Some(query), false).unwrap_or_else(|e| {
+                    panic!("expected case-insensitive match for {query:?}: {e}")
+                });
+            assert_eq!(backend_id, 43);
+            assert_eq!(actual_name, "SKILLS");
+        }
+    }
+
+    #[test]
+    fn find_ax_node_by_role_exact_name_stays_case_sensitive() {
+        let nodes = vec![ax_node("heading", "SKILLS", Some(43), false)];
+
+        let err = find_ax_node_by_role(&nodes, "heading", Some("Skills"), true)
+            .expect_err("exact matching must not ignore case");
+        assert!(err.contains("getByRole('heading'"));
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "heading", Some("SKILLS"), true)
+            .expect("exact match with identical case should still succeed");
+        assert_eq!(backend_id, 43);
+    }
+
+    #[test]
+    fn find_ax_node_by_role_supports_substring_matching() {
+        let nodes = vec![ax_node("button", "Submit form", Some(7), false)];
+
+        let (backend_id, actual_name) =
+            find_ax_node_by_role(&nodes, "button", Some("submit"), false)
+                .expect("substring matching should be allowed without exact");
+        assert_eq!(backend_id, 7);
+        assert_eq!(actual_name, "Submit form");
+
+        let err = find_ax_node_by_role(&nodes, "button", Some("Submit"), true)
+            .expect_err("exact matching should reject partial names");
+        assert!(err.contains("getByRole('button'"));
+    }
+
+    #[test]
+    fn find_ax_node_by_role_skips_ignored_nodes_and_requires_backend_id() {
+        let nodes = vec![
+            ax_node("link", "Services", Some(1), true),
+            ax_node("link", "Services", None, false),
+        ];
+
+        let err = find_ax_node_by_role(&nodes, "link", Some("Services"), true)
+            .expect_err("matching AX nodes must have a backend DOM node id");
+        assert!(err.contains("backendDOMNodeId"));
+    }
+
+    #[test]
+    fn find_ax_node_by_role_uses_later_actionable_match() {
+        let nodes = vec![
+            ax_node("link", "Services", None, false),
+            ax_node("link", "Services", Some(42), false),
+        ];
+
+        let (backend_id, actual_name) =
+            find_ax_node_by_role(&nodes, "link", Some("Services"), true)
+                .expect("lookup should continue past matching virtual AX nodes");
+        assert_eq!(backend_id, 42);
+        assert_eq!(actual_name, "Services");
+    }
+
+    #[test]
+    fn find_ax_node_by_role_no_match_reports_role_selector() {
+        let nodes = vec![ax_node("heading", "Skills", Some(43), false)];
+
+        let err = find_ax_node_by_role(&nodes, "heading", Some("Nope"), false)
+            .expect_err("no node should match an unrelated name");
+        assert!(err.contains("getByRole('heading'"));
+        assert!(err.contains("Nope"));
+    }
 
     async fn start_webdriver_response_server(
         responses: Vec<(&'static str, Value)>,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7864,6 +7864,7 @@ fn find_ax_node_by_role(
     exact: bool,
 ) -> Result<(i64, String), String> {
     let mut matched_without_backend_id = false;
+    let mut names_seen: Vec<String> = Vec::new();
 
     for node in nodes {
         if node.ignored.unwrap_or(false) {
@@ -7871,7 +7872,7 @@ fn find_ax_node_by_role(
         }
 
         let node_role = super::element::extract_ax_string(&node.role);
-        if node_role != role {
+        if !node_role.eq_ignore_ascii_case(role) {
             continue;
         }
 
@@ -7885,6 +7886,9 @@ fn find_ax_node_by_role(
         };
 
         if !matches {
+            if name.is_some() && !names_seen.contains(&node_name) {
+                names_seen.push(node_name);
+            }
             continue;
         }
 
@@ -7898,11 +7902,43 @@ fn find_ax_node_by_role(
     if matched_without_backend_id {
         return Err(match name {
             Some(target_name) => format!(
-                "AX node has no backendDOMNodeId for role={} name={}",
+                "Found role \"{}\" matching name \"{}\" in the accessibility tree, but it has no live DOM element to act on.",
                 role, target_name
             ),
-            None => format!("AX node has no backendDOMNodeId for role={}", role),
+            None => format!(
+                "Found role \"{}\" in the accessibility tree, but it has no live DOM element to act on.",
+                role
+            ),
         });
+    }
+
+    // A role match with no name match is more actionable than a blanket
+    // "not found": show what the query actually saw, so an agent can fix a
+    // typo'd name without a blind retry.
+    if let Some(target_name) = name {
+        if !names_seen.is_empty() {
+            let shown: Vec<String> = names_seen
+                .iter()
+                .take(5)
+                .map(|n| format!("\"{}\"", n))
+                .collect();
+            let more = if names_seen.len() > 5 { ", ..." } else { "" };
+            let (plural, verb) = if names_seen.len() == 1 {
+                ("", "has")
+            } else {
+                ("s", "have")
+            };
+            return Err(format!(
+                "{count} element{plural} {verb} role \"{role}\", but none match name \"{target_name}\". Names seen: {shown}{more}",
+                count = names_seen.len(),
+                plural = plural,
+                verb = verb,
+                role = role,
+                target_name = target_name,
+                shown = shown.join(", "),
+                more = more,
+            ));
+        }
     }
 
     let desc = build_role_selector(role, name, exact);
@@ -10513,10 +10549,19 @@ mod tests {
 
         let err = find_ax_node_by_role(&nodes, "heading", Some("Skills"), true)
             .expect_err("exact matching must not ignore case");
-        assert!(err.contains("getByRole('heading'"));
+        assert!(err.contains("Names seen: \"SKILLS\""));
 
         let (backend_id, _) = find_ax_node_by_role(&nodes, "heading", Some("SKILLS"), true)
             .expect("exact match with identical case should still succeed");
+        assert_eq!(backend_id, 43);
+    }
+
+    #[test]
+    fn find_ax_node_by_role_matches_role_case_insensitively() {
+        let nodes = vec![ax_node("heading", "Skills", Some(43), false)];
+
+        let (backend_id, _) = find_ax_node_by_role(&nodes, "Heading", None, false)
+            .expect("role matching should ignore case, same as name matching");
         assert_eq!(backend_id, 43);
     }
 
@@ -10532,7 +10577,7 @@ mod tests {
 
         let err = find_ax_node_by_role(&nodes, "button", Some("Submit"), true)
             .expect_err("exact matching should reject partial names");
-        assert!(err.contains("getByRole('button'"));
+        assert!(err.contains("Names seen: \"Submit form\""));
     }
 
     #[test]
@@ -10544,7 +10589,7 @@ mod tests {
 
         let err = find_ax_node_by_role(&nodes, "link", Some("Services"), true)
             .expect_err("matching AX nodes must have a backend DOM node id");
-        assert!(err.contains("backendDOMNodeId"));
+        assert!(err.contains("no live DOM element"));
     }
 
     #[test]
@@ -10562,11 +10607,26 @@ mod tests {
     }
 
     #[test]
-    fn find_ax_node_by_role_no_match_reports_role_selector() {
-        let nodes = vec![ax_node("heading", "Skills", Some(43), false)];
+    fn find_ax_node_by_role_name_miss_lists_names_seen() {
+        let nodes = vec![
+            ax_node("heading", "Skills", Some(43), false),
+            ax_node("heading", "Experience", Some(44), false),
+        ];
 
         let err = find_ax_node_by_role(&nodes, "heading", Some("Nope"), false)
             .expect_err("no node should match an unrelated name");
+        assert!(err.contains("2 elements have role \"heading\""));
+        assert!(err.contains("Nope"));
+        assert!(err.contains("\"Skills\""));
+        assert!(err.contains("\"Experience\""));
+    }
+
+    #[test]
+    fn find_ax_node_by_role_no_role_match_reports_role_selector() {
+        let nodes = vec![ax_node("button", "Submit", Some(7), false)];
+
+        let err = find_ax_node_by_role(&nodes, "heading", Some("Nope"), false)
+            .expect_err("no node has this role at all");
         assert!(err.contains("getByRole('heading'"));
         assert!(err.contains("Nope"));
     }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10803,8 +10803,11 @@ mod tests {
         .await;
         assert!(resp.get("success").and_then(|v| v.as_bool()) == Some(true));
 
-        for (role, expected) in [("none", "alpha"), ("presentation", "beta"), ("heading", "gamma")]
-        {
+        for (role, expected) in [
+            ("none", "alpha"),
+            ("presentation", "beta"),
+            ("heading", "gamma"),
+        ] {
             let resp = execute_command(
                 &json!({ "id": "3", "action": "getbyrole", "role": role, "subaction": "text" }),
                 &mut state,

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7326,3 +7326,90 @@ async fn e2e_presentational_role_honors_selected_frame() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+/// ARIA presentational-roles conflict resolution: role="none" on a focusable
+/// element (or one with global ARIA props) is ignored, so `find role none` must
+/// skip it but still match a truly presentational element. Force-red: drop the
+/// conflict check and the `<button role="none">` is matched.
+#[tokio::test]
+#[ignore]
+async fn e2e_presentational_role_respects_conflict_resolution() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Each non-matching element triggers conflict resolution a different way:
+    // native focusable, explicit tabindex=-1 (programmatically focusable), and a
+    // global ARIA property. Only the last, truly presentational div must match.
+    let html = concat!(
+        "<body>",
+        "<button role='none'>NativeFocusable</button>",
+        "<div role='none' tabindex='-1'>TabindexFocusable</div>",
+        "<div role='none' aria-label='named'>GlobalAria</div>",
+        "<div role='none'>Plain</div>",
+        "</body>"
+    );
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The focusable button keeps its implicit role, so the match must be the div.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbyrole", "role": "none", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["text"],
+        "Plain",
+        "role=none on a focusable button must be ignored (conflict resolution)"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+/// `find role document` must match the page root. Chrome exposes it as
+/// `RootWebArea`; without the normalization to `document` the query misses.
+/// End-to-end guard for that mapping (the unit test only checks the string).
+#[tokio::test]
+#[ignore]
+async fn e2e_find_role_document_matches_root() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode("<title>T</title><body>hi</body>")
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbyrole", "role": "document", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7170,3 +7170,101 @@ async fn e2e_removeinitscript_roundtrip() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+/// An earlier valid ARIA token in a multi-token role attribute is the operative
+/// role, so `role="mark none"` is a mark and must not answer `find role none`.
+/// Force-red: drop `mark` from the presentational VALID_ROLES set and the query
+/// matches this element, so the miss assertion fails.
+#[tokio::test]
+#[ignore]
+async fn e2e_presentational_role_respects_earlier_operative_token() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let html = "<html><body><span role='mark none'>marked</span></body></html>";
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbyrole", "role": "none", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "operative role is `mark`, so `find role none` must not match: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+/// `find role directory` must match an explicit `role="directory"` element but
+/// not an ordinary list. Chrome collapses `directory` into the `list` AX role,
+/// so this goes through the DOM-attribute path, not the AX tree. Force-red:
+/// route `directory` back through the AX tree and the explicit element is missed
+/// (its AX role is `list`), so the found-text assertion fails.
+#[tokio::test]
+#[ignore]
+async fn e2e_find_role_directory_matches_only_explicit_attribute() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A plain list must not be matched by `find role directory`.
+    let plain = "data:text/html;base64,".to_string()
+        + &STANDARD.encode("<html><body><ul><li>item</li></ul></body></html>");
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": plain }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbyrole", "role": "directory", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "a plain <ul> must not match `find role directory`: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+
+    // An explicit role="directory" element is found.
+    let explicit = "data:text/html;base64,".to_string()
+        + &STANDARD.encode("<html><body><div role='directory'>DIR</div></body></html>");
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "navigate", "url": explicit }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "getbyrole", "role": "directory", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["text"], "DIR");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1557,6 +1557,81 @@ async fn e2e_element_queries() {
     assert_success(&resp);
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_getbyrole_uses_accessibility_tree_for_implicit_roles() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let html = concat!(
+        "<html><head>",
+        "<link rel='stylesheet' href='data:text/css,body{}'>",
+        "</head><body>",
+        "<h1 style='text-transform:uppercase'>Welcome</h1>",
+        "<a id='services' href='#services' onclick='window.__clicked = \"services\"'>Services</a>",
+        "<button id='submit'>Submit</button>",
+        "</body></html>"
+    );
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Implicit role from a plain HTML tag (<h1> -> heading), matched
+    // case-insensitively against the accessible name despite the CSS
+    // text-transform rendering it as "WELCOME".
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "getbyrole",
+            "role": "heading",
+            "name": "welcome",
+            "subaction": "text"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["text"], "WELCOME");
+
+    // A real <a href> must win over the unrelated <link rel="stylesheet">
+    // element, which is not exposed as an AX "link" node at all.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "getbyrole",
+            "role": "link",
+            "name": "Services",
+            "exact": true,
+            "subaction": "click"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "window.__clicked" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "services");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // Wait command
 // ---------------------------------------------------------------------------

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7268,3 +7268,61 @@ async fn e2e_find_role_directory_matches_only_explicit_attribute() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+/// The presentational DOM lookup must honor the selected frame, not always the
+/// top document. Force-red: revert the frame dispatch in the presentational path
+/// (search the top document only) and the in-frame element is missed.
+#[tokio::test]
+#[ignore]
+async fn e2e_presentational_role_honors_selected_frame() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Top document has no role="none"; the same-origin iframe does. `srcdoc`
+    // inherits the parent origin, so the child is same-origin (the path this fix
+    // targets) without needing a server; a `data:` child would be cross-origin.
+    let outer = "<body><iframe id='f' srcdoc=\"<div role='none'>INSIDE</div>\"></iframe></body>";
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(outer));
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Before selecting the frame, the top document has no match.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "getbyrole", "role": "none", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "top document has no role=none: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+
+    // Select the frame; the presentational lookup must now find the frame element.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "frame", "selector": "#f" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "getbyrole", "role": "none", "subaction": "text" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["text"], "INSIDE");
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2069,9 +2069,9 @@ Actions (default: click):
 
 Options:
   --name <name>        Filter role by accessible name
-  --exact              Exact, case-sensitive accessible-name match
-                       (default: substring, ignoring case; the role value
-                       itself always ignores case)
+  --exact              Exact, case-sensitive match. For role it applies to
+                       the accessible name, whose default is a case-insensitive
+                       substring. The role value itself always ignores case.
 
 Global Options:
   --json               Output as JSON

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2065,7 +2065,7 @@ Locators:
   nth <index> <selector>   Nth matching element (0-based)
 
 Actions (default: click):
-  click, fill, type, hover, focus, check, uncheck
+  click, fill, check, hover, text
 
 Options:
   --name <name>        Filter role by accessible name

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2069,7 +2069,8 @@ Actions (default: click):
 
 Options:
   --name <name>        Filter role by accessible name
-  --exact              Require exact text match
+  --exact              Exact, case-sensitive whole-string match
+                       (default: substring; role names also ignore case)
 
 Global Options:
   --json               Output as JSON

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2069,8 +2069,9 @@ Actions (default: click):
 
 Options:
   --name <name>        Filter role by accessible name
-  --exact              Exact, case-sensitive whole-string match
-                       (default: substring; role names also ignore case)
+  --exact              Exact, case-sensitive accessible-name match
+                       (default: substring, ignoring case; the role value
+                       itself always ignores case)
 
 Global Options:
   --json               Output as JSON

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -100,7 +100,7 @@ This enables control of:
     <tr><td><code>--proxy-bypass &lt;hosts&gt;</code></td><td>Hosts to bypass proxy</td></tr>
     <tr><td><code>--json</code></td><td>JSON output for scripts</td></tr>
     <tr><td><code>--name, -n</code></td><td>Locator name filter</td></tr>
-    <tr><td><code>--exact</code></td><td>Exact text match</td></tr>
+    <tr><td><code>--exact</code></td><td>Exact, case-sensitive match (accessible name for role)</td></tr>
     <tr><td><code>--headed</code></td><td>Show browser window</td></tr>
     <tr><td><code>{"--cdp <port|url>"}</code></td><td>CDP connection (port or WebSocket URL)</td></tr>
     <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to running Chrome</td></tr>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -104,7 +104,7 @@ agent-browser find nth <n> <sel> <action> [value]
 Options:
 
 - `--name <name>`: filter role by accessible name
-- `--exact`: exact accessible-name match, case-sensitive (without it, matching is a case-insensitive substring)
+- `--exact`: exact, case-sensitive match. For `role` it applies to the accessible name, whose default is a case-insensitive substring.
 
 Examples:
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -110,7 +110,7 @@ Examples:
 
 ```bash
 agent-browser find role button click --name "Submit"
-agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, top-level <header>=banner
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find alt "Logo" click
 agent-browser find first ".item" click

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -109,7 +109,8 @@ Options:
 Examples:
 
 ```bash
-agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
+agent-browser find role button click --name "Submit"
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find alt "Logo" click
 agent-browser find first ".item" click

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -86,7 +86,7 @@ agent-browser is checked <sel>        # Check if checked
 
 ## Find elements
 
-Semantic locators with actions (`click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`):
+Semantic locators with actions (`click`, `fill`, `check`, `hover`, `text`):
 
 ```bash
 agent-browser find role <role> <action> [value]

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -104,12 +104,12 @@ agent-browser find nth <n> <sel> <action> [value]
 Options:
 
 - `--name <name>`: filter role by accessible name
-- `--exact`: require exact text match
+- `--exact`: exact accessible-name match, case-sensitive (without it, matching is a case-insensitive substring)
 
 Examples:
 
 ```bash
-agent-browser find role button click --name "Submit"
+agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find alt "Logo" click
 agent-browser find first ".item" click

--- a/docs/src/app/selectors/page.mdx
+++ b/docs/src/app/selectors/page.mdx
@@ -47,7 +47,7 @@ agent-browser click "xpath=//button[@type='submit']"
 Find elements by role, label, or other semantic properties:
 
 ```bash
-agent-browser find role button click --name "Submit"
+agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find placeholder "Search..." fill "query"
 agent-browser find testid "submit-btn" click

--- a/docs/src/app/selectors/page.mdx
+++ b/docs/src/app/selectors/page.mdx
@@ -48,7 +48,7 @@ Find elements by role, label, or other semantic properties:
 
 ```bash
 agent-browser find role button click --name "Submit"
-agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, top-level <header>=banner
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find placeholder "Search..." fill "query"
 agent-browser find testid "submit-btn" click

--- a/docs/src/app/selectors/page.mdx
+++ b/docs/src/app/selectors/page.mdx
@@ -47,7 +47,8 @@ agent-browser click "xpath=//button[@type='submit']"
 Find elements by role, label, or other semantic properties:
 
 ```bash
-agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
+agent-browser find role button click --name "Submit"
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
 agent-browser find label "Email" fill "test@test.com"
 agent-browser find placeholder "Search..." fill "query"
 agent-browser find testid "submit-btn" click

--- a/packages/@agent-browser/eve/extension/tools/find.ts
+++ b/packages/@agent-browser/eve/extension/tools/find.ts
@@ -9,7 +9,12 @@ export default defineTool({
   inputSchema: z.object({
     action: z.enum(["click", "fill", "type", "hover", "focus", "check", "uncheck", "text"]),
     by: z.enum(["role", "text", "label", "placeholder", "alt", "title", "testid", "first", "last"]),
-    exact: z.boolean().default(false).describe("Require an exact text match."),
+    exact: z
+      .boolean()
+      .default(false)
+      .describe(
+        'Exact, case-sensitive match. For "role" it applies to the accessible name, whose default is a case-insensitive substring.',
+      ),
     name: z
       .string()
       .optional()

--- a/packages/@agent-browser/eve/extension/tools/find.ts
+++ b/packages/@agent-browser/eve/extension/tools/find.ts
@@ -7,7 +7,7 @@ export default defineTool({
   description:
     'Find an element semantically (by ARIA role, text, label, placeholder, alt text, title, or test id) and act on it in one step. Useful when you know what the element is without taking a snapshot, e.g. find the "Email" label and fill it.',
   inputSchema: z.object({
-    action: z.enum(["click", "fill", "type", "hover", "focus", "check", "uncheck", "text"]),
+    action: z.enum(["click", "fill", "check", "hover", "text"]),
     by: z.enum(["role", "text", "label", "placeholder", "alt", "title", "testid", "first", "last"]),
     exact: z
       .boolean()

--- a/packages/@agent-browser/eve/extension/tools/find.ts
+++ b/packages/@agent-browser/eve/extension/tools/find.ts
@@ -22,10 +22,10 @@ export default defineTool({
     query: z
       .string()
       .describe('What to match: the role name, text, label, etc. For "first"/"last", a CSS selector.'),
-    value: z.string().optional().describe('Text to enter for "fill" and "type" actions.'),
+    value: z.string().optional().describe('Text to enter for the "fill" action.'),
   }),
   async execute({ action, by, exact, name, query, value }, ctx) {
-    if ((action === "fill" || action === "type") && value === undefined) {
+    if (action === "fill" && value === undefined) {
       throw new Error(`The "${action}" action requires a value.`);
     }
     const args = ["find", by, query, action];

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -139,7 +139,7 @@ Use semantic locators:
 
 ```bash
 agent-browser find role button click --name "Submit"
-agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, top-level <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact     # exact match only
 agent-browser find label "Email" fill "user@test.com"

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -138,7 +138,7 @@ agent-browser drag @e1 @e2                # drag and drop
 Use semantic locators:
 
 ```bash
-agent-browser find role button click --name "Submit"
+agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact     # exact match only
 agent-browser find label "Email" fill "user@test.com"

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -138,7 +138,8 @@ agent-browser drag @e1 @e2                # drag and drop
 Use semantic locators:
 
 ```bash
-agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
+agent-browser find role button click --name "Submit"
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact     # exact match only
 agent-browser find label "Email" fill "user@test.com"

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -144,7 +144,7 @@ agent-browser mouse wheel 100         # Scroll wheel
 
 ```bash
 agent-browser find role button click --name "Submit"
-agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, top-level <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact      # Exact match only
 agent-browser find label "Email" fill "user@test.com"

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -143,7 +143,8 @@ agent-browser mouse wheel 100         # Scroll wheel
 ## Semantic Locators (alternative to refs)
 
 ```bash
-agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
+agent-browser find role button click --name "Submit"
+agent-browser find role heading text --name "Skills"     # implicit roles work: <h2>=heading, <ul>=list, <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact      # Exact match only
 agent-browser find label "Email" fill "user@test.com"

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -143,7 +143,7 @@ agent-browser mouse wheel 100         # Scroll wheel
 ## Semantic Locators (alternative to refs)
 
 ```bash
-agent-browser find role button click --name "Submit"
+agent-browser find role button click --name "Submit"     # also matches implicit roles: <h1>-<h6>=heading, <ul>/<ol>=list, <header>=banner
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact      # Exact match only
 agent-browser find label "Email" fill "user@test.com"


### PR DESCRIPTION
## Bug

`find role` misses implicit ARIA roles (`<h2>` for heading, `<ul>` for list, `<header>` for banner). `handle_getbyrole` resolves roles with a CSS selector (`[role="{role}"], {role}`), which only matches an explicit `role=` attribute or a tag name equal to the role. `--name` matches raw `textContent`, not the accessible name, and is case-sensitive.

This is a regression. #1145 fixed it with the CDP accessibility tree. #1153 merged the same day on a stale branch and reverted it back to the CSS-selector version. #1325 caught the regression. #1331 fixes it but has sat open since 2026-05-07.

## Fix

- Query `Accessibility.getFullAXTree` instead of a CSS selector, matching role and name against the browser's computed values. Replicates and extends @cooleryu's fix in #1331.
- Role and non-exact `--name` matching are case-insensitive. Exact stays case-sensitive.
- A role match with no name match lists the names seen instead of a blank "not found."
- A match with no live DOM node no longer names internal AX/CDP fields in the error.
- Matches the first actionable candidate instead of failing on multiple matches.

## Verification

- `cargo test`: 961/961, `clippy`, `fmt` green.
- Confirmed against real Chrome: heading/list/banner match, `<link rel=stylesheet>` vs `<a>` resolves correctly, case-insensitive role and name matching, names-seen error text.
- No regression on a large page, an iframe, shadow DOM, and a native `<select>`.
- The no-backendDOMNodeId fallback (inherited from #1331) stays unit-tested only. Tried 5 real cases (closed `<select>`/`<option>`, `<datalist>`, image-map `<area>`, customizable `<select>`); none reach it in current Chrome.

Fixes #1325.

Co-authored-by: cooleryu <cooleryu@users.noreply.github.com>

## Review updates

- `find role none` / `find role presentation` regressed: Chrome prunes presentational elements from the AX tree entirely (verified with a raw `getFullAXTree` dump), so no tree query can see them. They now resolve through a DOM-attribute fallback with the old CSS-path behavior, plus a real-Chrome e2e test.
- `--help` and the MCP schema now describe the real `--exact` semantics; the earlier docs pass only covered markdown.
- Merged main (v0.32.1). 964/964, `clippy`, `fmt` green.


---

## Round 2 review notes

- `find role img` works now. Chrome's AX tree calls the role `image` and ARIA calls it `img`; both spellings normalize through one table. Verified against the built binary.
- `role="button none"` no longer answers `find role none`. The presentational fallback takes the first supported token as the operative role, per ARIA's fallback list. `role="none button"` still matches, and the AX path already resolved `role="button none"` to a button.
- `--help` and the MCP schema now say what is case-insensitive: the role value always, accessible names only without `--exact`.
- Two adjacent gaps fixed while checking against Playwright's contract: accessible names are whitespace-normalized on both sides, and the presentational fallback follows accessible-name precedence (`aria-labelledby`, then `aria-label`, then text content).
- Docs fix: `<header>=banner` only holds for a top-level header. All five surfaces carrying the example now say so.
- Removed em dashes and ` -- ` from added comments.
