### PR TITLE
fix(native): preserve locator detail in element-not-found errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ agent-browser find last <sel> <action> [value]        # Last match
 agent-browser find nth <n> <sel> <action> [value]     # Nth match
 ```
 
-**Actions:** `click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`
+**Actions:** `click`, `fill`, `check`, `hover`, `text`
 
 **Options:** `--name <name>` (filter role by accessible name), `--exact` (require exact text match)
 

--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ agent-browser is checked <sel>        # Check if checked
 
 ```bash
 agent-browser find role <role> <action> [value]       # By ARIA role
-agent-browser find text <text> <action>               # By text content
+agent-browser find text <text> <action> [value]       # By text content
 agent-browser find label <label> <action> [value]     # By label
 agent-browser find placeholder <ph> <action> [value]  # By placeholder
-agent-browser find alt <text> <action>                # By alt text
-agent-browser find title <text> <action>              # By title attr
+agent-browser find alt <text> <action> [value]        # By alt text
+agent-browser find title <text> <action> [value]      # By title attr
 agent-browser find testid <id> <action> [value]       # By data-testid
 agent-browser find first <sel> <action> [value]       # First match
 agent-browser find last <sel> <action> [value]        # Last match

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2556,11 +2556,11 @@ fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                 context: format!("find {}", locator),
                 usage: match *locator {
                     "role" => "find role <role> [action] [--name <name>] [--exact]",
-                    "text" => "find text <text> [action] [--exact]",
+                    "text" => "find text <text> [action] [value] [--exact]",
                     "label" => "find label <label> [action] [text] [--exact]",
                     "placeholder" => "find placeholder <text> [action] [text] [--exact]",
-                    "alt" => "find alt <text> [action] [--exact]",
-                    "title" => "find title <text> [action] [--exact]",
+                    "alt" => "find alt <text> [action] [value] [--exact]",
+                    "title" => "find title <text> [action] [value] [--exact]",
                     "testid" => "find testid <id> [action] [text]",
                     "first" => "find first <selector> [action] [text]",
                     "last" => "find last <selector> [action] [text]",
@@ -2613,9 +2613,13 @@ fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     }
                     Ok(cmd)
                 }
-                "text" => Ok(
-                    json!({ "id": id, "action": "getbytext", "text": value, "subaction": subaction, "exact": exact }),
-                ),
+                "text" => {
+                    let mut cmd = json!({ "id": id, "action": "getbytext", "text": value, "subaction": subaction, "exact": exact });
+                    if let Some(v) = fill_value {
+                        cmd["value"] = json!(v);
+                    }
+                    Ok(cmd)
+                }
                 "label" => {
                     let mut cmd = json!({ "id": id, "action": "getbylabel", "label": value, "subaction": subaction, "exact": exact });
                     if let Some(v) = fill_value {
@@ -2630,12 +2634,20 @@ fn parse_find(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     }
                     Ok(cmd)
                 }
-                "alt" => Ok(
-                    json!({ "id": id, "action": "getbyalttext", "text": value, "subaction": subaction, "exact": exact }),
-                ),
-                "title" => Ok(
-                    json!({ "id": id, "action": "getbytitle", "text": value, "subaction": subaction, "exact": exact }),
-                ),
+                "alt" => {
+                    let mut cmd = json!({ "id": id, "action": "getbyalttext", "text": value, "subaction": subaction, "exact": exact });
+                    if let Some(v) = fill_value {
+                        cmd["value"] = json!(v);
+                    }
+                    Ok(cmd)
+                }
+                "title" => {
+                    let mut cmd = json!({ "id": id, "action": "getbytitle", "text": value, "subaction": subaction, "exact": exact });
+                    if let Some(v) = fill_value {
+                        cmd["value"] = json!(v);
+                    }
+                    Ok(cmd)
+                }
                 "testid" => {
                     let mut cmd = json!({ "id": id, "action": "getbytestid", "testId": value, "subaction": subaction });
                     if let Some(v) = fill_value {
@@ -3905,6 +3917,26 @@ mod tests {
         assert_eq!(cmd["action"], "type");
         assert_eq!(cmd["selector"], "#input");
         assert_eq!(cmd["text"], "some text");
+    }
+
+    #[test]
+    fn test_find_fill_value_survives_for_all_locators() {
+        // fill is advertised for these locators, so the value must reach dispatch.
+        // Force-red: drop the value block from the text/alt/title arms and these
+        // assertions fail (value missing).
+        for (loc, action) in [
+            ("text", "getbytext"),
+            ("alt", "getbyalttext"),
+            ("title", "getbytitle"),
+        ] {
+            let cmd = parse_command(
+                &args(&format!("find {loc} Label fill hello")),
+                &default_flags(),
+            )
+            .unwrap();
+            assert_eq!(cmd["action"], action, "{loc}");
+            assert_eq!(cmd["value"], "hello", "{loc} dropped the fill value");
+        }
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1035,8 +1035,8 @@ fn parity_tools() -> Vec<Value> {
             json!({
                 "locator": { "type": "string", "enum": ["role", "text", "label", "placeholder", "alt", "title", "testid", "first", "last", "nth"] },
                 "value": { "type": "string", "description": "Role, text, label, selector, or test id." },
-                "action": { "type": "string", "description": "Optional action: click, fill, type, hover, focus, check, uncheck, text." },
-                "text": { "type": "string", "description": "Optional text/value for fill or type actions." },
+                "action": { "type": "string", "description": "Optional action: click, fill, check, hover, text." },
+                "text": { "type": "string", "description": "Optional value for the fill action." },
                 "index": { "type": "integer", "description": "Index for nth locator." },
                 "name": { "type": "string", "description": "Accessible name filter for role locator." },
                 "exact": { "type": "boolean", "default": false }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7720,6 +7720,20 @@ async fn execute_subaction(
         .get("subaction")
         .and_then(|v| v.as_str())
         .unwrap_or("click");
+
+    // Validate before dispatching: an agent that typed a documented-sounding
+    // but unsupported action (e.g. "type", "focus", "uncheck" -- all real
+    // standalone commands, just not `find` actions) gets a message naming
+    // the valid set, instead of a bare "Unknown subaction: type" or -- if a
+    // future caller reaches this before confirming a browser exists -- a
+    // misleading "Browser not launched" that hides the real problem.
+    if !matches!(subaction, "click" | "fill" | "check" | "hover" | "text") {
+        return Err(format!(
+            "Unknown action '{}' for find. Valid actions: click, fill, check, hover, text.",
+            subaction
+        ));
+    }
+
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -7790,7 +7804,17 @@ async fn execute_subaction(
             .await?;
             Ok(json!({ "text": text }))
         }
-        _ => Err(format!("Unknown subaction: {}", subaction)),
+        // Unreachable today (the guard above only lets these five strings
+        // through), but a real Err instead of unreachable!()/panic: if this
+        // ever drifts out of sync with the guard, a spawned task panicking
+        // here doesn't crash the daemon (tokio::sync::Mutex isn't poisoned
+        // by a panicking holder, verified empirically), but the caller gets
+        // a bare connection EOF after several retries instead of a clean
+        // error -- a worse failure than this fallback ever needs to cause.
+        _ => Err(format!(
+            "Internal error: action '{}' passed validation but has no handler.",
+            subaction
+        )),
     }
 }
 
@@ -10430,6 +10454,45 @@ mod tests {
     use std::fs;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    /// Locks down the exact set `find --help` and the MCP tool schema
+    /// document. `type`, `focus`, and `uncheck` are real standalone
+    /// commands but were never wired into `execute_subaction`, so they used
+    /// to reach here and fail with "Browser not launched" (masking the real
+    /// problem) or a bare "Unknown subaction: type". No prior test caught
+    /// this: `test_all_documented_actions_are_handled` only covers
+    /// top-level `action` values, not `find`'s nested `subaction`.
+    #[test]
+    fn execute_subaction_accepts_exactly_the_documented_actions() {
+        for action in ["click", "fill", "check", "hover", "text"] {
+            assert!(
+                matches!(action, "click" | "fill" | "check" | "hover" | "text"),
+                "documented action '{action}' must be in execute_subaction's accepted set"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_subaction_rejects_undocumented_actions_before_requiring_a_browser() {
+        let mut state = DaemonState::new();
+        assert!(state.browser.is_none());
+
+        for bogus in ["type", "focus", "uncheck", "drag", ""] {
+            let cmd = json!({ "subaction": bogus });
+            let err = execute_subaction(&cmd, &mut state, "@e1")
+                .await
+                .expect_err(&format!(
+                    "'{bogus}' is not a find action and must be rejected"
+                ));
+            assert_eq!(
+                err,
+                format!(
+                    "Unknown action '{}' for find. Valid actions: click, fill, check, hover, text.",
+                    bogus
+                )
+            );
+        }
+    }
 
     async fn start_webdriver_response_server(
         responses: Vec<(&'static str, Value)>,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1875,6 +1875,13 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         return error_response(&id, &err);
     }
 
+    // Invalid inputs are rejected before expensive setup: an unsupported
+    // `find` action must fail here, not after a browser launch and a locator
+    // resolution that can mask it with "element not found".
+    if let Err(err) = validate_find_subaction(&action, cmd) {
+        return error_response(&id, &err);
+    }
+
     if action == INTERNAL_DAEMON_SHUTDOWN_ACTION {
         let mut resp = match handle_close(state).await {
             Ok(data) => success_response(&id, data),
@@ -7717,6 +7724,43 @@ async fn handle_mainframe(state: &mut DaemonState) -> Result<Value, String> {
 /// silently reopening the "Unknown subaction: type" bug this fixes.
 const FIND_ACTIONS: &[&str] = &["click", "fill", "check", "hover", "text"];
 
+/// The daemon commands that dispatch a `find` subaction through
+/// `execute_subaction` after resolving their locator.
+const FIND_SUBACTION_COMMANDS: &[&str] = &[
+    "getbyrole",
+    "getbytext",
+    "getbylabel",
+    "getbyplaceholder",
+    "getbyalttext",
+    "getbytitle",
+    "getbytestid",
+    "nth",
+];
+
+/// Reject an unsupported `find` action before any browser launch or locator
+/// resolution. The guard inside `execute_subaction` only runs after both, so
+/// on a missing element it never runs at all: the caller fails first with an
+/// "element not found" error that names the wrong fault, after paying for a
+/// browser launch to say it. Validation order follows the input, not the
+/// setup cost.
+fn validate_find_subaction(action: &str, cmd: &Value) -> Result<(), String> {
+    if !FIND_SUBACTION_COMMANDS.contains(&action) {
+        return Ok(());
+    }
+    let subaction = cmd
+        .get("subaction")
+        .and_then(|v| v.as_str())
+        .unwrap_or("click");
+    if !FIND_ACTIONS.contains(&subaction) {
+        return Err(format!(
+            "Unknown action '{}' for find. Valid actions: {}.",
+            subaction,
+            FIND_ACTIONS.join(", ")
+        ));
+    }
+    Ok(())
+}
+
 async fn execute_subaction(
     cmd: &Value,
     state: &mut DaemonState,
@@ -7728,7 +7772,7 @@ async fn execute_subaction(
         .unwrap_or("click");
 
     // Validate before dispatching: an unsupported action (e.g. "type",
-    // "focus", "uncheck" -- all real standalone commands, just not `find`
+    // "focus", "uncheck", all real standalone commands, just not `find`
     // actions) gets a message naming the valid set here.
     if !FIND_ACTIONS.contains(&subaction) {
         return Err(format!(
@@ -10455,7 +10499,7 @@ mod tests {
     use tokio::net::TcpListener;
 
     /// `find --help`, the MCP tool schema, and the docs/skill references are
-    /// plain text, not generated from `FIND_ACTIONS` -- this pins their
+    /// plain text, not generated from `FIND_ACTIONS`; this pins their
     /// wording to the actual accepted set so an edit to one without the
     /// others fails here instead of drifting silently again.
     #[test]
@@ -10496,8 +10540,39 @@ mod tests {
         }
     }
 
+    /// The dispatch-level validation must reject an unsupported `find`
+    /// action for every find-family command, before any browser launch or
+    /// locator resolution. Without it, a missing element fails the locator
+    /// step first and masks the invalid action with "element not found"
+    /// (after paying for a browser launch to say it).
+    #[test]
+    fn validate_find_subaction_rejects_before_any_browser_work() {
+        for command in FIND_SUBACTION_COMMANDS {
+            let err = validate_find_subaction(command, &json!({ "subaction": "type" }))
+                .expect_err(&format!("'{command}' must validate its find action"));
+            assert_eq!(
+                err,
+                format!(
+                    "Unknown action 'type' for find. Valid actions: {}.",
+                    FIND_ACTIONS.join(", ")
+                )
+            );
+        }
+
+        // The default subaction and every accepted action pass.
+        assert!(validate_find_subaction("getbyrole", &json!({})).is_ok());
+        for accepted in FIND_ACTIONS {
+            assert!(
+                validate_find_subaction("getbytext", &json!({ "subaction": accepted })).is_ok()
+            );
+        }
+
+        // Commands outside the find family carry no subaction contract.
+        assert!(validate_find_subaction("click", &json!({ "subaction": "type" })).is_ok());
+    }
+
     /// Every entry in `FIND_ACTIONS` must actually dispatch in
-    /// `execute_subaction`'s match, not just pass the guard -- this is the
+    /// `execute_subaction`'s match, not just pass the guard; this is the
     /// real lock the guard alone can't provide, since the guard and the
     /// match arms are two separate lists that Rust can't check against each
     /// other at compile time.

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7711,6 +7711,12 @@ async fn handle_mainframe(state: &mut DaemonState) -> Result<Value, String> {
 // Semantic locator handlers
 // ---------------------------------------------------------------------------
 
+/// The exact set of `find` actions `execute_subaction` dispatches. Shared by
+/// the validation guard, the error message, and the accepted-actions test,
+/// so drift between the guard and the match arms fails a test instead of
+/// silently reopening the "Unknown subaction: type" bug this fixes.
+const FIND_ACTIONS: &[&str] = &["click", "fill", "check", "hover", "text"];
+
 async fn execute_subaction(
     cmd: &Value,
     state: &mut DaemonState,
@@ -7721,16 +7727,14 @@ async fn execute_subaction(
         .and_then(|v| v.as_str())
         .unwrap_or("click");
 
-    // Validate before dispatching: an agent that typed a documented-sounding
-    // but unsupported action (e.g. "type", "focus", "uncheck" -- all real
-    // standalone commands, just not `find` actions) gets a message naming
-    // the valid set, instead of a bare "Unknown subaction: type" or -- if a
-    // future caller reaches this before confirming a browser exists -- a
-    // misleading "Browser not launched" that hides the real problem.
-    if !matches!(subaction, "click" | "fill" | "check" | "hover" | "text") {
+    // Validate before dispatching: an unsupported action (e.g. "type",
+    // "focus", "uncheck" -- all real standalone commands, just not `find`
+    // actions) gets a message naming the valid set here.
+    if !FIND_ACTIONS.contains(&subaction) {
         return Err(format!(
-            "Unknown action '{}' for find. Valid actions: click, fill, check, hover, text.",
-            subaction
+            "Unknown action '{}' for find. Valid actions: {}.",
+            subaction,
+            FIND_ACTIONS.join(", ")
         ));
     }
 
@@ -7804,13 +7808,8 @@ async fn execute_subaction(
             .await?;
             Ok(json!({ "text": text }))
         }
-        // Unreachable today (the guard above only lets these five strings
-        // through), but a real Err instead of unreachable!()/panic: if this
-        // ever drifts out of sync with the guard, a spawned task panicking
-        // here doesn't crash the daemon (tokio::sync::Mutex isn't poisoned
-        // by a panicking holder, verified empirically), but the caller gets
-        // a bare connection EOF after several retries instead of a clean
-        // error -- a worse failure than this fallback ever needs to cause.
+        // Unreachable today; a real Err rather than unreachable!() in case
+        // this ever drifts out of sync with the guard above.
         _ => Err(format!(
             "Internal error: action '{}' passed validation but has no handler.",
             subaction
@@ -10455,29 +10454,31 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
-    /// Locks down the exact set `find --help` and the MCP tool schema
-    /// document. `type`, `focus`, and `uncheck` are real standalone
-    /// commands but were never wired into `execute_subaction`, so they used
-    /// to reach here and fail with "Browser not launched" (masking the real
-    /// problem) or a bare "Unknown subaction: type". No prior test caught
-    /// this: `test_all_documented_actions_are_handled` only covers
-    /// top-level `action` values, not `find`'s nested `subaction`.
+    /// `find --help`, the MCP tool schema, and the docs/skill references are
+    /// plain text, not generated from `FIND_ACTIONS` -- this pins their
+    /// wording to the actual accepted set so an edit to one without the
+    /// others fails here instead of drifting silently again.
     #[test]
-    fn execute_subaction_accepts_exactly_the_documented_actions() {
-        for action in ["click", "fill", "check", "hover", "text"] {
-            assert!(
-                matches!(action, "click" | "fill" | "check" | "hover" | "text"),
-                "documented action '{action}' must be in execute_subaction's accepted set"
-            );
-        }
+    fn find_actions_help_text_matches_the_accepted_set() {
+        assert_eq!(FIND_ACTIONS.join(", "), "click, fill, check, hover, text");
     }
 
+    /// `type`, `focus`, and `uncheck` are real standalone commands but were
+    /// never wired into `execute_subaction`, so they used to reach here and
+    /// fail with "Browser not launched" (masking the real problem) or a bare
+    /// "Unknown subaction: type". No prior test caught this:
+    /// `test_all_documented_actions_are_handled` only covers top-level
+    /// `action` values, not `find`'s nested `subaction`.
     #[tokio::test]
     async fn execute_subaction_rejects_undocumented_actions_before_requiring_a_browser() {
         let mut state = DaemonState::new();
         assert!(state.browser.is_none());
 
         for bogus in ["type", "focus", "uncheck", "drag", ""] {
+            assert!(
+                !FIND_ACTIONS.contains(&bogus),
+                "test fixture '{bogus}' must not overlap the real accepted set"
+            );
             let cmd = json!({ "subaction": bogus });
             let err = execute_subaction(&cmd, &mut state, "@e1")
                 .await
@@ -10487,11 +10488,60 @@ mod tests {
             assert_eq!(
                 err,
                 format!(
-                    "Unknown action '{}' for find. Valid actions: click, fill, check, hover, text.",
-                    bogus
+                    "Unknown action '{}' for find. Valid actions: {}.",
+                    bogus,
+                    FIND_ACTIONS.join(", ")
                 )
             );
         }
+    }
+
+    /// Every entry in `FIND_ACTIONS` must actually dispatch in
+    /// `execute_subaction`'s match, not just pass the guard -- this is the
+    /// real lock the guard alone can't provide, since the guard and the
+    /// match arms are two separate lists that Rust can't check against each
+    /// other at compile time.
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_execute_subaction_dispatches_every_find_action() {
+        let mut state = DaemonState::new();
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert!(resp.get("success").and_then(|v| v.as_bool()) == Some(true));
+
+        let resp = execute_command(
+            &json!({
+                "id": "2",
+                "action": "navigate",
+                "url": "data:text/html,<input id='i' role='textbox' value='x'><button>Go</button>"
+            }),
+            &mut state,
+        )
+        .await;
+        assert!(resp.get("success").and_then(|v| v.as_bool()) == Some(true));
+
+        for action in FIND_ACTIONS {
+            let mut cmd = json!({
+                "id": "3",
+                "action": "getbyrole",
+                "role": if *action == "fill" { "textbox" } else { "button" },
+                "subaction": action,
+            });
+            if *action == "fill" {
+                cmd["value"] = json!("y");
+            }
+            let resp = execute_command(&cmd, &mut state).await;
+            let error = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+            assert!(
+                !error.starts_with("Unknown action"),
+                "action '{action}' must dispatch, not be rejected as unknown: {error}"
+            );
+        }
+
+        let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     }
 
     async fn start_webdriver_response_server(

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -8357,23 +8357,41 @@ async fn handle_multiselect(cmd: &Value, state: &DaemonState) -> Result<Value, S
         .unwrap_or_default();
 
     let values_json = serde_json::to_string(&values).unwrap_or("[]".to_string());
+    // A locator miss returns a sentinel object rather than throwing, so the miss
+    // is detected structurally in Rust and normalized to the anchored
+    // "No element found: ..." shape the find path emits. Throwing would surface as
+    // "Evaluation error: ...", which is_locator_miss does not classify (no
+    // canonical prefix), so the miss would reach the caller raw. Detecting via a
+    // sentinel (not a substring of the thrown text) also avoids misclassifying an
+    // invalid-selector SyntaxError, whose message echoes the user's selector.
     let js = format!(
         r#"(() => {{
             const select = document.querySelector({sel});
-            if (!select) throw new Error('Select element not found');
+            if (!select) return {{ __ab_miss: true }};
             const vals = {vals};
             for (const opt of select.options) {{
                 opt.selected = vals.includes(opt.value);
             }}
             select.dispatchEvent(new Event('change', {{ bubbles: true }}));
-            return Array.from(select.selectedOptions).map(o => o.value);
+            return {{ selected: Array.from(select.selectedOptions).map(o => o.value) }};
         }})()"#,
         sel = serde_json::to_string(selector).unwrap_or_default(),
         vals = values_json,
     );
 
     let result = mgr.evaluate(&js, None).await?;
-    Ok(json!({ "selected": result }))
+    if result
+        .get("__ab_miss")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Err(format!("No element found: {selector}"));
+    }
+    let selected = result
+        .get("selected")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    Ok(json!({ "selected": selected }))
 }
 
 async fn handle_responsebody(cmd: &Value, state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -8357,13 +8357,10 @@ async fn handle_multiselect(cmd: &Value, state: &DaemonState) -> Result<Value, S
         .unwrap_or_default();
 
     let values_json = serde_json::to_string(&values).unwrap_or("[]".to_string());
-    // A locator miss returns a sentinel object rather than throwing, so the miss
-    // is detected structurally in Rust and normalized to the anchored
-    // "No element found: ..." shape the find path emits. Throwing would surface as
-    // "Evaluation error: ...", which is_locator_miss does not classify (no
-    // canonical prefix), so the miss would reach the caller raw. Detecting via a
-    // sentinel (not a substring of the thrown text) also avoids misclassifying an
-    // invalid-selector SyntaxError, whose message echoes the user's selector.
+    // A locator miss returns a sentinel instead of throwing, so it is detected in
+    // Rust and normalized to the anchored "No element found: ..." shape. A thrown
+    // error surfaces as "Evaluation error: ...", which is_locator_miss skips, and
+    // a sentinel avoids misclassifying an invalid-selector error too.
     let js = format!(
         r#"(() => {{
             const select = document.querySelector({sel});
@@ -8387,10 +8384,7 @@ async fn handle_multiselect(cmd: &Value, state: &DaemonState) -> Result<Value, S
     {
         return Err(format!("No element found: {selector}"));
     }
-    let selected = result
-        .get("selected")
-        .cloned()
-        .unwrap_or_else(|| json!([]));
+    let selected = result.get("selected").cloned().unwrap_or_else(|| json!([]));
     Ok(json!({ "selected": selected }))
 }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1878,7 +1878,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // Invalid inputs are rejected before expensive setup: an unsupported
     // `find` action must fail here, not after a browser launch and a locator
     // resolution that can mask it with "element not found".
-    if let Err(err) = validate_find_subaction(&action, cmd) {
+    if let Err(err) = validate_find_subaction(action, cmd) {
         return error_response(&id, &err);
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10516,7 +10516,7 @@ mod tests {
             &json!({
                 "id": "2",
                 "action": "navigate",
-                "url": "data:text/html,<input id='i' role='textbox' value='x'><button>Go</button>"
+                "url": "data:text/html,<input id='i' role='textbox' value='x'><button>Go</button><input type='checkbox' role='checkbox'>"
             }),
             &mut state,
         )
@@ -10527,17 +10527,25 @@ mod tests {
             let mut cmd = json!({
                 "id": "3",
                 "action": "getbyrole",
-                "role": if *action == "fill" { "textbox" } else { "button" },
+                "role": match *action {
+                    "fill" => "textbox",
+                    "check" => "checkbox",
+                    _ => "button",
+                },
                 "subaction": action,
             });
             if *action == "fill" {
                 cmd["value"] = json!("y");
             }
             let resp = execute_command(&cmd, &mut state).await;
+            // success == true is the only assertion that proves the action
+            // reached a real handler AND that handler worked: a guard-only
+            // check ("not Unknown action") stays green when an entry added
+            // to FIND_ACTIONS falls through to the internal-error fallback.
             let error = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
             assert!(
-                !error.starts_with("Unknown action"),
-                "action '{action}' must dispatch, not be rejected as unknown: {error}"
+                resp.get("success").and_then(|v| v.as_bool()) == Some(true),
+                "action '{action}' must dispatch to a working handler: {error}"
             );
         }
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -168,9 +168,13 @@ pub fn to_ai_friendly_error(error: &str) -> String {
 /// instead of discarding that detail.
 ///
 /// Deliberately narrower than a bare "no element" substring match, which
-/// would also catch unrelated WebDriver protocol errors like "No element in
-/// response" or "No element ID in response" -- those aren't locator misses,
-/// and "verify the selector is correct" is misleading advice for them.
+/// would also catch WebDriver protocol errors like "No element in response"
+/// or "No element ID in response"; those indicate a malformed driver
+/// payload, and "verify the selector is correct" is misleading advice for
+/// them. A genuine WebDriver locator miss never reaches this function in
+/// protocol shape: `element_id_from_value` translates the driver's
+/// "no such element" error into the anchored "No element found by ..."
+/// form, which this function classifies like any other miss.
 fn is_locator_miss(lower: &str) -> bool {
     lower.starts_with("element not found")
         || lower.starts_with("no element found")
@@ -2091,8 +2095,11 @@ mod tests {
     }
 
     /// WebDriver protocol errors happen to contain "element" and "no" but
-    /// are not locator misses -- "verify the selector is correct" would be
-    /// actively misleading advice for a malformed response payload.
+    /// are not locator misses; "verify the selector is correct" would be
+    /// actively misleading advice for a malformed response payload. Genuine
+    /// WebDriver misses are translated to the anchored form before they get
+    /// here (see `element_id_from_value`), so only malformed payloads keep
+    /// this protocol shape.
     #[test]
     fn test_to_ai_friendly_error_does_not_flatten_webdriver_protocol_errors() {
         assert_eq!(

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -137,6 +137,16 @@ fn active_page_index_after_removal(
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
+    // Classify a genuine locator miss first: its anchored shape ("No element
+    // found: ...") echoes the selector/name, which may itself contain a word like
+    // "timeout" or "intercept". The broad substring checks below would otherwise
+    // flatten such a miss into the wrong guidance.
+    if is_locator_miss(&lower) {
+        let detail = error.trim_end_matches('.');
+        return format!(
+            "{detail}. Verify the selector, role, or name is correct and the element exists in the DOM."
+        );
+    }
     if lower.contains("strict mode violation") {
         return "Element matched multiple results. Use a more specific selector.".to_string();
     }
@@ -151,12 +161,6 @@ pub fn to_ai_friendly_error(error: &str) -> String {
     if lower.contains("timeout") {
         return "Operation timed out. The page may still be loading or the element may not exist."
             .to_string();
-    }
-    if is_locator_miss(&lower) {
-        let detail = error.trim_end_matches('.');
-        return format!(
-            "{detail}. Verify the selector, role, or name is correct and the element exists in the DOM."
-        );
     }
     error.to_string()
 }
@@ -2046,6 +2050,25 @@ mod tests {
         assert_eq!(
             to_ai_friendly_error("Timeout waiting for element"),
             "Operation timed out. The page may still be loading or the element may not exist."
+        );
+    }
+
+    #[test]
+    fn test_to_ai_friendly_error_miss_wins_over_keyword_in_name() {
+        // A genuine locator miss whose echoed name contains a classifier keyword
+        // must classify as a miss, not be flattened by the broad substring checks.
+        // Force-red: run the broad checks before is_locator_miss and this returns
+        // the timeout guidance instead.
+        let out =
+            to_ai_friendly_error("No element found: getByRole('button', { name: 'timeout' })");
+        assert!(
+            out.starts_with("No element found") && out.contains("Verify the selector"),
+            "miss with 'timeout' in the name must stay a miss, got: {out}"
+        );
+        let out = to_ai_friendly_error("No element found: getByText('please do not intercept')");
+        assert!(
+            out.contains("Verify the selector"),
+            "miss with 'intercept' in the name must stay a miss, got: {out}"
         );
     }
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -152,11 +152,29 @@ pub fn to_ai_friendly_error(error: &str) -> String {
         return "Operation timed out. The page may still be loading or the element may not exist."
             .to_string();
     }
-    if lower.contains("element not found") || lower.contains("no element") {
-        return "Element not found. Verify the selector is correct and the element exists in the DOM."
-            .to_string();
+    if is_locator_miss(&lower) {
+        let detail = error.trim_end_matches('.');
+        return format!(
+            "{detail}. Verify the selector, role, or name is correct and the element exists in the DOM."
+        );
     }
     error.to_string()
+}
+
+/// True for the "couldn't find a matching element" family of messages
+/// produced by locator code (`find role`, `find text`, CSS/ref resolution,
+/// and friends). Every such message already carries the selector, role, or
+/// name that failed to match, so this only appends actionable advice
+/// instead of discarding that detail.
+///
+/// Deliberately narrower than a bare "no element" substring match, which
+/// would also catch unrelated WebDriver protocol errors like "No element in
+/// response" or "No element ID in response" -- those aren't locator misses,
+/// and "verify the selector is correct" is misleading advice for them.
+fn is_locator_miss(lower: &str) -> bool {
+    lower.starts_with("element not found")
+        || lower.starts_with("no element found")
+        || lower.starts_with("no element at index")
 }
 
 #[derive(Debug, Clone)]
@@ -1993,7 +2011,7 @@ mod tests {
     fn test_to_ai_friendly_error_not_found() {
         assert_eq!(
             to_ai_friendly_error("Element not found"),
-            "Element not found. Verify the selector is correct and the element exists in the DOM."
+            "Element not found. Verify the selector, role, or name is correct and the element exists in the DOM."
         );
     }
 
@@ -2010,11 +2028,43 @@ mod tests {
         assert_eq!(to_ai_friendly_error(err), err);
     }
 
+    /// The specific selector/role/name that failed to match must survive:
+    /// this used to get discarded and replaced with a single indistinguishable
+    /// generic message, which made it impossible to tell a role miss from a
+    /// name miss from an index-out-of-range miss.
     #[test]
-    fn test_to_ai_friendly_error_catches_no_element() {
-        let mapped =
-            "Element not found. Verify the selector is correct and the element exists in the DOM.";
-        assert_eq!(to_ai_friendly_error("No element found for css 'x'"), mapped);
+    fn test_to_ai_friendly_error_preserves_locator_detail() {
+        assert_eq!(
+            to_ai_friendly_error("No element found for css 'x'"),
+            "No element found for css 'x'. Verify the selector, role, or name is correct and the element exists in the DOM."
+        );
+        assert_eq!(
+            to_ai_friendly_error("No element found: getByRole('heading', { name: 'Skillz' })"),
+            "No element found: getByRole('heading', { name: 'Skillz' }). Verify the selector, role, or name is correct and the element exists in the DOM."
+        );
+        assert_eq!(
+            to_ai_friendly_error("No element at index 5 for selector '.card'"),
+            "No element at index 5 for selector '.card'. Verify the selector, role, or name is correct and the element exists in the DOM."
+        );
+        assert_eq!(
+            to_ai_friendly_error("Element not found in the selected frame: iframe#f"),
+            "Element not found in the selected frame: iframe#f. Verify the selector, role, or name is correct and the element exists in the DOM."
+        );
+    }
+
+    /// WebDriver protocol errors happen to contain "element" and "no" but
+    /// are not locator misses -- "verify the selector is correct" would be
+    /// actively misleading advice for a malformed response payload.
+    #[test]
+    fn test_to_ai_friendly_error_does_not_flatten_webdriver_protocol_errors() {
+        assert_eq!(
+            to_ai_friendly_error("No element in response"),
+            "No element in response"
+        );
+        assert_eq!(
+            to_ai_friendly_error("No element ID in response"),
+            "No element ID in response"
+        );
     }
 
     #[test]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7095,3 +7095,49 @@ async fn e2e_removeinitscript_roundtrip() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+/// A multiselect locator miss must surface the anchored "No element found"
+/// guidance, not a raw "Evaluation error: ...". Guards the handler wiring end to
+/// end: a unit test of the mapping alone stays green if the handler stops routing
+/// misses through it. Force-red: drop the sentinel miss handling in
+/// handle_multiselect and this assertion fails on the raw evaluate error.
+#[tokio::test]
+#[ignore]
+async fn e2e_multiselect_miss_surfaces_anchored_error() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // about:blank has no #picker, so the selector misses.
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "multiselect", "selector": "#picker", "values": ["a"] }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "multiselect on a missing selector should error: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    // Assert the full anchored shape, not just the guidance suffix: the miss must
+    // carry "No element found", retain the "#picker" selector detail, and end with
+    // the locator-miss guidance. A generic suffix-only check would pass even if the
+    // detail were dropped or a different classifier produced the guidance.
+    assert!(
+        err.starts_with("No element found") && err.contains("#picker"),
+        "miss should keep the anchored shape and selector detail, got: {err}"
+    );
+    assert!(
+        err.contains("Verify the selector, role, or name is correct"),
+        "miss should surface the anchored locator-miss guidance, got: {err}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}

--- a/cli/src/native/webdriver/client.rs
+++ b/cli/src/native/webdriver/client.rs
@@ -79,13 +79,7 @@ impl WebDriverClient {
             .await?;
 
         let element_value = response.get("value").ok_or("No element in response")?;
-
-        element_value
-            .get("element-6066-11e4-a52e-4f735466cecf")
-            .or_else(|| element_value.get("ELEMENT"))
-            .and_then(|v| v.as_str())
-            .map(String::from)
-            .ok_or("No element ID in response".to_string())
+        element_id_from_value(element_value, using, value)
     }
 
     pub async fn click_element(&self, element_id: &str) -> Result<(), String> {
@@ -212,6 +206,36 @@ impl WebDriverClient {
     }
 }
 
+/// Extract the element id from a WebDriver find-element `value` payload.
+///
+/// A genuine locator miss arrives as a WebDriver error payload
+/// ("no such element"), not as a malformed response. It is translated to the
+/// anchored locator-miss shape the rest of the CLI produces, so it keeps the
+/// selector detail and receives the AI-friendly guidance that
+/// `to_ai_friendly_error` reserves for locator misses. A payload with
+/// neither an error nor an element id is genuinely malformed and keeps the
+/// protocol-shaped message.
+fn element_id_from_value(
+    element_value: &Value,
+    using: &str,
+    value: &str,
+) -> Result<String, String> {
+    if element_value
+        .get("error")
+        .and_then(|e| e.as_str())
+        .is_some_and(|e| e == "no such element")
+    {
+        return Err(format!("No element found by {} '{}'", using, value));
+    }
+
+    element_value
+        .get("element-6066-11e4-a52e-4f735466cecf")
+        .or_else(|| element_value.get("ELEMENT"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or("No element ID in response".to_string())
+}
+
 async fn http_request(method: &str, url: &str, body: Option<&Value>) -> Result<Value, String> {
     let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {}", e))?;
     let host = parsed.host_str().unwrap_or("127.0.0.1");
@@ -314,5 +338,40 @@ mod tests {
     fn test_client_custom_port() {
         let client = WebDriverClient::new(9515);
         assert_eq!(client.base_url, "http://127.0.0.1:9515");
+    }
+
+    /// In the WebDriver engine a genuine locator miss surfaces as a
+    /// "no such element" error payload; it must translate to the anchored
+    /// locator-miss shape (selector included) so `to_ai_friendly_error`
+    /// appends its guidance, exactly as the CDP engine's misses do.
+    #[test]
+    fn test_find_element_miss_translates_to_locator_miss() {
+        let payload = json!({
+            "error": "no such element",
+            "message": "An element could not be located on the page using the given search parameters.",
+        });
+        let err = element_id_from_value(&payload, "css selector", ".missing")
+            .expect_err("an error payload is a miss, not an element");
+        assert_eq!(err, "No element found by css selector '.missing'");
+    }
+
+    #[test]
+    fn test_find_element_id_extracted_from_w3c_payload() {
+        let payload = json!({ "element-6066-11e4-a52e-4f735466cecf": "abc123" });
+        assert_eq!(
+            element_id_from_value(&payload, "css selector", "#x").unwrap(),
+            "abc123"
+        );
+    }
+
+    /// A payload with neither an error nor an element id is genuinely
+    /// malformed; it keeps the protocol-shaped message, which
+    /// `to_ai_friendly_error` deliberately passes through unchanged.
+    #[test]
+    fn test_find_element_malformed_payload_keeps_protocol_message() {
+        let payload = json!({ "unexpected": true });
+        let err = element_id_from_value(&payload, "css selector", "#x")
+            .expect_err("no id and no error is malformed");
+        assert_eq!(err, "No element ID in response");
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2065,7 +2065,7 @@ Locators:
   nth <index> <selector>   Nth matching element (0-based)
 
 Actions (default: click):
-  click, fill, type, hover, focus, check, uncheck
+  click, fill, check, hover, text
 
 Options:
   --name <name>        Filter role by accessible name
@@ -2079,10 +2079,11 @@ Examples:
   agent-browser find role button click --name Submit
   agent-browser find text "Sign In" click
   agent-browser find label "Email" fill "user@example.com"
-  agent-browser find placeholder "Search..." type "query"
+  agent-browser find placeholder "Search..." fill "query"
   agent-browser find testid "login-form" click
   agent-browser find first "li.item" click
   agent-browser find nth 2 ".card" hover
+  agent-browser find role heading text --name Welcome
 "##
         }
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -90,11 +90,11 @@ Semantic locators with actions (`click`, `fill`, `check`, `hover`, `text`):
 
 ```bash
 agent-browser find role <role> <action> [value]
-agent-browser find text <text> <action>
+agent-browser find text <text> <action> [value]
 agent-browser find label <label> <action> [value]
 agent-browser find placeholder <ph> <action> [value]
-agent-browser find alt <text> <action>
-agent-browser find title <text> <action>
+agent-browser find alt <text> <action> [value]
+agent-browser find title <text> <action> [value]
 agent-browser find testid <id> <action> [value]
 agent-browser find first <sel> <action> [value]
 agent-browser find last <sel> <action> [value]

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -86,7 +86,7 @@ agent-browser is checked <sel>        # Check if checked
 
 ## Find elements
 
-Semantic locators with actions (`click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`):
+Semantic locators with actions (`click`, `fill`, `check`, `hover`, `text`):
 
 ```bash
 agent-browser find role <role> <action> [value]

--- a/packages/@agent-browser/eve/extension/tools/find.ts
+++ b/packages/@agent-browser/eve/extension/tools/find.ts
@@ -7,7 +7,7 @@ export default defineTool({
   description:
     'Find an element semantically (by ARIA role, text, label, placeholder, alt text, title, or test id) and act on it in one step. Useful when you know what the element is without taking a snapshot, e.g. find the "Email" label and fill it.',
   inputSchema: z.object({
-    action: z.enum(["click", "fill", "type", "hover", "focus", "check", "uncheck", "text"]),
+    action: z.enum(["click", "fill", "check", "hover", "text"]),
     by: z.enum(["role", "text", "label", "placeholder", "alt", "title", "testid", "first", "last"]),
     exact: z.boolean().default(false).describe("Require an exact text match."),
     name: z
@@ -17,10 +17,10 @@ export default defineTool({
     query: z
       .string()
       .describe('What to match: the role name, text, label, etc. For "first"/"last", a CSS selector.'),
-    value: z.string().optional().describe('Text to enter for "fill" and "type" actions.'),
+    value: z.string().optional().describe('Text to enter for the "fill" action.'),
   }),
   async execute({ action, by, exact, name, query, value }, ctx) {
-    if ((action === "fill" || action === "type") && value === undefined) {
+    if (action === "fill" && value === undefined) {
       throw new Error(`The "${action}" action requires a value.`);
     }
     const args = ["find", by, query, action];

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -142,7 +142,7 @@ agent-browser find role button click --name "Submit"
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact     # exact match only
 agent-browser find label "Email" fill "user@test.com"
-agent-browser find placeholder "Search" type "query"
+agent-browser find placeholder "Search" fill "query"
 agent-browser find testid "submit-btn" click
 agent-browser find first ".card" click
 agent-browser find nth 2 ".card" hover

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -147,7 +147,7 @@ agent-browser find role button click --name "Submit"
 agent-browser find text "Sign In" click
 agent-browser find text "Sign In" click --exact      # Exact match only
 agent-browser find label "Email" fill "user@test.com"
-agent-browser find placeholder "Search" type "query"
+agent-browser find placeholder "Search" fill "query"
 agent-browser find alt "Logo" click
 agent-browser find title "Close" click
 agent-browser find testid "submit-btn" click


### PR DESCRIPTION
## Bug

`to_ai_friendly_error` flattens any error containing "element not found" or "no element" into one generic message. It discards the role, name, selector, or index the original error carried, and catches unrelated WebDriver errors like "No element in response" too.

`find --help`, the MCP tool schema, and the docs/skill references advertise find actions `type`, `focus`, and `uncheck`. None are wired into `execute_subaction`; all three are real standalone commands, just never connected as find actions.

## Fix

- Narrow the flattening match to the actual locator-miss message family and append advice instead of replacing the message, so the specific detail survives.
- Align the documented find actions with what's implemented (`click, fill, check, hover, text`) in `find --help`, the MCP schema, and the docs/skill references.
- Validate the action before dispatch, so an unknown action returns the valid list instead of a bare `Unknown subaction: type`. `FIND_ACTIONS` is one const, shared by the guard, the error message, and the tests.

## Verification

- `cargo test`: 954/954, `clippy`, `fmt` green.
- Added a real-Chrome e2e test (`#[ignore]`) that dispatches every `FIND_ACTIONS` entry. Ran it separately with `--ignored --test-threads=1`; it passes.
- Confirmed against the built binary: a role/name miss keeps its detail (`No element found: getByRole(...)`), an unknown find action returns the valid list, and `find role ... click` still works.
- The dispatch fallback returns a clean `Err` instead of panicking if the guard and the match arms ever drift apart.

`is_locator_miss` classifies error strings by prefix, produced by code in #1552 and elsewhere. That's a convention, not a compile-time check, across two independent PRs. Its test suite covers every current message shape, and an unmatched message just passes through unenriched rather than getting mangled, so drift degrades UX, it doesn't break anything.

## Review updates

- Merged main (v0.32.1).
- The root README and eve's find tool still advertised `type`/`focus`/`uncheck`; both now carry the real action set. `type` and `uncheck` stay reachable through eve's fill and set_checked tools.
- The e2e drift test now asserts `success == true` per action, with a checkbox fixture for `check`. The old assertion only rejected `Unknown action`, which the internal-error fallback passes, so an action added to `FIND_ACTIONS` without a handler went undetected. Verified by forcing that drift and watching the test fail before reverting.
- 956/956, `clippy`, `fmt`, eve `tsc` green.


---

## Round 2 review notes

- **Invalid find actions now fail before any browser work**. The guard lived in `execute_subaction`, which runs after locator resolution, and the daemon auto-launches before dispatch: a bad action paid for a launch, and a missing element masked it with "element not found". The dispatch entry now rejects unsupported actions first (`validate_find_subaction`, covering all eight find-family commands). The inner guard stays as defense in depth. `find role button type` with no page open now answers `Unknown action 'type' for find` instantly, without launching.
- **The wrapped-errors path was the WebDriver engine**. A genuine miss there surfaces as the driver's `no such element` error payload, which `find_element` reduced to the protocol-shaped "No element ID in response", so WebDriver misses lost both selector detail and guidance. `find_element` now translates the payload to `No element found by <strategy> '<value>'` (extracted as `element_id_from_value`, unit-tested). A payload with neither an error nor an element id keeps the protocol shape.
- Removed ` -- ` from the five comments this PR added.
