### PR TITLE
fix(chrome): suppress NTP tab in headed real-Chrome mode (#1544)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3193,7 +3193,14 @@ fn launch_options_from_env() -> LaunchOptions {
         no_xvfb: no_xvfb_from_env(),
         restrict_webrtc: env::var("AGENT_BROWSER_ALLOWED_DOMAINS")
             .is_ok_and(|domains| !domains.trim().is_empty()),
+        no_startup_window: no_startup_window_from_env(),
     }
+}
+
+fn no_startup_window_from_env() -> bool {
+    env::var("AGENT_BROWSER_NO_STARTUP_WINDOW")
+        .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no" | ""))
+        .unwrap_or(true)
 }
 
 fn hide_scrollbars_from_env() -> bool {
@@ -3654,6 +3661,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         webgpu: webgpu_from_launch_cmd(cmd),
         no_xvfb: no_xvfb_from_launch_cmd(cmd),
         restrict_webrtc,
+        no_startup_window: no_startup_window_from_env(),
     };
 
     state.plugin_init_scripts.clear();
@@ -11622,6 +11630,47 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         guard.set("AGENT_BROWSER_HIDE_SCROLLBARS", "false");
         let opts = launch_options_from_env();
         assert!(!opts.hide_scrollbars);
+    }
+
+    #[test]
+    fn test_launch_options_from_env_no_startup_window_default() {
+        // Default behavior: flag is ON so headed real-Chrome launches don't
+        // strand a phantom NTP tab. See issue #1544.
+        let guard = EnvGuard::new(&["AGENT_BROWSER_NO_STARTUP_WINDOW"]);
+        guard.remove("AGENT_BROWSER_NO_STARTUP_WINDOW");
+        let opts = launch_options_from_env();
+        assert!(
+            opts.no_startup_window,
+            "no_startup_window must default to true to fix issue #1544"
+        );
+    }
+
+    #[test]
+    fn test_launch_options_from_env_no_startup_window_opt_out() {
+        // Each of these values must opt out of the auto-injection.
+        for value in ["0", "false", "no", "FALSE", "No", ""] {
+            let guard = EnvGuard::new(&["AGENT_BROWSER_NO_STARTUP_WINDOW"]);
+            guard.set("AGENT_BROWSER_NO_STARTUP_WINDOW", value);
+            let opts = launch_options_from_env();
+            assert!(
+                !opts.no_startup_window,
+                "AGENT_BROWSER_NO_STARTUP_WINDOW={value:?} must opt out",
+            );
+        }
+    }
+
+    #[test]
+    fn test_launch_options_from_env_no_startup_window_opt_in() {
+        // Explicit non-falsy values must keep the default-on behavior.
+        for value in ["1", "true", "yes", "TRUE"] {
+            let guard = EnvGuard::new(&["AGENT_BROWSER_NO_STARTUP_WINDOW"]);
+            guard.set("AGENT_BROWSER_NO_STARTUP_WINDOW", value);
+            let opts = launch_options_from_env();
+            assert!(
+                opts.no_startup_window,
+                "AGENT_BROWSER_NO_STARTUP_WINDOW={value:?} must keep the flag enabled",
+            );
+        }
     }
 
     #[test]

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -329,6 +329,12 @@ pub struct LaunchOptions {
     /// Restrict WebRTC to proxied transports so direct UDP cannot bypass the
     /// HTTP domain filter. Enabled automatically with `--allowed-domains`.
     pub restrict_webrtc: bool,
+    /// When true (default) and launching a real Chrome binary in headed mode,
+    /// pass `--no-startup-window` so Chrome does not open its own NTP tab.
+    /// Without this, the NTP tab is filtered out by `should_track_target` and
+    /// ends up stranded in the window, producing a phantom tab on every
+    /// `open <url>`. Users can opt out via `AGENT_BROWSER_NO_STARTUP_WINDOW=0`.
+    pub no_startup_window: bool,
 }
 
 impl Default for LaunchOptions {
@@ -355,6 +361,7 @@ impl Default for LaunchOptions {
             webgpu: false,
             no_xvfb: false,
             restrict_webrtc: false,
+            no_startup_window: true,
         }
     }
 }
@@ -514,6 +521,22 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         // direct UDP traffic if page code obtains a native constructor.
         args.retain(|arg| !arg.starts_with("--force-webrtc-ip-handling-policy="));
         args.push("--force-webrtc-ip-handling-policy=disable_non_proxied_udp".to_string());
+    }
+
+    // When a real Chrome binary is launched in headed mode, Chrome would
+    // otherwise open its own New Tab Page tab. That tab is filtered out of
+    // agent-browser's tracked targets (it lives at `chrome://newtab/`) and
+    // therefore remains stranded in the window as a phantom tab on every
+    // `open <url>`. `--no-startup-window` keeps the window empty until the
+    // automation layer creates a tab, so the user only ever sees what the
+    // agent drives. Opt out with `AGENT_BROWSER_NO_STARTUP_WINDOW=0` or by
+    // passing `--no-startup-window=false` in `--args`.
+    if options.no_startup_window
+        && !options.headless
+        && options.executable_path.is_some()
+        && !args.iter().any(|a| a == "--no-startup-window")
+    {
+        args.push("--no-startup-window".to_string());
     }
 
     if should_disable_sandbox(&args) {
@@ -1690,6 +1713,109 @@ mod tests {
         assert!(result.temp_user_data_dir.is_some());
         let dir = result.temp_user_data_dir.unwrap();
         assert!(dir.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_headed_real_chrome_injects_no_startup_window() {
+        // Regression test for https://github.com/vercel-labs/agent-browser/issues/1544
+        let opts = LaunchOptions {
+            headless: false,
+            executable_path: Some(
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
+            ),
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            result.args.iter().any(|a| a == "--no-startup-window"),
+            "headed launch with a real Chrome binary should auto-inject --no-startup-window"
+        );
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_headed_chrome_for_testing_skips_no_startup_window() {
+        // Chrome for Testing ships without an NTP startup tab, so the flag
+        // must NOT be injected when no real binary path is configured.
+        let opts = LaunchOptions {
+            headless: false,
+            executable_path: None,
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            !result.args.iter().any(|a| a == "--no-startup-window"),
+            "headed launch without a real Chrome binary must not inject --no-startup-window"
+        );
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_headless_real_chrome_skips_no_startup_window() {
+        // Headless mode never opens a window, so the flag is unnecessary.
+        let opts = LaunchOptions {
+            headless: true,
+            executable_path: Some(
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
+            ),
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            !result.args.iter().any(|a| a == "--no-startup-window"),
+            "headless launch must never inject --no-startup-window"
+        );
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_user_supplied_no_startup_window_is_respected() {
+        // If the user already passed the flag via `options.args` we must not
+        // duplicate it, even when our default is enabled.
+        let opts = LaunchOptions {
+            headless: false,
+            executable_path: Some(
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
+            ),
+            args: vec!["--no-startup-window".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        let occurrences = result
+            .args
+            .iter()
+            .filter(|a| a.as_str() == "--no-startup-window")
+            .count();
+        assert_eq!(
+            occurrences, 1,
+            "user-supplied --no-startup-window must not be duplicated"
+        );
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_opt_out_disables_no_startup_window() {
+        // Setting `no_startup_window: false` in LaunchOptions disables the
+        // auto-injection even when other conditions are met.
+        let opts = LaunchOptions {
+            headless: false,
+            executable_path: Some(
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
+            ),
+            no_startup_window: false,
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        assert!(
+            !result.args.iter().any(|a| a == "--no-startup-window"),
+            "no_startup_window: false must opt out of the auto-injection"
+        );
+        let dir = result.temp_user_data_dir.unwrap();
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/docs/src/app/engines/chrome/page.mdx
+++ b/docs/src/app/engines/chrome/page.mdx
@@ -75,6 +75,34 @@ export AGENT_BROWSER_EXECUTABLE_PATH=/path/to/chromium
 agent-browser open example.com
 ```
 
+## Headed mode and the New Tab Page
+
+When `--headed` is combined with a real Chrome binary (via `--executable-path`
+or `AGENT_BROWSER_EXECUTABLE_PATH`), agent-browser automatically passes
+`--no-startup-window` so Chrome does not open its own New Tab Page tab.
+Without this, the NTP tab would be filtered out of agent-browser's tracked
+targets and remain stranded in the window as a phantom tab on every
+`open <url>`.
+
+The injection only runs when all of the following hold:
+
+- `headless: false` (i.e. `--headed` is set)
+- A real binary path is configured (Chrome for Testing has no startup tab)
+- The user has not already passed `--no-startup-window` via `--args`
+
+If you want the NTP tab back, opt out with `AGENT_BROWSER_NO_STARTUP_WINDOW=0`,
+or pass `--args "--no-startup-window=false"`:
+
+```bash
+export AGENT_BROWSER_NO_STARTUP_WINDOW=0
+agent-browser open example.com --headed --executable-path /path/to/chrome
+```
+
+> Note: with the default-on behavior, the first command of a fresh session
+> must be `open <url>` (or another command that creates a tab). Pure
+> inspection commands such as `snapshot` will produce no window because
+> Chrome starts with zero tabs.
+
 ## Chrome-Specific Features
 
 These features are available only with Chrome:


### PR DESCRIPTION
When launching a real Chrome binary in headed mode (via --executable-path or AGENT_BROWSER_EXECUTABLE_PATH), Chrome opens its own New Tab Page tab. That tab lives at chrome://newtab/ and is filtered out of agent-browser's tracked targets via should_track_target, so it ends up stranded in the window as a phantom tab on every `open <url>`.

Pass --no-startup-window to Chrome in this case so the window starts empty and the user only ever sees the tabs the agent drives. The injection only runs when all of the following hold:

- headless: false
- a real binary path is configured (Chrome for Testing has no startup tab)
- the user has not already passed --no-startup-window via --args

Users can opt out with AGENT_BROWSER_NO_STARTUP_WINDOW=0 (or by passing --no-startup-window=false in --args).

Fixes #1544