### PR TITLE
Support Atlas Cloud as a chat backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,6 +957,13 @@ export AI_GATEWAY_MODEL=anthropic/claude-sonnet-4.6           # optional, this i
 export AI_GATEWAY_URL=https://ai-gateway.vercel.sh           # optional, this is the default
 ```
 
+Atlas Cloud can also be used as the OpenAI-compatible backend:
+
+```bash
+export ATLASCLOUD_API_KEY=your_atlascloud_key
+export ATLASCLOUD_MODEL=qwen/qwen3.5-flash                   # optional, this is the default
+```
+
 **CLI usage:**
 
 ```bash
@@ -971,7 +978,7 @@ The `chat` command translates natural language instructions into agent-browser c
 
 **Dashboard usage:**
 
-The Chat tab is always visible in the dashboard. When `AI_GATEWAY_API_KEY` is set, the Rust server proxies requests to the gateway and streams responses back using the Vercel AI SDK's UI Message Stream protocol. Without the key, sending a message shows an error inline.
+The Chat tab is always visible in the dashboard. When `AI_GATEWAY_API_KEY` or `ATLASCLOUD_API_KEY` is set, the Rust server proxies requests to the configured OpenAI-compatible backend and streams responses back using the Vercel AI SDK's UI Message Stream protocol. Without a key, sending a message shows an error inline.
 
 ## Configuration
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -7,8 +7,6 @@ use crate::color;
 use crate::flags::Flags;
 use crate::native::stream::chat;
 
-const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4.6";
-
 #[derive(Clone, Copy, PartialEq)]
 enum Verbosity {
     Quiet,
@@ -21,12 +19,13 @@ pub fn run_chat(flags: &Flags, message: Option<String>) {
         if flags.json {
             println!(
                 "{}",
-                json!({"success": false, "error": "AI_GATEWAY_API_KEY not set. Set the AI_GATEWAY_API_KEY environment variable to enable chat."})
+                json!({"success": false, "error": chat::missing_api_key_message()})
             );
         } else {
             eprintln!(
-                "{} AI_GATEWAY_API_KEY not set. Set the AI_GATEWAY_API_KEY environment variable to enable chat.",
-                color::error_indicator()
+                "{} {}",
+                color::error_indicator(),
+                chat::missing_api_key_message()
             );
         }
         exit(1);
@@ -40,10 +39,7 @@ pub fn run_chat(flags: &Flags, message: Option<String>) {
         Verbosity::Normal
     };
 
-    let model = flags
-        .model
-        .clone()
-        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    let model = flags.model.clone().unwrap_or_else(chat::default_chat_model);
 
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
 
@@ -124,11 +120,8 @@ async fn run_interactive(session: &str, model: &str, verbosity: Verbosity, json_
     let mut openai_messages: Vec<Value> =
         vec![json!({"role": "system", "content": chat::get_system_prompt()})];
 
-    let gateway_url = std::env::var("AI_GATEWAY_URL")
-        .unwrap_or_else(|_| chat::DEFAULT_AI_GATEWAY_URL.to_string())
-        .trim_end_matches('/')
-        .to_string();
-    let api_key = std::env::var("AI_GATEWAY_API_KEY").unwrap_or_default();
+    let gateway_url = chat::configured_chat_base_url();
+    let api_key = chat::configured_chat_api_key().unwrap_or_default();
     let url = format!("{}/v1/chat/completions", gateway_url);
     let client = chat::http_client();
 
@@ -199,20 +192,21 @@ async fn run_chat_turn(
     verbosity: Verbosity,
     json_mode: bool,
 ) -> bool {
-    let gateway_url = std::env::var("AI_GATEWAY_URL")
-        .unwrap_or_else(|_| chat::DEFAULT_AI_GATEWAY_URL.to_string())
-        .trim_end_matches('/')
-        .to_string();
-    let api_key = match std::env::var("AI_GATEWAY_API_KEY") {
-        Ok(k) => k,
-        Err(_) => {
+    let gateway_url = chat::configured_chat_base_url();
+    let api_key = match chat::configured_chat_api_key() {
+        Some(k) => k,
+        None => {
             if json_mode {
                 println!(
                     "{}",
-                    json!({"success": false, "error": "AI_GATEWAY_API_KEY not set"})
+                    json!({"success": false, "error": chat::missing_api_key_message()})
                 );
             } else {
-                eprintln!("{} AI_GATEWAY_API_KEY not set", color::error_indicator());
+                eprintln!(
+                    "{} {}",
+                    color::error_indicator(),
+                    chat::missing_api_key_message()
+                );
             }
             return false;
         }

--- a/cli/src/native/stream/chat.rs
+++ b/cli/src/native/stream/chat.rs
@@ -7,6 +7,9 @@ use tokio::io::AsyncWriteExt;
 use super::http::cors_headers_for_origin;
 
 pub(crate) const DEFAULT_AI_GATEWAY_URL: &str = "https://ai-gateway.vercel.sh";
+pub(crate) const DEFAULT_ATLASCLOUD_URL: &str = "https://api.atlascloud.ai";
+pub(crate) const DEFAULT_AI_GATEWAY_MODEL: &str = "anthropic/claude-sonnet-4.6";
+pub(crate) const DEFAULT_ATLASCLOUD_MODEL: &str = "qwen/qwen3.5-flash";
 
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
@@ -14,17 +17,51 @@ pub(crate) fn http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(reqwest::Client::new)
 }
 
+pub(crate) fn configured_chat_base_url() -> String {
+    if let Ok(url) = std::env::var("AI_GATEWAY_URL") {
+        return url.trim_end_matches('/').to_string();
+    }
+    if std::env::var("ATLASCLOUD_API_KEY").is_ok() {
+        return std::env::var("ATLASCLOUD_API_BASE")
+            .unwrap_or_else(|_| DEFAULT_ATLASCLOUD_URL.to_string())
+            .trim_end_matches('/')
+            .to_string();
+    }
+    DEFAULT_AI_GATEWAY_URL.to_string()
+}
+
+pub(crate) fn configured_chat_api_key() -> Option<String> {
+    std::env::var("AI_GATEWAY_API_KEY")
+        .ok()
+        .or_else(|| std::env::var("ATLASCLOUD_API_KEY").ok())
+}
+
+pub(crate) fn default_chat_model() -> String {
+    if let Ok(model) = std::env::var("AI_GATEWAY_MODEL") {
+        return model;
+    }
+    if let Ok(model) = std::env::var("ATLASCLOUD_MODEL") {
+        return model;
+    }
+    if std::env::var("ATLASCLOUD_API_KEY").is_ok() {
+        return DEFAULT_ATLASCLOUD_MODEL.to_string();
+    }
+    DEFAULT_AI_GATEWAY_MODEL.to_string()
+}
+
+pub(crate) fn missing_api_key_message() -> &'static str {
+    "AI_GATEWAY_API_KEY or ATLASCLOUD_API_KEY not set. Set one of these environment variables to enable AI chat."
+}
+
 pub(crate) fn is_chat_enabled() -> bool {
-    std::env::var("AI_GATEWAY_API_KEY").is_ok()
+    configured_chat_api_key().is_some()
 }
 
 pub(super) fn chat_status_json() -> String {
     let enabled = is_chat_enabled();
     let mut obj = json!({ "enabled": enabled });
     if enabled {
-        if let Ok(model) = std::env::var("AI_GATEWAY_MODEL") {
-            obj["model"] = Value::String(model);
-        }
+        obj["model"] = Value::String(default_chat_model());
     }
     obj.to_string()
 }
@@ -34,13 +71,10 @@ pub(super) async fn handle_models_request(
     origin: Option<&str>,
 ) {
     let cors = cors_headers_for_origin(origin);
-    let gateway_url = std::env::var("AI_GATEWAY_URL")
-        .unwrap_or_else(|_| DEFAULT_AI_GATEWAY_URL.to_string())
-        .trim_end_matches('/')
-        .to_string();
-    let api_key = match std::env::var("AI_GATEWAY_API_KEY") {
-        Ok(k) => k,
-        Err(_) => {
+    let gateway_url = configured_chat_base_url();
+    let api_key = match configured_chat_api_key() {
+        Some(k) => k,
+        None => {
             let body = r#"{"data":[]}"#;
             let resp = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{cors}\r\n",
@@ -670,14 +704,11 @@ pub(super) async fn handle_chat_request(
     origin: Option<&str>,
 ) {
     let cors = cors_headers_for_origin(origin);
-    let gateway_url = std::env::var("AI_GATEWAY_URL")
-        .unwrap_or_else(|_| DEFAULT_AI_GATEWAY_URL.to_string())
-        .trim_end_matches('/')
-        .to_string();
-    let api_key = match std::env::var("AI_GATEWAY_API_KEY") {
-        Ok(k) => k,
-        Err(_) => {
-            let err = r#"{"error":"AI_GATEWAY_API_KEY not set. Set the AI_GATEWAY_API_KEY environment variable to enable AI chat."}"#;
+    let gateway_url = configured_chat_base_url();
+    let api_key = match configured_chat_api_key() {
+        Some(k) => k,
+        None => {
+            let err = format!(r#"{{"error":"{}"}}"#, missing_api_key_message());
             let resp = format!(
                 "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{cors}\r\n",
                 err.len()
@@ -688,8 +719,7 @@ pub(super) async fn handle_chat_request(
         }
     };
 
-    let default_model = std::env::var("AI_GATEWAY_MODEL")
-        .unwrap_or_else(|_| "anthropic/claude-sonnet-4.6".to_string());
+    let default_model = default_chat_model();
 
     let parsed: Value = match serde_json::from_str(body) {
         Ok(v) => v,
@@ -967,4 +997,78 @@ pub(super) async fn handle_chat_request(
     let _ = stream.write_all(finish_ev.as_bytes()).await;
     let done_ev = "data: [DONE]\n\n";
     let _ = stream.write_all(done_ev.as_bytes()).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::EnvGuard;
+
+    const CHAT_ENV: &[&str] = &[
+        "AI_GATEWAY_API_KEY",
+        "AI_GATEWAY_URL",
+        "AI_GATEWAY_MODEL",
+        "ATLASCLOUD_API_KEY",
+        "ATLASCLOUD_API_BASE",
+        "ATLASCLOUD_MODEL",
+    ];
+
+    #[test]
+    fn chat_config_uses_vercel_gateway_by_default() {
+        let env = EnvGuard::new(CHAT_ENV);
+        for name in CHAT_ENV {
+            env.remove(name);
+        }
+
+        assert!(!is_chat_enabled());
+        assert_eq!(configured_chat_api_key(), None);
+        assert_eq!(configured_chat_base_url(), DEFAULT_AI_GATEWAY_URL);
+        assert_eq!(default_chat_model(), DEFAULT_AI_GATEWAY_MODEL);
+    }
+
+    #[test]
+    fn chat_config_accepts_atlascloud_as_openai_compatible_backend() {
+        let env = EnvGuard::new(CHAT_ENV);
+        for name in CHAT_ENV {
+            env.remove(name);
+        }
+        env.set("ATLASCLOUD_API_KEY", "atlas-test-key");
+
+        assert!(is_chat_enabled());
+        assert_eq!(configured_chat_api_key().as_deref(), Some("atlas-test-key"));
+        assert_eq!(configured_chat_base_url(), DEFAULT_ATLASCLOUD_URL);
+        assert_eq!(default_chat_model(), DEFAULT_ATLASCLOUD_MODEL);
+    }
+
+    #[test]
+    fn chat_config_keeps_ai_gateway_env_precedence() {
+        let env = EnvGuard::new(CHAT_ENV);
+        for name in CHAT_ENV {
+            env.remove(name);
+        }
+        env.set("AI_GATEWAY_API_KEY", "gateway-key");
+        env.set("AI_GATEWAY_URL", "https://gateway.example/v1/");
+        env.set("AI_GATEWAY_MODEL", "openai/o3");
+        env.set("ATLASCLOUD_API_KEY", "atlas-key");
+        env.set("ATLASCLOUD_API_BASE", "https://api.atlascloud.ai");
+        env.set("ATLASCLOUD_MODEL", DEFAULT_ATLASCLOUD_MODEL);
+
+        assert_eq!(configured_chat_api_key().as_deref(), Some("gateway-key"));
+        assert_eq!(configured_chat_base_url(), "https://gateway.example/v1");
+        assert_eq!(default_chat_model(), "openai/o3");
+    }
+
+    #[test]
+    fn chat_config_allows_atlascloud_overrides() {
+        let env = EnvGuard::new(CHAT_ENV);
+        for name in CHAT_ENV {
+            env.remove(name);
+        }
+        env.set("ATLASCLOUD_API_KEY", "atlas-test-key");
+        env.set("ATLASCLOUD_API_BASE", "https://proxy.example/atlas/");
+        env.set("ATLASCLOUD_MODEL", "deepseek-ai/deepseek-v4-pro");
+
+        assert_eq!(configured_chat_base_url(), "https://proxy.example/atlas");
+        assert_eq!(default_chat_model(), "deepseek-ai/deepseek-v4-pro");
+    }
 }

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -453,7 +453,7 @@ Exit code is `0` if all checks pass (warnings are fine), `1` if any fail. See th
 
 ## Chat
 
-Use natural language to control the browser via AI. The `chat` command translates instructions into agent-browser commands, executes them, and streams the AI response. Requires `AI_GATEWAY_API_KEY` to be set.
+Use natural language to control the browser via AI. The `chat` command translates instructions into agent-browser commands, executes them, and streams the AI response. Requires `AI_GATEWAY_API_KEY` or `ATLASCLOUD_API_KEY` to be set.
 
 ```bash
 agent-browser chat "open google.com and search for cats"     # Single-shot instruction
@@ -468,7 +468,7 @@ agent-browser --json chat "open example.com"                 # Structured JSON o
 Chat-specific options:
 
 ```bash
---model <name>           # AI model (or AI_GATEWAY_MODEL env, default: anthropic/claude-sonnet-4.6)
+--model <name>           # AI model (or AI_GATEWAY_MODEL/ATLASCLOUD_MODEL env)
 -v, --verbose            # Show tool commands and their raw output
 -q, --quiet              # Show only the AI text response (hide tool calls)
 ```

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -298,8 +298,11 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_COLOR</code></td><td>Enable colored CLI output when truthy.</td><td>(disabled)</td></tr>
     <tr><td><code>NO_COLOR</code></td><td>Disable colored output when present.</td><td>(not set)</td></tr>
     <tr><td><code>AI_GATEWAY_URL</code></td><td>Vercel AI Gateway base URL.</td><td><code>https://ai-gateway.vercel.sh</code></td></tr>
-    <tr><td><code>AI_GATEWAY_API_KEY</code></td><td>API key for the Vercel AI Gateway. Required to enable AI chat.</td><td>(none)</td></tr>
+    <tr><td><code>AI_GATEWAY_API_KEY</code></td><td>API key for the Vercel AI Gateway. Required to enable AI chat unless <code>ATLASCLOUD_API_KEY</code> is set.</td><td>(none)</td></tr>
     <tr><td><code>AI_GATEWAY_MODEL</code></td><td>Default AI model for dashboard chat.</td><td><code>anthropic/claude-sonnet-4.6</code></td></tr>
+    <tr><td><code>ATLASCLOUD_API_KEY</code></td><td>Atlas Cloud API key for the OpenAI-compatible chat backend.</td><td>(none)</td></tr>
+    <tr><td><code>ATLASCLOUD_API_BASE</code></td><td>Atlas Cloud OpenAI-compatible base URL.</td><td><code>https://api.atlascloud.ai</code></td></tr>
+    <tr><td><code>ATLASCLOUD_MODEL</code></td><td>Default Atlas Cloud chat model when <code>AI_GATEWAY_MODEL</code> is not set.</td><td><code>qwen/qwen3.5-flash</code></td></tr>
   </tbody>
 </table>
 

--- a/docs/src/app/dashboard/page.mdx
+++ b/docs/src/app/dashboard/page.mdx
@@ -144,9 +144,16 @@ export AI_GATEWAY_URL=https://ai-gateway.vercel.sh   # this is the default
 export AI_GATEWAY_MODEL=openai/gpt-4o-mini           # default: anthropic/claude-sonnet-4.6
 ```
 
+Atlas Cloud can be used as the OpenAI-compatible chat backend:
+
+```bash
+export ATLASCLOUD_API_KEY=your_atlascloud_key
+export ATLASCLOUD_MODEL=qwen/qwen3.5-flash           # optional, this is the default for Atlas Cloud
+```
+
 ### How it works
 
-The Rust server proxies chat requests from the dashboard to the Vercel AI Gateway and streams responses back using the Vercel AI SDK's UI Message Stream protocol. The dashboard frontend uses `useChat` from `@ai-sdk/react` with `DefaultChatTransport`.
+The Rust server proxies chat requests from the dashboard to the configured OpenAI-compatible backend and streams responses back using the Vercel AI SDK's UI Message Stream protocol. The dashboard frontend uses `useChat` from `@ai-sdk/react` with `DefaultChatTransport`.
 
 <table>
   <thead>
@@ -154,7 +161,10 @@ The Rust server proxies chat requests from the dashboard to the Vercel AI Gatewa
   </thead>
   <tbody>
     <tr><td><code>AI_GATEWAY_URL</code></td><td>Vercel AI Gateway base URL.</td><td><code>https://ai-gateway.vercel.sh</code></td></tr>
-    <tr><td><code>AI_GATEWAY_API_KEY</code></td><td>API key for the AI Gateway. Required to enable AI chat responses.</td><td>(none)</td></tr>
+    <tr><td><code>AI_GATEWAY_API_KEY</code></td><td>API key for the AI Gateway. Required to enable AI chat responses unless <code>ATLASCLOUD_API_KEY</code> is set.</td><td>(none)</td></tr>
     <tr><td><code>AI_GATEWAY_MODEL</code></td><td>Default AI model for chat requests.</td><td><code>anthropic/claude-sonnet-4.6</code></td></tr>
+    <tr><td><code>ATLASCLOUD_API_KEY</code></td><td>Atlas Cloud API key for the OpenAI-compatible chat backend.</td><td>(none)</td></tr>
+    <tr><td><code>ATLASCLOUD_API_BASE</code></td><td>Atlas Cloud OpenAI-compatible base URL.</td><td><code>https://api.atlascloud.ai</code></td></tr>
+    <tr><td><code>ATLASCLOUD_MODEL</code></td><td>Default Atlas Cloud chat model when <code>AI_GATEWAY_MODEL</code> is not set.</td><td><code>qwen/qwen3.5-flash</code></td></tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- allow `ATLASCLOUD_API_KEY` to enable the existing OpenAI-compatible chat flow when `AI_GATEWAY_API_KEY` is not configured
- add Atlas Cloud defaults for base URL and model while preserving `AI_GATEWAY_*` precedence
- document Atlas Cloud chat configuration in the existing AI Chat docs

## Validation
- `cargo test --manifest-path cli/Cargo.toml chat_config`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `git diff --check`
- verified Atlas Cloud live model catalog includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

## README / promotion compliance
- README changes are limited to the existing AI Chat configuration section
- no sponsor block, logo, credits, partner copy, or promotional section added
