### PR TITLE
fix(recording): preserve browser capture colors

### DIFF
--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -102,7 +102,10 @@ fn build_ffmpeg_command(output_path: &str) -> tokio::process::Command {
             "-i",
             "pipe:0",
         ])
-        .args(["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2"]);
+        .args([
+            "-vf",
+            "pad=ceil(iw/2)*2:ceil(ih/2)*2,scale=in_range=pc:out_range=tv:out_color_matrix=bt709",
+        ]);
 
     if output_path.ends_with(".webm") {
         cmd.args(["-c:v", "libvpx", "-crf", "30", "-b:v", "1M"]);
@@ -110,7 +113,20 @@ fn build_ffmpeg_command(output_path: &str) -> tokio::process::Command {
         cmd.args(["-c:v", "libx264", "-preset", "ultrafast"]);
     }
 
-    cmd.args(["-pix_fmt", "yuv420p", "-threads", "1"])
+    cmd.args([
+        "-pix_fmt",
+        "yuv420p",
+        "-color_range",
+        "tv",
+        "-colorspace",
+        "bt709",
+        "-color_primaries",
+        "bt709",
+        "-color_trc",
+        "bt709",
+        "-threads",
+        "1",
+    ])
         .arg(output_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
@@ -309,6 +325,11 @@ mod tests {
         let args: Vec<&std::ffi::OsStr> = cmd.as_std().get_args().collect();
         let args_str: Vec<&str> = args.iter().filter_map(|a| a.to_str()).collect();
         assert!(args_str.contains(&"libvpx"));
+        assert!(args_str.contains(
+            &"pad=ceil(iw/2)*2:ceil(ih/2)*2,scale=in_range=pc:out_range=tv:out_color_matrix=bt709"
+        ));
+        assert!(args_str.contains(&"-color_range"));
+        assert!(args_str.contains(&"bt709"));
         assert!(args_str.contains(&"/tmp/out.webm"));
     }
 


### PR DESCRIPTION
## Summary

- convert full-range JPEG capture frames to limited-range BT.709 before video encoding
- tag encoded video with the matching range and color matrix
- cover the FFmpeg recording arguments with a regression assertion

## Why

`Page.captureScreenshot` JPEG frames enter FFmpeg as full-range BT.601-style YUV. The recorder previously forced `yuv420p` without converting the range or declaring an output matrix, producing WebM files tagged `pc` / `bt470bg`. Players commonly render those recordings with lifted blacks and washed-out contrast.

## Verification

- ran the generated FFmpeg filter and metadata arguments against a real 1440x900 browser capture
- verified the output reports `yuv420p`, `color_range=tv`, and `color_space=bt709` with `ffprobe`
- decoded a frame and compared it visually with the source sRGB screenshot
- `git diff --check`

Rust tests were not run locally because this machine does not have a Rust toolchain installed.