### PR TITLE
Prepare v0.32.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 # agent-browser
 
-## 0.31.2
+## 0.32.0
 
 <!-- release:start -->
+### New Features
+
+- **Eve extension** - Added `@agent-browser/eve`, an Eve extension that mounts the agent-browser tool set with namespaced browser tools, sandbox bootstrap helpers, docs, examples, CI, and release packaging (#1547)
+
+### Security
+
+- Hardened **domain allowlists** by blocking WebRTC bypasses, applying network containment across launch modes, workers, popups, restored state, and reused daemon sessions, rejecting unsafe startup arguments, and adding Chrome regression coverage (#1546)
+
+### Bug Fixes
+
+- Fixed **completed-page waits** so load and DOMContentLoaded waits resolve immediately when the current document is already ready, with structured Eve wait timeout handling and focused coverage (#1554)
+
+### Contributors
+
+- @ctate
+- @dnukumamras
+<!-- release:end -->
+
+## 0.31.2
+
 ### New Features
 
 - **WebGPU launch preset** - Added `--webgpu` across the CLI, config, environment, and MCP surfaces, with hardware backends on macOS and Windows, software Vulkan on Linux, automatic Xvfb for displayless headed sessions, and a `doctor --webgpu` render and screenshot probe (#1529)
@@ -14,7 +34,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.31.1
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.31.2"
+version = "0.32.0"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.32.0
+
+<p className="text-[#888] text-sm">July 15, 2026</p>
+
+### New Features
+
+- **Eve extension** - Added `@agent-browser/eve`, an Eve extension that mounts the agent-browser tool set with namespaced browser tools, sandbox bootstrap helpers, docs, examples, CI, and release packaging (#1547)
+
+### Security
+
+- Hardened **domain allowlists** by blocking WebRTC bypasses, applying network containment across launch modes, workers, popups, restored state, and reused daemon sessions, rejecting unsafe startup arguments, and adding Chrome regression coverage (#1546)
+
+### Bug Fixes
+
+- Fixed **completed-page waits** so load and DOMContentLoaded waits resolve immediately when the current document is already ready, with structured Eve wait timeout handling and focused coverage (#1554)
+
+---
+
 ## v0.31.2
 
 <p className="text-[#888] text-sm">July 13, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,
@@ -53,7 +53,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@agent-browser/sandbox": "^0.31.2",
+    "@agent-browser/sandbox": "workspace:^",
     "zod": "4.4.3"
   },
   "peerDependencies": {

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -28,8 +28,8 @@
   },
   "scripts": {
     "build": "eve extension build && tsc -p tsconfig.sandbox.json",
-    "prepare": "eve extension build && tsc -p tsconfig.sandbox.json",
-    "test": "pnpm run build && node --test test/*.test.mjs",
+    "prepare": "pnpm -C ../sandbox run build && pnpm run build",
+    "test": "pnpm -C ../sandbox run build && pnpm run build && node --test test/*.test.mjs",
     "typecheck": "tsc"
   },
   "keywords": [

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.31.2";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.32.0";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
   packages/@agent-browser/eve:
     dependencies:
       '@agent-browser/sandbox':
-        specifier: ^0.31.2
-        version: 0.31.2(@vercel/sandbox@2.2.1)
+        specifier: workspace:^
+        version: link:../sandbox
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -217,14 +217,6 @@ importers:
         version: 5.9.3
 
 packages:
-
-  '@agent-browser/sandbox@0.31.2':
-    resolution: {integrity: sha512-FSeAuBYBwW/xpDG3uUfdpZbOzHfU7KFnTChvtkixju6YzYWYC22NvHKdWF66aABuzRfm8A3N5EllQKD7dnKy1A==}
-    peerDependencies:
-      '@vercel/sandbox': '>=1.0.0'
-    peerDependenciesMeta:
-      '@vercel/sandbox':
-        optional: true
 
   '@ai-sdk/gateway@3.0.88':
     resolution: {integrity: sha512-AFoj7xdWAtCQcy0jJ235ENSakYM8D28qBX+rB+/rX4r8qe/LXgl0e5UivOqxAlIM5E9jnQdYxIPuj3XFtGk/yg==}
@@ -5687,10 +5679,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@agent-browser/sandbox@0.31.2(@vercel/sandbox@2.2.1)':
-    optionalDependencies:
-      '@vercel/sandbox': 2.2.1
 
   '@ai-sdk/gateway@3.0.88(zod@4.4.3)':
     dependencies:

--- a/scripts/check-version-sync.js
+++ b/scripts/check-version-sync.js
@@ -47,7 +47,7 @@ const sandboxRuntimeVersion = sandboxVersionMatch[1];
 // Read Eve package version
 const evePkg = JSON.parse(readFileSync(join(rootDir, 'packages/@agent-browser/eve/package.json'), 'utf-8'));
 const eveVersion = evePkg.version;
-const eveSandboxRange = evePkg.dependencies?.['@agent-browser/sandbox'];
+const eveSandboxDependency = evePkg.dependencies?.['@agent-browser/sandbox'];
 
 const mismatches = [];
 if (packageVersion !== cargoVersion) {
@@ -65,8 +65,8 @@ if (packageVersion !== sandboxRuntimeVersion) {
 if (packageVersion !== eveVersion) {
   mismatches.push(`  packages/@agent-browser/eve/package.json: ${eveVersion}`);
 }
-if (eveSandboxRange !== `^${packageVersion}`) {
-  mismatches.push(`  packages/@agent-browser/eve dependency @agent-browser/sandbox: ${eveSandboxRange}`);
+if (eveSandboxDependency !== 'workspace:^') {
+  mismatches.push(`  packages/@agent-browser/eve dependency @agent-browser/sandbox: ${eveSandboxDependency}`);
 }
 
 if (mismatches.length > 0) {

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -68,14 +68,14 @@ if (sandboxPkg.version !== version) {
   console.log(`  packages/@agent-browser/sandbox/package.json already up to date`);
 }
 
-// Update packages/@agent-browser/eve/package.json (version + sandbox dep range)
+// Update packages/@agent-browser/eve/package.json (version + workspace sandbox dependency)
 const evePkgPath = join(rootDir, "packages", "@agent-browser", "eve", "package.json");
 const evePkg = JSON.parse(readFileSync(evePkgPath, "utf-8"));
-const eveSandboxRange = `^${version}`;
-if (evePkg.version !== version || evePkg.dependencies["@agent-browser/sandbox"] !== eveSandboxRange) {
+const eveSandboxDependency = "workspace:^";
+if (evePkg.version !== version || evePkg.dependencies["@agent-browser/sandbox"] !== eveSandboxDependency) {
   const oldVersion = evePkg.version;
   evePkg.version = version;
-  evePkg.dependencies["@agent-browser/sandbox"] = eveSandboxRange;
+  evePkg.dependencies["@agent-browser/sandbox"] = eveSandboxDependency;
   writeFileSync(evePkgPath, JSON.stringify(evePkg, null, 2) + "\n");
   console.log(`  Updated packages/@agent-browser/eve/package.json: ${oldVersion} -> ${version}`);
 } else {


### PR DESCRIPTION
- Bump agent-browser, Cargo, dashboard, sandbox, and Eve package versions to 0.32.0
- Add v0.32.0 changelog entries for the Eve extension, domain allowlist hardening, and completed-page wait fixes
- Keep Eve linked to the local sandbox workspace package while preserving publish-time semver output