### PR TITLE
Prepare v0.32.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # agent-browser
 
-## 0.32.1
+## 0.32.2
 
 <!-- release:start -->
+### Improvements
+
+- Updated **eve extension packaging** for eve 0.25.1, adopting the new source and dist extension manifest format, updating the eve example to stable AI SDK releases, and keeping extension tests aligned with eve's scoped config registry (#1570)
+
+### Contributors
+
+- @AndrewBarba
+<!-- release:end -->
+
+## 0.32.1
+
 ### Improvements
 
 - Widened **eve compatibility** for `@agent-browser/eve` to accept eve 0.23 and future major releases without peer-resolution warnings (#1563)
@@ -14,7 +25,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.32.0
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.32.1"
+version = "0.32.2"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.32.1"
+version = "0.32.2"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.32.2
+
+<p className="text-[#888] text-sm">July 17, 2026</p>
+
+### Improvements
+
+- Updated **eve extension packaging** for eve 0.25.1, adopting the new source and dist extension manifest format, updating the eve example to stable AI SDK releases, and keeping extension tests aligned with eve's scoped config registry (#1570)
+
+---
+
 ## v0.32.1
 
 <p className="text-[#888] text-sm">July 16, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.32.1";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.32.2";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bump agent-browser packages and Cargo metadata to 0.32.2
- Add CHANGELOG.md release notes with active release markers
- Mirror the v0.32.2 entry in the docs changelog