### PR TITLE
Add set viewport reset to clear viewport emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 
 ```bash
 agent-browser set viewport <w> <h> [scale]  # Set viewport size (scale for retina, e.g. 2)
+agent-browser set viewport reset      # Restore the default viewport
 agent-browser set device <name>       # Emulate device ("iPhone 14")
 agent-browser set geo <lat> <lng>     # Set geolocation
 agent-browser set offline [on|off]    # Toggle offline mode

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2761,9 +2761,12 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 
     match rest.first().copied() {
         Some("viewport") => {
+            if rest.get(1).copied() == Some("reset") {
+                return Ok(json!({ "id": id, "action": "viewport", "reset": true }));
+            }
             let w_str = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                 context: "set viewport".to_string(),
-                usage: "set viewport <width> <height> [scale]",
+                usage: "set viewport <width> <height> [scale] | set viewport reset",
             })?;
             let h_str = rest.get(2).ok_or_else(|| ParseError::MissingArguments {
                 context: "set viewport".to_string(),
@@ -4723,6 +4726,15 @@ mod tests {
         assert_eq!(cmd["width"], 375);
         assert_eq!(cmd["height"], 812);
         assert_eq!(cmd["deviceScaleFactor"], 3.0);
+    }
+
+    #[test]
+    fn test_set_viewport_reset() {
+        let cmd = parse_command(&args("set viewport reset"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "viewport");
+        assert_eq!(cmd["reset"], true);
+        assert!(cmd.get("width").is_none());
+        assert!(cmd.get("height").is_none());
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1074,9 +1074,9 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_SET_VIEWPORT,
             "Set viewport",
-            "Set viewport size.",
-            json!({ "width": int_schema(), "height": int_schema(), "scale": number_schema() }),
-            &["width", "height"],
+            "Set viewport size. Pass reset:true (without width/height) to clear viewport emulation and restore the default viewport.",
+            json!({ "width": int_schema(), "height": int_schema(), "scale": number_schema(), "reset": { "type": "boolean" } }),
+            &[],
         ),
         tool(
             TOOL_SET_DEVICE,
@@ -2637,6 +2637,17 @@ fn call_mouse_wheel(arguments: &Value) -> Result<Value, ProtocolError> {
 }
 
 fn call_set_viewport(arguments: &Value) -> Result<Value, ProtocolError> {
+    if optional_bool(arguments, "reset")?.unwrap_or(false) {
+        return call_cli_tool(
+            arguments,
+            vec![
+                "set".to_string(),
+                "viewport".to_string(),
+                "reset".to_string(),
+            ],
+            None,
+        );
+    }
     let width = required_u64(arguments, "width")?;
     let height = required_u64(arguments, "height")?;
     let mut args = vec![

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5810,6 +5810,29 @@ async fn handle_tab_close(cmd: &Value, state: &mut DaemonState) -> Result<Value,
 
 async fn handle_viewport(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+
+    if cmd.get("reset").and_then(|v| v.as_bool()).unwrap_or(false) {
+        mgr.reset_viewport().await?;
+
+        state.viewport = None;
+
+        // Update stream server viewport so status messages and screencast use the new dimensions
+        if let Some(ref server) = state.stream_server {
+            server
+                .set_viewport(
+                    super::browser::DEFAULT_VIEWPORT_WIDTH as u32,
+                    super::browser::DEFAULT_VIEWPORT_HEIGHT as u32,
+                )
+                .await;
+        }
+
+        return Ok(json!({
+            "reset": true,
+            "width": super::browser::DEFAULT_VIEWPORT_WIDTH,
+            "height": super::browser::DEFAULT_VIEWPORT_HEIGHT,
+        }));
+    }
+
     let width = cmd.get("width").and_then(|v| v.as_i64()).unwrap_or(1280) as i32;
     let height = cmd.get("height").and_then(|v| v.as_i64()).unwrap_or(720) as i32;
     let scale = cmd

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -313,6 +313,11 @@ pub struct BrowserManager {
     direct_page: bool,
 }
 
+/// Default viewport dimensions used at launch (matches the `--window-size`
+/// fallback in `cdp::chrome` and the stream server's initial viewport).
+pub const DEFAULT_VIEWPORT_WIDTH: i32 = 1280;
+pub const DEFAULT_VIEWPORT_HEIGHT: i32 = 720;
+
 const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const LIGHTPANDA_CDP_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -1259,6 +1264,31 @@ impl BrowserManager {
 
         // Screencast captures the actual content area, not the emulated CSS
         // viewport, so resize the content area to match.
+        self.resize_content_area(width, height).await;
+
+        Ok(())
+    }
+
+    /// Clear any viewport emulation set via `set_viewport` and restore the
+    /// default content area size, returning pages to the launch-time viewport.
+    pub async fn reset_viewport(&self) -> Result<(), String> {
+        let session_id = self.active_session_id()?;
+        self.client
+            .send_command(
+                "Emulation.clearDeviceMetricsOverride",
+                None,
+                Some(session_id),
+            )
+            .await?;
+
+        self.resize_content_area(DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT)
+            .await;
+
+        Ok(())
+    }
+
+    /// Best-effort resize of the browser window's content area.
+    async fn resize_content_area(&self, width: i32, height: i32) {
         if let Ok(target_id) = self.active_target_id() {
             if let Ok(window_info) = self
                 .client
@@ -1288,8 +1318,6 @@ impl BrowserManager {
                 }
             }
         }
-
-        Ok(())
     }
 
     pub async fn set_user_agent(&self, user_agent: &str) -> Result<(), String> {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1877,6 +1877,34 @@ async fn e2e_viewport_emulation() {
         new_width
     );
 
+    // Reset viewport emulation
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "viewport", "reset": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["reset"], true);
+    assert!(state.viewport.is_none());
+
+    // Reload to apply the cleared override
+    let resp = execute_command(&json!({ "id": "8", "action": "reload" }), &mut state).await;
+    assert_success(&resp);
+
+    // Width should be back to the default, not the emulated 375
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "evaluate", "script": "window.innerWidth" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let reset_width = get_data(&resp)["result"].as_i64().unwrap();
+    assert!(
+        reset_width != 375,
+        "Viewport should no longer be emulated after reset (got {})",
+        reset_width
+    );
+
     // Set user agent
     let resp = execute_command(
         &json!({ "id": "5", "action": "user_agent", "userAgent": "TestBot/1.0" }),

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2126,6 +2126,7 @@ Configures various browser settings and emulation options.
 
 Settings:
   viewport <w> <h> [scale]   Set viewport size (scale = deviceScaleFactor, e.g. 2 for retina)
+  viewport reset             Clear viewport emulation and restore the default viewport
   device <name>              Emulate device (e.g., "iPhone 12")
   geo <lat> <lng>            Set geolocation
   offline [on|off]           Toggle offline mode
@@ -2141,6 +2142,7 @@ Global Options:
 Examples:
   agent-browser set viewport 1920 1080
   agent-browser set viewport 1920 1080 2    # 2x retina
+  agent-browser set viewport reset          # Back to the default viewport
   agent-browser set device "iPhone 12"
   agent-browser set geo 37.7749 -122.4194
   agent-browser set offline on
@@ -3366,7 +3368,7 @@ Mouse:  agent-browser mouse <action> [args]
   move <x> <y>, down [btn], up [btn], wheel <dy> [dx]
 
 Browser Settings:  agent-browser set <setting> [value]
-  viewport <w> <h>, device <name>, geo <lat> <lng>
+  viewport <w> <h>, viewport reset, device <name>, geo <lat> <lng>
   offline [on|off], headers <json>, credentials <user> <pass>
   media [dark|light] [reduced-motion]
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -166,6 +166,7 @@ See [Files & Clipboard](/files) for clipboard, upload, download, local file, scr
 
 ```bash
 agent-browser set viewport <w> <h> [scale]  # Set viewport size (scale for retina, e.g. 2)
+agent-browser set viewport reset      # Restore the default viewport
 agent-browser set device <name>       # Emulate device ("iPhone 14")
 agent-browser set geo <lat> <lng>     # Set geolocation
 agent-browser set offline [on|off]    # Toggle offline mode

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -161,6 +161,7 @@ agent-browser find nth 2 "a" hover
 ```bash
 agent-browser set viewport 1920 1080          # Set viewport size
 agent-browser set viewport 1920 1080 2        # 2x retina (same CSS size, higher res screenshots)
+agent-browser set viewport reset              # Restore the default viewport (clears viewport/device emulation)
 agent-browser set device "iPhone 14"          # Emulate device
 agent-browser set geo 37.7749 -122.4194       # Set geolocation (alias: geolocation)
 agent-browser set offline on                  # Toggle offline mode


### PR DESCRIPTION
set viewport applies Emulation.setDeviceMetricsOverride and resizes the window content area, but there was no way to undo it short of relaunching the browser. set viewport reset clears the device metrics override, restores the default 1280x720 content area, and stops the override from being re-applied on relaunch or state restore. Since set device stores its dimensions through the same state, reset also clears the viewport half of device emulation (the user agent override is a separate setting and is left untouched).

The agent_browser_set_viewport MCP tool gains a matching optional reset parameter that delegates through the CLI parser.

Covered by a parser unit test and an extension of the viewport e2e test that emulates 375x812, resets, and asserts window.innerWidth returns to the default.