### PR TITLE
Widen eve peer dependency range to >=0.22.5

### DIFF
--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -57,7 +57,7 @@
     "zod": "4.4.3"
   },
   "peerDependencies": {
-    "eve": "^0.22.5"
+    "eve": ">=0.22.5"
   },
   "devDependencies": {
     "@types/node": "24.x",


### PR DESCRIPTION
## Summary
- Change the `eve` peer dependency in `@agent-browser/eve` from `^0.22.5` to `>=0.22.5` so the extension accepts eve 0.23+ and future majors without peer-resolution warnings.
- The `devDependencies` entry stays at `^0.22.5` so local builds and tests keep installing a known 0.22.x.