### PR TITLE
Expose provider metadata in session info

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,8 @@ Use a browser provider plugin:
 agent-browser --provider cloud-browser open https://example.com
 ```
 
+Browser provider plugins may return opaque `metadata` from `browser.launch`. agent-browser exposes it as `providerMetadata` in the launch response and `session info --json` without interpreting provider-specific keys.
+
 Use a launch mutator plugin for stealth or local launch customization. The plugin can append Chrome args, extensions, and init scripts before the browser starts:
 
 ```bash
@@ -1670,6 +1672,14 @@ agent-browser open https://example.com
 
 When enabled, agent-browser connects to a Browserbase session instead of launching a local browser. All commands work identically.
 
+Browserbase sessions expose live-view URLs through session diagnostics. These URLs are capability-bearing and should only be shown to authorized users:
+
+```bash
+agent-browser session info --json
+```
+
+While the Browserbase session is active, the JSON includes `provider: "browserbase"` and `providerMetadata` with `sessionId`; successful live-view lookup adds `debuggerUrl` and `debuggerFullscreenUrl`. Those live-view URLs come from Browserbase's `GET /v1/sessions/{id}/debug` after CDP connects and event handlers are wired, so session create and CDP connect are never delayed by the lookup. Live-view lookup is best-effort; browsing still works if Browserbase temporarily cannot return debugger URLs, though the launch response may wait up to five seconds for the debug call. A failed lookup becomes eligible for retry through `session info` after a 30-second cooldown, without relaunching the browser.
+
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview).
 
 ### Browser Use
@@ -1761,6 +1771,8 @@ Optional configuration via environment variables:
 **Browser profiles:** When `AGENTCORE_PROFILE_ID` is set, browser state (cookies, localStorage) is persisted across sessions automatically.
 
 When enabled, agent-browser connects to an AgentCore cloud browser session instead of launching a local browser. All commands work identically.
+
+AgentCore launch and session diagnostics expose generic `providerMetadata` containing `sessionId`, `browserIdentifier`, `region`, and `liveViewUrl`. Existing `agentCoreSessionId` and `agentCoreLiveViewUrl` launch fields remain available for compatibility.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1678,7 +1678,7 @@ Browserbase sessions expose live-view URLs through session diagnostics. These UR
 agent-browser session info --json
 ```
 
-While the Browserbase session is active, the JSON includes `provider: "browserbase"` and `providerMetadata` with `sessionId`; successful live-view lookup adds `debuggerUrl` and `debuggerFullscreenUrl`. Those live-view URLs come from Browserbase's `GET /v1/sessions/{id}/debug` after CDP connects and event handlers are wired, so session create and CDP connect are never delayed by the lookup. Live-view lookup is best-effort; browsing still works if Browserbase temporarily cannot return debugger URLs, though the launch response may wait up to five seconds for the debug call. A failed lookup becomes eligible for retry through `session info` after a 30-second cooldown, without relaunching the browser.
+While active, the JSON includes `provider: "browserbase"` and `providerMetadata` with `sessionId`. A best-effort lookup after CDP connect adds `debuggerUrl` and `debuggerFullscreenUrl`. Treat those URLs as secrets.
 
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview).
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,7 @@ mod test_utils;
 mod upgrade;
 mod validation;
 
-use serde_json::json;
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
@@ -585,18 +585,21 @@ fn run_session_info(session: &str, json_mode: bool) {
     });
 
     if json_mode {
+        let mut data = json!({
+            "session": session,
+            "namespace": env::var("AGENT_BROWSER_NAMESPACE").ok(),
+            "socketDir": get_socket_dir().to_string_lossy(),
+            "active": active.is_some(),
+            "pid": active.map(|s| s.pid),
+            "version": active.and_then(|s| s.version.clone()),
+            "runtime": runtime_data,
+            "runtimeError": runtime_error,
+        });
+        let runtime_diagnostics = data.get("runtime").cloned();
+        copy_provider_diagnostics(&mut data, runtime_diagnostics.as_ref());
         print_json_value(json!({
             "success": true,
-            "data": {
-                "session": session,
-                "namespace": env::var("AGENT_BROWSER_NAMESPACE").ok(),
-                "socketDir": get_socket_dir().to_string_lossy(),
-                "active": active.is_some(),
-                "pid": active.map(|s| s.pid),
-                "version": active.and_then(|s| s.version.clone()),
-                "runtime": runtime_data,
-                "runtimeError": runtime_error,
-            }
+            "data": data,
         }));
         return;
     }
@@ -627,8 +630,39 @@ fn run_session_info(session: &str, json_mode: bool) {
         if let Some(launched) = data.get("browserLaunched").and_then(|v| v.as_bool()) {
             println!("Browser launched: {}", launched);
         }
+        print_provider_diagnostics(&data);
     } else if let Some(err) = runtime_error {
         println!("Runtime info unavailable: {}", err);
+    }
+}
+
+fn copy_provider_diagnostics(data: &mut Value, runtime_data: Option<&Value>) {
+    let Some(runtime_data) = runtime_data else {
+        return;
+    };
+    for key in ["provider", "providerMetadata"] {
+        if let Some(value) = runtime_data.get(key) {
+            data[key] = value.clone();
+        }
+    }
+}
+
+fn print_provider_diagnostics(runtime_data: &Value) {
+    if let Some(provider) = runtime_data.get("provider").and_then(|v| v.as_str()) {
+        println!("Provider: {}", provider);
+    }
+    let Some(metadata) = runtime_data
+        .get("providerMetadata")
+        .and_then(|v| v.as_object())
+    else {
+        return;
+    };
+    for (key, value) in metadata {
+        match value {
+            Value::String(text) => println!("{}: {}", key, text),
+            Value::Null => {}
+            other => println!("{}: {}", key, other),
+        }
     }
 }
 
@@ -2200,5 +2234,22 @@ mod tests {
         assert_eq!(prompt.action, "plugin:stealth:launch.mutate");
         assert_eq!(prompt.description, "plugin:stealth:launch.mutate");
         assert_eq!(prompt.confirmation_id, "original-command");
+    }
+
+    #[test]
+    fn test_session_info_promotes_provider_diagnostics_from_runtime() {
+        let runtime = json!({
+            "provider": "browserbase",
+            "providerMetadata": {
+                "sessionId": "sess_123",
+                "debuggerUrl": "https://debugger.example/session"
+            }
+        });
+        let mut data = json!({ "runtime": runtime.clone() });
+
+        copy_provider_diagnostics(&mut data, Some(&runtime));
+
+        assert_eq!(data["provider"], "browserbase");
+        assert_eq!(data["providerMetadata"]["sessionId"], "sess_123");
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -658,12 +658,40 @@ fn print_provider_diagnostics(runtime_data: &Value) {
         return;
     };
     for (key, value) in metadata {
+        let label = provider_metadata_label(key);
         match value {
-            Value::String(text) => println!("{}: {}", key, text),
+            Value::String(text) => println!("{}: {}", label, text),
             Value::Null => {}
-            other => println!("{}: {}", key, other),
+            other => println!("{}: {}", label, other),
         }
     }
+}
+
+fn provider_metadata_label(key: &str) -> String {
+    match key {
+        "sessionId" => "Session ID".to_string(),
+        "debuggerUrl" => "Debugger URL".to_string(),
+        "debuggerFullscreenUrl" => "Debugger fullscreen URL".to_string(),
+        "liveViewUrl" => "Live View URL".to_string(),
+        "browserIdentifier" => "Browser identifier".to_string(),
+        "region" => "Region".to_string(),
+        _ => humanize_camel_case(key),
+    }
+}
+
+fn humanize_camel_case(key: &str) -> String {
+    let mut label = String::new();
+    for (i, ch) in key.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            label.push(' ');
+        }
+        if i == 0 {
+            label.extend(ch.to_uppercase());
+        } else {
+            label.push(ch);
+        }
+    }
+    label
 }
 
 fn run_session(args: &[String], session: &str, json_mode: bool) {
@@ -2251,5 +2279,17 @@ mod tests {
 
         assert_eq!(data["provider"], "browserbase");
         assert_eq!(data["providerMetadata"]["sessionId"], "sess_123");
+    }
+
+    #[test]
+    fn test_provider_metadata_labels_use_title_case() {
+        assert_eq!(provider_metadata_label("sessionId"), "Session ID");
+        assert_eq!(provider_metadata_label("debuggerUrl"), "Debugger URL");
+        assert_eq!(
+            provider_metadata_label("debuggerFullscreenUrl"),
+            "Debugger fullscreen URL"
+        );
+        assert_eq!(provider_metadata_label("liveViewUrl"), "Live View URL");
+        assert_eq!(provider_metadata_label("dashboardUrl"), "Dashboard Url");
     }
 }

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1646,7 +1646,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_SESSION_INFO,
             "Session info",
-            "Show session, daemon, launch, and restore diagnostics.",
+            "Show session, daemon, launch, provider, and restore diagnostics.",
             json!({}),
             &[],
         ),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1740,12 +1740,12 @@ fn provider_launch_response(
     requested_provider: &str,
     relaunched_browser: bool,
 ) -> Value {
+    // Preserve the established launch-response contract by echoing the
+    // caller's provider spelling. Active session diagnostics use the
+    // canonical provider name retained in ActiveProvider.
     let mut response = json!({
         "launched": true,
         "relaunchedBrowser": relaunched_browser,
-        // Preserve the established launch-response contract by echoing the
-        // caller's provider spelling. Active session diagnostics use the
-        // canonical provider name retained in ActiveProvider.
         "provider": requested_provider,
     });
     if let Some(metadata) = &active.provider.metadata {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -65,9 +65,9 @@ pub struct PendingConfirmation {
     approved_actions: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct ActiveProviderSession {
-    session: providers::ProviderSession,
+    provider: providers::ActiveProvider,
     plugins: Vec<crate::plugins::PluginConfig>,
 }
 
@@ -356,7 +356,7 @@ pub struct DaemonState {
     pub viewport: Option<(i32, i32, f64, bool)>,
     /// Init script sources returned by launch mutator plugins for this launch.
     pub plugin_init_scripts: Vec<String>,
-    /// Provider cleanup metadata for the active external browser session.
+    /// Provider identity, metadata, and cleanup state for the active browser.
     active_provider_session: Option<ActiveProviderSession>,
     /// Actions already approved while replaying a confirmed command.
     confirmed_policy_actions: HashSet<String>,
@@ -1716,20 +1716,51 @@ async fn apply_restore_config_after_confirmation(
     Ok(restore_key_changed && had_browser)
 }
 
-fn remember_active_provider_session(
+fn remember_active_provider(
     state: &mut DaemonState,
-    session: Option<providers::ProviderSession>,
+    connection: providers::ProviderConnection,
     plugins: &[crate::plugins::PluginConfig],
 ) {
-    state.active_provider_session = session.map(|session| ActiveProviderSession {
-        session,
+    state.active_provider_session = Some(ActiveProviderSession {
+        provider: connection.into_active(),
         plugins: plugins.to_vec(),
     });
 }
 
+/// Enrich provider-owned metadata after CDP handlers are subscribed so a slow
+/// observability lookup cannot delay the initial connection or miss events.
+async fn enrich_active_provider_metadata(state: &mut DaemonState) {
+    if let Some(active) = state.active_provider_session.as_mut() {
+        active.provider.enrich_metadata_after_connect().await;
+    }
+}
+
+fn provider_launch_response(
+    active: &ActiveProviderSession,
+    requested_provider: &str,
+    relaunched_browser: bool,
+) -> Value {
+    let mut response = json!({
+        "launched": true,
+        "relaunchedBrowser": relaunched_browser,
+        // Preserve the established launch-response contract by echoing the
+        // caller's provider spelling. Active session diagnostics use the
+        // canonical provider name retained in ActiveProvider.
+        "provider": requested_provider,
+    });
+    if let Some(metadata) = &active.provider.metadata {
+        response["providerMetadata"] = metadata.clone();
+        if active.provider.name == "agentcore" {
+            response["agentCoreSessionId"] = metadata["sessionId"].clone();
+            response["agentCoreLiveViewUrl"] = metadata["liveViewUrl"].clone();
+        }
+    }
+    response
+}
+
 async fn close_active_provider_session(state: &mut DaemonState) {
     if let Some(active) = state.active_provider_session.take() {
-        providers::close_provider_session_with_plugins(&active.session, &active.plugins).await;
+        active.provider.close(&active.plugins).await;
     }
 }
 
@@ -2911,20 +2942,14 @@ async fn auto_launch(
         if !p.is_empty() && p != "ios" && p != "safari" {
             let conn = providers::connect_provider_with_plugins(&p, &plugins).await?;
             if conn.direct_page && !allowed_domains.is_empty() {
-                if let Some(ref ps) = conn.session {
-                    providers::close_provider_session_with_plugins(ps, &plugins).await;
-                }
+                conn.close(&plugins).await;
                 return Err(direct_page_allowed_domains_error());
             }
-            let ws_headers = if p == "agentcore" {
-                providers::take_agentcore_ws_headers()
-            } else {
-                None
-            };
             let connect_result = if conn.direct_page {
                 BrowserManager::connect_cdp_direct(&conn.ws_url).await
-            } else if ws_headers.is_some() {
-                BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers).await
+            } else if conn.ws_headers.is_some() {
+                BrowserManager::connect_cdp_with_headers(&conn.ws_url, conn.ws_headers.clone())
+                    .await
             } else {
                 BrowserManager::connect_cdp(&conn.ws_url).await
             };
@@ -2943,7 +2968,7 @@ async fn auto_launch(
                     state.reset_input_state();
                     state.browser = Some(mgr);
                     state.launch_hash = Some(hash);
-                    remember_active_provider_session(state, conn.session.clone(), &plugins);
+                    remember_active_provider(state, conn, &plugins);
                     state.subscribe_to_browser_events();
                     state.start_fetch_handler();
                     state.start_dialog_handler();
@@ -2953,12 +2978,11 @@ async fn auto_launch(
                     apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
                     try_auto_restore_state(state).await;
                     try_load_storage_state(state, &storage_state_path).await;
+                    enrich_active_provider_metadata(state).await;
                     return Ok(());
                 }
                 Err(e) => {
-                    if let Some(ref ps) = conn.session {
-                        providers::close_provider_session_with_plugins(ps, &plugins).await;
-                    }
+                    conn.close(&plugins).await;
                     return Err(format!("Provider '{}' connection failed: {}", p, e));
                 }
             }
@@ -3808,24 +3832,16 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                 )
                 .await?;
                 if conn.direct_page && !allowed_domains.is_empty() {
-                    if let Some(ref ps) = conn.session {
-                        providers::close_provider_session_with_plugins(ps, &command_plugins).await;
-                    }
+                    conn.close(&command_plugins).await;
                     restore_domain_filter(state, &previous_domain_filter).await;
                     return Err(direct_page_allowed_domains_error());
                 }
-                let provider_metadata = conn.metadata.clone();
-
-                let ws_headers = if provider.eq_ignore_ascii_case("agentcore") {
-                    providers::take_agentcore_ws_headers()
-                } else {
-                    None
-                };
 
                 let connect_result = if conn.direct_page {
                     BrowserManager::connect_cdp_direct(&conn.ws_url).await
-                } else if ws_headers.is_some() {
-                    BrowserManager::connect_cdp_with_headers(&conn.ws_url, ws_headers).await
+                } else if conn.ws_headers.is_some() {
+                    BrowserManager::connect_cdp_with_headers(&conn.ws_url, conn.ws_headers.clone())
+                        .await
                 } else {
                     BrowserManager::connect_cdp(&conn.ws_url).await
                 };
@@ -3834,11 +3850,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.reset_input_state();
                         state.browser = Some(mgr);
                         state.launch_hash = Some(new_hash);
-                        remember_active_provider_session(
-                            state,
-                            conn.session.clone(),
-                            &command_plugins,
-                        );
+                        remember_active_provider(state, conn, &command_plugins);
                         state.subscribe_to_browser_events();
                         state.start_fetch_handler();
                         state.start_dialog_handler();
@@ -3849,35 +3861,16 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                             .await;
                         try_auto_restore_state(state).await;
                         load_storage_state_or_rollback(state, &storage_state_owned).await?;
+                        enrich_active_provider_metadata(state).await;
 
-                        if let Some(info) = providers::get_agentcore_info() {
-                            return Ok(json!({
-                                "launched": true,
-                                "relaunchedBrowser": had_browser_before_launch,
-                                "provider": provider,
-                                "agentCoreSessionId": info.session_id,
-                                "agentCoreLiveViewUrl": info.live_view_url
-                            }));
-                        }
-
-                        if let Some(metadata) = provider_metadata {
-                            return Ok(json!({
-                                "launched": true,
-                                "relaunchedBrowser": had_browser_before_launch,
-                                "provider": provider,
-                                "providerMetadata": metadata
-                            }));
-                        }
-
-                        return Ok(
-                            json!({ "launched": true, "relaunchedBrowser": had_browser_before_launch, "provider": provider }),
-                        );
+                        return Ok(provider_launch_response(
+                            state.active_provider_session.as_ref().unwrap(),
+                            provider,
+                            had_browser_before_launch,
+                        ));
                     }
                     Err(e) => {
-                        if let Some(ref ps) = conn.session {
-                            providers::close_provider_session_with_plugins(ps, &command_plugins)
-                                .await;
-                        }
+                        conn.close(&command_plugins).await;
                         return Err(e);
                     }
                 }
@@ -5393,8 +5386,11 @@ async fn handle_errors(state: &DaemonState) -> Result<Value, String> {
     Ok(state.event_tracker.get_errors_json())
 }
 
-async fn handle_session_info(state: &DaemonState) -> Result<Value, String> {
-    Ok(json!({
+async fn handle_session_info(state: &mut DaemonState) -> Result<Value, String> {
+    // Retry best-effort provider metadata after its cooldown. This lets a
+    // transient observability outage recover without relaunching the browser.
+    enrich_active_provider_metadata(state).await;
+    let mut info = json!({
         "session": state.session_id,
         "namespace": env::var("AGENT_BROWSER_NAMESPACE").ok(),
         "socketDir": get_socket_dir().to_string_lossy(),
@@ -5420,7 +5416,14 @@ async fn handle_session_info(state: &DaemonState) -> Result<Value, String> {
         "restoreCheckUrl": state.restore_check_url,
         "restoreCheckText": state.restore_check_text,
         "restoreCheckFn": state.restore_check_fn,
-    }))
+    });
+    if let Some(active_provider) = &state.active_provider_session {
+        info["provider"] = json!(active_provider.provider.name);
+        if let Some(metadata) = &active_provider.provider.metadata {
+            info["providerMetadata"] = metadata.clone();
+        }
+    }
+    Ok(info)
 }
 
 async fn handle_state_save(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
@@ -11240,6 +11243,106 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{
         assert!(!marker_path.exists());
     }
 
+    #[tokio::test]
+    async fn test_session_info_includes_active_provider_metadata() {
+        let mut state = DaemonState::new();
+        state.active_provider_session = Some(ActiveProviderSession {
+            provider: providers::ActiveProvider::new(
+                "cloud-browser",
+                Some(json!({
+                    "sessionId": "sess_123",
+                    "dashboard": { "url": "https://provider.example/session" }
+                })),
+            ),
+            plugins: Vec::new(),
+        });
+
+        let info = handle_session_info(&mut state).await.unwrap();
+        assert_eq!(info["provider"], "cloud-browser");
+        assert_eq!(info["providerMetadata"]["sessionId"], "sess_123");
+        assert_eq!(
+            info["providerMetadata"]["dashboard"]["url"],
+            "https://provider.example/session"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enrich_provider_metadata_preserves_immediate_metadata() {
+        let mut state = DaemonState::new();
+        state.active_provider_session = Some(ActiveProviderSession {
+            provider: providers::ActiveProvider::new(
+                "cloud-browser",
+                Some(json!({ "sessionId": "from-plugin" })),
+            ),
+            plugins: Vec::new(),
+        });
+
+        enrich_active_provider_metadata(&mut state).await;
+
+        assert_eq!(
+            state
+                .active_provider_session
+                .as_ref()
+                .unwrap()
+                .provider
+                .metadata
+                .as_ref()
+                .unwrap()["sessionId"],
+            "from-plugin"
+        );
+    }
+
+    #[test]
+    fn test_agentcore_launch_response_keeps_legacy_and_generic_metadata() {
+        let active = ActiveProviderSession {
+            provider: providers::ActiveProvider::new(
+                "agentcore",
+                Some(json!({
+                    "sessionId": "agentcore-session",
+                    "liveViewUrl": "https://console.aws.amazon.com/live-view",
+                    "region": "us-east-1"
+                })),
+            ),
+            plugins: Vec::new(),
+        };
+
+        let response = provider_launch_response(&active, "agentcore", false);
+        assert_eq!(response["provider"], "agentcore");
+        assert_eq!(response["providerMetadata"]["region"], "us-east-1");
+        assert_eq!(response["agentCoreSessionId"], "agentcore-session");
+        assert_eq!(
+            response["agentCoreLiveViewUrl"],
+            "https://console.aws.amazon.com/live-view"
+        );
+    }
+
+    #[test]
+    fn test_provider_launch_response_preserves_requested_provider_spelling() {
+        let active = ActiveProviderSession {
+            provider: providers::ActiveProvider::new("browser-use", None),
+            plugins: Vec::new(),
+        };
+
+        let response = provider_launch_response(&active, "BrowserUse", false);
+        assert_eq!(response["provider"], "BrowserUse");
+    }
+
+    #[tokio::test]
+    async fn test_close_current_browser_clears_provider_info_without_cleanup_session() {
+        let mut state = DaemonState::new();
+        state.active_provider_session = Some(ActiveProviderSession {
+            provider: providers::ActiveProvider::new("browserbase", None),
+            plugins: Vec::new(),
+        });
+
+        close_current_browser(&mut state).await.unwrap();
+
+        assert!(state.active_provider_session.is_none());
+        let info = handle_session_info(&mut state).await.unwrap();
+        assert!(info.get("provider").is_none());
+        assert!(info.get("providerMetadata").is_none());
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn test_close_current_browser_closes_active_provider_plugin_session() {
@@ -11262,10 +11365,12 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
 
         let mut state = DaemonState::new();
         state.active_provider_session = Some(ActiveProviderSession {
-            session: providers::ProviderSession {
-                provider: "plugin:cloud-browser".to_string(),
-                session_id: r#"{"sessionId":"s1"}"#.to_string(),
-            },
+            provider: providers::ActiveProvider::new("cloud-browser", None).with_cleanup(
+                providers::ProviderCleanup::Plugin {
+                    provider: "cloud-browser".to_string(),
+                    data: json!({ "sessionId": "s1" }),
+                },
+            ),
             plugins: vec![crate::plugins::PluginConfig {
                 name: "cloud-browser".to_string(),
                 command: plugin_path.to_string_lossy().to_string(),

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -130,8 +130,8 @@ impl ProviderConnection {
     }
 }
 
-/// Connects to the specified browser provider and returns a CDP WebSocket URL
-/// along with session info for cleanup on failure.
+/// Connects to the specified browser provider and returns a CDP connection
+/// (WebSocket URL, optional headers, metadata, and cleanup state).
 pub async fn connect_provider(provider_name: &str) -> Result<ProviderConnection, String> {
     let plugins = crate::plugins::plugins_from_env();
     connect_provider_with_plugins(provider_name, &plugins).await
@@ -352,7 +352,7 @@ async fn connect_browserbase() -> Result<ProviderConnection, String> {
     let response = client
         .post("https://api.browserbase.com/v1/sessions")
         .header("content-type", "application/json")
-        .header("x-bb-api-key", &api_key)
+        .header("X-BB-API-Key", &api_key)
         .body("{}")
         .send()
         .await
@@ -432,7 +432,7 @@ async fn fetch_browserbase_debug_metadata(
             "https://api.browserbase.com/v1/sessions/{}/debug",
             urlencoding::encode(session_id)
         ))
-        .header("x-bb-api-key", api_key)
+        .header("X-BB-API-Key", api_key)
         .timeout(BROWSERBASE_LIVE_VIEW_TIMEOUT)
         .send()
         .await

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -5,21 +5,129 @@
 
 use serde_json::{json, Value};
 use std::env;
+use std::time::{Duration, Instant};
 
-/// Provider session info for cleanup on failure.
+const BROWSERBASE_LIVE_VIEW_TIMEOUT: Duration = Duration::from_secs(5);
+const BROWSERBASE_LIVE_VIEW_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+/// Provider-owned cleanup data retained for connection failures and shutdown.
 #[derive(Debug, Clone)]
-pub struct ProviderSession {
-    pub provider: String,
-    pub session_id: String,
+pub enum ProviderCleanup {
+    Browserbase {
+        session_id: String,
+    },
+    Browserless {
+        stop_url: String,
+    },
+    BrowserUse {
+        session_id: String,
+    },
+    Kernel {
+        session_id: String,
+    },
+    AgentCore {
+        session_id: String,
+        region: String,
+        browser_identifier: String,
+    },
+    Plugin {
+        provider: String,
+        data: Value,
+    },
+}
+
+#[derive(Debug)]
+enum PostConnectMetadata {
+    Browserbase {
+        session_id: String,
+        retry_after: Option<Instant>,
+    },
+}
+
+/// Provider state retained for the lifetime of an active browser connection.
+#[derive(Debug)]
+pub struct ActiveProvider {
+    pub name: String,
+    pub metadata: Option<Value>,
+    cleanup: Option<ProviderCleanup>,
+    post_connect_metadata: Option<PostConnectMetadata>,
+}
+
+impl ActiveProvider {
+    pub fn new(name: impl Into<String>, metadata: Option<Value>) -> Self {
+        Self {
+            name: name.into(),
+            metadata,
+            cleanup: None,
+            post_connect_metadata: None,
+        }
+    }
+
+    pub fn with_cleanup(mut self, cleanup: ProviderCleanup) -> Self {
+        self.cleanup = Some(cleanup);
+        self
+    }
+
+    /// Best-effort metadata enrichment that must run only after CDP event
+    /// handlers have been installed. Provider failures never fail browsing.
+    pub async fn enrich_metadata_after_connect(&mut self) {
+        let session_id = match &self.post_connect_metadata {
+            Some(PostConnectMetadata::Browserbase {
+                session_id,
+                retry_after,
+            }) if retry_after.is_none_or(|deadline| Instant::now() >= deadline) => {
+                session_id.clone()
+            }
+            _ => return,
+        };
+
+        match browserbase_live_view_metadata(&session_id).await {
+            Some(metadata) => {
+                self.metadata = Some(metadata);
+                self.post_connect_metadata = None;
+            }
+            None => {
+                if let Some(PostConnectMetadata::Browserbase { retry_after, .. }) =
+                    self.post_connect_metadata.as_mut()
+                {
+                    *retry_after = Some(Instant::now() + BROWSERBASE_LIVE_VIEW_RETRY_DELAY);
+                }
+            }
+        }
+    }
+
+    pub async fn close(self, plugins: &[crate::plugins::PluginConfig]) {
+        if let Some(cleanup) = self.cleanup {
+            close_provider_cleanup_with_plugins(&cleanup, plugins).await;
+        }
+    }
 }
 
 #[derive(Debug)]
 pub struct ProviderConnection {
+    pub provider: String,
     pub ws_url: String,
-    pub session: Option<ProviderSession>,
+    pub ws_headers: Option<Vec<(String, String)>>,
+    pub cleanup: Option<ProviderCleanup>,
     /// If true, the WebSocket IS the page session (no Target.* commands).
     pub direct_page: bool,
     pub metadata: Option<Value>,
+    post_connect_metadata: Option<PostConnectMetadata>,
+}
+
+impl ProviderConnection {
+    pub fn into_active(self) -> ActiveProvider {
+        ActiveProvider {
+            name: self.provider,
+            metadata: self.metadata,
+            cleanup: self.cleanup,
+            post_connect_metadata: self.post_connect_metadata,
+        }
+    }
+
+    pub async fn close(self, plugins: &[crate::plugins::PluginConfig]) {
+        self.into_active().close(plugins).await;
+    }
 }
 
 /// Connects to the specified browser provider and returns a CDP WebSocket URL
@@ -49,51 +157,44 @@ pub async fn connect_provider_with_plugins_and_options(
     launch_options: Option<Value>,
 ) -> Result<ProviderConnection, String> {
     match provider_name.to_lowercase().as_str() {
-        "browserbase" => {
-            let (url, session) = connect_browserbase().await?;
-            Ok(ProviderConnection {
-                ws_url: url,
-                session,
-                direct_page: false,
-                metadata: None,
-            })
-        }
+        "browserbase" => connect_browserbase().await,
         "browserless" => {
-            let (url, session) = connect_browserless().await?;
+            let (url, cleanup) = connect_browserless().await?;
             Ok(ProviderConnection {
+                provider: "browserless".to_string(),
                 ws_url: url,
-                session,
+                ws_headers: None,
+                cleanup,
                 direct_page: false,
                 metadata: None,
+                post_connect_metadata: None,
             })
         }
         "browser-use" | "browseruse" => {
-            let (url, session) = connect_browser_use().await?;
+            let (url, cleanup) = connect_browser_use().await?;
             Ok(ProviderConnection {
+                provider: "browser-use".to_string(),
                 ws_url: url,
-                session,
+                ws_headers: None,
+                cleanup,
                 direct_page: false,
                 metadata: None,
+                post_connect_metadata: None,
             })
         }
         "kernel" => {
-            let (url, session) = connect_kernel().await?;
+            let (url, cleanup) = connect_kernel().await?;
             Ok(ProviderConnection {
+                provider: "kernel".to_string(),
                 ws_url: url,
-                session,
+                ws_headers: None,
+                cleanup,
                 direct_page: false,
                 metadata: None,
+                post_connect_metadata: None,
             })
         }
-        "agentcore" => {
-            let (url, session) = connect_agentcore().await?;
-            Ok(ProviderConnection {
-                ws_url: url,
-                session,
-                direct_page: false,
-                metadata: None,
-            })
-        }
+        "agentcore" => connect_agentcore().await,
         _ => {
             connect_plugin_provider_with_plugins_and_options(provider_name, plugins, launch_options)
                 .await
@@ -101,34 +202,18 @@ pub async fn connect_provider_with_plugins_and_options(
     }
 }
 
-/// Close a provider session (call on CDP connect failure).
-pub async fn close_provider_session(session: &ProviderSession) {
-    let plugins = crate::plugins::plugins_from_env();
-    close_provider_session_with_plugins(session, &plugins).await;
-}
-
-/// Close a provider session with the plugin registry that created it.
-pub async fn close_provider_session_with_plugins(
-    session: &ProviderSession,
+/// Close provider-owned resources with the plugin registry that created them.
+pub async fn close_provider_cleanup_with_plugins(
+    cleanup: &ProviderCleanup,
     plugins: &[crate::plugins::PluginConfig],
 ) {
-    if let Some(plugin_name) = session.provider.strip_prefix("plugin:") {
-        if let Ok(cleanup) = serde_json::from_str::<Value>(&session.session_id) {
-            let _ =
-                crate::plugins::close_browser_provider_with_plugins(plugin_name, plugins, cleanup)
-                    .await;
-        }
-        return;
-    }
-
     let client = reqwest::Client::new();
-    match session.provider.as_str() {
-        "browserbase" => {
+    match cleanup {
+        ProviderCleanup::Browserbase { session_id } => {
             if let Ok(api_key) = env::var("BROWSERBASE_API_KEY") {
                 let _ = client
                     .post(format!(
-                        "https://api.browserbase.com/v1/sessions/{}",
-                        session.session_id
+                        "https://api.browserbase.com/v1/sessions/{session_id}"
                     ))
                     .header("Content-Type", "application/json")
                     .header("X-BB-API-Key", &api_key)
@@ -137,12 +222,14 @@ pub async fn close_provider_session_with_plugins(
                     .await;
             }
         }
-        "browser-use" => {
+        ProviderCleanup::Browserless { stop_url } => {
+            let _ = client.delete(stop_url).send().await;
+        }
+        ProviderCleanup::BrowserUse { session_id } => {
             if let Ok(api_key) = env::var("BROWSER_USE_API_KEY") {
                 let _ = client
                     .patch(format!(
-                        "https://api.browser-use.com/api/v2/browsers/{}",
-                        session.session_id
+                        "https://api.browser-use.com/api/v2/browsers/{session_id}"
                     ))
                     .header("X-Browser-Use-API-Key", &api_key)
                     .header("Content-Type", "application/json")
@@ -151,11 +238,7 @@ pub async fn close_provider_session_with_plugins(
                     .await;
             }
         }
-        "browserless" => {
-            // session_id holds the stop URL for browserless
-            let _ = client.delete(&session.session_id).send().await;
-        }
-        "kernel" => {
+        ProviderCleanup::Kernel { session_id } => {
             if let Ok(api_key) = env::var("KERNEL_API_KEY") {
                 let endpoint = env::var("KERNEL_ENDPOINT")
                     .unwrap_or_else(|_| "https://api.onkernel.com".to_string());
@@ -163,18 +246,28 @@ pub async fn close_provider_session_with_plugins(
                     .delete(format!(
                         "{}/browsers/{}",
                         endpoint.trim_end_matches('/'),
-                        session.session_id
+                        session_id
                     ))
                     .header("Authorization", format!("Bearer {}", api_key))
                     .send()
                     .await;
             }
         }
-        "agentcore" => {
-            // AgentCore session cleanup is handled via signed DELETE request
-            let _ = close_agentcore_session(&session.session_id).await;
+        ProviderCleanup::AgentCore {
+            session_id,
+            region,
+            browser_identifier,
+        } => {
+            let _ = close_agentcore_session(session_id, region, browser_identifier).await;
         }
-        _ => {}
+        ProviderCleanup::Plugin { provider, data } => {
+            let _ = crate::plugins::close_browser_provider_with_plugins(
+                provider,
+                plugins,
+                data.clone(),
+            )
+            .await;
+        }
     }
 }
 
@@ -229,15 +322,18 @@ pub async fn connect_plugin_provider_with_plugins_and_options(
     let browser =
         crate::plugins::connect_browser_provider_with_plugins(provider_name, plugins, request)
             .await?;
-    let session = browser.cleanup.as_ref().map(|cleanup| ProviderSession {
-        provider: format!("plugin:{}", provider_name),
-        session_id: serde_json::to_string(cleanup).unwrap_or_else(|_| "{}".to_string()),
+    let cleanup = browser.cleanup.map(|data| ProviderCleanup::Plugin {
+        provider: provider_name.to_string(),
+        data,
     });
     Ok(ProviderConnection {
+        provider: provider_name.to_string(),
         ws_url: browser.cdp_url,
-        session,
+        ws_headers: None,
+        cleanup,
         direct_page: browser.direct_page,
         metadata: browser.metadata,
+        post_connect_metadata: None,
     })
 }
 
@@ -248,7 +344,7 @@ fn env_var_is_truthy(name: &str) -> bool {
     }
 }
 
-async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), String> {
+async fn connect_browserbase() -> Result<ProviderConnection, String> {
     let api_key = env::var("BROWSERBASE_API_KEY")
         .map_err(|_| "BROWSERBASE_API_KEY environment variable is not set")?;
 
@@ -279,28 +375,106 @@ async fn connect_browserbase() -> Result<(String, Option<ProviderSession>), Stri
     let json: Value =
         serde_json::from_str(&body).map_err(|e| format!("Invalid Browserbase response: {}", e))?;
 
-    let session_id = json
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-
-    let ws_url = json
-        .get("connectUrl")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .ok_or_else(|| "Browserbase response missing connectUrl".to_string())?;
-
-    Ok((
+    let (session_id, ws_url) = parse_browserbase_session(&json)?;
+    // Browserbase requires connecting to connectUrl promptly after session
+    // create (sessions time out if unused). Live-view URLs come from a separate
+    // GET /v1/sessions/{id}/debug call after CDP connect succeeds.
+    Ok(ProviderConnection {
+        provider: "browserbase".to_string(),
         ws_url,
-        Some(ProviderSession {
-            provider: "browserbase".to_string(),
-            session_id,
+        ws_headers: None,
+        cleanup: Some(ProviderCleanup::Browserbase {
+            session_id: session_id.clone(),
         }),
-    ))
+        direct_page: false,
+        metadata: Some(json!({ "sessionId": session_id.clone() })),
+        post_connect_metadata: Some(PostConnectMetadata::Browserbase {
+            session_id,
+            retry_after: None,
+        }),
+    })
 }
 
-async fn connect_browserless() -> Result<(String, Option<ProviderSession>), String> {
+/// Best-effort Browserbase live-view metadata from `GET /v1/sessions/{id}/debug`.
+///
+/// Returns only the session-scoped `debuggerUrl` / `debuggerFullscreenUrl` fields
+/// (plus `sessionId`). Omits `wsUrl` and per-page URLs from the SessionLiveUrls
+/// response because those are additional capability-bearing surfaces.
+pub async fn browserbase_live_view_metadata(session_id: &str) -> Option<Value> {
+    let api_key = env::var("BROWSERBASE_API_KEY").ok()?;
+    let client = reqwest::Client::new();
+    fetch_browserbase_debug_metadata(&client, &api_key, session_id)
+        .await
+        .ok()
+}
+
+fn parse_browserbase_session(json: &Value) -> Result<(String, String), String> {
+    let session_id = json
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Browserbase response missing id".to_string())?;
+    let connect_url = json
+        .get("connectUrl")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Browserbase response missing connectUrl".to_string())?;
+    Ok((session_id.to_string(), connect_url.to_string()))
+}
+
+async fn fetch_browserbase_debug_metadata(
+    client: &reqwest::Client,
+    api_key: &str,
+    session_id: &str,
+) -> Result<Value, String> {
+    let response = client
+        .get(format!(
+            "https://api.browserbase.com/v1/sessions/{}/debug",
+            urlencoding::encode(session_id)
+        ))
+        .header("x-bb-api-key", api_key)
+        .timeout(BROWSERBASE_LIVE_VIEW_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| format!("Browserbase live-view request failed: {}", e))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Browserbase live-view response: {}", e))?;
+    if !status.is_success() {
+        return Err(format!(
+            "Browserbase live-view API error ({}): {}",
+            status.as_u16(),
+            body
+        ));
+    }
+    let json: Value = serde_json::from_str(&body)
+        .map_err(|e| format!("Invalid Browserbase live-view response: {}", e))?;
+    parse_browserbase_debug_metadata(session_id, &json)
+}
+
+fn parse_browserbase_debug_metadata(session_id: &str, json: &Value) -> Result<Value, String> {
+    let debugger_url = json
+        .get("debuggerUrl")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Browserbase live-view response missing debuggerUrl".to_string())?;
+    let debugger_fullscreen_url = json
+        .get("debuggerFullscreenUrl")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "Browserbase live-view response missing debuggerFullscreenUrl".to_string()
+        })?;
+    Ok(json!({
+        "sessionId": session_id,
+        "debuggerUrl": debugger_url,
+        "debuggerFullscreenUrl": debugger_fullscreen_url,
+    }))
+}
+
+async fn connect_browserless() -> Result<(String, Option<ProviderCleanup>), String> {
     let api_key = env::var("BROWSERLESS_API_KEY")
         .map_err(|_| "BROWSERLESS_API_KEY environment variable is not set")?;
 
@@ -371,17 +545,10 @@ async fn connect_browserless() -> Result<(String, Option<ProviderSession>), Stri
         .map(String::from)
         .ok_or_else(|| "Browserless response missing 'stop' URL".to_string())?;
 
-    Ok((
-        connect_url,
-        Some(ProviderSession {
-            provider: "browserless".to_string(),
-            // Store the stop URL as the session_id for cleanup
-            session_id: stop_url,
-        }),
-    ))
+    Ok((connect_url, Some(ProviderCleanup::Browserless { stop_url })))
 }
 
-async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), String> {
+async fn connect_browser_use() -> Result<(String, Option<ProviderCleanup>), String> {
     let api_key = env::var("BROWSER_USE_API_KEY")
         .map_err(|_| "BROWSER_USE_API_KEY environment variable is not set")?;
 
@@ -390,7 +557,7 @@ async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), Stri
     Ok((ws_url, None))
 }
 
-async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {
+async fn connect_kernel() -> Result<(String, Option<ProviderCleanup>), String> {
     let api_key = env::var("KERNEL_API_KEY").ok();
     let endpoint =
         env::var("KERNEL_ENDPOINT").unwrap_or_else(|_| "https://api.onkernel.com".to_string());
@@ -470,13 +637,7 @@ async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {
                 .to_string()
         })?;
 
-    Ok((
-        ws_url,
-        Some(ProviderSession {
-            provider: "kernel".to_string(),
-            session_id,
-        }),
-    ))
+    Ok((ws_url, Some(ProviderCleanup::Kernel { session_id })))
 }
 
 // ============================================================================
@@ -486,43 +647,7 @@ async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {
 mod agentcore {
     use super::*;
 
-    /// AgentCore-specific session info for Live View URL
-    pub struct AgentCoreSessionInfo {
-        pub session_id: String,
-        pub browser_identifier: String,
-        pub region: String,
-        pub live_view_url: String,
-    }
-
-    thread_local! {
-        static AGENTCORE_INFO: std::cell::RefCell<Option<AgentCoreSessionInfo>> = const { std::cell::RefCell::new(None) };
-        static AGENTCORE_WS_HEADERS: std::cell::RefCell<Option<Vec<(String, String)>>> = const { std::cell::RefCell::new(None) };
-    }
-
-    pub fn set_agentcore_info(info: AgentCoreSessionInfo) {
-        AGENTCORE_INFO.with(|cell| *cell.borrow_mut() = Some(info));
-    }
-
-    pub fn get_agentcore_info() -> Option<AgentCoreSessionInfo> {
-        AGENTCORE_INFO.with(|cell| {
-            cell.borrow().as_ref().map(|i| AgentCoreSessionInfo {
-                session_id: i.session_id.clone(),
-                browser_identifier: i.browser_identifier.clone(),
-                region: i.region.clone(),
-                live_view_url: i.live_view_url.clone(),
-            })
-        })
-    }
-
-    pub fn set_agentcore_ws_headers(headers: Vec<(String, String)>) {
-        AGENTCORE_WS_HEADERS.with(|cell| *cell.borrow_mut() = Some(headers));
-    }
-
-    pub fn take_agentcore_ws_headers() -> Option<Vec<(String, String)>> {
-        AGENTCORE_WS_HEADERS.with(|cell| cell.borrow_mut().take())
-    }
-
-    pub async fn connect() -> Result<(String, Option<ProviderSession>), String> {
+    pub async fn connect() -> Result<ProviderConnection, String> {
         let region = env::var("AGENTCORE_REGION")
             .or_else(|_| env::var("AWS_REGION"))
             .or_else(|_| env::var("AWS_DEFAULT_REGION"))
@@ -606,13 +731,6 @@ mod agentcore {
             region, browser_identifier, session_id
         );
 
-        set_agentcore_info(AgentCoreSessionInfo {
-            session_id: session_id.clone(),
-            browser_identifier: browser_identifier.clone(),
-            region: region.clone(),
-            live_view_url: live_view_url.clone(),
-        });
-
         eprintln!("Session: {}", session_id);
         eprintln!("Live View: {}", live_view_url);
 
@@ -629,15 +747,25 @@ mod agentcore {
             None,
         )
         .await?;
-        set_agentcore_ws_headers(ws_headers);
 
-        Ok((
+        Ok(ProviderConnection {
+            provider: "agentcore".to_string(),
             ws_url,
-            Some(ProviderSession {
-                provider: "agentcore".to_string(),
-                session_id,
+            ws_headers: Some(ws_headers),
+            cleanup: Some(ProviderCleanup::AgentCore {
+                session_id: session_id.clone(),
+                region: region.clone(),
+                browser_identifier: browser_identifier.clone(),
             }),
-        ))
+            direct_page: false,
+            metadata: Some(json!({
+                "sessionId": session_id,
+                "browserIdentifier": browser_identifier,
+                "region": region,
+                "liveViewUrl": live_view_url,
+            })),
+            post_connect_metadata: None,
+        })
     }
 
     /// Get AWS credentials from environment variables or AWS CLI
@@ -816,32 +944,22 @@ mod agentcore {
         Ok(headers)
     }
 
-    pub async fn close_session(session_id: &str) -> Result<(), String> {
-        let info = get_agentcore_info();
-        let (region, browser_id) = match &info {
-            Some(i) => (i.region.clone(), i.browser_identifier.clone()),
-            None => {
-                let region = env::var("AGENTCORE_REGION")
-                    .or_else(|_| env::var("AWS_REGION"))
-                    .or_else(|_| env::var("AWS_DEFAULT_REGION"))
-                    .unwrap_or_else(|_| "us-east-1".to_string());
-                let browser_id = env::var("AGENTCORE_BROWSER_ID")
-                    .unwrap_or_else(|_| "aws.browser.v1".to_string());
-                (region, browser_id)
-            }
-        };
-
+    pub async fn close_session(
+        session_id: &str,
+        region: &str,
+        browser_id: &str,
+    ) -> Result<(), String> {
         let host = format!("bedrock-agentcore.{}.amazonaws.com", region);
         let path = format!(
             "/browsers/{}/sessions/stop",
-            urlencoding::encode(&browser_id)
+            urlencoding::encode(browser_id)
         );
         let url = format!("https://{}{}", host, path);
 
         let body = serde_json::to_string(&json!({ "sessionId": session_id }))
             .map_err(|e| format!("Failed to serialize close request: {}", e))?;
 
-        let signed_headers = sign_request("PUT", &url, &region, Some(&body)).await?;
+        let signed_headers = sign_request("PUT", &url, region, Some(&body)).await?;
 
         let client = reqwest::Client::new();
         let mut req = client.put(&url).body(body);
@@ -854,14 +972,16 @@ mod agentcore {
     }
 }
 
-pub use agentcore::{get_agentcore_info, take_agentcore_ws_headers};
-
-async fn connect_agentcore() -> Result<(String, Option<ProviderSession>), String> {
+async fn connect_agentcore() -> Result<ProviderConnection, String> {
     agentcore::connect().await
 }
 
-async fn close_agentcore_session(session_id: &str) -> Result<(), String> {
-    agentcore::close_session(session_id).await
+async fn close_agentcore_session(
+    session_id: &str,
+    region: &str,
+    browser_identifier: &str,
+) -> Result<(), String> {
+    agentcore::close_session(session_id, region, browser_identifier).await
 }
 
 #[cfg(test)]
@@ -896,6 +1016,75 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_browserbase_session_requires_id_and_connect_url() {
+        let parsed = parse_browserbase_session(&json!({
+            "id": "sess_123",
+            "connectUrl": "wss://connect.browserbase.com/session"
+        }))
+        .unwrap();
+        assert_eq!(parsed.0, "sess_123");
+        assert_eq!(parsed.1, "wss://connect.browserbase.com/session");
+
+        assert!(parse_browserbase_session(&json!({ "connectUrl": "wss://example.com" })).is_err());
+        assert!(parse_browserbase_session(&json!({ "id": "sess_123" })).is_err());
+    }
+
+    #[test]
+    fn test_parse_browserbase_debug_metadata_keeps_only_safe_live_view_fields() {
+        let metadata = parse_browserbase_debug_metadata(
+            "sess_123",
+            &json!({
+                "debuggerUrl": "https://debugger.browserbase.com/session",
+                "debuggerFullscreenUrl": "https://debugger.browserbase.com/session/fullscreen",
+                "wsUrl": "wss://api.browserbase.com/private-capability",
+                "pages": []
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(metadata["sessionId"], "sess_123");
+        assert_eq!(
+            metadata["debuggerFullscreenUrl"],
+            "https://debugger.browserbase.com/session/fullscreen"
+        );
+        assert!(metadata.get("wsUrl").is_none());
+        assert!(metadata.get("pages").is_none());
+    }
+
+    #[test]
+    fn test_parse_browserbase_debug_metadata_requires_both_debugger_urls() {
+        let result = parse_browserbase_debug_metadata(
+            "sess_123",
+            &json!({ "debuggerUrl": "https://debugger.browserbase.com/session" }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_browserbase_debug_metadata_is_non_fatal() {
+        let metadata = parse_browserbase_debug_metadata("sess_123", &json!({})).ok();
+        assert!(metadata.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_browserbase_metadata_retry_cooldown_preserves_pending_enrichment() {
+        let mut provider = ActiveProvider {
+            name: "browserbase".to_string(),
+            metadata: Some(json!({ "sessionId": "sess_123" })),
+            cleanup: None,
+            post_connect_metadata: Some(PostConnectMetadata::Browserbase {
+                session_id: "sess_123".to_string(),
+                retry_after: Some(Instant::now() + Duration::from_secs(60)),
+            }),
+        };
+
+        provider.enrich_metadata_after_connect().await;
+
+        assert_eq!(provider.metadata.unwrap()["sessionId"], "sess_123");
+        assert!(provider.post_connect_metadata.is_some());
+    }
+
+    #[test]
     fn test_agentcore_env_defaults() {
         // Test that default values are used when env vars not set
         std::env::remove_var("AGENTCORE_REGION");
@@ -914,40 +1103,31 @@ mod tests {
     }
 
     #[test]
-    fn test_agentcore_session_info_storage() {
-        let info = agentcore::AgentCoreSessionInfo {
-            session_id: "test-session".to_string(),
-            browser_identifier: "aws.browser.v1".to_string(),
-            region: "us-east-1".to_string(),
-            live_view_url: "https://example.com".to_string(),
-        };
-
-        agentcore::set_agentcore_info(info);
-        let retrieved = get_agentcore_info();
-        assert!(retrieved.is_some());
-        let retrieved = retrieved.unwrap();
-        assert_eq!(retrieved.session_id, "test-session");
-        assert_eq!(retrieved.region, "us-east-1");
-    }
-
-    #[test]
-    fn test_agentcore_ws_headers_storage() {
-        let headers = vec![
-            (
+    fn test_agentcore_connection_carries_headers_metadata_and_typed_cleanup() {
+        let connection = ProviderConnection {
+            provider: "agentcore".to_string(),
+            ws_url: "wss://example.com/automation".to_string(),
+            ws_headers: Some(vec![(
                 "Authorization".to_string(),
                 "AWS4-HMAC-SHA256...".to_string(),
-            ),
-            ("X-Amz-Date".to_string(), "20260304T180000Z".to_string()),
-        ];
+            )]),
+            cleanup: Some(ProviderCleanup::AgentCore {
+                session_id: "test-session".to_string(),
+                region: "us-east-1".to_string(),
+                browser_identifier: "aws.browser.v1".to_string(),
+            }),
+            direct_page: false,
+            metadata: Some(json!({
+                "sessionId": "test-session",
+                "liveViewUrl": "https://example.com"
+            })),
+            post_connect_metadata: None,
+        };
 
-        agentcore::set_agentcore_ws_headers(headers);
-        let taken = take_agentcore_ws_headers();
-        assert!(taken.is_some());
-        assert_eq!(taken.unwrap().len(), 2);
-
-        // Should be None after take
-        let taken_again = take_agentcore_ws_headers();
-        assert!(taken_again.is_none());
+        assert_eq!(connection.ws_headers.as_ref().unwrap().len(), 1);
+        let active = connection.into_active();
+        assert_eq!(active.name, "agentcore");
+        assert_eq!(active.metadata.unwrap()["sessionId"], "test-session");
     }
 
     #[cfg(unix)]
@@ -971,9 +1151,9 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         perms.set_mode(0o755);
         std::fs::set_permissions(&plugin_path, perms).unwrap();
 
-        let session = ProviderSession {
-            provider: "plugin:cloud-browser".to_string(),
-            session_id: r#"{"sessionId":"s1"}"#.to_string(),
+        let cleanup = ProviderCleanup::Plugin {
+            provider: "cloud-browser".to_string(),
+            data: json!({ "sessionId": "s1" }),
         };
         let plugins = vec![crate::plugins::PluginConfig {
             name: "cloud-browser".to_string(),
@@ -983,7 +1163,7 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             ..crate::plugins::PluginConfig::default()
         }];
 
-        rt.block_on(close_provider_session_with_plugins(&session, &plugins));
+        rt.block_on(close_provider_cleanup_with_plugins(&cleanup, &plugins));
 
         let request = std::fs::read_to_string(marker_path).unwrap();
         assert!(request.contains(r#""type":"browser.close""#));
@@ -1012,7 +1192,7 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             &plugin_path,
             r#"#!/bin/sh
 cat > "$1"
-printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cdpUrl":"ws://127.0.0.1:9222/devtools/browser/test"}}'
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cdpUrl":"ws://127.0.0.1:9222/devtools/browser/test","metadata":{"dashboard":{"url":"https://provider.example/session"}}}}'
 "#,
         )
         .unwrap();
@@ -1028,12 +1208,18 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
             ..crate::plugins::PluginConfig::default()
         }];
 
-        rt.block_on(connect_provider_with_plugins("cloud-browser", &plugins))
+        let connection = rt
+            .block_on(connect_provider_with_plugins("cloud-browser", &plugins))
             .unwrap();
 
         let request: Value =
             serde_json::from_str(&std::fs::read_to_string(request_path).unwrap()).unwrap();
         assert_eq!(request["request"]["launchOptions"]["headed"], false);
+        assert_eq!(connection.provider, "cloud-browser");
+        assert_eq!(
+            connection.metadata.unwrap()["dashboard"]["url"],
+            "https://provider.example/session"
+        );
     }
 
     #[cfg(unix)]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2705,7 +2705,7 @@ instance with separate cookies, storage, and state.
 Operations:
   (none)               Show current session name
   id                   Generate stable session id (--scope worktree|cwd|git-root, --prefix)
-  info                 Show daemon, launch, and restore diagnostics
+  info                 Show daemon, launch, provider, and restore diagnostics
   list                 List all active sessions
 
 Environment:

--- a/docs/src/app/plugins/page.mdx
+++ b/docs/src/app/plugins/page.mdx
@@ -348,6 +348,8 @@ agent-browser --provider cloud-browser open https://example.com
 
 If `cleanup` is returned and connection fails, agent-browser later sends it back as the request body for `browser.close`.
 
+The optional `metadata` object is opaque and provider-owned. agent-browser returns it as `providerMetadata` from provider launches and `session info --json`; it does not normalize or interpret provider-specific keys. Plugins must return metadata from `browser.launch`; there is no post-connect metadata lifecycle call.
+
 ## Launch mutator plugin
 
 A launch mutator receives local launch options before Chrome starts and can append arguments, extensions, init scripts, or a user agent:

--- a/docs/src/app/providers/agentcore/page.mdx
+++ b/docs/src/app/providers/agentcore/page.mdx
@@ -61,6 +61,8 @@ Live View: https://us-east-1.console.aws.amazon.com/bedrock-agentcore/browser/aw
 
 Open this URL in your browser to watch the agent session in real time from the AWS Console.
 
+The launch response and `agent-browser session info --json` also expose this information through generic `providerMetadata` with `sessionId`, `browserIdentifier`, `region`, and `liveViewUrl`. The existing `agentCoreSessionId` and `agentCoreLiveViewUrl` launch fields remain available for compatibility.
+
 ## Credential Resolution
 
 AgentCore uses lightweight manual SigV4 signing (no AWS SDK dependency). Credentials are resolved in order:

--- a/docs/src/app/providers/browserbase/page.mdx
+++ b/docs/src/app/providers/browserbase/page.mdx
@@ -21,4 +21,14 @@ The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
 
 When enabled, agent-browser connects to a Browserbase session instead of launching a local browser. All commands work identically.
 
+## Live view
+
+Inspect the active session to retrieve Browserbase live-view URLs:
+
+```bash
+agent-browser session info --json
+```
+
+The response includes `provider: "browserbase"` and a `providerMetadata` object with `sessionId` while a Browserbase session is active. Successful live-view lookup adds `debuggerUrl` and `debuggerFullscreenUrl`. Those URLs come from Browserbase's [`GET /v1/sessions/{id}/debug`](https://docs.browserbase.com/reference/api/session-live-urls) after CDP connects and event handlers are wired, so session create and CDP connect are never delayed by the lookup. Live-view lookup is best-effort; browsing still works if Browserbase temporarily cannot return debugger URLs, though the launch response may wait up to five seconds for the debug call. A failed lookup becomes eligible for retry through `session info` after a 30-second cooldown, without relaunching the browser. Treat debugger URLs as capability-bearing secrets and expose them only to authorized users.
+
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview).

--- a/docs/src/app/providers/browserbase/page.mdx
+++ b/docs/src/app/providers/browserbase/page.mdx
@@ -21,7 +21,7 @@ The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
 
 When enabled, agent-browser connects to a Browserbase session instead of launching a local browser. All commands work identically.
 
-## Live view
+## Live View
 
 Inspect the active session to retrieve Browserbase live-view URLs:
 
@@ -29,6 +29,6 @@ Inspect the active session to retrieve Browserbase live-view URLs:
 agent-browser session info --json
 ```
 
-The response includes `provider: "browserbase"` and a `providerMetadata` object with `sessionId` while a Browserbase session is active. Successful live-view lookup adds `debuggerUrl` and `debuggerFullscreenUrl`. Those URLs come from Browserbase's [`GET /v1/sessions/{id}/debug`](https://docs.browserbase.com/reference/api/session-live-urls) after CDP connects and event handlers are wired, so session create and CDP connect are never delayed by the lookup. Live-view lookup is best-effort; browsing still works if Browserbase temporarily cannot return debugger URLs, though the launch response may wait up to five seconds for the debug call. A failed lookup becomes eligible for retry through `session info` after a 30-second cooldown, without relaunching the browser. Treat debugger URLs as capability-bearing secrets and expose them only to authorized users.
+While active, the JSON includes `provider: "browserbase"` and `providerMetadata` with `sessionId`. A best-effort lookup after CDP connect adds `debuggerUrl` and `debuggerFullscreenUrl` from Browserbase's [`GET /v1/sessions/{id}/debug`](https://docs.browserbase.com/reference/api/session-live-urls). Treat those URLs as capability-bearing secrets and expose them only to authorized users.
 
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview).

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -23,9 +23,11 @@ agent-browser session
 # Generate a stable worktree-scoped session id
 agent-browser session id --scope worktree --prefix next-dev-loop
 
-# Inspect daemon, launch, and restore status
+# Inspect daemon, launch, provider, and restore status
 agent-browser session info --json
 ```
+
+For an active browser provider, diagnostics include a canonical `provider` name and may include an opaque `providerMetadata` object. Each provider owns its metadata schema. Treat capability-bearing URLs or tokens in provider metadata as secrets.
 
 ## Session isolation
 

--- a/packages/@agent-browser/eve/README.md
+++ b/packages/@agent-browser/eve/README.md
@@ -135,7 +135,7 @@ export default disableTool();
 
 Each tool shells out to the `agent-browser` CLI inside the sandbox from `ctx.getSandbox()`, using an isolated browser session named after the sandbox id, and returns the parsed `--json` payload. The browser and its state live entirely in the sandbox; the app runtime only relays commands.
 
-When `includeProviderMetadata` is enabled, `goto` navigation performs a best-effort `session info` lookup and attaches the active provider name and opaque provider-owned metadata to the channel result. History actions (`back` / `forward` / `reload`) skip that lookup. The metadata is removed from model-visible output via `toModelOutput`; any other tool that attaches `provider` or `providerMetadata` must do the same. Browserbase uses this path for its `sessionId`, `debuggerUrl`, and `debuggerFullscreenUrl`; applications must authenticate any UI that renders capability-bearing metadata.
+When `includeProviderMetadata` is enabled, `goto` navigation performs a best-effort `session info` lookup and attaches the active provider name and opaque provider-owned metadata to the channel result. History actions (`back` / `forward` / `reload`) skip that lookup. The metadata is removed from model-visible output via `toModelOutput`; any other tool that attaches `provider` or `providerMetadata` must do the same. Authenticate any UI that renders capability-bearing metadata.
 
 ## Example
 

--- a/packages/@agent-browser/eve/README.md
+++ b/packages/@agent-browser/eve/README.md
@@ -59,6 +59,8 @@ export default browser({
   // Output
   inlineScreenshots: true, // embed screenshots in tool output as data URLs for channels/UIs
   // (hidden from the model via toModelOutput; capped at 4 MB per image)
+  includeProviderMetadata: false, // attach active provider metadata to navigation channel output
+  // (hidden from the model; capability URLs must only be rendered to authorized users)
 
   // Install behavior
   autoInstall: true, // install agent-browser on first use when missing
@@ -132,6 +134,8 @@ export default disableTool();
 ## How it works
 
 Each tool shells out to the `agent-browser` CLI inside the sandbox from `ctx.getSandbox()`, using an isolated browser session named after the sandbox id, and returns the parsed `--json` payload. The browser and its state live entirely in the sandbox; the app runtime only relays commands.
+
+When `includeProviderMetadata` is enabled, `goto` navigation performs a best-effort `session info` lookup and attaches the active provider name and opaque provider-owned metadata to the channel result. History actions (`back` / `forward` / `reload`) skip that lookup. The metadata is removed from model-visible output via `toModelOutput`; any other tool that attaches `provider` or `providerMetadata` must do the same. Browserbase uses this path for its `sessionId`, `debuggerUrl`, and `debuggerFullscreenUrl`; applications must authenticate any UI that renders capability-bearing metadata.
 
 ## Example
 

--- a/packages/@agent-browser/eve/extension/extension.ts
+++ b/packages/@agent-browser/eve/extension/extension.ts
@@ -19,6 +19,8 @@ export default defineExtension({
     installSystemDependencies: z.boolean().default(true),
     /** Embed captured screenshots in the tool output as data URLs so channels/UIs can render them inline (hidden from the model). */
     inlineScreenshots: z.boolean().default(true),
+    /** Attach active browser-provider metadata to navigation channel output (hidden from the model). */
+    includeProviderMetadata: z.boolean().default(false),
     /** Truncate page output to this many characters. */
     maxOutputChars: z.number().int().positive().optional(),
     /** Proxy server URL used by the browser. */

--- a/packages/@agent-browser/eve/extension/tools/navigate.ts
+++ b/packages/@agent-browser/eve/extension/tools/navigate.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 
 import extension from "../extension";
-import { runBrowser } from "../lib/browser";
+import { runBrowser, type BrowserToolContext } from "../lib/browser";
 
 interface SessionInfo {
   readonly provider?: string;
@@ -15,7 +15,7 @@ interface NavigateOutput extends Record<string, unknown> {
 }
 
 async function withProviderMetadata(
-  ctx: Parameters<typeof runBrowser>[0],
+  ctx: BrowserToolContext,
   output: Record<string, unknown>,
 ): Promise<NavigateOutput> {
   if (!extension.config.includeProviderMetadata) {
@@ -48,16 +48,15 @@ export default defineTool({
     url: z.string().optional().describe('Required when action is "goto".'),
   }),
   async execute({ action, url }, ctx) {
-    let output: Record<string, unknown>;
     if (action === "goto") {
       if (url === undefined) {
         throw new Error('The "goto" action requires a url.');
       }
-      output = await runBrowser<Record<string, unknown>>(ctx, ["open", url]);
-      // Live-view URLs are useful when a session starts or changes page; skip
-      // the extra session-info round-trip for history actions.
+      const output = await runBrowser<Record<string, unknown>>(ctx, ["open", url]);
       return await withProviderMetadata(ctx, output);
     }
+    // Skip the extra session-info round-trip for history actions; live-view
+    // URLs are most useful when a session starts or changes page.
     return await runBrowser<Record<string, unknown>>(ctx, [action]);
   },
   // Provider live-view URLs are capability-bearing UI data. Preserve them in

--- a/packages/@agent-browser/eve/extension/tools/navigate.ts
+++ b/packages/@agent-browser/eve/extension/tools/navigate.ts
@@ -1,7 +1,41 @@
 import { defineTool } from "eve/tools";
 import { z } from "zod";
 
+import extension from "../extension";
 import { runBrowser } from "../lib/browser";
+
+interface SessionInfo {
+  readonly provider?: string;
+  readonly providerMetadata?: unknown;
+}
+
+interface NavigateOutput extends Record<string, unknown> {
+  readonly provider?: string;
+  readonly providerMetadata?: unknown;
+}
+
+async function withProviderMetadata(
+  ctx: Parameters<typeof runBrowser>[0],
+  output: Record<string, unknown>,
+): Promise<NavigateOutput> {
+  if (!extension.config.includeProviderMetadata) {
+    return output;
+  }
+  try {
+    const info = await runBrowser<SessionInfo>(ctx, ["session", "info"]);
+    return {
+      ...output,
+      ...(info.provider === undefined ? {} : { provider: info.provider }),
+      ...(info.providerMetadata === undefined
+        ? {}
+        : { providerMetadata: info.providerMetadata }),
+    };
+  } catch {
+    // Provider metadata is for channel observability only. Navigation remains
+    // usable with older CLIs or providers that do not expose session details.
+    return output;
+  }
+}
 
 export default defineTool({
   description:
@@ -14,12 +48,23 @@ export default defineTool({
     url: z.string().optional().describe('Required when action is "goto".'),
   }),
   async execute({ action, url }, ctx) {
+    let output: Record<string, unknown>;
     if (action === "goto") {
       if (url === undefined) {
         throw new Error('The "goto" action requires a url.');
       }
-      return await runBrowser(ctx, ["open", url]);
+      output = await runBrowser<Record<string, unknown>>(ctx, ["open", url]);
+      // Live-view URLs are useful when a session starts or changes page; skip
+      // the extra session-info round-trip for history actions.
+      return await withProviderMetadata(ctx, output);
     }
-    return await runBrowser(ctx, [action]);
+    return await runBrowser<Record<string, unknown>>(ctx, [action]);
+  },
+  // Provider live-view URLs are capability-bearing UI data. Preserve them in
+  // the channel result while keeping the model-facing result unchanged. Any
+  // other tool that attaches provider/providerMetadata must strip them here too.
+  toModelOutput(output) {
+    const { provider: _provider, providerMetadata: _providerMetadata, ...visible } = output;
+    return { type: "json", value: visible };
   },
 });

--- a/packages/@agent-browser/eve/test/extension.test.mjs
+++ b/packages/@agent-browser/eve/test/extension.test.mjs
@@ -82,6 +82,114 @@ test("navigate requires a url for goto", async () => {
   );
 });
 
+test("navigate includes provider metadata only when opted in", async () => {
+  resetConfig({ includeProviderMetadata: true });
+  const sandbox = fakeSandbox({
+    id: "provider-metadata",
+    respond(command) {
+      if (command.includes(" session info ")) {
+        return {
+          stdout: OK({
+            provider: "cloud-browser",
+            providerMetadata: {
+              sessionId: "sess_123",
+              dashboard: {
+                url: "https://provider.example/sessions/sess_123",
+              },
+            },
+          }),
+        };
+      }
+      return { stdout: OK({ title: "Example", url: "https://example.com/" }) };
+    },
+  });
+
+  const result = await tools.navigate.execute(
+    { action: "goto", url: "https://example.com" },
+    fakeCtx(sandbox),
+  );
+
+  assert.equal(result.provider, "cloud-browser");
+  assert.equal(result.providerMetadata.sessionId, "sess_123");
+  assert.equal(
+    result.providerMetadata.dashboard.url,
+    "https://provider.example/sessions/sess_123",
+  );
+  assert.equal(sandbox.commands.filter((command) => command.includes(" session info ")).length, 1);
+  assert.deepEqual(tools.navigate.toModelOutput(result), {
+    type: "json",
+    value: { title: "Example", url: "https://example.com/" },
+  });
+  resetConfig();
+});
+
+test("navigate does not request provider metadata unless opted in", async () => {
+  resetConfig();
+  const sandbox = fakeSandbox({
+    id: "provider-metadata-opt-out",
+    respond(command) {
+      if (command.includes(" session info ")) {
+        throw new Error("session info should not be called");
+      }
+      return { stdout: OK({ title: "Example", url: "https://example.com/" }) };
+    },
+  });
+
+  const result = await tools.navigate.execute(
+    { action: "goto", url: "https://example.com" },
+    fakeCtx(sandbox),
+  );
+
+  assert.deepEqual(result, { title: "Example", url: "https://example.com/" });
+  assert.equal(sandbox.commands.filter((command) => command.includes(" session info ")).length, 0);
+});
+
+test("navigate skips provider metadata lookup for history actions", async () => {
+  resetConfig({ includeProviderMetadata: true });
+  const sandbox = fakeSandbox({
+    id: "provider-metadata-history",
+    respond(command) {
+      if (command.includes(" session info ")) {
+        return {
+          stdout: OK({
+            provider: "browserbase",
+            providerMetadata: { sessionId: "sess_should_not_fetch" },
+          }),
+        };
+      }
+      return { stdout: OK({ title: "Example", url: "https://example.com/" }) };
+    },
+  });
+
+  const result = await tools.navigate.execute({ action: "back" }, fakeCtx(sandbox));
+  assert.deepEqual(result, { title: "Example", url: "https://example.com/" });
+  assert.equal(sandbox.commands.filter((command) => command.includes(" session info ")).length, 0);
+  resetConfig();
+});
+
+test("navigate keeps working when opted-in provider metadata is unavailable", async () => {
+  resetConfig({ includeProviderMetadata: true });
+  const sandbox = fakeSandbox({
+    id: "provider-metadata-unavailable",
+    respond(command) {
+      if (command.includes(" session info ")) {
+        return {
+          exitCode: 1,
+          stdout: JSON.stringify({ success: false, data: null, error: "unsupported" }),
+        };
+      }
+      return { stdout: OK({ title: "Example", url: "https://example.com/" }) };
+    },
+  });
+
+  const result = await tools.navigate.execute(
+    { action: "goto", url: "https://example.com" },
+    fakeCtx(sandbox),
+  );
+  assert.deepEqual(result, { title: "Example", url: "https://example.com/" });
+  resetConfig();
+});
+
 test("probes for the binary once per sandbox and skips install when present", async () => {
   resetConfig();
   const sandbox = fakeSandbox({ id: "probe-once" });

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -241,7 +241,7 @@ agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open
 agent-browser --session "$SESSION" session info --json
 ```
 
-For active cloud providers, session info may also include `provider` and provider-specific `providerMetadata`. Browserbase always retains its session id and adds capability-bearing debugger URLs after a best-effort lookup; failed lookups can retry through later session-info calls. Do not print or share debugger URLs unless the user explicitly needs an authorized live view.
+For active cloud providers, session info may also include `provider` and provider-specific `providerMetadata`. Treat capability-bearing URLs in that metadata as secrets.
 
 ### Extract data
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -241,6 +241,8 @@ agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open
 agent-browser --session "$SESSION" session info --json
 ```
 
+For active cloud providers, session info may also include `provider` and provider-specific `providerMetadata`. Browserbase always retains its session id and adds capability-bearing debugger URLs after a best-effort lookup; failed lookups can retry through later session-info calls. Do not print or share debugger URLs unless the user explicitly needs an authorized live view.
+
 ### Extract data
 
 ```bash

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -71,6 +71,8 @@ Use `agent-browser session info --json` for diagnostics:
 agent-browser --session "$SESSION" session info --json
 ```
 
+For an active provider session, diagnostics may include `provider` and `providerMetadata`. Browserbase retains `sessionId` immediately and adds `debuggerUrl` and `debuggerFullscreenUrl` from `GET /v1/sessions/{id}/debug` after CDP connects and event handlers are wired. A failed lookup becomes eligible for retry through `session info` after a 30-second cooldown. Treat debugger URLs as capability-bearing secrets and only surface them to authorized users.
+
 ### Manual State Files
 
 Use `state save`, `state load`, and `--state <path>` when you need an explicit portable JSON file. Do not make agents construct paths under `~/.agent-browser/sessions/`; prefer `--restore` for reusable agent sessions.

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -71,7 +71,7 @@ Use `agent-browser session info --json` for diagnostics:
 agent-browser --session "$SESSION" session info --json
 ```
 
-For an active provider session, diagnostics may include `provider` and `providerMetadata`. Browserbase retains `sessionId` immediately and adds `debuggerUrl` and `debuggerFullscreenUrl` from `GET /v1/sessions/{id}/debug` after CDP connects and event handlers are wired. A failed lookup becomes eligible for retry through `session info` after a 30-second cooldown. Treat debugger URLs as capability-bearing secrets and only surface them to authorized users.
+For an active provider session, diagnostics may include `provider` and `providerMetadata`. Browserbase retains `sessionId` immediately and adds `debuggerUrl` and `debuggerFullscreenUrl` from `GET /v1/sessions/{id}/debug` after CDP connects. Failed lookups can retry through later `session info` calls. Treat debugger URLs as capability-bearing secrets.
 
 ### Manual State Files
 


### PR DESCRIPTION
Expose opaque `provider` / `providerMetadata` from launches and `session info`, including Browserbase live-view URLs after CDP connect. Eve can opt in to attach the same metadata on navigation for channels.