### PR TITLE
fix: preserve edge:// URLs in open command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ agent-browser find role button click --name "Submit"
 ```bash
 agent-browser open                    # Launch browser (no navigation); stays on about:blank
 agent-browser open <url>              # Launch + navigate to URL (aliases: goto, navigate)
+agent-browser --executable-path /path/to/msedge open edge://extensions  # Edge internal URL
 agent-browser read [url]              # Fetch agent-readable text, or read rendered active-tab DOM
 agent-browser click <sel>             # Click element (--new-tab to open in new tab)
 agent-browser dblclick <sel>          # Double-click element

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -367,6 +367,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 }
             };
             let url_lower = url.to_lowercase();
+            // Preserve recognized URL schemes; normalize other inputs with https://.
             let url = if url_lower.starts_with("http://")
                 || url_lower.starts_with("https://")
                 || url_lower.starts_with("about:")
@@ -374,6 +375,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 || url_lower.starts_with("file:")
                 || url_lower.starts_with("chrome-extension://")
                 || url_lower.starts_with("chrome://")
+                || url_lower.starts_with("edge://")
             {
                 url.to_string()
             } else {
@@ -3823,6 +3825,13 @@ mod tests {
         let cmd = parse_command(&args("open chrome://extensions"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "navigate");
         assert_eq!(cmd["url"], "chrome://extensions");
+    }
+
+    #[test]
+    fn test_navigate_edge_url() {
+        let cmd = parse_command(&args("open edge://extensions"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "navigate");
+        assert_eq!(cmd["url"], "edge://extensions");
     }
 
     // === Set Headers Tests ===

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -3981,6 +3981,13 @@ mod tests {
     }
 
     #[test]
+    fn open_args_preserve_edge_url_for_cli_parser() {
+        let args = open_args(&json!({ "url": "edge://extensions" })).unwrap();
+
+        assert_eq!(args, vec!["open", "edge://extensions"]);
+    }
+
+    #[test]
     fn react_json_uses_command_local_raw_json_flag() {
         let mut args = vec!["react".to_string(), "tree".to_string()];
         append_react_raw_json_arg(&json!({ "json": true }), &mut args).unwrap();

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1262,8 +1262,9 @@ you stage state (network routes, cookies, init scripts) before the first
 real navigation — useful for SSR debug, auth setup, and capturing fresh
 `react suspense` / `vitals` state without noise from a prior page.
 
-With a URL, launches and navigates. If no protocol is provided, https://
-is automatically prepended.
+With a URL, launches and navigates. Inputs without a recognized URL scheme are
+normalized with https://. The chrome:// and edge:// schemes are passed through
+unchanged; edge:// URLs require launching an Edge executable.
 
 The `goto` and `navigate` aliases still require a URL.
 
@@ -1279,6 +1280,7 @@ Examples:
   agent-browser open                     # Launch, no nav
   agent-browser open example.com
   agent-browser open https://github.com
+  agent-browser --executable-path /path/to/msedge open edge://extensions
   agent-browser open localhost:3000
   agent-browser open api.example.com --headers '{"Authorization": "Bearer token"}'
     # ^ Headers only sent to api.example.com, not other domains

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -5,6 +5,7 @@
 ```bash
 agent-browser open                    # Launch browser (no nav); stays on about:blank
 agent-browser open <url>              # Launch + navigate (aliases: goto, navigate)
+agent-browser --executable-path /path/to/msedge open edge://extensions  # Edge internal URL
 agent-browser read [url]              # Fetch agent-readable text, or read rendered active-tab DOM
 agent-browser click <sel>             # Click element (--new-tab to open in new tab)
 agent-browser dblclick <sel>          # Double-click

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -9,8 +9,9 @@ agent-browser open            # Launch browser (no navigation); stays on about:b
                               # Pair with `network route`, `cookies set --curl`, or
                               # `addinitscript` to stage state before the first navigation.
 agent-browser open <url>      # Launch + navigate (aliases: goto, navigate)
-                              # Supports: https://, http://, file://, about:, data://
-                              # Auto-prepends https:// if no protocol given
+                              # Recognizes: https://, http://, file:, about:, data:,
+                              # chrome-extension://, chrome://, and edge://
+                              # Other inputs are normalized with https://
 agent-browser read [url]      # Fetch agent-readable text, or read rendered active-tab DOM
                               # Explicit URLs send Accept: text/markdown, then try .md if needed
                               # Walks ancestor paths for llms.txt before HTML fallback


### PR DESCRIPTION
## Summary

- preserve `edge://` URLs instead of prefixing them with `https://`
- keep the MCP open path aligned with the CLI parser
- document recognized schemes and the Edge executable requirement

## Validation

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` (953 passed, 84 ignored)
- doctor CLI tests (2 passed)

Fixes #1535

## AI assistance

Implemented with OpenAI Codex (GPT-5) and validated with multiple independent clean code-review passes.