### PR TITLE
fix(cli): preserve Edge internal URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ agent-browser find role button click --name "Submit"
 ```bash
 agent-browser open                    # Launch browser (no navigation); stays on about:blank
 agent-browser open <url>              # Launch + navigate to URL (aliases: goto, navigate)
+agent-browser --executable-path <path-to-edge> open edge://extensions  # Open an Edge internal URL
 agent-browser read [url]              # Fetch agent-readable text, or read rendered active-tab DOM
 agent-browser click <sel>             # Click element (--new-tab to open in new tab)
 agent-browser dblclick <sel>          # Double-click element

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -374,6 +374,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 || url_lower.starts_with("file:")
                 || url_lower.starts_with("chrome-extension://")
                 || url_lower.starts_with("chrome://")
+                || url_lower.starts_with("edge://")
             {
                 url.to_string()
             } else {
@@ -3823,6 +3824,13 @@ mod tests {
         let cmd = parse_command(&args("open chrome://extensions"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "navigate");
         assert_eq!(cmd["url"], "chrome://extensions");
+    }
+
+    #[test]
+    fn test_navigate_edge_url() {
+        let cmd = parse_command(&args("open edge://extensions"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "navigate");
+        assert_eq!(cmd["url"], "edge://extensions");
     }
 
     // === Set Headers Tests ===

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -367,6 +367,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 }
             };
             let url_lower = url.to_lowercase();
+            // Preserve recognized URL schemes; normalize other inputs with https://.
             let url = if url_lower.starts_with("http://")
                 || url_lower.starts_with("https://")
                 || url_lower.starts_with("about:")

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -3791,6 +3791,16 @@ mod tests {
     }
 
     #[test]
+    fn open_args_preserve_edge_url_through_cli_parser() {
+        let args = open_args(&json!({ "url": "edge://extensions" })).unwrap();
+        let flags = crate::flags::parse_flags(&args);
+        let command = crate::commands::parse_command(&args, &flags).unwrap();
+
+        assert_eq!(command["action"], "navigate");
+        assert_eq!(command["url"], "edge://extensions");
+    }
+
+    #[test]
     fn doctor_tool_exposes_webgpu_option() {
         let tools = tools();
         let doctor = tools

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1262,8 +1262,9 @@ you stage state (network routes, cookies, init scripts) before the first
 real navigation — useful for SSR debug, auth setup, and capturing fresh
 `react suspense` / `vitals` state without noise from a prior page.
 
-With a URL, launches and navigates. If no protocol is provided, https://
-is automatically prepended.
+With a URL, launches and navigates. Recognized schemes, including chrome://
+and edge://, are passed through unchanged. Other inputs are normalized with
+https://. Opening edge:// URLs requires launching Microsoft Edge.
 
 The `goto` and `navigate` aliases still require a URL.
 
@@ -1279,6 +1280,7 @@ Examples:
   agent-browser open                     # Launch, no nav
   agent-browser open example.com
   agent-browser open https://github.com
+  agent-browser --executable-path <path-to-edge> open edge://extensions
   agent-browser open localhost:3000
   agent-browser open api.example.com --headers '{"Authorization": "Bearer token"}'
     # ^ Headers only sent to api.example.com, not other domains

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -5,6 +5,7 @@
 ```bash
 agent-browser open                    # Launch browser (no nav); stays on about:blank
 agent-browser open <url>              # Launch + navigate (aliases: goto, navigate)
+agent-browser --executable-path <path-to-edge> open edge://extensions  # Open an Edge internal URL
 agent-browser read [url]              # Fetch agent-readable text, or read rendered active-tab DOM
 agent-browser click <sel>             # Click element (--new-tab to open in new tab)
 agent-browser dblclick <sel>          # Double-click

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -9,8 +9,9 @@ agent-browser open            # Launch browser (no navigation); stays on about:b
                               # Pair with `network route`, `cookies set --curl`, or
                               # `addinitscript` to stage state before the first navigation.
 agent-browser open <url>      # Launch + navigate (aliases: goto, navigate)
-                              # Supports: https://, http://, file://, about:, data://
-                              # Auto-prepends https:// if no protocol given
+                              # Recognizes: https://, http://, file:, about:, data:,
+                              # chrome-extension://, chrome://, and edge://
+                              # Other inputs are normalized with https://
 agent-browser read [url]      # Fetch agent-readable text, or read rendered active-tab DOM
                               # Explicit URLs send Accept: text/markdown, then try .md if needed
                               # Walks ancestor paths for llms.txt before HTML fallback


### PR DESCRIPTION
## Summary

- preserve `edge://` URLs instead of prefixing them with `https://`
- keep MCP open behavior aligned with the canonical CLI parser
- document recognized internal browser URL schemes across the CLI help, README, docs, and skill reference
- add focused CLI and MCP regression coverage

Fixes #1535.

## Tests

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --profile ci --manifest-path cli/Cargo.toml commands::tests::`
- `cargo test --profile ci --manifest-path cli/Cargo.toml mcp::tests::`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `node scripts/check-version-sync.js`