### PR TITLE
Fix wait handling for completed pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1269,7 +1269,7 @@ import browser from "@agent-browser/eve";
 export default browser({});
 ```
 
-This composes ~20 namespaced tools into the agent — `browser__navigate`, `browser__snapshot`, `browser__click`, `browser__fill`, `browser__find`, `browser__screenshot`, and more — all running agent-browser inside the agent's sandbox. agent-browser installs automatically on first use; pre-install it in `agent/sandbox.ts` with the `@agent-browser/sandbox/eve` helpers to bake the cost into the sandbox template instead. Configuration (domain allowlists, output limits, session naming) and per-tool overrides are covered in the [package README](packages/@agent-browser/eve/README.md), and the [eve example](examples/eve/) is a complete app with the extension mounted.
+This composes ~20 namespaced tools into the agent — `browser__navigate`, `browser__snapshot`, `browser__click`, `browser__fill`, `browser__find`, `browser__screenshot`, and more — all running agent-browser inside the agent's sandbox. agent-browser installs automatically on first use; pre-install it in `agent/sandbox.ts` with the `@agent-browser/eve/sandbox` helpers to bake the cost into the sandbox template instead. Configuration (domain allowlists, output limits, session naming) and per-tool overrides are covered in the [package README](packages/@agent-browser/eve/README.md), and the [eve example](examples/eve/) is a complete app with the extension mounted.
 
 ### Serverless (AWS Lambda)
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -836,7 +836,45 @@ impl BrowserManager {
         wait_until: WaitUntil,
         session_id: &str,
     ) -> Result<(), String> {
+        // Subscribe before probing so a lifecycle event that fires between
+        // the probe and the wait cannot be missed.
         let mut rx = self.client.subscribe();
+
+        // `wait_for_lifecycle` waits for the NEXT lifecycle event, which is
+        // right mid-navigation but wrong for a standalone `wait --load`: a
+        // page that already finished loading (or navigated client-side,
+        // which fires no new load event) never emits another one, so the
+        // wait would burn its entire timeout. Resolve immediately when the
+        // document is already in the requested state.
+        let already_reached = match wait_until {
+            WaitUntil::Load => Some("document.readyState === 'complete'"),
+            // readyState leaves 'loading' when DOMContentLoaded fires.
+            WaitUntil::DomContentLoaded => Some("document.readyState !== 'loading'"),
+            // Network idle is tracked from live network events; its poller
+            // already treats a quiet stream as idle.
+            WaitUntil::NetworkIdle | WaitUntil::None => None,
+        };
+        if let Some(expression) = already_reached {
+            let probe: Result<EvaluateResult, String> = self
+                .client
+                .send_command_typed(
+                    "Runtime.evaluate",
+                    &EvaluateParams {
+                        expression: expression.to_string(),
+                        return_by_value: Some(true),
+                        await_promise: Some(false),
+                    },
+                    Some(session_id),
+                )
+                .await;
+            // A failed probe is not fatal; fall back to waiting for the event.
+            if let Ok(result) = probe {
+                if result.result.value.as_ref().and_then(|v| v.as_bool()) == Some(true) {
+                    return Ok(());
+                }
+            }
+        }
+
         self.wait_for_lifecycle(wait_until, session_id, &mut rx)
             .await
     }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1620,6 +1620,48 @@ async fn e2e_wait() {
     assert_success(&resp);
 }
 
+// wait --load on a page that already finished loading must resolve
+// immediately instead of waiting for a Page.loadEventFired that will never
+// come (the common case after a click that triggers an SPA navigation).
+#[tokio::test]
+#[ignore]
+async fn e2e_wait_load_state_resolves_immediately_when_already_loaded() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Loaded</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    for (id, load_state) in [("3", "load"), ("4", "domcontentloaded")] {
+        let start = std::time::Instant::now();
+        let resp = execute_command(
+            &json!({ "id": id, "action": "waitforloadstate", "state": load_state, "timeout": 10000 }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        assert!(
+            start.elapsed().as_millis() < 3000,
+            "wait --load {} on an already-loaded page should resolve immediately, took {}ms",
+            load_state,
+            start.elapsed().as_millis()
+        );
+    }
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // Same-document navigation regression test
 // ---------------------------------------------------------------------------

--- a/docs/src/app/eve/page.mdx
+++ b/docs/src/app/eve/page.mdx
@@ -8,11 +8,7 @@
 pnpm add @agent-browser/eve
 ```
 
-`eve` is a peer dependency and should already be present in an Eve app. Add `@agent-browser/sandbox` directly too if your sandbox bootstrap imports the preinstall helpers shown below.
-
-```bash
-pnpm add @agent-browser/sandbox
-```
+`eve` is a peer dependency and should already be present in an Eve app. The sandbox preinstall helpers shown below ship with the same package, so no other install is needed.
 
 ## Mount
 
@@ -36,7 +32,7 @@ The extension can install `agent-browser`, Chromium, and required Linux librarie
 
 ```ts
 // agent/sandbox.ts
-import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/sandbox/eve";
+import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/eve/sandbox";
 import { defineSandbox } from "eve/sandbox";
 import { vercel } from "eve/sandbox/vercel";
 

--- a/examples/eve/README.md
+++ b/examples/eve/README.md
@@ -3,7 +3,7 @@
 This is a scaffold-style [eve](https://eve.dev) app based on `eve init --channel-web-nextjs`. Its agent gets a full browser tool set from the [`@agent-browser/eve`](../../packages/@agent-browser/eve/) extension.
 
 - `agent/extensions/browser.ts` mounts the extension, composing ~20 tools into the agent under the `browser` namespace (`browser__navigate`, `browser__snapshot`, `browser__click`, ...).
-- `agent/sandbox.ts` pre-installs Chromium system dependencies, `agent-browser`, and Chrome into the sandbox template with the `@agent-browser/sandbox/eve` helpers, so sessions never pay the install cost. Without this bootstrap the extension still works — it auto-installs on first tool use — just slower on fresh sandboxes.
+- `agent/sandbox.ts` pre-installs Chromium system dependencies, `agent-browser`, and Chrome into the sandbox template with the `@agent-browser/eve/sandbox` helpers, so sessions never pay the install cost. Without this bootstrap the extension still works — it auto-installs on first tool use — just slower on fresh sandboxes.
 
 ## Run Locally
 

--- a/examples/eve/agent/instructions.md
+++ b/examples/eve/agent/instructions.md
@@ -9,5 +9,11 @@ You have a full browser tool set mounted under the `browser` namespace
 `@agent-browser/eve` extension. Use it to inspect web pages, interact with web
 apps, and verify that URLs render correctly.
 
+All web access goes through the `browser` tools: navigate to pages, read them,
+and search by visiting a search engine or the site itself. Never fetch web
+content another way (no `curl`/`wget` from bash) — the browser renders
+JavaScript, keeps cookies, and can take screenshots, so it is both the policy
+and the better tool.
+
 When you return page findings, describe what is visible from the accessibility
 snapshot and include the URL you inspected.

--- a/examples/eve/agent/sandbox.ts
+++ b/examples/eve/agent/sandbox.ts
@@ -1,4 +1,4 @@
-import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/sandbox/eve";
+import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/eve/sandbox";
 import { defineSandbox } from "eve/sandbox";
 import { vercel } from "eve/sandbox/vercel";
 

--- a/examples/eve/agent/tools/web_fetch.ts
+++ b/examples/eve/agent/tools/web_fetch.ts
@@ -1,0 +1,6 @@
+import { disableTool } from "eve/tools";
+
+// Drop the web_fetch default for the same reason as web_search: all web
+// content should flow through the agent-browser tools so pages render with a
+// real browser (JavaScript, cookies, screenshots) inside the sandbox.
+export default disableTool();

--- a/examples/eve/agent/tools/web_search.ts
+++ b/examples/eve/agent/tools/web_search.ts
@@ -1,0 +1,6 @@
+import { disableTool } from "eve/tools";
+
+// Drop the provider-managed web_search default so the agent researches the
+// web through its agent-browser tools (browser__navigate, browser__read, ...)
+// instead of a search API.
+export default disableTool();

--- a/examples/eve/package.json
+++ b/examples/eve/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@agent-browser/eve": "link:../../packages/@agent-browser/eve",
-    "@agent-browser/sandbox": "file:../../packages/@agent-browser/sandbox",
     "@vercel/connect": "0.2.2",
     "ai": "7.0.0-beta.178",
     "eve": "^0.22.5",

--- a/examples/eve/pnpm-lock.yaml
+++ b/examples/eve/pnpm-lock.yaml
@@ -13,9 +13,6 @@ importers:
       '@agent-browser/eve':
         specifier: link:../../packages/@agent-browser/eve
         version: link:../../packages/@agent-browser/eve
-      '@agent-browser/sandbox':
-        specifier: file:../../packages/@agent-browser/sandbox
-        version: file:../../packages/@agent-browser/sandbox
       '@radix-ui/react-use-controllable-state':
         specifier: 1.2.2
         version: 1.2.2(@types/react@19.2.15)(react@19.2.6)
@@ -115,14 +112,6 @@ importers:
         version: 6.0.3
 
 packages:
-
-  '@agent-browser/sandbox@file:../../packages/@agent-browser/sandbox':
-    resolution: {directory: ../../packages/@agent-browser/sandbox, type: directory}
-    peerDependencies:
-      '@vercel/sandbox': '>=1.0.0'
-    peerDependenciesMeta:
-      '@vercel/sandbox':
-        optional: true
 
   '@ai-sdk/gateway@4.0.0-beta.109':
     resolution: {integrity: sha512-W/1kLlPb6Bgbhwep3CA3R6do0HD7SXV5gyuz2XBLY1YABqgxYkw+IhEcjOYlmn9v+Tifjqy5yJqmWdSHMJhyPQ==}
@@ -3124,8 +3113,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@agent-browser/sandbox@file:../../packages/@agent-browser/sandbox': {}
 
   '@ai-sdk/gateway@4.0.0-beta.109(zod@4.4.3)':
     dependencies:

--- a/packages/@agent-browser/eve/README.md
+++ b/packages/@agent-browser/eve/README.md
@@ -29,7 +29,7 @@ On first tool use in a fresh sandbox, the extension installs agent-browser (and 
 
 ```ts
 // agent/sandbox.ts
-import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/sandbox/eve";
+import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/eve/sandbox";
 import { defineSandbox } from "eve/sandbox";
 import { vercel } from "eve/sandbox/vercel";
 
@@ -42,6 +42,8 @@ export default defineSandbox({
   },
 });
 ```
+
+`@agent-browser/eve/sandbox` also exports `runAgentBrowser` for calling agent-browser from a hand-written eve tool. It derives a short, stable session name from the eve sandbox id; pass `session` when multiple independent browser sessions should share one sandbox.
 
 ## Configuration
 

--- a/packages/@agent-browser/eve/extension/lib/browser.ts
+++ b/packages/@agent-browser/eve/extension/lib/browser.ts
@@ -121,19 +121,25 @@ async function ensureInstalled(sandbox: EveSandboxSession, abortSignal?: AbortSi
 
 async function installIfMissing(sandbox: EveSandboxSession, abortSignal?: AbortSignal): Promise<void> {
   const config = extension.config;
-  const probe = await sandbox.run({
-    abortSignal,
-    command: `command -v ${quoteShellArg(config.binary)} >/dev/null 2>&1`,
-  });
+  const probe = await withDeadline(
+    sandbox.run({
+      abortSignal,
+      command: `command -v ${quoteShellArg(config.binary)} >/dev/null 2>&1`,
+    }),
+    "The browser install probe",
+  );
   if ((probe.exitCode ?? 0) === 0) {
     return;
   }
-  await installAgentBrowser(sandbox, {
-    abortSignal,
-    installBrowser: config.installBrowser,
-    installSpec: config.installSpec,
-    installSystemDependencies: config.installSystemDependencies,
-  });
+  await withDeadline(
+    installAgentBrowser(sandbox, {
+      abortSignal,
+      installBrowser: config.installBrowser,
+      installSpec: config.installSpec,
+      installSystemDependencies: config.installSystemDependencies,
+    }),
+    "Installing agent-browser",
+  );
 }
 
 function configArgs(): string[] {

--- a/packages/@agent-browser/eve/extension/lib/browser.ts
+++ b/packages/@agent-browser/eve/extension/lib/browser.ts
@@ -4,11 +4,7 @@ import {
   defaultSessionName,
   quoteShellArg,
 } from "@agent-browser/sandbox";
-import {
-  buildAgentBrowserCommand,
-  installAgentBrowser,
-  type EveSandboxSession,
-} from "@agent-browser/sandbox/eve";
+import { buildAgentBrowserCommand, installAgentBrowser, type EveSandboxSession } from "./sandbox";
 
 import extension from "../extension";
 

--- a/packages/@agent-browser/eve/extension/lib/sandbox.ts
+++ b/packages/@agent-browser/eve/extension/lib/sandbox.ts
@@ -9,7 +9,7 @@ import {
   type AgentBrowserCommandResult,
   type AgentBrowserInstallOptions,
   type BuildShellCommandOptions,
-} from "./shared.js";
+} from "@agent-browser/sandbox";
 
 export {
   AgentBrowserCommandError,
@@ -19,7 +19,7 @@ export {
   resolveAgentBrowserInstallSpec,
   type AgentBrowserCommandResult,
   type AgentBrowserInstallOptions,
-} from "./index.js";
+} from "@agent-browser/sandbox";
 
 export interface EveSandboxCommandResult {
   readonly exitCode?: number;

--- a/packages/@agent-browser/eve/extension/tools/wait_for.ts
+++ b/packages/@agent-browser/eve/extension/tools/wait_for.ts
@@ -10,22 +10,29 @@ interface WaitOutcome {
   readonly result?: unknown;
 }
 
+/**
+ * Models routinely send "" for optional fields they don't mean to use; a
+ * literal empty condition then burns its full timeout (`wait ''` can never
+ * match) or errors (`wait --fn ''`), so blank means absent.
+ */
+const optionalCondition = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+  z.string().optional(),
+);
+
 export default defineTool({
   description:
     "Wait for conditions on the page: an element, text, a URL pattern, a load state, a JavaScript expression, and/or a fixed delay. Provide at least one; multiple conditions are awaited in sequence (load state first, delay last). Navigation already waits for the page to load, so this is only needed for content that appears later. A condition that does not come true within the timeout returns satisfied: false rather than failing — note that busy pages may never reach networkidle.",
   inputSchema: z.object({
-    jsCondition: z
-      .string()
-      .optional()
-      .describe(
-        'JavaScript expression to wait for, e.g. "window.ready === true". Also the way to wait for something to disappear: "!document.querySelector(\'#spinner\')".',
-      ),
-    loadState: z.enum(["load", "domcontentloaded", "networkidle"]).optional(),
-    selector: z
-      .string()
-      .optional()
-      .describe(`Wait for this element to be visible. ${SELECTOR_HINT}`),
-    text: z.string().optional().describe("Wait for this text to appear (substring match)."),
+    jsCondition: optionalCondition.describe(
+      'JavaScript expression to wait for, e.g. "window.ready === true". Also the way to wait for something to disappear: "!document.querySelector(\'#spinner\')".',
+    ),
+    loadState: z.preprocess(
+      (value) => (value === "" ? undefined : value),
+      z.enum(["load", "domcontentloaded", "networkidle"]).optional(),
+    ),
+    selector: optionalCondition.describe(`Wait for this element to be visible. ${SELECTOR_HINT}`),
+    text: optionalCondition.describe("Wait for this text to appear (substring match)."),
     timeMs: z
       .number()
       .int()
@@ -40,7 +47,7 @@ export default defineTool({
       .max(30_000)
       .default(10_000)
       .describe("Max time to wait per condition before giving up."),
-    urlPattern: z.string().optional().describe('Wait for a URL glob pattern, e.g. "**/dashboard".'),
+    urlPattern: optionalCondition.describe('Wait for a URL glob pattern, e.g. "**/dashboard".'),
   }),
   async execute({ jsCondition, loadState, selector, text, timeMs, timeoutMs, urlPattern }, ctx) {
     const waits: { args: string[]; condition: string; isDelay?: boolean }[] = [];
@@ -88,8 +95,10 @@ async function runWait(
     return { condition, satisfied: true, result };
   } catch (error) {
     // A wait that runs out of time is an answer ("it didn't happen"), not a
-    // failure — surfacing it as an error sends models into retry loops.
-    if (error instanceof Error && /timed out/i.test(error.message)) {
+    // failure — surfacing it as an error sends models into retry loops. The
+    // CLI phrases these as "Wait timed out after Nms" or "Timeout waiting for
+    // load state: X" depending on the variant.
+    if (error instanceof Error && /timed out|timeout waiting/i.test(error.message)) {
       return { condition, satisfied: false, timedOut: true };
     }
     throw error;

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -20,11 +20,15 @@
     "./tools": {
       "types": "./dist/tools/index.d.ts",
       "default": "./dist/tools/index.mjs"
+    },
+    "./sandbox": {
+      "types": "./dist/sandbox/sandbox.d.ts",
+      "default": "./dist/sandbox/sandbox.js"
     }
   },
   "scripts": {
-    "build": "eve extension build",
-    "prepare": "eve extension build",
+    "build": "eve extension build && tsc -p tsconfig.sandbox.json",
+    "prepare": "eve extension build && tsc -p tsconfig.sandbox.json",
     "test": "pnpm run build && node --test test/*.test.mjs",
     "typecheck": "tsc"
   },

--- a/packages/@agent-browser/eve/test/extension.test.mjs
+++ b/packages/@agent-browser/eve/test/extension.test.mjs
@@ -440,6 +440,73 @@ test("errors instead of hanging when the sandbox stops responding", async (t) =>
   await rejection;
 });
 
+test("errors instead of hanging when the install probe stops responding", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  resetConfig();
+  const sandbox = { id: "wedged-probe", run: () => new Promise(() => {}) };
+  const rejection = assert.rejects(
+    () => tools.close.execute({}, fakeCtx(sandbox)),
+    /The browser install probe did not respond within 180s/,
+  );
+  // Let the async chain reach the probe's sandbox.run and arm the deadline timer.
+  await new Promise((resolve) => setImmediate(resolve));
+  t.mock.timers.tick(180_001);
+  await rejection;
+});
+
+test("wait_for schema drops empty-string conditions", () => {
+  const parsed = tools.wait_for.inputSchema.parse({
+    jsCondition: "",
+    loadState: "",
+    selector: "",
+    text: "Welcome",
+    urlPattern: " ",
+  });
+  assert.equal(parsed.jsCondition, undefined);
+  assert.equal(parsed.loadState, undefined);
+  assert.equal(parsed.selector, undefined);
+  assert.equal(parsed.urlPattern, undefined);
+  assert.equal(parsed.text, "Welcome");
+});
+
+test("wait_for runs only the conditions that are actually set", async () => {
+  resetConfig();
+  const sandbox = fakeSandbox({ id: "wait-only-set" });
+  const input = tools.wait_for.inputSchema.parse({ selector: "", text: "Welcome", urlPattern: "" });
+  const result = await tools.wait_for.execute(input, fakeCtx(sandbox));
+  assert.deepEqual(result, { condition: 'text "Welcome"', satisfied: true, result: {} });
+  const waits = sandbox.commands.filter((command) => command.includes(" wait "));
+  assert.equal(waits.length, 1);
+  assert.ok(waits[0].includes("--text Welcome"));
+});
+
+test("wait_for reports load-state timeout as unsatisfied instead of throwing", async () => {
+  resetConfig();
+  const sandbox = fakeSandbox({
+    id: "wait-load-timeout",
+    respond: (command) =>
+      command.includes("--load")
+        ? {
+            exitCode: 1,
+            stdout: JSON.stringify({
+              success: false,
+              data: null,
+              error: "Timeout waiting for load state: networkidle",
+            }),
+          }
+        : {},
+  });
+  const result = await tools.wait_for.execute(
+    { loadState: "networkidle", timeoutMs: 1000 },
+    fakeCtx(sandbox),
+  );
+  assert.deepEqual(result, {
+    condition: "load state networkidle",
+    satisfied: false,
+    timedOut: true,
+  });
+});
+
 test("mount factory validates config", () => {
   assert.throws(() => extension({ maxOutputChars: -1 }));
   resetConfig();

--- a/packages/@agent-browser/eve/test/sandbox.test.mjs
+++ b/packages/@agent-browser/eve/test/sandbox.test.mjs
@@ -6,7 +6,7 @@ import {
   buildAgentBrowserCommand,
   installAgentBrowser,
   runAgentBrowser,
-} from "../dist/eve.js";
+} from "../dist/sandbox/sandbox.js";
 
 test("builds Eve revalidation key from install options", () => {
   assert.equal(

--- a/packages/@agent-browser/eve/tsconfig.sandbox.json
+++ b/packages/@agent-browser/eve/tsconfig.sandbox.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "lib": ["DOM", "ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist/sandbox",
+    "rootDir": "extension/lib",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["extension/lib/sandbox.ts"]
+}

--- a/packages/@agent-browser/sandbox/README.md
+++ b/packages/@agent-browser/sandbox/README.md
@@ -6,30 +6,7 @@ This package does not define model tools. Use it from framework-specific tools, 
 
 ## Eve
 
-```ts
-import { defineSandbox } from "eve/sandbox";
-import { vercel } from "eve/sandbox/vercel";
-import { agentBrowserRevalidationKey, installAgentBrowser } from "@agent-browser/sandbox/eve";
-
-export default defineSandbox({
-  backend: vercel({ runtime: "node24", resources: { vcpus: 2 } }),
-  revalidationKey: () => agentBrowserRevalidationKey(),
-  async bootstrap({ use }) {
-    const sandbox = await use();
-    await installAgentBrowser(sandbox);
-  },
-});
-```
-
-Then call `agent-browser` from an Eve tool:
-
-```ts
-import { runAgentBrowser } from "@agent-browser/sandbox/eve";
-
-const result = await runAgentBrowser(ctx, ["open", "https://example.com"]);
-```
-
-The Eve helper derives a short, stable `agent-browser` session name from the Eve sandbox id. Pass `session` to `runAgentBrowser` when multiple independent browser sessions should share one sandbox.
+For Eve agents, use [`@agent-browser/eve`](../eve/) — it mounts the full browser tool set and exposes the sandbox bootstrap helpers from `@agent-browser/eve/sandbox`, with this package as an internal dependency.
 
 ## Vercel Sandbox
 
@@ -53,7 +30,7 @@ const snapshot = await withAgentBrowserSandbox(async (sandbox) => {
 });
 ```
 
-The Eve and Vercel helpers install browser system dependencies by default. Pass `installSystemDependencies: false` only when the sandbox image already provides Chromium's required libraries.
+The Vercel helpers install browser system dependencies by default. Pass `installSystemDependencies: false` only when the sandbox image already provides Chromium's required libraries.
 
 Set `AGENT_BROWSER_SNAPSHOT_ID` to boot from a prebuilt Vercel Sandbox snapshot. Without a snapshot, the helper installs system dependencies, `agent-browser`, and Chrome on first boot.
 

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -13,10 +13,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./eve": {
-      "types": "./dist/eve.d.ts",
-      "import": "./dist/eve.js"
-    },
     "./vercel": {
       "types": "./dist/vercel.d.ts",
       "import": "./dist/vercel.js"

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -62,7 +62,7 @@ Configure the MCP client to launch `agent-browser` with `["mcp"]`. The server de
 
 ## Eve agent integration
 
-For Eve agents, mount the `@agent-browser/eve` extension instead of hand-writing browser tools. It adds namespaced tools such as `browser__navigate`, `browser__snapshot`, `browser__click`, `browser__fill`, `browser__find`, and `browser__screenshot`, all backed by agent-browser running inside the Eve sandbox. Install `@agent-browser/sandbox` directly if the agent's `agent/sandbox.ts` bootstrap imports `installAgentBrowser` from `@agent-browser/sandbox/eve`.
+For Eve agents, mount the `@agent-browser/eve` extension instead of hand-writing browser tools. It adds namespaced tools such as `browser__navigate`, `browser__snapshot`, `browser__click`, `browser__fill`, `browser__find`, and `browser__screenshot`, all backed by agent-browser running inside the Eve sandbox. The sandbox bootstrap helpers (`installAgentBrowser`, `agentBrowserRevalidationKey`) ship with the same package under `@agent-browser/eve/sandbox`, so `agent/sandbox.ts` needs no extra dependency.
 
 ## Reading a page
 


### PR DESCRIPTION
- Resolve load and DOMContentLoaded waits immediately when the current document is already ready.
- Treat Eve wait timeouts and empty optional conditions as structured outcomes.
- Add focused native and extension coverage for wait and install timeout behavior.