### PR TITLE
fix(native): propagate launch init scripts to new targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,8 @@ agent-browser addinitscript <js>                  # Register at runtime (returns
 agent-browser removeinitscript <identifier>       # Remove a previously registered init script
 ```
 
+Launch-time scripts from `--init-script`, `AGENT_BROWSER_INIT_SCRIPTS`, `--enable`, and launch mutator plugins are retained for the browser session. They are registered on new tabs and auto-attached page targets before those targets resume. Runtime `addinitscript` and `removeinitscript` commands continue to operate on the active page session.
+
 ### Setup
 
 ```bash
@@ -888,8 +890,8 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--headers <json>` | Set HTTP headers scoped to the URL's origin |
 | `--executable-path <path>` | Custom browser executable (or `AGENT_BROWSER_EXECUTABLE_PATH` env) |
 | `--extension <path>` | Load browser extension (repeatable; or `AGENT_BROWSER_EXTENSIONS` env) |
-| `--init-script <path>` | Register a page init script before the first navigation (repeatable; or `AGENT_BROWSER_INIT_SCRIPTS` env) |
-| `--enable <feature>` | Built-in init scripts: `react-devtools` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
+| `--init-script <path>` | Register a page init script on the initial page and new page targets (repeatable; or `AGENT_BROWSER_INIT_SCRIPTS` env) |
+| `--enable <feature>` | Built-in init scripts for the initial page and new page targets: `react-devtools` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
 | `--args <args>` | Browser launch args, comma or newline separated (or `AGENT_BROWSER_ARGS` env) |
 | `--user-agent <ua>` | Custom User-Agent string (or `AGENT_BROWSER_USER_AGENT` env) |
 | `--proxy <url>` | Proxy server URL with optional auth (or `AGENT_BROWSER_PROXY` env) |

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -391,8 +391,8 @@ pub struct DaemonState {
     /// Hash of launch options used for the current browser, for relaunch detection.
     launch_hash: Option<u64>,
     /// Whether browser-level auto-attach has been enabled for the current
-    /// browser so top-level popups pause before their first request.
-    network_auto_attach_installed: bool,
+    /// browser so top-level popups pause for network controls and init scripts.
+    browser_auto_attach_installed: bool,
     /// Browser engine name (e.g. "chrome", "lightpanda") for observability.
     pub engine: String,
     /// Default timeout for wait operations, from AGENT_BROWSER_DEFAULT_TIMEOUT env var.
@@ -472,7 +472,7 @@ impl DaemonState {
             stream_client: None,
             stream_server: None,
             launch_hash: None,
-            network_auto_attach_installed: false,
+            browser_auto_attach_installed: false,
             engine: env::var("AGENT_BROWSER_ENGINE").unwrap_or_else(|_| "chrome".to_string()),
             // README documents 25s, intentionally below the CLI's 30s IPC
             // read timeout so the daemon reports a proper timeout error
@@ -523,9 +523,9 @@ impl DaemonState {
         }
     }
 
-    /// Start the background task that processes Fetch.requestPaused and
-    /// Fetch.authRequired events in real-time (domain filtering, route
-    /// interception, origin-scoped headers, proxy authentication).
+    /// Start the background task that prepares auto-attached targets and
+    /// processes Fetch events in real time. Page targets receive launch init
+    /// scripts before they resume; Fetch events enforce network controls.
     /// Must be called after the browser is set and events are subscribed.
     fn start_fetch_handler(&mut self) {
         // Abort any existing handler.
@@ -543,6 +543,7 @@ impl DaemonState {
         let routes = self.routes.clone();
         let origin_headers = self.origin_headers.clone();
         let proxy_credentials = self.proxy_credentials.clone();
+        let launch_init_scripts = browser.launch_init_script_registry();
 
         self.fetch_handler_task = Some(tokio::spawn(async move {
             loop {
@@ -601,17 +602,31 @@ impl DaemonState {
                         let target_needs_controls = target_info
                             .as_ref()
                             .is_some_and(target_supports_network_controls);
+                        let target_needs_init_scripts =
+                            target_info.as_ref().is_some_and(should_track_target)
+                                && !launch_init_scripts.is_empty().await;
 
                         let df = domain_filter.read().await.clone();
                         let has_proxy_creds = proxy_credentials.read().await.is_some();
                         let controls_active = df.is_some() || has_proxy_creds;
-                        let controls_result = if controls_active && target_needs_controls {
-                            async {
+                        let setup_result = async {
+                            if target_needs_init_scripts {
                                 if let Some(ref target) = target_info {
-                                    prepare_network_control_target_session(&client, &sid, target)
+                                    prepare_auto_attached_session(&client, &sid).await?;
+                                    launch_init_scripts
+                                        .install(&client, &target.target_id, &sid)
                                         .await?;
                                 }
+                            }
+
+                            if controls_active && target_needs_controls {
                                 if let Some(ref target) = target_info {
+                                    if !target_needs_init_scripts {
+                                        prepare_network_control_target_session(
+                                            &client, &sid, target,
+                                        )
+                                        .await?;
+                                    }
                                     if target_is_worker_like(target) {
                                         install_worker_network_controls_for_session(
                                             &client,
@@ -633,13 +648,13 @@ impl DaemonState {
                                 } else {
                                     Ok(())
                                 }
+                            } else {
+                                Ok(())
                             }
-                            .await
-                        } else {
-                            Ok(())
-                        };
+                        }
+                        .await;
 
-                        if controls_result.is_ok() {
+                        if setup_result.is_ok() {
                             let _ = client
                                 .send_command_no_wait(
                                     "Runtime.runIfWaitingForDebugger",
@@ -647,11 +662,17 @@ impl DaemonState {
                                     Some(&sid),
                                 )
                                 .await;
-                        } else if let Err(error) = controls_result {
-                            eprintln!(
-                                "Failed to apply browser network controls to auto-attached target: {}",
-                                error
-                            );
+                        } else if let Err(error) = setup_result {
+                            eprintln!("Failed to prepare auto-attached target: {}", error);
+                            if !controls_active {
+                                let _ = client
+                                    .send_command_no_wait(
+                                        "Runtime.runIfWaitingForDebugger",
+                                        None,
+                                        Some(&sid),
+                                    )
+                                    .await;
+                            }
                         }
                     }
                     Ok(event) if event.method == "Fetch.requestPaused" => {
@@ -840,6 +861,9 @@ impl DaemonState {
         // Remove destroyed targets
         for target_id in &drained.destroyed_targets {
             if let Some(ref mut mgr) = self.browser {
+                mgr.launch_init_script_registry()
+                    .forget_target(target_id)
+                    .await;
                 mgr.remove_page_by_target_id(target_id);
             }
         }
@@ -897,6 +921,9 @@ impl DaemonState {
             let setup_result = if let Some(ref mut mgr) = self.browser {
                 async {
                     mgr.prepare_domains_pub(page_sid).await?;
+                    mgr.launch_init_script_registry()
+                        .install(&mgr.client, &target_info.target_id, page_sid)
+                        .await?;
                     if controls_active {
                         install_network_controls_for_session(
                             &mgr.client,
@@ -951,6 +978,9 @@ impl DaemonState {
                     "Warning: failed to prepare attached page session: {}",
                     error
                 );
+                if let Some(ref mgr) = self.browser {
+                    let _ = mgr.resume_if_waiting_pub(page_sid).await;
+                }
             }
         }
 
@@ -1026,6 +1056,9 @@ impl DaemonState {
                         )
                         .await?;
                     mgr.prepare_domains_pub(&attach.session_id).await?;
+                    mgr.launch_init_script_registry()
+                        .install(&mgr.client, &te.target_info.target_id, &attach.session_id)
+                        .await?;
                     if controls_active {
                         install_network_controls_for_session(
                             &mgr.client,
@@ -1873,7 +1906,7 @@ pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(),
 
     close_active_provider_session(state).await;
     state.launch_hash = None;
-    state.network_auto_attach_installed = false;
+    state.browser_auto_attach_installed = false;
     state.screencasting = false;
     state.reset_input_state();
     state.update_stream_client().await;
@@ -2851,7 +2884,7 @@ async fn install_active_network_controls(
         return Err(direct_page_allowed_domains_error());
     }
 
-    if !state.network_auto_attach_installed && !direct_page {
+    if !state.browser_auto_attach_installed && !direct_page {
         {
             let mgr = state
                 .browser
@@ -2859,7 +2892,7 @@ async fn install_active_network_controls(
                 .ok_or("Browser is not available for network control installation")?;
             mgr.enable_browser_auto_attach_pub().await?;
         }
-        state.network_auto_attach_installed = true;
+        state.browser_auto_attach_installed = true;
     }
 
     let mgr = state
@@ -3201,18 +3234,16 @@ fn allowed_domains_from_launch_command(cmd: &Value) -> Option<Vec<String>> {
 }
 
 async fn apply_launch_init_scripts(
-    state: &DaemonState,
+    state: &mut DaemonState,
     enable_features: &[String],
     init_script_paths: &[String],
 ) {
-    let Some(mgr) = state.browser.as_ref() else {
-        return;
-    };
+    let mut sources = Vec::new();
 
     for feature in enable_features {
         match feature.as_str() {
             "react-devtools" | "react" => {
-                let _ = mgr.add_script_to_evaluate(react::INSTALL_HOOK_JS).await;
+                sources.push(react::INSTALL_HOOK_JS.to_string());
             }
             other => {
                 eprintln!("warning: unknown --enable feature '{}'", other);
@@ -3223,7 +3254,7 @@ async fn apply_launch_init_scripts(
     for path in init_script_paths {
         match fs::read_to_string(path) {
             Ok(source) => {
-                let _ = mgr.add_script_to_evaluate(&source).await;
+                sources.push(source);
             }
             Err(e) => {
                 eprintln!("warning: failed to read --init-script '{}': {}", path, e);
@@ -3231,8 +3262,33 @@ async fn apply_launch_init_scripts(
         }
     }
 
-    for source in &state.plugin_init_scripts {
-        let _ = mgr.add_script_to_evaluate(source).await;
+    sources.extend(state.plugin_init_scripts.iter().cloned());
+
+    let should_enable_auto_attach = if let Some(mgr) = state.browser.as_ref() {
+        let has_sources = !sources.is_empty();
+        if let Err(error) = mgr.set_launch_init_scripts(sources).await {
+            eprintln!("warning: failed to install launch init scripts: {}", error);
+            return;
+        }
+        has_sources && !mgr.is_direct_page_connection()
+    } else {
+        false
+    };
+
+    if should_enable_auto_attach && !state.browser_auto_attach_installed {
+        let enable_result = state
+            .browser
+            .as_ref()
+            .expect("browser checked above")
+            .enable_browser_auto_attach_pub()
+            .await;
+        match enable_result {
+            Ok(()) => state.browser_auto_attach_installed = true,
+            Err(error) => eprintln!(
+                "warning: failed to enable init scripts for new page targets: {}",
+                error
+            ),
+        }
     }
 }
 
@@ -6270,6 +6326,9 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
 
         let new_session_id = attach_result.session_id.clone();
         mgr.prepare_domains_pub(&new_session_id).await?;
+        mgr.launch_init_script_registry()
+            .install(&mgr.client, &create_result.target_id, &new_session_id)
+            .await?;
 
         // Re-apply download behavior to the recording context.
         // Without this, downloads in the recording context are silently dropped
@@ -8599,6 +8658,9 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
             .await?;
 
         mgr.prepare_domains_pub(&attach.session_id).await?;
+        mgr.launch_init_script_registry()
+            .install(&mgr.client, &create_result.target_id, &attach.session_id)
+            .await?;
 
         let tab_id = mgr.assign_tab_id();
         mgr.add_page(super::browser::PageInfo {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -104,6 +104,72 @@ pub(crate) fn should_track_target(target: &TargetInfo) -> bool {
         && (target.url.is_empty() || !is_internal_chrome_target(&target.url))
 }
 
+async fn add_script_to_session(
+    client: &CdpClient,
+    session_id: &str,
+    source: &str,
+) -> Result<String, String> {
+    let result = client
+        .send_command(
+            "Page.addScriptToEvaluateOnNewDocument",
+            Some(json!({ "source": source })),
+            Some(session_id),
+        )
+        .await?;
+    Ok(result
+        .get("identifier")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string())
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct LaunchInitScriptRegistry {
+    state: Arc<Mutex<LaunchInitScriptState>>,
+}
+
+#[derive(Default)]
+struct LaunchInitScriptState {
+    scripts: Vec<String>,
+    installed_targets: HashSet<String>,
+}
+
+impl LaunchInitScriptRegistry {
+    async fn replace(&self, scripts: Vec<String>) {
+        let mut state = self.state.lock().await;
+        state.scripts = scripts;
+        state.installed_targets.clear();
+    }
+
+    pub(crate) async fn is_empty(&self) -> bool {
+        self.state.lock().await.scripts.is_empty()
+    }
+
+    pub(crate) async fn forget_target(&self, target_id: &str) {
+        self.state.lock().await.installed_targets.remove(target_id);
+    }
+
+    pub(crate) async fn install(
+        &self,
+        client: &CdpClient,
+        target_id: &str,
+        session_id: &str,
+    ) -> Result<(), String> {
+        let mut state = self.state.lock().await;
+        if state.installed_targets.contains(target_id) {
+            return Ok(());
+        }
+
+        for source in &state.scripts {
+            add_script_to_session(client, session_id, source).await?;
+        }
+        if !state.scripts.is_empty() {
+            state.installed_targets.insert(target_id.to_string());
+        }
+        Ok(())
+    }
+}
+
 fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo) -> bool {
     if let Some(page) = pages.iter_mut().find(|p| p.target_id == target.target_id) {
         page.url = target.url.clone();
@@ -311,6 +377,8 @@ pub struct BrowserManager {
     /// True when the CDP WebSocket is already scoped to a page target and
     /// browser-level Target.* commands are not available.
     direct_page: bool,
+    /// Launch-time scripts replayed into every page target created by this manager.
+    launch_init_scripts: LaunchInitScriptRegistry,
 }
 
 const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -384,6 +452,7 @@ impl BrowserManager {
                 visited_origins: HashSet::new(),
                 next_tab_id: 1,
                 direct_page: false,
+                launch_init_scripts: LaunchInitScriptRegistry::default(),
             };
             manager.discover_and_attach_targets().await?;
             manager
@@ -474,6 +543,7 @@ impl BrowserManager {
             visited_origins: HashSet::new(),
             next_tab_id: 1,
             direct_page,
+            launch_init_scripts: LaunchInitScriptRegistry::default(),
         };
 
         if direct_page {
@@ -999,6 +1069,12 @@ impl BrowserManager {
 
         let tab_id = self.next_tab_id;
         self.next_tab_id += 1;
+        self.prepare_domains(&attach_result.session_id).await?;
+        self.launch_init_scripts
+            .install(&self.client, &result.target_id, &attach_result.session_id)
+            .await?;
+        self.resume_if_waiting(&attach_result.session_id).await?;
+
         self.pages.push(PageInfo {
             tab_id,
             label: None,
@@ -1009,8 +1085,6 @@ impl BrowserManager {
             target_type: "page".to_string(),
         });
         self.active_page_index = 0;
-        self.enable_domains(&attach_result.session_id).await?;
-
         Ok(())
     }
 
@@ -1111,13 +1185,18 @@ impl BrowserManager {
         }
 
         let target_url = url.unwrap_or("about:blank");
+        let create_url = if self.launch_init_scripts.is_empty().await {
+            target_url
+        } else {
+            "about:blank"
+        };
 
         let result: CreateTargetResult = self
             .client
             .send_command_typed(
                 "Target.createTarget",
                 &CreateTargetParams {
-                    url: target_url.to_string(),
+                    url: create_url.to_string(),
                 },
                 None,
             )
@@ -1135,7 +1214,11 @@ impl BrowserManager {
             )
             .await?;
 
-        self.enable_domains(&attach.session_id).await?;
+        self.prepare_domains(&attach.session_id).await?;
+        self.launch_init_scripts
+            .install(&self.client, &result.target_id, &attach.session_id)
+            .await?;
+        self.resume_if_waiting(&attach.session_id).await?;
 
         let tab_id = self.next_tab_id;
         self.next_tab_id += 1;
@@ -1146,11 +1229,15 @@ impl BrowserManager {
             label: label.clone(),
             target_id: result.target_id,
             session_id: attach.session_id,
-            url: target_url.to_string(),
+            url: create_url.to_string(),
             title: String::new(),
             target_type: "page".to_string(),
         });
         self.active_page_index = index;
+
+        if create_url != target_url {
+            self.navigate(target_url, WaitUntil::Load).await?;
+        }
 
         Ok(json!({
             "tabId": format_tab_id(tab_id),
@@ -1455,19 +1542,21 @@ impl BrowserManager {
 
     pub async fn add_script_to_evaluate(&self, source: &str) -> Result<String, String> {
         let session_id = self.active_session_id()?;
-        let result = self
-            .client
-            .send_command(
-                "Page.addScriptToEvaluateOnNewDocument",
-                Some(json!({ "source": source })),
-                Some(session_id),
-            )
+        add_script_to_session(&self.client, session_id, source).await
+    }
+
+    pub async fn set_launch_init_scripts(&self, scripts: Vec<String>) -> Result<(), String> {
+        let target_id = self.active_target_id()?.to_string();
+        let session_id = self.active_session_id()?.to_string();
+        self.launch_init_scripts.replace(scripts).await;
+        self.launch_init_scripts
+            .install(&self.client, &target_id, &session_id)
             .await?;
-        Ok(result
-            .get("identifier")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string())
+        Ok(())
+    }
+
+    pub(crate) fn launch_init_script_registry(&self) -> LaunchInitScriptRegistry {
+        self.launch_init_scripts.clone()
     }
 
     pub async fn remove_script_to_evaluate(&self, identifier: &str) -> Result<(), String> {
@@ -1702,6 +1791,7 @@ async fn initialize_lightpanda_manager(
             visited_origins: HashSet::new(),
             next_tab_id: 1,
             direct_page: false,
+            launch_init_scripts: LaunchInitScriptRegistry::default(),
         };
 
         match discover_and_attach_lightpanda_targets(&mut manager, deadline).await {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7052,6 +7052,200 @@ async fn e2e_pushstate_changes_url() {
 
 #[tokio::test]
 #[ignore]
+async fn e2e_launch_builtin_init_script_runs_before_page_code_in_new_tab() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "enable": ["react-devtools"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let page_url = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode(
+            "<script>window.__PAGE_SAW_REACT_HOOK__ = typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === 'object';</script>"
+        )
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "tab_new", "url": page_url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "window.__PAGE_SAW_REACT_HOOK__ === true"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], true);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_launch_init_script_runs_before_page_code_in_new_tab() {
+    let temp_dir = tempfile::tempdir().expect("create init script temp directory");
+    let init_script_path = temp_dir.path().join("launch-init.js");
+    std::fs::write(
+        &init_script_path,
+        "window.__AGENT_BROWSER_LAUNCH_INIT__ = true;",
+    )
+    .expect("write launch init script");
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "initScripts": [init_script_path.to_string_lossy()]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let page_url = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode(
+            "<script>window.__PAGE_SAW_LAUNCH_INIT__ = window.__AGENT_BROWSER_LAUNCH_INIT__ === true;</script>"
+        )
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "tab_new", "url": page_url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "window.__PAGE_SAW_LAUNCH_INIT__ === true"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], true);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_launch_init_script_runs_before_page_code_in_popup() {
+    let temp_dir = tempfile::tempdir().expect("create init script temp directory");
+    let init_script_path = temp_dir.path().join("launch-init.js");
+    std::fs::write(
+        &init_script_path,
+        "window.__AGENT_BROWSER_LAUNCH_INIT__ = true;",
+    )
+    .expect("write launch init script");
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind popup server");
+    let port = listener.local_addr().expect("popup server address").port();
+    let server = tokio::spawn(async move {
+        for _ in 0..5 {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut request = vec![0u8; 4096];
+                let _ = stream.read(&mut request).await;
+                let body = "<script>window.__PAGE_SAW_LAUNCH_INIT__ = window.__AGENT_BROWSER_LAUNCH_INIT__ === true;</script><title>init-popup</title>";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "initScripts": [init_script_path.to_string_lossy()]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let popup_url = format!("http://127.0.0.1:{port}/popup");
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "evaluate",
+            "script": format!("window.open({}); 'opened'", serde_json::to_string(&popup_url).unwrap())
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let resp = execute_command(&json!({ "id": "3", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().expect("tab list array");
+    let popup = tabs
+        .iter()
+        .find(|tab| tab["tabId"] != "t1")
+        .unwrap_or_else(|| panic!("popup should appear in tab list: {tabs:?}"));
+    let popup_tab_id = popup["tabId"].as_str().expect("popup tab id");
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "tab_switch", "tabId": popup_tab_id }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "evaluate",
+            "script": "({ pageSawInit: window.__PAGE_SAW_LAUNCH_INIT__ === true, initPresent: window.__AGENT_BROWSER_LAUNCH_INIT__ === true })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"]["pageSawInit"],
+        true,
+        "popup launch init timing: {:?}",
+        get_data(&resp)["result"]
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+#[tokio::test]
+#[ignore]
 async fn e2e_removeinitscript_roundtrip() {
     let mut state = DaemonState::new();
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1272,8 +1272,8 @@ Global Options:
   --session <name>     Use specific session
   --headers <json>     Set HTTP headers (scoped to this origin)
   --headed             Show browser window
-  --enable react-devtools   Inject the React DevTools hook before any page JS
-  --init-script <path>      Register a page init script (repeatable)
+  --enable react-devtools   Inject the React DevTools hook into initial and new pages
+  --init-script <path>      Register an init script for initial and new pages (repeatable)
 
 Examples:
   agent-browser open                     # Launch, no nav
@@ -3510,9 +3510,10 @@ Options:
                              (or AGENT_BROWSER_NAMESPACE env)
   --executable-path <path>   Custom browser executable (or AGENT_BROWSER_EXECUTABLE_PATH)
   --extension <path>         Load browser extensions (repeatable)
-  --init-script <path>       Register a page init script before the first navigation (repeatable)
+  --init-script <path>       Register an init script for the initial page and new page targets (repeatable)
                              (or AGENT_BROWSER_INIT_SCRIPTS env, comma-separated)
-  --enable <feature>         Built-in init scripts: react-devtools (repeatable or comma-separated)
+  --enable <feature>         Built-in init scripts for initial and new pages: react-devtools
+                             (repeatable or comma-separated)
                              (or AGENT_BROWSER_ENABLE env)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
                              e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
@@ -3590,8 +3591,8 @@ Environment:
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete states older than N days (default: 30)
   AGENT_BROWSER_EXECUTABLE_PATH  Custom browser executable path
   AGENT_BROWSER_EXTENSIONS       Comma-separated browser extension paths
-  AGENT_BROWSER_INIT_SCRIPTS     Comma-separated paths to page init scripts
-  AGENT_BROWSER_ENABLE           Comma-separated built-in init script features (e.g. react-devtools)
+  AGENT_BROWSER_INIT_SCRIPTS     Comma-separated init scripts for initial and new pages
+  AGENT_BROWSER_ENABLE           Built-in init scripts for initial and new pages (e.g. react-devtools)
   AGENT_BROWSER_HEADED           Show browser window (not headless)
   AGENT_BROWSER_NO_XVFB          Disable automatic Xvfb for headed mode on displayless Linux hosts
   AGENT_BROWSER_WEBGPU           Enable WebGPU (SwiftShader software Vulkan on Linux)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -524,6 +524,8 @@ agent-browser addinitscript <js>                  # Register at runtime (returns
 agent-browser removeinitscript <identifier>       # Remove a previously registered init script
 ```
 
+Launch-time scripts are installed on the initial page and new page targets for the lifetime of the browser session. Runtime init script commands operate on the active page session.
+
 See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime scripts, built-in React DevTools, and extensions.
 
 ## Global options

--- a/docs/src/app/init-scripts/page.mdx
+++ b/docs/src/app/init-scripts/page.mdx
@@ -16,7 +16,7 @@ export AGENT_BROWSER_INIT_SCRIPTS="./a.js,./b.js"
 agent-browser open https://example.com
 ```
 
-Launch-time scripts are applied when the browser starts. If the daemon is already running, close it before changing launch-time script options.
+Launch-time scripts are retained for the browser session and registered on the initial page, new tabs, recording contexts, independent windows, and auto-attached page targets before those targets resume. This applies to `--init-script`, `AGENT_BROWSER_INIT_SCRIPTS`, built-in scripts, and init scripts returned by launch mutator plugins. If the daemon is already running, close it before changing launch-time script options.
 
 ## Built-in scripts
 
@@ -24,7 +24,7 @@ Launch-time scripts are applied when the browser starts. If the daemon is alread
 agent-browser --enable react-devtools open http://localhost:3000
 ```
 
-`react-devtools` is the built-in feature currently available. It installs the React DevTools hook before application code runs and is required for `react tree`, `react inspect`, `react renders`, and `react suspense`.
+`react-devtools` is the built-in feature currently available. It installs the React DevTools hook before application code runs on the initial page and later page targets, and is required for `react tree`, `react inspect`, `react renders`, and `react suspense`.
 
 ## Runtime scripts
 
@@ -35,7 +35,7 @@ agent-browser addinitscript "window.__testMode = true"
 agent-browser removeinitscript <identifier>
 ```
 
-Runtime init scripts are useful after a session has started. They are still init scripts, so they affect future documents and navigations rather than rewriting already-executed page code.
+Runtime init scripts are useful after a session has started. They operate on the active page session and affect its future documents and navigations rather than rewriting already-executed page code. They are not added to the launch-time registry for other page targets.
 
 ## Pre-navigation setup
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -455,7 +455,7 @@ agent-browser vitals [url]                       # LCP/CLS/TTFB/FCP/INP + hydrat
 agent-browser pushstate <url>                    # SPA navigation (auto-detects Next router)
 ```
 
-Without `--enable react-devtools`, the `react …` commands error. `vitals` and `pushstate` work on any site regardless of framework. `vitals` prints a summary by default; use `--json` for the full structured payload.
+Without `--enable react-devtools`, the `react …` commands error. Launch-time built-in scripts remain installed when the session opens new tabs or page targets. `vitals` and `pushstate` work on any site regardless of framework. `vitals` prints a summary by default; use `--json` for the full structured payload.
 
 ## Working safely
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -430,6 +430,8 @@ agent-browser addinitscript <js>                    # Register at runtime (retur
 agent-browser removeinitscript <identifier>         # Remove a previously registered init script
 ```
 
+Scripts supplied at launch through `--init-script`, `AGENT_BROWSER_INIT_SCRIPTS`, `--enable`, or launch mutator plugins are installed on the initial page and new page targets for the lifetime of the browser session. Runtime `addinitscript` and `removeinitscript` operate on the active page session.
+
 ## cURL cookie import
 
 ```bash


### PR DESCRIPTION
## Summary

- retain resolved launch-time init scripts for the browser session
- install them on explicit tabs, auto-attached popups, recording contexts, independent windows, and empty-page recovery before targets resume
- prevent duplicate registration when multiple CDP event consumers observe the same target
- document the launch-time propagation contract while keeping runtime `addinitscript` semantics unchanged

## Root cause

`Page.addScriptToEvaluateOnNewDocument` is target-scoped, but launch-time scripts were only registered on the active session. Their resolved sources were not retained, so later page targets silently lost user scripts, launch-mutator scripts, and built-in hooks such as `react-devtools`.

Explicit tab creation now starts at `about:blank`, installs the retained scripts, resumes the target, and then performs the requested navigation. Browser-level auto-attach handles page-created targets before their first network document runs. Installation is idempotent by target ID to avoid duplicate script execution across concurrent event consumers.

This change does not alter runtime `addinitscript` or `removeinitscript` behavior and does not overlap the CLI exposure work in #1522.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets`
- `cargo test --manifest-path cli/Cargo.toml e2e_launch_init_script_runs -- --ignored --test-threads=1`
- `cargo test --manifest-path cli/Cargo.toml e2e_launch_builtin_init_script_runs_before_page_code_in_new_tab -- --ignored --test-threads=1`
- `corepack pnpm --dir docs build`
- black-box debug CLI check confirming a file launch script runs before inline code in a new tab

The serial unit suite passed 932 tests locally. One existing Windows-specific downloader test remains sensitive to the dependency's connection-error wording. The full serial Chrome E2E run passed 58 tests, including all new coverage and the local popup containment test; tests that require `https://example.com` were blocked by the current environment's external connectivity.

Fixes #1521
