### PR TITLE
fix(cli): recognize dotfile screenshot paths

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -803,14 +803,15 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 (Some(first), None) => {
                     // One arg: determine if it's a selector or a path
                     let is_relative_path = first.starts_with("./") || first.starts_with("../");
-                    let is_selector = !is_relative_path
-                        && (first.starts_with('.')
-                            || first.starts_with('#')
-                            || first.starts_with('@'));
                     let has_path_extension = first.ends_with(".png")
                         || first.ends_with(".jpg")
                         || first.ends_with(".jpeg")
                         || first.ends_with(".webp");
+                    let is_selector = !is_relative_path
+                        && !has_path_extension
+                        && (first.starts_with('.')
+                            || first.starts_with('#')
+                            || first.starts_with('@'));
                     let is_path = is_relative_path || first.contains('/') || has_path_extension;
                     if is_selector || !is_path {
                         (Some(*first), None)
@@ -4197,6 +4198,14 @@ mod tests {
         assert_eq!(cmd["action"], "screenshot");
         assert_eq!(cmd["selector"], serde_json::Value::Null);
         assert_eq!(cmd["path"], "./output.png");
+    }
+
+    #[test]
+    fn test_screenshot_with_dotfile_path() {
+        let cmd = parse_command(&args("screenshot .capture.png"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "screenshot");
+        assert_eq!(cmd["selector"], serde_json::Value::Null);
+        assert_eq!(cmd["path"], ".capture.png");
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -2518,7 +2518,7 @@ fn call_wait_download(arguments: &Value) -> Result<Value, ProtocolError> {
     call_cli_tool(arguments, args, None)
 }
 
-fn call_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
+fn screenshot_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
     let mut args = Vec::new();
     if optional_bool(arguments, "annotate")?.unwrap_or(false) {
         args.push("--annotate".to_string());
@@ -2546,6 +2546,11 @@ fn call_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
     if optional_bool(arguments, "fullPage")?.unwrap_or(false) {
         args.push("--full".to_string());
     }
+    Ok(args)
+}
+
+fn call_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
+    let args = screenshot_args(arguments)?;
     call_cli_tool(arguments, args, None)
 }
 
@@ -3787,6 +3792,14 @@ mod tests {
         assert_eq!(
             open_args(&json!({ "headed": false })).unwrap(),
             vec!["--headed", "false", "open"]
+        );
+    }
+
+    #[test]
+    fn screenshot_args_preserve_dotfile_path() {
+        assert_eq!(
+            screenshot_args(&json!({ "path": ".capture.png" })).unwrap(),
+            vec!["screenshot", ".capture.png"]
         );
     }
 


### PR DESCRIPTION
## Summary

- classify recognized screenshot file extensions before the dot-prefixed selector heuristic
- preserve CSS class selector behavior while allowing paths such as `.capture.png`
- add regression coverage for both CLI parsing and MCP argument forwarding

Before this change, `agent-browser screenshot .capture.png` treated the filename as a CSS class selector instead of an output path.

## Tests

- `cargo test --profile ci --manifest-path cli/Cargo.toml commands::tests::`
- `cargo test --profile ci --manifest-path cli/Cargo.toml mcp::tests::`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `node scripts/check-version-sync.js`