### PR TITLE
fix(state): restore storage before page scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ agent-browser state clear --all       # Clear all saved states
 agent-browser state clean --older-than <days>  # Delete old states
 ```
 
+State loading stages `localStorage` and `sessionStorage` before application scripts run at each saved origin, then removes the temporary staging script. This ensures startup authentication checks can read restored values, including large session values, before deciding whether to redirect to login.
+
 ### Navigation
 
 ```bash

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1433,7 +1433,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_STATE_LOAD,
             "State load",
-            "Load cookies and storage state.",
+            "Load cookies and storage state before application scripts run.",
             json!({ "path": { "type": "string" } }),
             &["path"],
         ),

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -32,6 +32,38 @@ fn get_data(resp: &Value) -> &Value {
     resp.get("data").expect("Missing 'data' in response")
 }
 
+async fn spawn_static_html_server(body: String) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind static HTML server");
+    let origin = format!(
+        "http://127.0.0.1:{}",
+        listener.local_addr().expect("static server address").port()
+    );
+    let body = Arc::new(body);
+    let server = tokio::spawn(async move {
+        for _ in 0..20 {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let body = body.clone();
+            tokio::spawn(async move {
+                let mut request = vec![0u8; 4096];
+                let _ = stream.read(&mut request).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    (origin, server)
+}
+
 fn native_test_fixture_html(name: &str) -> &'static str {
     match name {
         "drag_probe" => include_str!("test_fixtures/drag_probe.html"),
@@ -6684,6 +6716,156 @@ async fn e2e_restore_key_switch_reloads_instead_of_reusing_live_browser() {
     let _ = std::fs::remove_file(format!("{}.previous", path_a));
     let _ = std::fs::remove_file(&path_b);
     let _ = std::fs::remove_file(format!("{}.previous", path_b));
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_state_load_restores_large_session_storage_before_page_scripts() {
+    let (login_origin, login_server) =
+        spawn_static_html_server("<title>login</title>".to_string()).await;
+    let expected_login_origin = login_origin.clone();
+    let app_body = format!(
+        r#"<script>
+            const auth = sessionStorage.getItem('large-auth-state');
+            if (auth && auth.length === 24576) {{
+                document.title = 'authenticated';
+            }} else {{
+                location.replace({});
+            }}
+        </script>"#,
+        serde_json::to_string(&login_origin).expect("serialize login origin"),
+    );
+    let (app_origin, app_server) = spawn_static_html_server(app_body).await;
+
+    let temp_dir = tempfile::tempdir().expect("create state temp directory");
+    let state_path = temp_dir.path().join("large-state.json");
+    std::fs::write(
+        &state_path,
+        serde_json::to_vec_pretty(&json!({
+            "cookies": [],
+            "origins": [{
+                "origin": app_origin,
+                "localStorage": [],
+                "sessionStorage": [{
+                    "name": "large-auth-state",
+                    "value": "x".repeat(24 * 1024)
+                }]
+            }]
+        }))
+        .expect("serialize state fixture"),
+    )
+    .expect("write state fixture");
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "state_load", "path": state_path }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let transported_resp = execute_command(
+        &json!({
+            "id": "transported",
+            "action": "storage_get",
+            "type": "session",
+            "key": "large-auth-state"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&transported_resp);
+    assert_eq!(
+        get_data(&transported_resp)["value"]
+            .as_str()
+            .expect("transported session value")
+            .len(),
+        24 * 1024,
+        "the 24 KB value should survive CDP transport"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "navigate", "url": app_origin }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    let url_resp = execute_command(&json!({ "id": "4", "action": "url" }), &mut state).await;
+
+    let clear_resp = execute_command(
+        &json!({ "id": "5", "action": "storage_clear", "type": "session" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&clear_resp);
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "navigate", "url": app_origin }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    let cleared_url_resp =
+        execute_command(&json!({ "id": "7", "action": "url" }), &mut state).await;
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+
+    let mut launch_state = DaemonState::new();
+    let launch_resp = execute_command(
+        &json!({
+            "id": "launch-state",
+            "action": "launch",
+            "headless": true,
+            "storageState": state_path
+        }),
+        &mut launch_state,
+    )
+    .await;
+    assert_success(&launch_resp);
+    let resp = execute_command(
+        &json!({ "id": "launch-navigate", "action": "navigate", "url": app_origin }),
+        &mut launch_state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    let launch_url_resp = execute_command(
+        &json!({ "id": "launch-url", "action": "url" }),
+        &mut launch_state,
+    )
+    .await;
+    let _ = execute_command(
+        &json!({ "id": "launch-close", "action": "close" }),
+        &mut launch_state,
+    )
+    .await;
+
+    app_server.abort();
+    login_server.abort();
+
+    assert_success(&url_resp);
+    assert_eq!(get_data(&url_resp)["url"], format!("{app_origin}/"));
+    assert_success(&cleared_url_resp);
+    assert_eq!(
+        get_data(&cleared_url_resp)["url"],
+        format!("{expected_login_origin}/"),
+        "the temporary restore script must not reapply cleared state"
+    );
+    assert_success(&launch_url_resp);
+    assert_eq!(
+        get_data(&launch_url_resp)["url"],
+        format!("{app_origin}/"),
+        "launch-time storage state should use the same pre-document restore path"
+    );
 }
 
 /// Verify that explicit `state_load` restores cookies into an existing

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -64,6 +64,39 @@ async fn spawn_static_html_server(body: String) -> (String, tokio::task::JoinHan
     (origin, server)
 }
 
+async fn spawn_stalled_html_server(body: String) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stalled HTML server");
+    let origin = format!(
+        "http://127.0.0.1:{}",
+        listener
+            .local_addr()
+            .expect("stalled server address")
+            .port()
+    );
+    let body = Arc::new(body);
+    let server = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let body = body.clone();
+            tokio::spawn(async move {
+                let mut request = vec![0u8; 4096];
+                let _ = stream.read(&mut request).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len() + 1024,
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+                tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+            });
+        }
+    });
+
+    (origin, server)
+}
+
 fn native_test_fixture_html(name: &str) -> &'static str {
     match name {
         "drag_probe" => include_str!("test_fixtures/drag_probe.html"),
@@ -6716,6 +6749,68 @@ async fn e2e_restore_key_switch_reloads_instead_of_reusing_live_browser() {
     let _ = std::fs::remove_file(format!("{}.previous", path_a));
     let _ = std::fs::remove_file(&path_b);
     let _ = std::fs::remove_file(format!("{}.previous", path_b));
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_state_load_does_not_wait_for_stalled_page_load() {
+    let (app_origin, app_server) =
+        spawn_stalled_html_server("<title>still loading</title>".to_string()).await;
+    let temp_dir = tempfile::tempdir().expect("create state temp directory");
+    let state_path = temp_dir.path().join("stalled-state.json");
+    std::fs::write(
+        &state_path,
+        serde_json::to_vec_pretty(&json!({
+            "cookies": [],
+            "origins": [{
+                "origin": app_origin,
+                "localStorage": [],
+                "sessionStorage": [{
+                    "name": "auth-state",
+                    "value": "restored"
+                }]
+            }]
+        }))
+        .expect("serialize state fixture"),
+    )
+    .expect("write state fixture");
+
+    let mut state = DaemonState::new();
+    let launch_resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&launch_resp);
+
+    let started = std::time::Instant::now();
+    let load_resp = execute_command(
+        &json!({ "id": "2", "action": "state_load", "path": state_path }),
+        &mut state,
+    )
+    .await;
+    let elapsed = started.elapsed();
+
+    let storage_resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "storage_get",
+            "type": "session",
+            "key": "auth-state"
+        }),
+        &mut state,
+    )
+    .await;
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    app_server.abort();
+
+    assert_success(&load_resp);
+    assert!(
+        elapsed < tokio::time::Duration::from_secs(5),
+        "state load should finish after the restore script runs, not after page load: {elapsed:?}"
+    );
+    assert_success(&storage_resp);
+    assert_eq!(get_data(&storage_resp)["value"], "restored");
 }
 
 #[tokio::test]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::{
-    AttachToTargetParams, AttachToTargetResult, CloseTargetParams, CreateTargetParams,
+    AttachToTargetParams, AttachToTargetResult, CdpEvent, CloseTargetParams, CreateTargetParams,
     CreateTargetResult, EvaluateParams,
 };
 use super::cookies::{self, Cookie};
@@ -460,6 +460,86 @@ pub fn validate_state_file(path: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn storage_restore_init_script(origin: &OriginStorage) -> Result<String, String> {
+    let expected_origin = serde_json::to_string(&origin.origin)
+        .map_err(|e| format!("Failed to serialize storage origin: {}", e))?;
+    let local_entries = serde_json::to_string(&origin.local_storage)
+        .map_err(|e| format!("Failed to serialize localStorage entries: {}", e))?;
+    let session_entries = serde_json::to_string(&origin.session_storage)
+        .map_err(|e| format!("Failed to serialize sessionStorage entries: {}", e))?;
+
+    Ok(format!(
+        r#"(() => {{
+            if (location.origin !== {expected_origin}) return;
+            for (const entry of {local_entries}) {{
+                localStorage.setItem(entry.name, entry.value);
+            }}
+            for (const entry of {session_entries}) {{
+                sessionStorage.setItem(entry.name, entry.value);
+            }}
+        }})()"#
+    ))
+}
+
+async fn remove_storage_restore_init_script(
+    client: &CdpClient,
+    session_id: &str,
+    identifier: &str,
+) -> Result<(), String> {
+    client
+        .send_command(
+            "Page.removeScriptToEvaluateOnNewDocument",
+            Some(json!({ "identifier": identifier })),
+            Some(session_id),
+        )
+        .await?;
+    Ok(())
+}
+
+async fn wait_for_storage_restore_document(
+    event_rx: &mut tokio::sync::broadcast::Receiver<CdpEvent>,
+    session_id: &str,
+    loader_id: &str,
+) -> Result<(), String> {
+    let wait = async {
+        let mut saw_expected_document = false;
+        loop {
+            match event_rx.recv().await {
+                Ok(event)
+                    if event.session_id.as_deref() == Some(session_id)
+                        && event.method == "Page.frameNavigated"
+                        && event
+                            .params
+                            .get("frame")
+                            .and_then(|frame| frame.get("loaderId"))
+                            .and_then(|value| value.as_str())
+                            == Some(loader_id) =>
+                {
+                    saw_expected_document = true;
+                }
+                Ok(event)
+                    if event.session_id.as_deref() == Some(session_id)
+                        && saw_expected_document
+                        && matches!(
+                            event.method.as_str(),
+                            "Page.domContentEventFired" | "Page.loadEventFired"
+                        ) =>
+                {
+                    return Ok(());
+                }
+                Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err("CDP event channel closed during storage restore".to_string());
+                }
+            }
+        }
+    };
+
+    tokio::time::timeout(tokio::time::Duration::from_secs(10), wait)
+        .await
+        .map_err(|_| "Timed out waiting for storage restore navigation".to_string())?
+}
+
 pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Result<(), String> {
     let json_str = read_state_json(path)?;
 
@@ -482,18 +562,60 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
             continue;
         }
 
-        // Navigate to origin to set storage
+        // Seed storage before application scripts run. The post-navigation writes
+        // below remain as a compatibility pass for the loaded document.
+        let init_source = storage_restore_init_script(origin)?;
+        let init_result = client
+            .send_command(
+                "Page.addScriptToEvaluateOnNewDocument",
+                Some(json!({ "source": init_source })),
+                Some(session_id),
+            )
+            .await?;
+        let init_identifier = init_result
+            .get("identifier")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .ok_or("Storage restore init script did not return an identifier")?;
+
+        let mut event_rx = client.subscribe();
         let navigate_url = format!("{}/", origin.origin.trim_end_matches('/'));
-        client
+        let staging_result = match client
             .send_command(
                 "Page.navigate",
                 Some(json!({ "url": navigate_url })),
                 Some(session_id),
             )
-            .await?;
+            .await
+        {
+            Ok(result) => match result.get("loaderId").and_then(|value| value.as_str()) {
+                Some(loader_id) => {
+                    wait_for_storage_restore_document(&mut event_rx, session_id, loader_id).await
+                }
+                None => Err("Storage restore navigation did not create a document".to_string()),
+            },
+            Err(error) => Err(error),
+        };
 
-        // Brief wait for navigation
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        // Never retain state-bearing source beyond this origin's staging navigation.
+        let cleanup_result =
+            remove_storage_restore_init_script(client, session_id, init_identifier).await;
+        match (staging_result, cleanup_result) {
+            (Ok(()), Ok(())) => {}
+            (Err(error), Ok(())) => return Err(error),
+            (Ok(()), Err(cleanup_error)) => {
+                return Err(format!(
+                    "Failed to remove temporary storage restore script: {}",
+                    cleanup_error
+                ));
+            }
+            (Err(error), Err(cleanup_error)) => {
+                return Err(format!(
+                    "{}; also failed to remove temporary storage restore script: {}",
+                    error, cleanup_error
+                ));
+            }
+        }
 
         for entry in &origin.local_storage {
             let js = format!(
@@ -893,6 +1015,29 @@ mod tests {
         let parsed: StorageState = serde_json::from_str(&json).unwrap();
         assert!(parsed.cookies.is_empty());
         assert!(parsed.origins.is_empty());
+    }
+
+    #[test]
+    fn test_storage_restore_init_script_is_origin_scoped() {
+        let origin = OriginStorage {
+            origin: "https://example.test".to_string(),
+            local_storage: vec![StorageEntry {
+                name: "local-key".to_string(),
+                value: "local-value".to_string(),
+            }],
+            session_storage: vec![StorageEntry {
+                name: "session-key".to_string(),
+                value: "session-value".to_string(),
+            }],
+        };
+
+        let script = storage_restore_init_script(&origin).expect("build restore init script");
+
+        assert!(script.contains(r#"location.origin !== "https://example.test""#));
+        assert!(script.contains(r#"[{"name":"local-key","value":"local-value"}]"#));
+        assert!(script.contains(r#"[{"name":"session-key","value":"session-value"}]"#));
+        assert!(script.contains("localStorage.setItem"));
+        assert!(script.contains("sessionStorage.setItem"));
     }
 
     #[test]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -6,10 +6,11 @@ use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::{
-    AttachToTargetParams, AttachToTargetResult, CdpEvent, CloseTargetParams, CreateTargetParams,
+    AttachToTargetParams, AttachToTargetResult, CloseTargetParams, CreateTargetParams,
     CreateTargetResult, EvaluateParams,
 };
 use super::cookies::{self, Cookie};
@@ -460,9 +461,13 @@ pub fn validate_state_file(path: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn storage_restore_init_script(origin: &OriginStorage) -> Result<String, String> {
+static NEXT_STORAGE_RESTORE_MARKER: AtomicU64 = AtomicU64::new(1);
+
+fn storage_restore_init_script(origin: &OriginStorage, marker: &str) -> Result<String, String> {
     let expected_origin = serde_json::to_string(&origin.origin)
         .map_err(|e| format!("Failed to serialize storage origin: {}", e))?;
+    let marker = serde_json::to_string(marker)
+        .map_err(|e| format!("Failed to serialize storage restore marker: {}", e))?;
     let local_entries = serde_json::to_string(&origin.local_storage)
         .map_err(|e| format!("Failed to serialize localStorage entries: {}", e))?;
     let session_entries = serde_json::to_string(&origin.session_storage)
@@ -477,6 +482,11 @@ fn storage_restore_init_script(origin: &OriginStorage) -> Result<String, String>
             for (const entry of {session_entries}) {{
                 sessionStorage.setItem(entry.name, entry.value);
             }}
+            Object.defineProperty(globalThis, {marker}, {{
+                value: true,
+                configurable: true,
+                enumerable: false,
+            }});
         }})()"#
     ))
 }
@@ -497,41 +507,45 @@ async fn remove_storage_restore_init_script(
 }
 
 async fn wait_for_storage_restore_document(
-    event_rx: &mut tokio::sync::broadcast::Receiver<CdpEvent>,
+    client: &CdpClient,
     session_id: &str,
-    loader_id: &str,
+    expected_origin: &str,
+    marker: &str,
 ) -> Result<(), String> {
+    let expected_origin = serde_json::to_string(expected_origin)
+        .map_err(|e| format!("Failed to serialize storage origin: {}", e))?;
+    let marker = serde_json::to_string(marker)
+        .map_err(|e| format!("Failed to serialize storage restore marker: {}", e))?;
+    let expression = format!(
+        r#"(() => {{
+            if (location.origin !== {expected_origin} || globalThis[{marker}] !== true) {{
+                return false;
+            }}
+            delete globalThis[{marker}];
+            return true;
+        }})()"#
+    );
     let wait = async {
-        let mut saw_expected_document = false;
         loop {
-            match event_rx.recv().await {
-                Ok(event)
-                    if event.session_id.as_deref() == Some(session_id)
-                        && event.method == "Page.frameNavigated"
-                        && event
-                            .params
-                            .get("frame")
-                            .and_then(|frame| frame.get("loaderId"))
-                            .and_then(|value| value.as_str())
-                            == Some(loader_id) =>
-                {
-                    saw_expected_document = true;
-                }
-                Ok(event)
-                    if event.session_id.as_deref() == Some(session_id)
-                        && saw_expected_document
-                        && matches!(
-                            event.method.as_str(),
-                            "Page.domContentEventFired" | "Page.loadEventFired"
-                        ) =>
+            if let Ok(result) = client
+                .send_command_typed::<_, super::cdp::types::EvaluateResult>(
+                    "Runtime.evaluate",
+                    &EvaluateParams {
+                        expression: expression.clone(),
+                        return_by_value: Some(true),
+                        await_promise: Some(false),
+                    },
+                    Some(session_id),
+                )
+                .await
+            {
+                if result.exception_details.is_none()
+                    && result.result.value.as_ref().and_then(Value::as_bool) == Some(true)
                 {
                     return Ok(());
                 }
-                Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    return Err("CDP event channel closed during storage restore".to_string());
-                }
             }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         }
     };
 
@@ -564,7 +578,11 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
 
         // Seed storage before application scripts run. The post-navigation writes
         // below remain as a compatibility pass for the loaded document.
-        let init_source = storage_restore_init_script(origin)?;
+        let marker = format!(
+            "__agent_browser_storage_restore_{}",
+            NEXT_STORAGE_RESTORE_MARKER.fetch_add(1, Ordering::Relaxed)
+        );
+        let init_source = storage_restore_init_script(origin, &marker)?;
         let init_result = client
             .send_command(
                 "Page.addScriptToEvaluateOnNewDocument",
@@ -578,7 +596,6 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
             .filter(|value| !value.is_empty())
             .ok_or("Storage restore init script did not return an identifier")?;
 
-        let mut event_rx = client.subscribe();
         let navigate_url = format!("{}/", origin.origin.trim_end_matches('/'));
         let staging_result = match client
             .send_command(
@@ -589,8 +606,9 @@ pub async fn load_state(client: &CdpClient, session_id: &str, path: &str) -> Res
             .await
         {
             Ok(result) => match result.get("loaderId").and_then(|value| value.as_str()) {
-                Some(loader_id) => {
-                    wait_for_storage_restore_document(&mut event_rx, session_id, loader_id).await
+                Some(_) => {
+                    wait_for_storage_restore_document(client, session_id, &origin.origin, &marker)
+                        .await
                 }
                 None => Err("Storage restore navigation did not create a document".to_string()),
             },
@@ -1031,13 +1049,15 @@ mod tests {
             }],
         };
 
-        let script = storage_restore_init_script(&origin).expect("build restore init script");
+        let script = storage_restore_init_script(&origin, "restore-ready")
+            .expect("build restore init script");
 
         assert!(script.contains(r#"location.origin !== "https://example.test""#));
         assert!(script.contains(r#"[{"name":"local-key","value":"local-value"}]"#));
         assert!(script.contains(r#"[{"name":"session-key","value":"session-value"}]"#));
         assert!(script.contains("localStorage.setItem"));
         assert!(script.contains("sessionStorage.setItem"));
+        assert!(script.contains("restore-ready"));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2675,6 +2675,10 @@ Automatic State Persistence:
   agent-browser --session myapp --restore open https://example.com
   Or set AGENT_BROWSER_RESTORE environment variable.
 
+Restore Ordering:
+  localStorage and sessionStorage are staged before application scripts run at
+  each saved origin. The temporary staging script is removed after navigation.
+
 State Encryption:
   Set AGENT_BROWSER_ENCRYPTION_KEY (64-char hex) for AES-256-GCM encryption.
   Generate a key: openssl rand -hex 32

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -126,6 +126,8 @@ agent-browser state load ./my-auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
+State loading stages `localStorage` and `sessionStorage` before application scripts run at each saved origin, then removes the temporary staging script. Startup authentication checks can therefore read restored values, including large session values, before deciding whether to redirect to login.
+
 Combine with `--session <id> --restore` so the imported auth auto-persists across restarts:
 
 ```bash

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -60,6 +60,8 @@ agent-browser state load ./my-auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
+State loading stages `localStorage` and `sessionStorage` before application scripts run at each saved origin, then removes the temporary staging script. Startup authentication checks can therefore read restored values, including large session values, before deciding whether to redirect to login.
+
 This works for any site, including those with complex OAuth flows, SSO, or 2FA, as long as Chrome already has valid session cookies.
 
 > **Security note:** State files contain session tokens in plaintext. Add them to `.gitignore`, delete when no longer needed, and set `AGENT_BROWSER_ENCRYPTION_KEY` for encryption at rest. See [Security Best Practices](#security-best-practices).


### PR DESCRIPTION
## Summary

- stage saved `localStorage` and `sessionStorage` with an origin-scoped pre-document script before the application can run authentication guards
- wait for the exact navigation loader and DOM readiness, remove the temporary state-bearing script on success or failure, and retain the existing post-navigation writes as a compatibility pass
- add a local two-origin Chrome regression covering a 24 KB session value through both runtime `state load` and launch-time `storageState`, including proof that the temporary script does not reapply cleared state

## Root cause

The 24 KB value survives CDP transport. The previous sequence navigated first and wrote storage after a fixed delay. An application startup guard could redirect to login before that write, causing the value to be stored under the redirected login origin instead of the saved application origin.

## Testing

- `cargo test --manifest-path cli/Cargo.toml native::state::tests -- --test-threads=1`
- `cargo test --manifest-path cli/Cargo.toml e2e_state_load_restores_large_session_storage_before_page_scripts -- --ignored --test-threads=1`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets`
- `corepack pnpm --dir docs build`
- full serial unit suite: 933 passed; the existing Windows-specific connection-refused text assertion remained the only failure

Fixes #1505.

This is the behavioral follow-up to #1573. The branches are independently testable; I will rebase whichever remains open if the shared state-restoration area conflicts after one merges.