### PR TITLE
fix(state): report storage restore failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ agent-browser state clear --all       # Clear all saved states
 agent-browser state clean --older-than <days>  # Delete old states
 ```
 
+State restoration fails immediately if a `localStorage` or `sessionStorage` entry cannot be written. The error identifies the storage type, origin, entry position, and key/value byte lengths without including the stored key or value. Cookies and earlier storage entries may already have been applied, so retry from a fresh browser context after correcting the failure.
+
 ### Navigation
 
 ```bash

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1433,7 +1433,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_STATE_LOAD,
             "State load",
-            "Load cookies and storage state.",
+            "Load cookies and storage state. Storage write failures return secret-safe context.",
             json!({ "path": { "type": "string" } }),
             &["path"],
         ),

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6686,6 +6686,104 @@ async fn e2e_restore_key_switch_reloads_instead_of_reusing_live_browser() {
     let _ = std::fs::remove_file(format!("{}.previous", path_b));
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_state_load_reports_storage_write_failures_without_secrets() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind storage failure server");
+    let port = listener
+        .local_addr()
+        .expect("storage failure server address")
+        .port();
+    let origin = format!("http://127.0.0.1:{port}");
+    let server = tokio::spawn(async move {
+        for _ in 0..5 {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut request = vec![0u8; 4096];
+                let _ = stream.read(&mut request).await;
+                let body = r#"<script>
+                    const originalSetItem = Storage.prototype.setItem;
+                    Storage.prototype.setItem = function(name, value) {
+                        if (this === window.sessionStorage) {
+                            throw new Error('forced storage write failure');
+                        }
+                        return originalSetItem.call(this, name, value);
+                    };
+                </script>"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    let secret_name = "secret-session-key";
+    let secret_value = "secret-session-value";
+    let local_name = "restored-before-failure";
+    let local_value = "local-value";
+    let temp_dir = tempfile::tempdir().expect("create state temp directory");
+    let state_path = temp_dir.path().join("state.json");
+    std::fs::write(
+        &state_path,
+        serde_json::to_vec_pretty(&json!({
+            "cookies": [],
+            "origins": [{
+                "origin": origin,
+                "localStorage": [{ "name": local_name, "value": local_value }],
+                "sessionStorage": [{ "name": secret_name, "value": secret_value }]
+            }]
+        }))
+        .expect("serialize state fixture"),
+    )
+    .expect("write state fixture");
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let load_resp = execute_command(
+        &json!({ "id": "2", "action": "state_load", "path": state_path }),
+        &mut state,
+    )
+    .await;
+
+    let local_resp = execute_command(
+        &json!({ "id": "3", "action": "storage_get", "type": "local", "key": local_name }),
+        &mut state,
+    )
+    .await;
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+
+    assert_eq!(
+        load_resp["success"], false,
+        "state load must report failure"
+    );
+    let error = load_resp["error"].as_str().expect("state load error");
+    assert!(
+        error.contains("sessionStorage"),
+        "unexpected error: {error}"
+    );
+    assert!(error.contains(&origin), "unexpected error: {error}");
+    assert!(!error.contains(secret_name), "error exposed storage key");
+    assert!(!error.contains(secret_value), "error exposed storage value");
+    assert_success(&local_resp);
+    assert_eq!(get_data(&local_resp)["value"], local_value);
+}
+
 /// Verify that explicit `state_load` restores cookies into an existing
 /// session (baseline sanity check — this path is known to work).
 #[tokio::test]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -460,6 +460,96 @@ pub fn validate_state_file(path: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum StorageKind {
+    Local,
+    Session,
+}
+
+impl StorageKind {
+    fn object_name(self) -> &'static str {
+        match self {
+            Self::Local => "localStorage",
+            Self::Session => "sessionStorage",
+        }
+    }
+}
+
+fn storage_restore_error(
+    kind: StorageKind,
+    origin: &str,
+    entry_index: usize,
+    entry_count: usize,
+    entry: &StorageEntry,
+    reason: &str,
+) -> String {
+    format!(
+        "Failed to restore {} for origin '{}': {} for entry {} of {} (keyBytes={}, valueBytes={})",
+        kind.object_name(),
+        origin,
+        reason,
+        entry_index + 1,
+        entry_count,
+        entry.name.len(),
+        entry.value.len(),
+    )
+}
+
+async fn restore_storage_entries(
+    client: &CdpClient,
+    session_id: &str,
+    origin: &str,
+    kind: StorageKind,
+    entries: &[StorageEntry],
+) -> Result<(), String> {
+    for (entry_index, entry) in entries.iter().enumerate() {
+        let js = format!(
+            "{}.setItem({}, {})",
+            kind.object_name(),
+            serde_json::to_string(&entry.name).expect("storage key should serialize"),
+            serde_json::to_string(&entry.value).expect("storage value should serialize"),
+        );
+        let result = client
+            .send_command_typed::<_, super::cdp::types::EvaluateResult>(
+                "Runtime.evaluate",
+                &EvaluateParams {
+                    expression: js,
+                    return_by_value: Some(true),
+                    await_promise: Some(false),
+                },
+                Some(session_id),
+            )
+            .await
+            .map_err(|_| {
+                storage_restore_error(
+                    kind,
+                    origin,
+                    entry_index,
+                    entries.len(),
+                    entry,
+                    "CDP evaluation failed",
+                )
+            })?;
+
+        if result.exception_details.is_some() {
+            return Err(storage_restore_error(
+                kind,
+                origin,
+                entry_index,
+                entries.len(),
+                entry,
+                "page evaluation threw an exception",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Restores cookies and origin storage in file order.
+///
+/// Storage failures stop the restore and return secret-safe context. Cookies and
+/// earlier storage entries may already have been applied when an error is returned.
 pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Result<(), String> {
     let json_str = read_state_json(path)?;
 
@@ -495,43 +585,22 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
         // Brief wait for navigation
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-        for entry in &origin.local_storage {
-            let js = format!(
-                "localStorage.setItem({}, {})",
-                serde_json::to_string(&entry.name).unwrap_or_default(),
-                serde_json::to_string(&entry.value).unwrap_or_default(),
-            );
-            let _ = client
-                .send_command_typed::<_, super::cdp::types::EvaluateResult>(
-                    "Runtime.evaluate",
-                    &EvaluateParams {
-                        expression: js,
-                        return_by_value: Some(true),
-                        await_promise: Some(false),
-                    },
-                    Some(session_id),
-                )
-                .await;
-        }
-
-        for entry in &origin.session_storage {
-            let js = format!(
-                "sessionStorage.setItem({}, {})",
-                serde_json::to_string(&entry.name).unwrap_or_default(),
-                serde_json::to_string(&entry.value).unwrap_or_default(),
-            );
-            let _ = client
-                .send_command_typed::<_, super::cdp::types::EvaluateResult>(
-                    "Runtime.evaluate",
-                    &EvaluateParams {
-                        expression: js,
-                        return_by_value: Some(true),
-                        await_promise: Some(false),
-                    },
-                    Some(session_id),
-                )
-                .await;
-        }
+        restore_storage_entries(
+            client,
+            session_id,
+            &origin.origin,
+            StorageKind::Local,
+            &origin.local_storage,
+        )
+        .await?;
+        restore_storage_entries(
+            client,
+            session_id,
+            &origin.origin,
+            StorageKind::Session,
+            &origin.session_storage,
+        )
+        .await?;
     }
 
     Ok(())
@@ -893,6 +962,36 @@ mod tests {
         let parsed: StorageState = serde_json::from_str(&json).unwrap();
         assert!(parsed.cookies.is_empty());
         assert!(parsed.origins.is_empty());
+    }
+
+    #[test]
+    fn test_storage_restore_error_reports_context_without_secrets() {
+        let entry = StorageEntry {
+            name: "secret-key-name".to_string(),
+            value: "secret-token-value".to_string(),
+        };
+
+        for (kind, expected_name) in [
+            (StorageKind::Local, "localStorage"),
+            (StorageKind::Session, "sessionStorage"),
+        ] {
+            let error = storage_restore_error(
+                kind,
+                "https://example.test",
+                1,
+                3,
+                &entry,
+                "page evaluation threw an exception",
+            );
+
+            assert!(error.contains(expected_name));
+            assert!(error.contains("https://example.test"));
+            assert!(error.contains("entry 2 of 3"));
+            assert!(error.contains("keyBytes=15"));
+            assert!(error.contains("valueBytes=18"));
+            assert!(!error.contains(&entry.name));
+            assert!(!error.contains(&entry.value));
+        }
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2675,6 +2675,11 @@ Automatic State Persistence:
   agent-browser --session myapp --restore open https://example.com
   Or set AGENT_BROWSER_RESTORE environment variable.
 
+Restore Failures:
+  Storage write failures stop the restore and report the storage type, origin,
+  entry position, and byte lengths without exposing keys or values. Cookies and
+  earlier storage entries may already be applied when an error is returned.
+
 State Encryption:
   Set AGENT_BROWSER_ENCRYPTION_KEY (64-char hex) for AES-256-GCM encryption.
   Generate a key: openssl rand -hex 32

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -126,6 +126,8 @@ agent-browser state load ./my-auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
+If a `localStorage` or `sessionStorage` write fails, state loading stops and returns secret-safe context including the storage type, origin, entry position, and byte lengths. It does not include the stored key or value. Because cookies and earlier storage entries may already be applied, retry from a fresh browser context after correcting the failure.
+
 Combine with `--session <id> --restore` so the imported auth auto-persists across restarts:
 
 ```bash

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -60,6 +60,8 @@ agent-browser state load ./my-auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
+If a `localStorage` or `sessionStorage` write fails, state loading stops and returns secret-safe context including the storage type, origin, entry position, and byte lengths. It does not include the stored key or value. Because cookies and earlier storage entries may already be applied, retry from a fresh browser context after correcting the failure.
+
 This works for any site, including those with complex OAuth flows, SSO, or 2FA, as long as Chrome already has valid session cookies.
 
 > **Security note:** State files contain session tokens in plaintext. Add them to `.gitignore`, delete when no longer needed, and set `AGENT_BROWSER_ENCRYPTION_KEY` for encryption at rest. See [Security Best Practices](#security-best-practices).


### PR DESCRIPTION
## Summary

- stop discarding CDP transport errors and page evaluation exceptions while restoring `localStorage` and `sessionStorage`
- return fail-fast diagnostics with the storage type, origin, entry position, and byte lengths while omitting stored keys, values, and raw page exceptions
- document partial-application semantics across CLI help, README, the core skill reference, sessions docs, inline comments, and the MCP tool description

## Testing

- `cargo test --manifest-path cli/Cargo.toml native::state::tests -- --test-threads=1`
- `cargo test --manifest-path cli/Cargo.toml e2e_state_load_reports_storage_write_failures_without_secrets -- --ignored --test-threads=1`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets`
- `corepack pnpm --dir docs build`
- full serial unit suite: 933 passed; the existing Windows-specific connection-refused text assertion remained the only failure

Related to #1505. This change makes storage replay failures observable; the reported large-value restoration problem remains a separate follow-up.