### PR TITLE
fix(cli): preserve JSON for startup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--hide-scrollbars <bool>` | Hide native scrollbars in headless Chromium screenshots, enabled by default (or `AGENT_BROWSER_HIDE_SCROLLBARS` env) |
 | `-p, --provider <name>` | Browser provider, including configured `browser.provider` plugins (or `AGENT_BROWSER_PROVIDER` env) |
 | `--device <name>` | iOS device name, e.g. "iPhone 15 Pro" (or `AGENT_BROWSER_IOS_DEVICE` env) |
-| `--json` | JSON output (for agents) |
+| `--json` | JSON output for commands and startup errors, including invalid explicit config files |
 | `--annotate` | Annotated screenshot with numbered element labels (or `AGENT_BROWSER_ANNOTATE` env) |
 | `--screenshot-dir <path>` | Default screenshot output directory (or `AGENT_BROWSER_SCREENSHOT_DIR` env) |
 | `--screenshot-quality <n>` | JPEG quality 0-100 (or `AGENT_BROWSER_SCREENSHOT_QUALITY` env) |
@@ -1110,6 +1110,8 @@ agent-browser snapshot --json
 agent-browser get text @e1 --json
 agent-browser is visible @e2 --json
 ```
+
+Errors that occur before daemon dispatch also honor `--json`, including missing or malformed explicit config files and invalid standalone subcommands. They return a nonzero exit code with a typed payload such as `{"success":false,"error":"...","type":"config_error"}` on stdout.
 
 ### Optimal AI Workflow
 

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -181,17 +181,20 @@ impl Config {
     }
 }
 
+fn try_read_config_file(path: &Path) -> Result<Config, String> {
+    let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let mut config = serde_json::from_str::<Config>(&content).map_err(|e| e.to_string())?;
+    config.idle_timeout = parse_idle_timeout_value(
+        config.idle_timeout.take(),
+        &format!("config file {}", path.display()),
+    );
+    Ok(config)
+}
+
 fn read_config_file(path: &Path) -> Option<Config> {
-    let content = fs::read_to_string(path).ok()?;
-    match serde_json::from_str::<Config>(&content) {
-        Ok(mut config) => {
-            config.idle_timeout = parse_idle_timeout_value(
-                config.idle_timeout.take(),
-                &format!("config file {}", path.display()),
-            );
-            Some(config)
-        }
-        Err(e) => {
+    match try_read_config_file(path) {
+        Ok(config) => Some(config),
+        Err(e) if path.exists() => {
             eprintln!(
                 "{} invalid config file {}: {}",
                 color::warning_indicator(),
@@ -200,6 +203,7 @@ fn read_config_file(path: &Path) -> Option<Config> {
             );
             None
         }
+        Err(_) => None,
     }
 }
 
@@ -232,6 +236,44 @@ fn parse_bool_arg(args: &[String], i: usize) -> (bool, bool) {
     }
 }
 
+const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
+    "--session",
+    "--restore-save",
+    "--restore-check-url",
+    "--restore-check-text",
+    "--restore-check-fn",
+    "--namespace",
+    "--headers",
+    "--executable-path",
+    "--cdp",
+    "--extension",
+    "--init-script",
+    "--enable",
+    "--profile",
+    "--state",
+    "--proxy",
+    "--proxy-bypass",
+    "--args",
+    "--user-agent",
+    "-p",
+    "--provider",
+    "--device",
+    "--session-name",
+    "--color-scheme",
+    "--download-path",
+    "--max-output",
+    "--allowed-domains",
+    "--action-policy",
+    "--confirm-actions",
+    "--config",
+    "--engine",
+    "--screenshot-dir",
+    "--screenshot-quality",
+    "--screenshot-format",
+    "--idle-timeout",
+    "--model",
+];
+
 /// Extract --config <path> from args before full flag parsing.
 /// Returns `Some(Some(path))` if --config <path> found, `Some(None)` if --config
 /// was the last arg with no value, `None` if --config not present.
@@ -241,48 +283,12 @@ fn parse_bool_arg(args: &[String], i: usize) -> (bool, bool) {
 /// intentionally absent -- they don't take a value, so they can't cause
 /// the next argument to be mis-consumed.
 fn extract_config_path(args: &[String]) -> Option<Option<String>> {
-    const FLAGS_WITH_VALUE: &[&str] = &[
-        "--session",
-        "--restore-save",
-        "--restore-check-url",
-        "--restore-check-text",
-        "--restore-check-fn",
-        "--namespace",
-        "--headers",
-        "--executable-path",
-        "--cdp",
-        "--extension",
-        "--init-script",
-        "--enable",
-        "--profile",
-        "--state",
-        "--proxy",
-        "--proxy-bypass",
-        "--args",
-        "--user-agent",
-        "-p",
-        "--provider",
-        "--device",
-        "--session-name",
-        "--color-scheme",
-        "--download-path",
-        "--max-output",
-        "--allowed-domains",
-        "--action-policy",
-        "--confirm-actions",
-        "--engine",
-        "--screenshot-dir",
-        "--screenshot-quality",
-        "--screenshot-format",
-        "--idle-timeout",
-        "--model",
-    ];
     let mut i = 0;
     while i < args.len() {
         if args[i] == "--config" {
             return Some(args.get(i + 1).cloned());
         }
-        if FLAGS_WITH_VALUE.contains(&args[i].as_str()) {
+        if GLOBAL_FLAGS_WITH_VALUE.contains(&args[i].as_str()) {
             i += 1;
         }
         i += 1;
@@ -305,8 +311,8 @@ pub fn load_config(args: &[String]) -> Result<Config, String> {
         if !path.exists() {
             return Err(format!("config file not found: {}", path_str));
         }
-        return read_config_file(&path)
-            .ok_or_else(|| format!("failed to load config from {}", path_str));
+        return try_read_config_file(&path)
+            .map_err(|e| format!("failed to load config from {}: {}", path_str, e));
     }
 
     let user_config = dirs::home_dir()
@@ -399,11 +405,28 @@ pub struct Flags {
     pub cli_restore: bool,
 }
 
-pub fn parse_flags(args: &[String]) -> Flags {
-    let config = load_config(args).unwrap_or_else(|e| {
-        eprintln!("{} {}", color::warning_indicator(), e);
-        std::process::exit(1);
-    });
+/// Resolve JSON output intent without loading configuration so startup errors
+/// can still honor the environment and explicit CLI override.
+pub fn json_output_requested(args: &[String]) -> bool {
+    let mut json = env_var_is_truthy("AGENT_BROWSER_JSON");
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            let (value, consumed) = parse_bool_arg(args, i);
+            json = value;
+            if consumed {
+                i += 1;
+            }
+        } else if GLOBAL_FLAGS_WITH_VALUE.contains(&args[i].as_str()) {
+            i += 1;
+        }
+        i += 1;
+    }
+    json
+}
+
+pub fn try_parse_flags(args: &[String]) -> Result<Flags, String> {
+    let config = load_config(args)?;
 
     let extensions_env = env::var("AGENT_BROWSER_EXTENSIONS")
         .ok()
@@ -1000,7 +1023,15 @@ pub fn parse_flags(args: &[String]) -> Flags {
         }
         i += 1;
     }
-    flags
+    Ok(flags)
+}
+
+#[cfg(test)]
+pub fn parse_flags(args: &[String]) -> Flags {
+    try_parse_flags(args).unwrap_or_else(|e| {
+        eprintln!("{} {}", color::warning_indicator(), e);
+        std::process::exit(1);
+    })
 }
 
 fn looks_like_command(value: &str) -> bool {
@@ -1034,45 +1065,6 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--quick",
         "--fix",
     ];
-    // Global flags that always take a value (need to skip the next arg too)
-    const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
-        "--session",
-        "--restore-save",
-        "--restore-check-url",
-        "--restore-check-text",
-        "--restore-check-fn",
-        "--namespace",
-        "--headers",
-        "--executable-path",
-        "--cdp",
-        "--extension",
-        "--init-script",
-        "--enable",
-        "--profile",
-        "--state",
-        "--proxy",
-        "--proxy-bypass",
-        "--args",
-        "--user-agent",
-        "-p",
-        "--provider",
-        "--device",
-        "--session-name",
-        "--color-scheme",
-        "--download-path",
-        "--max-output",
-        "--allowed-domains",
-        "--action-policy",
-        "--confirm-actions",
-        "--config",
-        "--engine",
-        "--screenshot-dir",
-        "--screenshot-quality",
-        "--screenshot-format",
-        "--idle-timeout",
-        "--model",
-    ];
-
     let mut i = 0;
     let mut seen_command = false;
     while i < args.len() {
@@ -1127,6 +1119,24 @@ mod tests {
 
     fn args(s: &str) -> Vec<String> {
         s.split_whitespace().map(String::from).collect()
+    }
+
+    #[test]
+    fn test_json_output_requested_honors_cli_override() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_JSON"]);
+        guard.remove("AGENT_BROWSER_JSON");
+        assert!(!json_output_requested(&args("open example.com")));
+        assert!(json_output_requested(&args("--json open example.com")));
+
+        guard.set("AGENT_BROWSER_JSON", "1");
+        assert!(json_output_requested(&args("open example.com")));
+        assert!(!json_output_requested(&args(
+            "--json false open example.com"
+        )));
+        guard.remove("AGENT_BROWSER_JSON");
+        assert!(!json_output_requested(&args(
+            "--args --json open example.com"
+        )));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,9 @@ use connection::{
     cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
     send_command, walk_daemons, DaemonOptions, Response,
 };
-use flags::{clean_args, parse_flags, Flags};
+#[cfg(test)]
+use flags::parse_flags;
+use flags::{clean_args, json_output_requested, try_parse_flags, Flags};
 use install::run_install;
 use output::{
     print_command_help, print_help, print_response_with_opts, print_version, OutputOptions,
@@ -964,7 +966,17 @@ fn main() {
     }
 
     let args: Vec<String> = env::args().skip(1).collect();
-    let mut flags = parse_flags(&args);
+    let mut flags = match try_parse_flags(&args) {
+        Ok(flags) => flags,
+        Err(error) => {
+            if json_output_requested(&args) {
+                print_json_error_with_type(error, "config_error");
+            } else {
+                eprintln!("{} {}", color::warning_indicator(), error);
+            }
+            exit(1);
+        }
+    };
     if flags.restore_uses_session {
         flags.restore = Some(flags.session.clone());
     }
@@ -1047,11 +1059,12 @@ fn main() {
                 return;
             }
             Some(unknown) => {
-                eprintln!(
-                    "{} Unknown dashboard subcommand: {}",
-                    color::error_indicator(),
-                    unknown
-                );
+                let error = format!("Unknown dashboard subcommand: {}", unknown);
+                if flags.json {
+                    print_json_error_with_type(error, "unknown_subcommand");
+                } else {
+                    eprintln!("{} {}", color::error_indicator(), error);
+                }
                 exit(1);
             }
         }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3527,7 +3527,7 @@ Options:
                              Use --hide-scrollbars false to keep scrollbars visible
   -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
-  --json                     JSON output
+  --json                     JSON output, including startup and config errors
   --annotate                 Annotated screenshot with numbered labels and legend
   --screenshot-dir <path>    Default screenshot output directory (or AGENT_BROWSER_SCREENSHOT_DIR)
   --screenshot-quality <n>   JPEG quality 0-100; ignored for PNG (or AGENT_BROWSER_SCREENSHOT_QUALITY)

--- a/cli/tests/early_error_json.rs
+++ b/cli/tests/early_error_json.rs
@@ -1,0 +1,136 @@
+//! Integration tests for failures that occur before daemon dispatch.
+
+use std::process::Command;
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_agent-browser");
+
+fn build_cli(tmp: &TempDir) -> Command {
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    let mut cmd = Command::new(BIN);
+    cmd.current_dir(tmp.path())
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("NO_COLOR", "1")
+        .env_remove("AGENT_BROWSER_CONFIG")
+        .env_remove("AGENT_BROWSER_JSON");
+    cmd
+}
+
+#[test]
+fn explicit_config_error_honors_json_mode() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("missing.json");
+    let output = build_cli(&tmp)
+        .args([
+            "--json",
+            "--config",
+            missing.to_str().unwrap(),
+            "open",
+            "about:blank",
+        ])
+        .output()
+        .expect("run CLI with missing config");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout was not JSON: {error}\n{stdout}"));
+
+    assert_eq!(payload["success"], false);
+    assert_eq!(payload["type"], "config_error");
+    assert!(payload["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("config file not found")));
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
+}
+
+#[test]
+fn explicit_config_error_preserves_text_mode() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("missing.json");
+    let output = build_cli(&tmp)
+        .args(["--config", missing.to_str().unwrap(), "open", "about:blank"])
+        .output()
+        .expect("run CLI with missing config");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("config file not found"), "stderr: {stderr}");
+}
+
+#[test]
+fn malformed_explicit_config_honors_json_mode() {
+    let tmp = TempDir::new().unwrap();
+    let malformed = tmp.path().join("malformed.json");
+    std::fs::write(&malformed, "{ not valid JSON").unwrap();
+    let output = build_cli(&tmp)
+        .args([
+            "--json",
+            "--config",
+            malformed.to_str().unwrap(),
+            "open",
+            "about:blank",
+        ])
+        .output()
+        .expect("run CLI with malformed config");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout was not JSON: {error}\n{stdout}"));
+
+    assert_eq!(payload["success"], false);
+    assert_eq!(payload["type"], "config_error");
+    assert!(payload["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("failed to load config")));
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn config_error_honors_json_environment_variable() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("missing-from-env.json");
+    let output = build_cli(&tmp)
+        .args(["open", "about:blank"])
+        .env("AGENT_BROWSER_CONFIG", &missing)
+        .env("AGENT_BROWSER_JSON", "1")
+        .output()
+        .expect("run CLI with config and JSON environment variables");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout was not JSON: {error}\n{stdout}"));
+
+    assert_eq!(payload["success"], false);
+    assert_eq!(payload["type"], "config_error");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn standalone_subcommand_error_honors_json_mode() {
+    let tmp = TempDir::new().unwrap();
+    let output = build_cli(&tmp)
+        .args(["--json", "dashboard", "unexpected"])
+        .output()
+        .expect("run dashboard with unknown subcommand");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout was not JSON: {error}\n{stdout}"));
+
+    assert_eq!(payload["success"], false);
+    assert_eq!(payload["type"], "unknown_subcommand");
+    assert!(payload["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("Unknown dashboard subcommand")));
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
+}

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -175,6 +175,8 @@ agent-browser --headed true open example.com  # explicit
 
 This applies to boolean flags such as `--headed`, `--debug`, `--json`, `--ignore-https-errors`, `--allow-file-access`, `--hide-scrollbars`, `--auto-connect`, `--annotate`, `--content-boundaries`, `--confirm-interactive`, and `--no-auto-dialog`.
 
+`--json` applies even when startup fails before daemon dispatch. Missing or malformed explicit config files and invalid standalone subcommands return a nonzero exit code with a typed `{"success":false,"error":"...","type":"..."}` payload on stdout instead of an unstructured stderr-only failure. `AGENT_BROWSER_JSON` enables the same behavior, while an explicit `--json false` keeps text output.
+
 ## Extensions Merging
 
 Extensions from user-level and project-level configs are **concatenated**, not replaced. For example, if `~/.agent-browser/config.json` specifies `["/ext1"]` and `./agent-browser.json` specifies `["/ext2"]`, the result is `["/ext1", "/ext2"]`.

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -369,7 +369,7 @@ Tool calls use the same config files and environment variables as the CLI. Each 
 
 ```bash
 agent-browser --session <name> ...    # Isolated browser session
-agent-browser --json ...              # JSON output for parsing
+agent-browser --json ...              # JSON output for commands and startup errors
 agent-browser --headed ...            # Show browser window (not headless; on displayless Linux an Xvfb display starts automatically)
 agent-browser --webgpu ...            # Enable WebGPU (SwiftShader software Vulkan on Linux, no GPU needed)
 agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
@@ -385,6 +385,8 @@ agent-browser --help                  # Show help (-h)
 agent-browser --version               # Show version (-V)
 agent-browser <command> --help        # Show detailed help for a command
 ```
+
+`--json` also covers failures before daemon dispatch, including missing or malformed explicit config files and invalid standalone subcommands. Expect a nonzero exit code and a typed `{"success":false,"error":"...","type":"..."}` payload on stdout.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary

- return explicit configuration load failures to the main output boundary instead of exiting inside flag parsing
- resolve JSON output intent before configuration loading so startup failures honor `--json`, `--json false`, and `AGENT_BROWSER_JSON`
- emit typed JSON for configuration failures and unknown dashboard subcommands while preserving existing text-mode behavior
- document the startup-error guarantee across CLI help, README, docs, and the core command reference

MCP stdio behavior is intentionally unchanged. Its stdout is reserved for JSON-RPC, and configuration parsing occurs before the server starts.

## Tests

- `cargo test --manifest-path cli/Cargo.toml --test early_error_json`
- `cargo test --manifest-path cli/Cargo.toml flags::tests -- --test-threads=1`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets`
- `corepack pnpm --dir docs build`

The serial Rust suite passed 933 tests. The only failure was the existing Windows-specific `install::tests::download_bytes_connection_refused_includes_details` assertion, where the dependency reports `connection closed before message completed` instead of `connection refused`.