### PR TITLE
Lowercase eve brand name in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!-- release:start -->
 ### New Features
 
-- **Eve extension** - Added `@agent-browser/eve`, an Eve extension that mounts the agent-browser tool set with namespaced browser tools, sandbox bootstrap helpers, docs, examples, CI, and release packaging (#1547)
+- **eve extension** - Added `@agent-browser/eve`, an eve extension that mounts the agent-browser tool set with namespaced browser tools, sandbox bootstrap helpers, docs, examples, CI, and release packaging (#1547)
 
 ### Security
 
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
-- Fixed **completed-page waits** so load and DOMContentLoaded waits resolve immediately when the current document is already ready, with structured Eve wait timeout handling and focused coverage (#1554)
+- Fixed **completed-page waits** so load and DOMContentLoaded waits resolve immediately when the current document is already ready, with structured eve wait timeout handling and focused coverage (#1554)
 
 ### Contributors
 
@@ -87,7 +87,7 @@
 
 ### Improvements
 
-- Defaulted **sandbox system dependency installs** so the Eve and Vercel sandbox helpers install Chromium's required libraries unless explicitly disabled, making first-run sandbox setup simpler (#1469)
+- Defaulted **sandbox system dependency installs** so the eve and Vercel sandbox helpers install Chromium's required libraries unless explicitly disabled, making first-run sandbox setup simpler (#1469)
 
 ### Contributors
 
@@ -97,7 +97,7 @@
 
 ### New Features
 
-- **Sandbox package** - Added `@agent-browser/sandbox` with shared, Eve, and Vercel Sandbox helpers, example projects, and docs for running agent-browser in hosted sandbox environments (#1465)
+- **Sandbox package** - Added `@agent-browser/sandbox` with shared, eve, and Vercel Sandbox helpers, example projects, and docs for running agent-browser in hosted sandbox environments (#1465)
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -1256,9 +1256,9 @@ const result = await withAgentBrowserSandbox(async (sandbox) => {
 
 Install `@agent-browser/sandbox` and `@vercel/sandbox` in the consuming app. See the [sandbox helper example](examples/sandbox/) for minimal Vercel Sandbox usage, or the [environments example](examples/environments/) for a full UI demo with a deploy-to-Vercel button.
 
-Fresh Vercel and Eve sandboxes install Chromium system dependencies by default. Pass `installSystemDependencies: false` only when your sandbox image already includes those libraries.
+Fresh Vercel and eve sandboxes install Chromium system dependencies by default. Pass `installSystemDependencies: false` only when your sandbox image already includes those libraries.
 
-### Eve extension
+### eve extension
 
 Give an [eve](https://eve.dev) agent the full browser tool set by mounting the [`@agent-browser/eve`](packages/@agent-browser/eve/) extension:
 

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -6,7 +6,7 @@
 
 ### New Features
 
-- **Eve extension** - Added `@agent-browser/eve`, an Eve extension that mounts the agent-browser tool set with namespaced browser tools, sandbox bootstrap helpers, docs, examples, CI, and release packaging (#1547)
+- **eve extension** - Added `@agent-browser/eve`, an eve extension that mounts the agent-browser tool set with namespaced browser tools, sandbox bootstrap helpers, docs, examples, CI, and release packaging (#1547)
 
 ### Security
 
@@ -14,7 +14,7 @@
 
 ### Bug Fixes
 
-- Fixed **completed-page waits** so load and DOMContentLoaded waits resolve immediately when the current document is already ready, with structured Eve wait timeout handling and focused coverage (#1554)
+- Fixed **completed-page waits** so load and DOMContentLoaded waits resolve immediately when the current document is already ready, with structured eve wait timeout handling and focused coverage (#1554)
 
 ---
 
@@ -86,7 +86,7 @@
 
 ### Improvements
 
-- Defaulted **sandbox system dependency installs** so the Eve and Vercel sandbox helpers install Chromium's required libraries unless explicitly disabled, making first-run sandbox setup simpler (#1469)
+- Defaulted **sandbox system dependency installs** so the eve and Vercel sandbox helpers install Chromium's required libraries unless explicitly disabled, making first-run sandbox setup simpler (#1469)
 
 ---
 
@@ -96,7 +96,7 @@
 
 ### New Features
 
-- **Sandbox package** - Added `@agent-browser/sandbox` with shared, Eve, and Vercel Sandbox helpers, example projects, and docs for running agent-browser in hosted sandbox environments (#1465)
+- **Sandbox package** - Added `@agent-browser/sandbox` with shared, eve, and Vercel Sandbox helpers, example projects, and docs for running agent-browser in hosted sandbox environments (#1465)
 
 ### Improvements
 

--- a/docs/src/app/eve/page.mdx
+++ b/docs/src/app/eve/page.mdx
@@ -1,6 +1,6 @@
-# Eve Extension
+# eve Extension
 
-`@agent-browser/eve` mounts the full agent-browser tool set into an [Eve](https://eve.dev) agent. The tools run `agent-browser` inside the agent sandbox, so the browser process, downloads, screenshots, and state stay out of the Next.js runtime.
+`@agent-browser/eve` mounts the full agent-browser tool set into an [eve](https://eve.dev) agent. The tools run `agent-browser` inside the agent sandbox, so the browser process, downloads, screenshots, and state stay out of the Next.js runtime.
 
 ## Install
 
@@ -8,7 +8,7 @@
 pnpm add @agent-browser/eve
 ```
 
-`eve` is a peer dependency and should already be present in an Eve app. The sandbox preinstall helpers shown below ship with the same package, so no other install is needed.
+`eve` is a peer dependency and should already be present in an eve app. The sandbox preinstall helpers shown below ship with the same package, so no other install is needed.
 
 ## Mount
 
@@ -28,7 +28,7 @@ The agent gets namespaced tools such as `browser__navigate`, `browser__snapshot`
 
 ## Sandbox bootstrap
 
-The extension can install `agent-browser`, Chromium, and required Linux libraries on first tool use. For production, install them in the Eve sandbox template so sessions start warm.
+The extension can install `agent-browser`, Chromium, and required Linux libraries on first tool use. For production, install them in the eve sandbox template so sessions start warm.
 
 ```ts
 // agent/sandbox.ts
@@ -71,8 +71,8 @@ For reading articles or docs, prefer `browser__read`. For apps, use `browser__sn
 
 ## Security
 
-Cookie, storage, and saved-auth-state commands are intentionally not exposed by the extension because they can reveal credential material to the model. Use standard Eve extension overrides when you need to disable a tool, add approval requirements, or provide an app-specific guarded tool.
+Cookie, storage, and saved-auth-state commands are intentionally not exposed by the extension because they can reveal credential material to the model. Use standard eve extension overrides when you need to disable a tool, add approval requirements, or provide an app-specific guarded tool.
 
 ## Example
 
-See [`examples/eve`](https://github.com/vercel-labs/agent-browser/tree/main/examples/eve) for a complete Next.js Eve app with the extension mounted.
+See [`examples/eve`](https://github.com/vercel-labs/agent-browser/tree/main/examples/eve) for a complete Next.js eve app with the extension mounted.

--- a/docs/src/app/page.mdx
+++ b/docs/src/app/page.mdx
@@ -17,7 +17,7 @@ npx agent-browser open example.com
 - **Ref-based**: Snapshot returns accessibility tree with refs for deterministic element selection
 - **Complete**: 50+ commands for navigation, forms, screenshots, network, storage, files, tabs, frames, and debugging
 - **Observable**: [Video recording](/recording), [streaming](/streaming), [debugging](/debugging), [profiler](/profiler), and [diffing](/diffing) tools are built in
-- **Modern apps**: [Network control](/network), [React & Web Vitals](/react), [init scripts](/init-scripts), [Next.js + Vercel](/next), and [Eve Extension](/eve) workflows have first-class docs
+- **Modern apps**: [Network control](/network), [React & Web Vitals](/react), [init scripts](/init-scripts), [Next.js + Vercel](/next), and [eve Extension](/eve) workflows have first-class docs
 - **Stateful**: [Sessions](/sessions), profiles, auth state, cookies, storage, proxy, and security controls support long-running agents
 - **Cross-platform**: macOS, Linux, Windows with native binaries
 

--- a/docs/src/app/skills/page.mdx
+++ b/docs/src/app/skills/page.mdx
@@ -70,9 +70,9 @@ This design solves the version drift problem: the installed SKILL.md rarely chan
 
 Use `agent-browser skills list` to see all available skills, then `agent-browser skills get <name>` to load one. `agent-browser skills get core --full` is the recommended starting point for most browser tasks.
 
-## Eve agents
+## eve agents
 
-For Eve agents, mount the [`@agent-browser/eve`](/eve) extension instead of writing browser tools by hand. It gives the agent namespaced browser tools backed by agent-browser inside the Eve sandbox.
+For eve agents, mount the [`@agent-browser/eve`](/eve) extension instead of writing browser tools by hand. It gives the agent namespaced browser tools backed by agent-browser inside the eve sandbox.
 
 ## Source
 

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -48,7 +48,7 @@ export const navigation: NavSection[] = [
       { name: "iOS Simulator", href: "/ios" },
       { name: "Security", href: "/security" },
       { name: "Next.js + Vercel", href: "/next" },
-      { name: "Eve Extension", href: "/eve" },
+      { name: "eve Extension", href: "/eve" },
       { name: "Native Mode", href: "/native-mode" },
     ],
   },

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -27,7 +27,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "engines/chrome": "Chrome",
   "engines/lightpanda": "Lightpanda",
   next: "Next.js + Vercel",
-  eve: "Eve Extension",
+  eve: "eve Extension",
   "native-mode": "Native Mode",
   "providers/agentcore": "AgentCore",
   "providers/browser-use": "Browser Use",

--- a/examples/eve/README.md
+++ b/examples/eve/README.md
@@ -1,4 +1,4 @@
-# Agent Browser Eve Example
+# Agent Browser eve Example
 
 This is a scaffold-style [eve](https://eve.dev) app based on `eve init --channel-web-nextjs`. Its agent gets a full browser tool set from the [`@agent-browser/eve`](../../packages/@agent-browser/eve/) extension.
 

--- a/packages/@agent-browser/sandbox/README.md
+++ b/packages/@agent-browser/sandbox/README.md
@@ -4,9 +4,9 @@ Helpers for installing and running `agent-browser` inside sandbox runtimes.
 
 This package does not define model tools. Use it from framework-specific tools, agents, route handlers, or jobs that already decide what the browser should do.
 
-## Eve
+## eve
 
-For Eve agents, use [`@agent-browser/eve`](../eve/) — it mounts the full browser tool set and exposes the sandbox bootstrap helpers from `@agent-browser/eve/sandbox`, with this package as an internal dependency.
+For eve agents, use [`@agent-browser/eve`](../eve/) — it mounts the full browser tool set and exposes the sandbox bootstrap helpers from `@agent-browser/eve/sandbox`, with this package as an internal dependency.
 
 ## Vercel Sandbox
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -60,9 +60,9 @@ agent-browser mcp --tools core,network,react
 
 Configure the MCP client to launch `agent-browser` with `["mcp"]`. The server defaults to MCP protocol 2025-11-25 and accepts older supported client protocol versions during initialization. The default tools profile is `core`, which keeps MCP context small for everyday browser automation. Use `--tools all` for the full typed CLI parity surface, or combine profiles with commas, such as `--tools core,network,react`. Profiles are `core`, `network`, `state`, `debug`, `tabs`, `react`, `mobile`, and `all`; the `debug` profile includes plugin registry and command.run tools. Each tool accepts typed arguments plus `extraArgs` for advanced CLI flags and exact CLI parity. The common `allowedDomains` array maps to `--allowed-domains` and activates the same WebRTC containment and launch-mode restrictions. Tool discovery is paginated and includes read-only/open-world annotations so modern MCP clients can load the large typed surface incrementally. Use the tool `session` argument or `AGENT_BROWSER_SESSION` to isolate browser sessions.
 
-## Eve agent integration
+## eve agent integration
 
-For Eve agents, mount the `@agent-browser/eve` extension instead of hand-writing browser tools. It adds namespaced tools such as `browser__navigate`, `browser__snapshot`, `browser__click`, `browser__fill`, `browser__find`, and `browser__screenshot`, all backed by agent-browser running inside the Eve sandbox. The sandbox bootstrap helpers (`installAgentBrowser`, `agentBrowserRevalidationKey`) ship with the same package under `@agent-browser/eve/sandbox`, so `agent/sandbox.ts` needs no extra dependency.
+For eve agents, mount the `@agent-browser/eve` extension instead of hand-writing browser tools. It adds namespaced tools such as `browser__navigate`, `browser__snapshot`, `browser__click`, `browser__fill`, `browser__find`, and `browser__screenshot`, all backed by agent-browser running inside the eve sandbox. The sandbox bootstrap helpers (`installAgentBrowser`, `agentBrowserRevalidationKey`) ship with the same package under `@agent-browser/eve/sandbox`, so `agent/sandbox.ts` needs no extra dependency.
 
 ## Reading a page
 


### PR DESCRIPTION
## Summary

- Lowercase every brand reference to **eve** across the docs — docs site pages, nav label and page-title map, README, CHANGELOG, `examples/eve`, `skill-data/core/SKILL.md`, and the sandbox package README
- Other words in titles keep their capitalization (e.g. "eve Extension" in the docs nav and page heading)

## Verification

Ran the docs site locally — `/eve` renders with `<title>eve Extension | agent-browser</title>` and the updated nav label.