### PR TITLE
feat: add memory diagnostics and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ agent-browser trace start             # Start recording trace
 agent-browser trace stop [path]       # Stop and save trace
 agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
+agent-browser memory metrics           # Read JS heap and DOM counters
+agent-browser memory sampling start    # Start allocation sampling on this page
+agent-browser memory sampling stop     # Save allocation profile and top call sites
+agent-browser memory snapshot          # Stream a heap snapshot to a local file
+agent-browser memory status            # Show the active capture
+agent-browser memory cancel            # Cancel the active capture
 agent-browser console                 # View console messages (log, error, warn, info)
 agent-browser console --json          # JSON output with raw CDP args for programmatic access
 agent-browser console --clear         # Clear console
@@ -403,6 +409,28 @@ agent-browser state clear [name]      # Clear states for session
 agent-browser state clear --all       # Clear all saved states
 agent-browser state clean --older-than <days>  # Delete old states
 ```
+
+### Memory diagnostics
+
+Memory diagnostics reuse the current agent-browser Chrome session. No separate CDP port or address is required. They are disabled on Lightpanda, Safari, and other engines that do not provide the required Chrome memory capabilities.
+
+```bash
+agent-browser open https://example.com
+agent-browser memory metrics
+
+agent-browser memory sampling start --sampling-interval 65536
+# Repeat the page flow that may retain objects
+agent-browser memory sampling stop ./allocations.heapprofile --top 10
+
+agent-browser memory collect-garbage
+agent-browser memory snapshot ./after.heapsnapshot --timeout 120000
+```
+
+Only one memory capture can be active in a browser session. Allocation sampling stays bound to the page where it started even if another tab becomes active. `memory status` reports the capture ID, type, original page, and start time. `memory cancel` stops sampling or interrupts an in-progress snapshot and removes partial output.
+
+Heap snapshots are written one chunk at a time and are never printed to the terminal or JSON response. If no path is supplied, artifacts go to the runtime temporary directory and default artifacts older than 24 hours are cleaned when a new capture starts. Use `--max-size <bytes>` to cap artifact size, `--no-gc` to skip the default garbage collection before a snapshot, and `--json` for structured summaries and stable `errorCode` values.
+
+Heap snapshots and allocation profiles can contain page text, application data, credentials, and tokens. Keep them on trusted local storage, do not commit them, and delete them when the diagnosis is complete.
 
 ### Navigation
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -147,6 +147,8 @@ pub fn is_top_level_command(value: &str) -> bool {
             | "dialog"
             | "trace"
             | "profiler"
+            | "memory"
+            | "coverage"
             | "record"
             | "console"
             | "errors"
@@ -1653,6 +1655,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             }
         }
 
+        // === Page memory diagnostics (Chrome only) ===
+        "memory" => parse_memory(&rest, &id),
+
+        // === JavaScript code coverage (Chrome only) ===
+        "coverage" => parse_coverage(&rest, &id),
+
         // === Recording (browser video recording) ===
         "record" => {
             const VALID: &[&str] = &["start", "stop", "restart"];
@@ -2015,6 +2023,250 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         _ => Err(ParseError::UnknownCommand {
             command: cmd.to_string(),
+        }),
+    }
+}
+
+fn parse_positive_u64(value: &str, flag: &str, usage: &'static str) -> Result<u64, ParseError> {
+    let parsed = value.parse::<u64>().map_err(|_| ParseError::InvalidValue {
+        message: format!("Invalid value for {}: {}", flag, value),
+        usage,
+    })?;
+    if parsed == 0 {
+        return Err(ParseError::InvalidValue {
+            message: format!("{} must be greater than zero", flag),
+            usage,
+        });
+    }
+    Ok(parsed)
+}
+
+fn parse_memory(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+    const MEMORY_USAGE: &str =
+        "memory <metrics|status|sampling|snapshot|collect-garbage|cancel> ...";
+    const SAMPLING_START_USAGE: &str = "memory sampling start [--sampling-interval <bytes>]";
+    const SAMPLING_STOP_USAGE: &str =
+        "memory sampling stop [path] [--top <count>] [--max-size <bytes>]";
+    const SNAPSHOT_USAGE: &str =
+        "memory snapshot [path] [--no-gc] [--timeout <ms>] [--max-size <bytes>]";
+
+    match rest.first().copied() {
+        Some("metrics") => Ok(json!({ "id": id, "action": "memory_metrics" })),
+        Some("status") => Ok(json!({ "id": id, "action": "memory_status" })),
+        Some("collect-garbage") => Ok(json!({ "id": id, "action": "memory_collect_garbage" })),
+        Some("cancel") => Ok(json!({ "id": id, "action": "memory_cancel" })),
+        Some("sampling") => match rest.get(1).copied() {
+            Some("start") => {
+                let mut command = json!({ "id": id, "action": "memory_sampling_start" });
+                let mut index = 2;
+                while index < rest.len() {
+                    match rest[index] {
+                        "--sampling-interval" => {
+                            let value = rest.get(index + 1).ok_or_else(|| {
+                                ParseError::MissingArguments {
+                                    context: "memory sampling start --sampling-interval"
+                                        .to_string(),
+                                    usage: SAMPLING_START_USAGE,
+                                }
+                            })?;
+                            command["samplingInterval"] = json!(parse_positive_u64(
+                                value,
+                                "--sampling-interval",
+                                SAMPLING_START_USAGE,
+                            )?);
+                            index += 2;
+                        }
+                        option => {
+                            return Err(ParseError::InvalidValue {
+                                message: format!(
+                                    "Unknown memory sampling start option: {}",
+                                    option
+                                ),
+                                usage: SAMPLING_START_USAGE,
+                            });
+                        }
+                    }
+                }
+                Ok(command)
+            }
+            Some("stop") => {
+                let mut command = json!({ "id": id, "action": "memory_sampling_stop" });
+                let mut index = 2;
+                while index < rest.len() {
+                    match rest[index] {
+                        "--top" | "--max-size" => {
+                            let flag = rest[index];
+                            let value = rest.get(index + 1).ok_or_else(|| {
+                                ParseError::MissingArguments {
+                                    context: format!("memory sampling stop {}", flag),
+                                    usage: SAMPLING_STOP_USAGE,
+                                }
+                            })?;
+                            let parsed = parse_positive_u64(value, flag, SAMPLING_STOP_USAGE)?;
+                            if flag == "--top" {
+                                command["top"] = json!(parsed);
+                            } else {
+                                command["maxSize"] = json!(parsed);
+                            }
+                            index += 2;
+                        }
+                        path if !path.starts_with("--") && command.get("path").is_none() => {
+                            command["path"] = json!(path);
+                            index += 1;
+                        }
+                        option => {
+                            return Err(ParseError::InvalidValue {
+                                message: format!("Unknown memory sampling stop option: {}", option),
+                                usage: SAMPLING_STOP_USAGE,
+                            });
+                        }
+                    }
+                }
+                Ok(command)
+            }
+            Some(subcommand) => Err(ParseError::UnknownSubcommand {
+                subcommand: subcommand.to_string(),
+                valid_options: &["start", "stop"],
+            }),
+            None => Err(ParseError::MissingArguments {
+                context: "memory sampling".to_string(),
+                usage: "memory sampling <start|stop> [options]",
+            }),
+        },
+        Some("snapshot") => {
+            let mut command = json!({
+                "id": id,
+                "action": "memory_snapshot",
+                "collectGarbage": true,
+                "timeout": 120000_u64,
+            });
+            let mut index = 1;
+            while index < rest.len() {
+                match rest[index] {
+                    "--no-gc" => {
+                        command["collectGarbage"] = json!(false);
+                        index += 1;
+                    }
+                    "--timeout" | "--max-size" => {
+                        let flag = rest[index];
+                        let value =
+                            rest.get(index + 1)
+                                .ok_or_else(|| ParseError::MissingArguments {
+                                    context: format!("memory snapshot {}", flag),
+                                    usage: SNAPSHOT_USAGE,
+                                })?;
+                        let parsed = parse_positive_u64(value, flag, SNAPSHOT_USAGE)?;
+                        if flag == "--timeout" {
+                            command["timeout"] = json!(parsed);
+                        } else {
+                            command["maxSize"] = json!(parsed);
+                        }
+                        index += 2;
+                    }
+                    path if !path.starts_with("--") && command.get("path").is_none() => {
+                        command["path"] = json!(path);
+                        index += 1;
+                    }
+                    option => {
+                        return Err(ParseError::InvalidValue {
+                            message: format!("Unknown memory snapshot option: {}", option),
+                            usage: SNAPSHOT_USAGE,
+                        });
+                    }
+                }
+            }
+            Ok(command)
+        }
+        Some(subcommand) => Err(ParseError::UnknownSubcommand {
+            subcommand: subcommand.to_string(),
+            valid_options: &[
+                "metrics",
+                "status",
+                "sampling",
+                "snapshot",
+                "collect-garbage",
+                "cancel",
+            ],
+        }),
+        None => Err(ParseError::MissingArguments {
+            context: "memory".to_string(),
+            usage: MEMORY_USAGE,
+        }),
+    }
+}
+
+fn parse_coverage(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+    const COVERAGE_USAGE: &str =
+        "coverage <status|start|take|stop|cancel> [path] [--label <name>] [--max-size <bytes>]";
+    match rest.first().copied() {
+        Some("status") => Ok(json!({ "id": id, "action": "coverage_status" })),
+        Some("cancel") => Ok(json!({ "id": id, "action": "coverage_cancel" })),
+        Some("start") => {
+            let mut command = json!({ "id": id, "action": "coverage_start" });
+            for option in &rest[1..] {
+                if *option == "--call-count" {
+                    command["callCount"] = json!(true);
+                } else {
+                    return Err(ParseError::InvalidValue {
+                        message: format!("Unknown coverage start option: {}", option),
+                        usage: "coverage start [--call-count]",
+                    });
+                }
+            }
+            Ok(command)
+        }
+        Some("take" | "stop") => {
+            let action = if rest[0] == "take" {
+                "coverage_take"
+            } else {
+                "coverage_stop"
+            };
+            let mut command = json!({ "id": id, "action": action });
+            let mut index = 1;
+            while index < rest.len() {
+                match rest[index] {
+                    "--label" => {
+                        let value =
+                            rest.get(index + 1)
+                                .ok_or_else(|| ParseError::MissingArguments {
+                                    context: format!("coverage {} --label", rest[0]),
+                                    usage: COVERAGE_USAGE,
+                                })?;
+                        command["label"] = json!(value);
+                        index += 2;
+                    }
+                    "--max-size" => {
+                        let value =
+                            rest.get(index + 1)
+                                .ok_or_else(|| ParseError::MissingArguments {
+                                    context: format!("coverage {} --max-size", rest[0]),
+                                    usage: COVERAGE_USAGE,
+                                })?;
+                        command["maxSize"] =
+                            json!(parse_positive_u64(value, "--max-size", COVERAGE_USAGE,)?);
+                        index += 2;
+                    }
+                    path if !path.starts_with("--") && command.get("path").is_none() => {
+                        command["path"] = json!(path);
+                        index += 1;
+                    }
+                    option => {
+                        return Err(ParseError::InvalidValue {
+                            message: format!("Unknown coverage {} option: {}", rest[0], option),
+                            usage: COVERAGE_USAGE,
+                        });
+                    }
+                }
+            }
+            Ok(command)
+        }
+        Some(subcommand) => Err(ParseError::UnknownSubcommand {
+            subcommand: subcommand.to_string(),
+            valid_options: &["status", "start", "take", "stop", "cancel"],
+        }),
+        None => Err(ParseError::MissingArguments {
+            context: "coverage".to_string(),
+            usage: COVERAGE_USAGE,
         }),
     }
 }
@@ -4753,6 +5005,106 @@ mod tests {
             result.unwrap_err(),
             ParseError::MissingArguments { .. }
         ));
+    }
+
+    // === Memory Tests ===
+
+    #[test]
+    fn test_memory_metrics() {
+        let cmd = parse_command(&args("memory metrics"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "memory_metrics");
+    }
+
+    #[test]
+    fn test_memory_sampling_start_options() {
+        let cmd = parse_command(
+            &args("memory sampling start --sampling-interval 65536"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "memory_sampling_start");
+        assert_eq!(cmd["samplingInterval"], 65_536);
+    }
+
+    #[test]
+    fn test_memory_sampling_stop_options() {
+        let cmd = parse_command(
+            &args("memory sampling stop result.heapprofile --top 10 --max-size 4096"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "memory_sampling_stop");
+        assert_eq!(cmd["path"], "result.heapprofile");
+        assert_eq!(cmd["top"], 10);
+        assert_eq!(cmd["maxSize"], 4096);
+    }
+
+    #[test]
+    fn test_memory_snapshot_options_and_timeout() {
+        let cmd = parse_command(
+            &args("memory snapshot result.heapsnapshot --no-gc --timeout 5000 --max-size 9999"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "memory_snapshot");
+        assert_eq!(cmd["path"], "result.heapsnapshot");
+        assert_eq!(cmd["collectGarbage"], false);
+        assert_eq!(cmd["timeout"], 5000);
+        assert_eq!(cmd["maxSize"], 9999);
+    }
+
+    #[test]
+    fn test_memory_rejects_zero_and_unknown_options() {
+        let zero = parse_command(
+            &args("memory sampling start --sampling-interval 0"),
+            &default_flags(),
+        );
+        assert!(matches!(zero, Err(ParseError::InvalidValue { .. })));
+
+        let unknown = parse_command(&args("memory snapshot --output foo"), &default_flags());
+        assert!(matches!(unknown, Err(ParseError::InvalidValue { .. })));
+    }
+
+    // === JavaScript Coverage Tests ===
+
+    #[test]
+    fn test_coverage_start_and_status() {
+        let start = parse_command(&args("coverage start --call-count"), &default_flags()).unwrap();
+        assert_eq!(start["action"], "coverage_start");
+        assert_eq!(start["callCount"], true);
+
+        let status = parse_command(&args("coverage status"), &default_flags()).unwrap();
+        assert_eq!(status["action"], "coverage_status");
+    }
+
+    #[test]
+    fn test_coverage_take_and_stop_options() {
+        let take = parse_command(
+            &args("coverage take first-screen.json --label first-screen --max-size 4096"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(take["action"], "coverage_take");
+        assert_eq!(take["path"], "first-screen.json");
+        assert_eq!(take["label"], "first-screen");
+        assert_eq!(take["maxSize"], 4096);
+
+        let stop = parse_command(&args("coverage stop --label orders"), &default_flags()).unwrap();
+        assert_eq!(stop["action"], "coverage_stop");
+        assert_eq!(stop["label"], "orders");
+        assert!(stop.get("path").is_none());
+    }
+
+    #[test]
+    fn test_coverage_cancel_and_invalid_options() {
+        let cancel = parse_command(&args("coverage cancel"), &default_flags()).unwrap();
+        assert_eq!(cancel["action"], "coverage_cancel");
+
+        let zero = parse_command(&args("coverage take --max-size 0"), &default_flags());
+        assert!(matches!(zero, Err(ParseError::InvalidValue { .. })));
+
+        let unknown = parse_command(&args("coverage start --detailed"), &default_flags());
+        assert!(matches!(unknown, Err(ParseError::InvalidValue { .. })));
     }
 
     // === Eval Tests ===

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -35,6 +35,8 @@ pub struct Response {
     pub success: bool,
     pub data: Option<Value>,
     pub error: Option<String>,
+    #[serde(rename = "errorCode", skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1211,12 +1211,14 @@ fn main() {
                 success: true,
                 data: Some(data),
                 error: None,
+                error_code: None,
                 warning: None,
             },
             Err(e) => connection::Response {
                 success: false,
                 data: None,
                 error: Some(e),
+                error_code: None,
                 warning: None,
             },
         };
@@ -2192,6 +2194,7 @@ mod tests {
                 }
             })),
             error: None,
+            error_code: None,
             warning: None,
         };
 

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -106,6 +106,13 @@ const TOOL_TRACE_START: &str = "agent_browser_trace_start";
 const TOOL_TRACE_STOP: &str = "agent_browser_trace_stop";
 const TOOL_PROFILER_START: &str = "agent_browser_profiler_start";
 const TOOL_PROFILER_STOP: &str = "agent_browser_profiler_stop";
+const TOOL_MEMORY_METRICS: &str = "agent_browser_memory_metrics";
+const TOOL_MEMORY_STATUS: &str = "agent_browser_memory_status";
+const TOOL_MEMORY_SAMPLING_START: &str = "agent_browser_memory_sampling_start";
+const TOOL_MEMORY_SAMPLING_STOP: &str = "agent_browser_memory_sampling_stop";
+const TOOL_MEMORY_SNAPSHOT: &str = "agent_browser_memory_snapshot";
+const TOOL_MEMORY_COLLECT_GARBAGE: &str = "agent_browser_memory_collect_garbage";
+const TOOL_MEMORY_CANCEL: &str = "agent_browser_memory_cancel";
 const TOOL_RECORD_START: &str = "agent_browser_record_start";
 const TOOL_RECORD_STOP: &str = "agent_browser_record_stop";
 const TOOL_RECORD_RESTART: &str = "agent_browser_record_restart";
@@ -256,7 +263,7 @@ impl ToolProfile {
             Self::Core => "Everyday browser automation with navigation, snapshots, common interaction, waits, screenshots, basic reads, tab basics, JavaScript eval, close, and profile discovery.",
             Self::Network => "Network interception, request inspection, HAR capture, headers, credentials, and offline mode.",
             Self::State => "Cookies, storage, auth profiles, saved browser state, sessions, Chrome profiles, and bundled skills.",
-            Self::Debug => "Console/errors, highlighting, DevTools, tracing, profiling, accessibility audits, PDF, downloads/uploads, recording, clipboard, plugin registry and plugin command.run, doctor, dashboard, install, upgrade, and chat.",
+            Self::Debug => "Console/errors, highlighting, DevTools, tracing, profiling, memory diagnostics, accessibility audits, PDF, downloads/uploads, recording, clipboard, plugin registry and plugin command.run, doctor, dashboard, install, upgrade, and chat.",
             Self::Tabs => "Tab, window, frame, and JavaScript dialog management.",
             Self::React => "React tree inspection, render recording, Suspense inspection, Web Vitals, SPA pushstate, and init-script removal.",
             Self::Mobile => "Viewport/device/geolocation/media emulation plus touch, swipe, and lower-level mouse tools.",
@@ -408,6 +415,13 @@ const DEBUG_PROFILE_TOOLS: &[&str] = &[
     TOOL_TRACE_STOP,
     TOOL_PROFILER_START,
     TOOL_PROFILER_STOP,
+    TOOL_MEMORY_METRICS,
+    TOOL_MEMORY_STATUS,
+    TOOL_MEMORY_SAMPLING_START,
+    TOOL_MEMORY_SAMPLING_STOP,
+    TOOL_MEMORY_SNAPSHOT,
+    TOOL_MEMORY_COLLECT_GARBAGE,
+    TOOL_MEMORY_CANCEL,
     TOOL_RECORD_START,
     TOOL_RECORD_STOP,
     TOOL_RECORD_RESTART,
@@ -1308,6 +1322,66 @@ fn parity_tools() -> Vec<Value> {
             &[],
         ),
         tool(
+            TOOL_MEMORY_METRICS,
+            "Memory metrics",
+            "Read lightweight JavaScript heap and DOM counters for the current page.",
+            json!({}),
+            &[],
+        ),
+        tool(
+            TOOL_MEMORY_STATUS,
+            "Memory capture status",
+            "Show the allocation sampling or heap snapshot capture bound to this browser session.",
+            json!({}),
+            &[],
+        ),
+        tool(
+            TOOL_MEMORY_SAMPLING_START,
+            "Memory sampling start",
+            "Start allocation sampling on the current page.",
+            json!({
+                "samplingInterval": { "type": "integer", "minimum": 1, "description": "Average number of allocated bytes between samples." }
+            }),
+            &[],
+        ),
+        tool(
+            TOOL_MEMORY_SAMPLING_STOP,
+            "Memory sampling stop",
+            "Stop allocation sampling on its original page and save the profile.",
+            json!({
+                "path": { "type": "string" },
+                "top": { "type": "integer", "minimum": 1 },
+                "maxSize": { "type": "integer", "minimum": 1, "description": "Maximum artifact size in bytes." }
+            }),
+            &[],
+        ),
+        tool(
+            TOOL_MEMORY_SNAPSHOT,
+            "Memory heap snapshot",
+            "Stream a heap snapshot from the current page directly to a local file.",
+            json!({
+                "path": { "type": "string" },
+                "collectGarbage": { "type": "boolean", "default": true },
+                "timeoutMs": { "type": "integer", "minimum": 1, "default": 120000 },
+                "maxSize": { "type": "integer", "minimum": 1, "description": "Maximum artifact size in bytes." }
+            }),
+            &[],
+        ),
+        tool(
+            TOOL_MEMORY_COLLECT_GARBAGE,
+            "Memory collect garbage",
+            "Request garbage collection on the current page.",
+            json!({}),
+            &[],
+        ),
+        tool(
+            TOOL_MEMORY_CANCEL,
+            "Memory capture cancel",
+            "Cancel the current memory capture and clean up partial output.",
+            json!({}),
+            &[],
+        ),
+        tool(
             TOOL_RECORD_START,
             "Record start",
             "Start video recording.",
@@ -1976,6 +2050,8 @@ fn is_read_only_tool(name: &str) -> bool {
             | TOOL_COOKIES_GET
             | TOOL_TAB_LIST
             | TOOL_DIALOG_STATUS
+            | TOOL_MEMORY_METRICS
+            | TOOL_MEMORY_STATUS
             | TOOL_CLIPBOARD_READ
             | TOOL_AUTH_LIST
             | TOOL_AUTH_SHOW
@@ -2179,6 +2255,13 @@ fn call_tool(params: Option<&Value>, config: &McpConfig) -> Result<Value, Protoc
         TOOL_TRACE_STOP => call_optional_one(arguments, &["trace", "stop"], "path"),
         TOOL_PROFILER_START => call_profiler_start(arguments),
         TOOL_PROFILER_STOP => call_optional_one(arguments, &["profiler", "stop"], "path"),
+        TOOL_MEMORY_METRICS => call_literal(arguments, &["memory", "metrics"]),
+        TOOL_MEMORY_STATUS => call_literal(arguments, &["memory", "status"]),
+        TOOL_MEMORY_SAMPLING_START => call_memory_sampling_start(arguments),
+        TOOL_MEMORY_SAMPLING_STOP => call_memory_sampling_stop(arguments),
+        TOOL_MEMORY_SNAPSHOT => call_memory_snapshot(arguments),
+        TOOL_MEMORY_COLLECT_GARBAGE => call_literal(arguments, &["memory", "collect-garbage"]),
+        TOOL_MEMORY_CANCEL => call_literal(arguments, &["memory", "cancel"]),
         TOOL_RECORD_START => call_record_start(arguments, "start"),
         TOOL_RECORD_STOP => call_literal(arguments, &["record", "stop"]),
         TOOL_RECORD_RESTART => call_record_start(arguments, "restart"),
@@ -2903,6 +2986,58 @@ fn call_profiler_start(arguments: &Value) -> Result<Value, ProtocolError> {
     if let Some(categories) = optional_string(arguments, "categories")? {
         args.push("--categories".to_string());
         args.push(categories);
+    }
+    call_cli_tool(arguments, args, None)
+}
+
+fn call_memory_sampling_start(arguments: &Value) -> Result<Value, ProtocolError> {
+    let mut args = vec![
+        "memory".to_string(),
+        "sampling".to_string(),
+        "start".to_string(),
+    ];
+    if let Some(interval) = optional_u64(arguments, "samplingInterval")? {
+        args.push("--sampling-interval".to_string());
+        args.push(interval.to_string());
+    }
+    call_cli_tool(arguments, args, None)
+}
+
+fn call_memory_sampling_stop(arguments: &Value) -> Result<Value, ProtocolError> {
+    let mut args = vec![
+        "memory".to_string(),
+        "sampling".to_string(),
+        "stop".to_string(),
+    ];
+    if let Some(path) = optional_string(arguments, "path")? {
+        args.push(path);
+    }
+    if let Some(top) = optional_u64(arguments, "top")? {
+        args.push("--top".to_string());
+        args.push(top.to_string());
+    }
+    if let Some(max_size) = optional_u64(arguments, "maxSize")? {
+        args.push("--max-size".to_string());
+        args.push(max_size.to_string());
+    }
+    call_cli_tool(arguments, args, None)
+}
+
+fn call_memory_snapshot(arguments: &Value) -> Result<Value, ProtocolError> {
+    let mut args = vec!["memory".to_string(), "snapshot".to_string()];
+    if let Some(path) = optional_string(arguments, "path")? {
+        args.push(path);
+    }
+    if optional_bool(arguments, "collectGarbage")? == Some(false) {
+        args.push("--no-gc".to_string());
+    }
+    if let Some(timeout) = optional_u64(arguments, "timeoutMs")? {
+        args.push("--timeout".to_string());
+        args.push(timeout.to_string());
+    }
+    if let Some(max_size) = optional_u64(arguments, "maxSize")? {
+        args.push("--max-size".to_string());
+        args.push(max_size.to_string());
     }
     call_cli_tool(arguments, args, None)
 }
@@ -3818,6 +3953,13 @@ mod tests {
         assert!(names.contains(&TOOL_GET_CDP_URL));
         assert!(names.contains(&TOOL_NETWORK_HAR_START));
         assert!(names.contains(&TOOL_REACT_SUSPENSE));
+        assert!(names.contains(&TOOL_MEMORY_METRICS));
+        assert!(names.contains(&TOOL_MEMORY_STATUS));
+        assert!(names.contains(&TOOL_MEMORY_SAMPLING_START));
+        assert!(names.contains(&TOOL_MEMORY_SAMPLING_STOP));
+        assert!(names.contains(&TOOL_MEMORY_SNAPSHOT));
+        assert!(names.contains(&TOOL_MEMORY_COLLECT_GARBAGE));
+        assert!(names.contains(&TOOL_MEMORY_CANCEL));
         assert!(names.contains(&TOOL_SKILLS_GET));
         assert!(names.contains(&TOOL_PLUGIN_ADD));
         assert!(names.contains(&TOOL_PLUGIN_LIST));
@@ -3986,6 +4128,18 @@ mod tests {
         assert!(config.allows(TOOL_READ));
         assert!(config.allows(TOOL_NETWORK_HAR_START));
         assert!(config.allows(TOOL_REACT_TREE));
+    }
+
+    #[test]
+    fn debug_profile_contains_memory_tools() {
+        let config = McpConfig::from_profiles(vec![ToolProfile::Debug]);
+        assert!(config.allows(TOOL_MEMORY_METRICS));
+        assert!(config.allows(TOOL_MEMORY_STATUS));
+        assert!(config.allows(TOOL_MEMORY_SAMPLING_START));
+        assert!(config.allows(TOOL_MEMORY_SAMPLING_STOP));
+        assert!(config.allows(TOOL_MEMORY_SNAPSHOT));
+        assert!(config.allows(TOOL_MEMORY_COLLECT_GARBAGE));
+        assert!(config.allows(TOOL_MEMORY_CANCEL));
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -24,10 +24,12 @@ use super::cdp::types::{
     TargetInfoChangedEvent,
 };
 use super::cookies;
+use super::coverage::{self, CoverageState};
 use super::diff;
 use super::element::RefMap;
 use super::inspect_server::InspectServer;
 use super::interaction;
+use super::memory::{self, MemoryState};
 use super::network::{self, DomainFilter, EventTracker};
 use super::policy::{ActionPolicy, ConfirmActions, PolicyResult};
 use super::providers;
@@ -362,6 +364,12 @@ pub struct DaemonState {
     pub last_autosave_attempt: Option<std::time::Instant>,
     pub session_id: String,
     pub tracing_state: TracingState,
+    /// Shared lifecycle state for allocation sampling and heap snapshots.
+    /// It is independent from the active tab so a capture remains bound to
+    /// the page where it started.
+    pub memory_state: MemoryState,
+    /// Shared lifecycle state for JavaScript precise coverage checkpoints.
+    pub coverage_state: CoverageState,
     pub recording_state: RecordingState,
     event_rx: Option<broadcast::Receiver<CdpEvent>>,
     pub screencasting: bool,
@@ -485,6 +493,8 @@ impl DaemonState {
             last_autosave_attempt: None,
             session_id: env::var("AGENT_BROWSER_SESSION").unwrap_or_else(|_| "default".to_string()),
             tracing_state: TracingState::new(),
+            memory_state: MemoryState::new(),
+            coverage_state: CoverageState::new(),
             recording_state: RecordingState::new(),
             event_rx: None,
             screencasting: false,
@@ -927,6 +937,8 @@ impl DaemonState {
 
         // Remove destroyed targets
         for target_id in &drained.destroyed_targets {
+            self.memory_state.cancel_target(target_id);
+            self.coverage_state.cancel_target(target_id);
             if let Some(ref mut mgr) = self.browser {
                 mgr.remove_page_by_target_id(target_id);
             }
@@ -1731,6 +1743,8 @@ impl DaemonState {
 
 impl Drop for DaemonState {
     fn drop(&mut self) {
+        self.memory_state.cancel_all();
+        self.coverage_state.cancel_all();
         // The background fetch handler sits in rx.recv().await indefinitely.
         // Without aborting it, the tokio runtime won't shut down (tests hang).
         if let Some(task) = self.fetch_handler_task.take() {
@@ -1960,6 +1974,39 @@ async fn close_active_provider_session(state: &mut DaemonState) {
 }
 
 pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(), String> {
+    if let (Some(capture), Some(mgr)) =
+        (state.memory_state.active_capture(), state.browser.as_ref())
+    {
+        if capture.kind == memory::CaptureKind::Sampling && mgr.has_target(&capture.target_id) {
+            let _ = mgr
+                .client
+                .send_command_no_params("HeapProfiler.stopSampling", Some(&capture.cdp_session_id))
+                .await;
+            let _ = mgr
+                .client
+                .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+                .await;
+        }
+    }
+    state.memory_state.cancel_all();
+    if let (Some(capture), Some(mgr)) = (
+        state.coverage_state.active_capture(),
+        state.browser.as_ref(),
+    ) {
+        let _ = mgr
+            .client
+            .send_command_no_params(
+                "Profiler.stopPreciseCoverage",
+                Some(&capture.cdp_session_id),
+            )
+            .await;
+        let _ = mgr
+            .client
+            .send_command_no_params("Profiler.disable", Some(&capture.cdp_session_id))
+            .await;
+    }
+    state.coverage_state.cancel_all();
+
     let close_error = if let Some(mut mgr) = state.browser.take() {
         mgr.close().await.err()
     } else {
@@ -2063,6 +2110,9 @@ fn skip_launch_action(action: &str) -> bool {
             | "stream_disable"
             | "stream_status"
             | "session_info"
+            | "memory_status"
+            | "memory_sampling_stop"
+            | "memory_cancel"
     )
 }
 
@@ -2418,6 +2468,18 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "trace_stop" => handle_trace_stop(cmd, state).await,
         "profiler_start" => handle_profiler_start(cmd, state).await,
         "profiler_stop" => handle_profiler_stop(cmd, state).await,
+        "memory_metrics" => handle_memory_metrics(state).await,
+        "memory_status" => Ok(state.memory_state.status()),
+        "memory_sampling_start" => handle_memory_sampling_start(cmd, state).await,
+        "memory_sampling_stop" => handle_memory_sampling_stop(cmd, state).await,
+        "memory_snapshot" => handle_memory_snapshot(cmd, state).await,
+        "memory_collect_garbage" => handle_memory_collect_garbage(state).await,
+        "memory_cancel" => handle_memory_cancel(state).await,
+        "coverage_status" => Ok(state.coverage_state.status()),
+        "coverage_start" => handle_coverage_start(cmd, state).await,
+        "coverage_take" => handle_coverage_take(cmd, state).await,
+        "coverage_stop" => handle_coverage_stop(cmd, state).await,
+        "coverage_cancel" => handle_coverage_cancel(state).await,
         "recording_start" => handle_recording_start(cmd, state).await,
         "recording_stop" => handle_recording_stop(state).await,
         "recording_restart" => handle_recording_restart(cmd, state).await,
@@ -2545,8 +2607,29 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     }
 
     let mut resp = match result {
-        Ok(data) => success_response(&id, data),
-        Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
+        Ok(data) => success_response(
+            &id,
+            if action.starts_with("memory_") {
+                memory::with_api_version(data)
+            } else if action.starts_with("coverage_") {
+                coverage::with_api_version(data)
+            } else {
+                data
+            },
+        ),
+        Err(e) => {
+            let mut response = error_response(&id, &super::browser::to_ai_friendly_error(&e));
+            if action.starts_with("memory_") {
+                if let Some(object) = response.as_object_mut() {
+                    object.insert("errorCode".to_string(), json!(memory::error_code(&e)));
+                }
+            } else if action.starts_with("coverage_") {
+                if let Some(object) = response.as_object_mut() {
+                    object.insert("errorCode".to_string(), json!(coverage::error_code(&e)));
+                }
+            }
+            response
+        }
     };
     inject_lifecycle(
         &mut resp,
@@ -6356,6 +6439,178 @@ async fn handle_profiler_stop(cmd: &Value, state: &mut DaemonState) -> Result<Va
     let session_id = mgr.active_session_id()?.to_string();
     let path = cmd.get("path").and_then(|v| v.as_str());
     native_tracing::profiler_stop(&mgr.client, &session_id, &mut state.tracing_state, path).await
+}
+
+fn ensure_memory_supported(state: &DaemonState) -> Result<(), String> {
+    if !matches!(state.backend_type, BackendType::Cdp) || state.engine != "chrome" {
+        return Err(format!(
+            "Memory diagnostics are only supported with the Chrome engine; current engine is {}",
+            state.engine
+        ));
+    }
+    Ok(())
+}
+
+async fn handle_memory_metrics(state: &DaemonState) -> Result<Value, String> {
+    ensure_memory_supported(state)?;
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    memory::metrics(mgr, &state.session_id).await
+}
+
+async fn handle_memory_collect_garbage(state: &DaemonState) -> Result<Value, String> {
+    ensure_memory_supported(state)?;
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    memory::collect_garbage(mgr, &state.session_id).await
+}
+
+async fn handle_memory_sampling_start(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    ensure_memory_supported(state)?;
+    if state.coverage_state.active_capture().is_some() {
+        return Err("Stop code coverage before starting memory allocation sampling".to_string());
+    }
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    memory::sampling_start(
+        mgr,
+        &state.memory_state,
+        &state.session_id,
+        cmd.get("samplingInterval").and_then(Value::as_u64),
+    )
+    .await
+}
+
+async fn handle_memory_sampling_stop(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    ensure_memory_supported(state)?;
+    let mgr = state.browser.as_ref().ok_or_else(|| {
+        state.memory_state.cancel_all();
+        "The target bound to the memory capture has left or closed".to_string()
+    })?;
+    memory::sampling_stop(
+        mgr,
+        &state.memory_state,
+        cmd.get("path").and_then(Value::as_str),
+        cmd.get("top")
+            .and_then(Value::as_u64)
+            .map(|value| value as usize),
+        cmd.get("maxSize").and_then(Value::as_u64),
+    )
+    .await
+}
+
+async fn handle_memory_snapshot(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    ensure_memory_supported(state)?;
+    if state.coverage_state.active_capture().is_some() {
+        return Err("Stop code coverage before taking a memory snapshot".to_string());
+    }
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    memory::snapshot(
+        mgr,
+        &state.memory_state,
+        &state.session_id,
+        cmd.get("path").and_then(Value::as_str),
+        cmd.get("collectGarbage")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        cmd.get("timeout").and_then(Value::as_u64),
+        cmd.get("maxSize").and_then(Value::as_u64),
+    )
+    .await
+}
+
+async fn handle_memory_cancel(state: &DaemonState) -> Result<Value, String> {
+    let capture = state
+        .memory_state
+        .active_capture()
+        .ok_or_else(|| "No memory capture is active".to_string())?;
+    if capture.kind == memory::CaptureKind::Snapshot {
+        return memory::snapshot_cancel_response(&state.memory_state);
+    }
+    if let Some(mgr) = state.browser.as_ref() {
+        memory::cancel_sampling(mgr, &state.memory_state).await
+    } else {
+        state.memory_state.request_cancel()?;
+        state.memory_state.finish(&capture.capture_id);
+        Ok(json!({
+            "cancelled": true,
+            "captureId": capture.capture_id,
+            "captureType": capture.kind.as_str(),
+        }))
+    }
+}
+
+fn ensure_coverage_supported(state: &DaemonState) -> Result<(), String> {
+    if !matches!(state.backend_type, BackendType::Cdp) || state.engine != "chrome" {
+        return Err(format!(
+            "Code coverage is only supported with the Chrome engine; current engine is {}",
+            state.engine
+        ));
+    }
+    Ok(())
+}
+
+async fn handle_coverage_start(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    ensure_coverage_supported(state)?;
+    if state.memory_state.active_capture().is_some() {
+        return Err("Stop the active memory capture before starting code coverage".to_string());
+    }
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    coverage::start(
+        mgr,
+        &state.coverage_state,
+        &state.session_id,
+        cmd.get("callCount")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    )
+    .await
+}
+
+async fn handle_coverage_take(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    ensure_coverage_supported(state)?;
+    let mgr = state.browser.as_ref().ok_or_else(|| {
+        state.coverage_state.cancel_all();
+        "The target bound to the code coverage capture has left or closed".to_string()
+    })?;
+    coverage::take(
+        mgr,
+        &state.coverage_state,
+        cmd.get("path").and_then(Value::as_str),
+        cmd.get("label").and_then(Value::as_str),
+        cmd.get("maxSize").and_then(Value::as_u64),
+    )
+    .await
+}
+
+async fn handle_coverage_stop(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    ensure_coverage_supported(state)?;
+    let mgr = state.browser.as_ref().ok_or_else(|| {
+        state.coverage_state.cancel_all();
+        "The target bound to the code coverage capture has left or closed".to_string()
+    })?;
+    coverage::stop(
+        mgr,
+        &state.coverage_state,
+        cmd.get("path").and_then(Value::as_str),
+        cmd.get("label").and_then(Value::as_str),
+        cmd.get("maxSize").and_then(Value::as_u64),
+    )
+    .await
+}
+
+async fn handle_coverage_cancel(state: &DaemonState) -> Result<Value, String> {
+    let capture = state
+        .coverage_state
+        .active_capture()
+        .ok_or_else(|| "No code coverage capture is active".to_string())?;
+    if let Some(mgr) = state.browser.as_ref() {
+        coverage::cancel(mgr, &state.coverage_state).await
+    } else {
+        state.coverage_state.finish(&capture.capture_id);
+        Ok(json!({
+            "cancelled": true,
+            "captureId": capture.capture_id,
+            "targetId": capture.target_id,
+        }))
+    }
 }
 
 async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -14507,5 +14762,27 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
             let auto_handled = auto_dialog && matches!(*dialog_type, "beforeunload" | "alert");
             assert!(!auto_handled, "{dialog_type} should NOT be auto-handled");
         }
+    }
+
+    #[tokio::test]
+    async fn memory_status_exposes_api_version_without_launching_browser() {
+        let mut state = DaemonState::new();
+        let response = execute_command(
+            &json!({ "id": "memory-status", "action": "memory_status" }),
+            &mut state,
+        )
+        .await;
+        assert_eq!(response["success"], true);
+        assert_eq!(response["data"]["active"], false);
+        assert_eq!(response["data"]["memoryApiVersion"], memory::API_VERSION);
+        assert!(state.browser.is_none());
+    }
+
+    #[test]
+    fn memory_rejects_unsupported_engine_with_stable_code() {
+        let mut state = DaemonState::new();
+        state.engine = "lightpanda".to_string();
+        let error = ensure_memory_supported(&state).unwrap_err();
+        assert_eq!(memory::error_code(&error), memory::ERROR_UNSUPPORTED_ENGINE);
     }
 }

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -234,6 +234,25 @@ impl CdpClient {
         params: Option<Value>,
         session_id: Option<&str>,
     ) -> Result<Value, String> {
+        self.send_command_with_timeout(
+            method,
+            params,
+            session_id,
+            std::time::Duration::from_secs(30),
+        )
+        .await
+    }
+
+    /// Send a CDP command with an operation-specific response timeout.
+    /// Most commands use the 30-second default; long-running streaming
+    /// commands such as heap snapshots provide their own bounded timeout.
+    pub async fn send_command_with_timeout(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        session_id: Option<&str>,
+        timeout: std::time::Duration,
+    ) -> Result<Value, String> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
 
         let cmd = CdpCommand {
@@ -268,7 +287,7 @@ impl CdpClient {
                 .map_err(|e| format!("Failed to send CDP command: {}", e))?;
         }
 
-        let response = match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
+        let response = match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(resp)) => {
                 guard.done = true;
                 resp

--- a/cli/src/native/coverage.rs
+++ b/cli/src/native/coverage.rs
@@ -1,0 +1,433 @@
+use serde_json::{json, Value};
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use super::browser::BrowserManager;
+
+pub const API_VERSION: u64 = 1;
+const DEFAULT_MAX_SIZE_BYTES: u64 = 512 * 1024 * 1024;
+
+pub fn error_code(message: &str) -> &'static str {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("not supported") || lower.contains("only supported") {
+        "coverage_unsupported_engine"
+    } else if lower.contains("already active") {
+        "coverage_capture_active"
+    } else if lower.contains("no code coverage") {
+        "coverage_no_capture"
+    } else if lower.contains("target") && (lower.contains("closed") || lower.contains("left")) {
+        "coverage_target_gone"
+    } else if lower.contains("size limit") {
+        "coverage_size_limit"
+    } else {
+        "coverage_command_failed"
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ActiveCoverage {
+    pub capture_id: String,
+    pub browser_session: String,
+    pub target_id: String,
+    pub cdp_session_id: String,
+    pub url: String,
+    pub started_at: String,
+    pub call_count: bool,
+    pub checkpoint_count: u64,
+}
+
+impl ActiveCoverage {
+    fn status(&self) -> Value {
+        json!({
+            "active": true,
+            "captureId": self.capture_id,
+            "browserSession": self.browser_session,
+            "targetId": self.target_id,
+            "url": self.url,
+            "startedAt": self.started_at,
+            "callCount": self.call_count,
+            "checkpointCount": self.checkpoint_count,
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct CoverageState {
+    active: Arc<Mutex<Option<ActiveCoverage>>>,
+}
+
+impl CoverageState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn begin(&self, capture: ActiveCoverage) -> Result<(), String> {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(existing) = active.as_ref() {
+            return Err(format!(
+                "A code coverage capture is already active for target {} (captureId: {})",
+                existing.target_id, existing.capture_id
+            ));
+        }
+        *active = Some(capture);
+        Ok(())
+    }
+
+    pub fn active_capture(&self) -> Option<ActiveCoverage> {
+        self.active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+
+    pub fn status(&self) -> Value {
+        self.active_capture()
+            .map(|capture| capture.status())
+            .unwrap_or_else(|| json!({ "active": false }))
+    }
+
+    fn next_checkpoint(&self, capture_id: &str) -> Result<ActiveCoverage, String> {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let capture = active
+            .as_mut()
+            .filter(|capture| capture.capture_id == capture_id)
+            .ok_or_else(|| "No code coverage capture is active".to_string())?;
+        capture.checkpoint_count += 1;
+        Ok(capture.clone())
+    }
+
+    pub fn finish(&self, capture_id: &str) {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if active
+            .as_ref()
+            .is_some_and(|capture| capture.capture_id == capture_id)
+        {
+            *active = None;
+        }
+    }
+
+    pub fn cancel_target(&self, target_id: &str) {
+        if self
+            .active_capture()
+            .is_some_and(|capture| capture.target_id == target_id)
+        {
+            let mut active = self
+                .active
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            *active = None;
+        }
+    }
+
+    pub fn cancel_all(&self) {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *active = None;
+    }
+}
+
+pub fn with_api_version(mut data: Value) -> Value {
+    if let Some(object) = data.as_object_mut() {
+        object.insert("coverageApiVersion".to_string(), json!(API_VERSION));
+    }
+    data
+}
+
+pub async fn start(
+    mgr: &BrowserManager,
+    state: &CoverageState,
+    browser_session: &str,
+    call_count: bool,
+) -> Result<Value, String> {
+    let (target_id, cdp_session_id, url) = active_page(mgr)?;
+    let capture = ActiveCoverage {
+        capture_id: format!("cov_{}", uuid::Uuid::new_v4().simple()),
+        browser_session: browser_session.to_string(),
+        target_id,
+        cdp_session_id,
+        url,
+        started_at: now_rfc3339(),
+        call_count,
+        checkpoint_count: 0,
+    };
+    state.begin(capture.clone())?;
+
+    let result = async {
+        mgr.client
+            .send_command_no_params("Profiler.enable", Some(&capture.cdp_session_id))
+            .await?;
+        mgr.client
+            .send_command(
+                "Profiler.startPreciseCoverage",
+                Some(json!({
+                    "callCount": call_count,
+                    "detailed": true,
+                    "allowTriggeredUpdates": false,
+                })),
+                Some(&capture.cdp_session_id),
+            )
+            .await
+    }
+    .await;
+
+    if let Err(error) = result {
+        state.finish(&capture.capture_id);
+        let _ = mgr
+            .client
+            .send_command_no_params("Profiler.disable", Some(&capture.cdp_session_id))
+            .await;
+        return Err(error);
+    }
+
+    Ok(capture.status())
+}
+
+pub async fn take(
+    mgr: &BrowserManager,
+    state: &CoverageState,
+    path: Option<&str>,
+    label: Option<&str>,
+    max_size_bytes: Option<u64>,
+) -> Result<Value, String> {
+    let capture = state
+        .active_capture()
+        .ok_or_else(|| "No code coverage capture is active".to_string())?;
+    if !mgr.has_target(&capture.target_id) {
+        state.finish(&capture.capture_id);
+        return Err(format!(
+            "The target bound to code coverage capture {} has left or closed",
+            capture.capture_id
+        ));
+    }
+
+    let result = mgr
+        .client
+        .send_command_no_params(
+            "Profiler.takePreciseCoverage",
+            Some(&capture.cdp_session_id),
+        )
+        .await?;
+    let checkpoint = state.next_checkpoint(&capture.capture_id)?;
+    let scripts = result.get("result").cloned().unwrap_or_else(|| json!([]));
+    let script_count = scripts.as_array().map(|items| items.len()).unwrap_or(0);
+    let function_count = scripts
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|script| script.get("functions").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    let range_count = scripts
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|script| script.get("functions").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|function| function.get("ranges").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    let captured_at = now_rfc3339();
+    let artifact = json!({
+        "schemaVersion": 1,
+        "captureId": checkpoint.capture_id,
+        "checkpoint": checkpoint.checkpoint_count,
+        "label": label,
+        "browserSession": checkpoint.browser_session,
+        "targetId": checkpoint.target_id,
+        "url": checkpoint.url,
+        "startedAt": checkpoint.started_at,
+        "capturedAt": captured_at,
+        "timestamp": result.get("timestamp"),
+        "scripts": scripts,
+    });
+    let output_path = prepare_output_path(path, &checkpoint, label)?;
+    write_artifact(&output_path, &artifact, max_size_bytes)?;
+    let file_size = fs::metadata(&output_path)
+        .map_err(|error| format!("Failed to inspect code coverage artifact: {}", error))?
+        .len();
+
+    Ok(json!({
+        "captureId": checkpoint.capture_id,
+        "checkpoint": checkpoint.checkpoint_count,
+        "label": label,
+        "browserSession": checkpoint.browser_session,
+        "targetId": checkpoint.target_id,
+        "url": checkpoint.url,
+        "capturedAt": captured_at,
+        "path": output_path.to_string_lossy(),
+        "fileSize": file_size,
+        "scriptCount": script_count,
+        "functionCount": function_count,
+        "rangeCount": range_count,
+    }))
+}
+
+pub async fn stop(
+    mgr: &BrowserManager,
+    state: &CoverageState,
+    path: Option<&str>,
+    label: Option<&str>,
+    max_size_bytes: Option<u64>,
+) -> Result<Value, String> {
+    let capture = state
+        .active_capture()
+        .ok_or_else(|| "No code coverage capture is active".to_string())?;
+    let result = take(mgr, state, path, label, max_size_bytes).await;
+    let _ = mgr
+        .client
+        .send_command_no_params(
+            "Profiler.stopPreciseCoverage",
+            Some(&capture.cdp_session_id),
+        )
+        .await;
+    let _ = mgr
+        .client
+        .send_command_no_params("Profiler.disable", Some(&capture.cdp_session_id))
+        .await;
+    state.finish(&capture.capture_id);
+    result
+}
+
+pub async fn cancel(mgr: &BrowserManager, state: &CoverageState) -> Result<Value, String> {
+    let capture = state
+        .active_capture()
+        .ok_or_else(|| "No code coverage capture is active".to_string())?;
+    let _ = mgr
+        .client
+        .send_command_no_params(
+            "Profiler.stopPreciseCoverage",
+            Some(&capture.cdp_session_id),
+        )
+        .await;
+    let _ = mgr
+        .client
+        .send_command_no_params("Profiler.disable", Some(&capture.cdp_session_id))
+        .await;
+    state.finish(&capture.capture_id);
+    Ok(json!({
+        "cancelled": true,
+        "captureId": capture.capture_id,
+        "targetId": capture.target_id,
+    }))
+}
+
+fn active_page(mgr: &BrowserManager) -> Result<(String, String, String), String> {
+    let target_id = mgr.active_target_id()?.to_string();
+    let cdp_session_id = mgr.active_session_id()?.to_string();
+    let url = mgr
+        .pages_list()
+        .into_iter()
+        .find(|page| page.target_id == target_id)
+        .map(|page| page.url)
+        .unwrap_or_default();
+    Ok((target_id, cdp_session_id, url))
+}
+
+fn prepare_output_path(
+    path: Option<&str>,
+    capture: &ActiveCoverage,
+    label: Option<&str>,
+) -> Result<PathBuf, String> {
+    let suffix = label.map(sanitize_label).filter(|value| !value.is_empty());
+    let default_name = suffix
+        .map(|value| {
+            format!(
+                "{}-{}-{}.coverage.json",
+                capture.capture_id, capture.checkpoint_count, value
+            )
+        })
+        .unwrap_or_else(|| {
+            format!(
+                "{}-{}.coverage.json",
+                capture.capture_id, capture.checkpoint_count
+            )
+        });
+    let output = path.map(PathBuf::from).unwrap_or_else(|| {
+        std::env::temp_dir()
+            .join("agent-browser-coverage")
+            .join(&capture.browser_session)
+            .join(default_name)
+    });
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Failed to create code coverage artifact directory {}: {}",
+                parent.display(),
+                error
+            )
+        })?;
+    }
+    Ok(output)
+}
+
+fn write_artifact(
+    path: &Path,
+    artifact: &Value,
+    max_size_bytes: Option<u64>,
+) -> Result<(), String> {
+    let partial = path.with_extension("coverage.json.partial");
+    let file = File::create(&partial)
+        .map_err(|error| format!("Failed to create {}: {}", partial.display(), error))?;
+    let mut writer = BufWriter::new(file);
+    if let Err(error) = serde_json::to_writer(&mut writer, artifact) {
+        drop(writer);
+        let _ = fs::remove_file(&partial);
+        return Err(format!("Failed to write code coverage artifact: {}", error));
+    }
+    writer
+        .flush()
+        .map_err(|error| format!("Failed to finish code coverage artifact: {}", error))?;
+    drop(writer);
+    let file_size = fs::metadata(&partial)
+        .map_err(|error| format!("Failed to inspect code coverage artifact: {}", error))?
+        .len();
+    let max_size = max_size_bytes.unwrap_or(DEFAULT_MAX_SIZE_BYTES);
+    if file_size > max_size {
+        let _ = fs::remove_file(&partial);
+        return Err(format!(
+            "Code coverage artifact exceeded the size limit of {} bytes",
+            max_size
+        ));
+    }
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)
+            .map_err(|error| format!("Failed to replace {}: {}", path.display(), error))?;
+    }
+    fs::rename(&partial, path)
+        .map_err(|error| format!("Failed to finalize {}: {}", path.display(), error))
+}
+
+fn sanitize_label(label: &str) -> String {
+    label
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .take(64)
+        .collect()
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "unknown".to_string())
+}

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -16,6 +16,7 @@ use super::actions::{
     maybe_autosave_restore_state, DaemonState,
 };
 use super::cdp::client::CdpClient;
+use super::memory::{self, CaptureKind, MemoryState};
 use super::state;
 use super::stream::{IdleActivity, StreamServer};
 use crate::connection::INTERNAL_DAEMON_SHUTDOWN_ACTION;
@@ -239,12 +240,11 @@ async fn run_socket_server(
     } else {
         None
     };
+    let daemon_state =
+        DaemonState::new_with_stream(stream_client, stream_server, idle_activity.clone());
+    let memory_state = daemon_state.memory_state.clone();
     let state: std::sync::Arc<tokio::sync::Mutex<DaemonState>> =
-        std::sync::Arc::new(tokio::sync::Mutex::new(DaemonState::new_with_stream(
-            stream_client,
-            stream_server,
-            idle_activity.clone(),
-        )));
+        std::sync::Arc::new(tokio::sync::Mutex::new(daemon_state));
 
     // Notifier used by handle_connection to signal the daemon loop to exit
     // after a "close" command, instead of calling process::exit() which skips
@@ -266,8 +266,17 @@ async fn run_socket_server(
                         let idle_activity = idle_activity.clone();
                         let sf = stream_file.clone();
                         let cn = close_notify.clone();
+                        let memory_state = memory_state.clone();
                         tokio::spawn(async move {
-                            handle_connection(stream, state, idle_activity, sf, cn).await;
+                            handle_connection(
+                                stream,
+                                state,
+                                memory_state,
+                                idle_activity,
+                                sf,
+                                cn,
+                            )
+                            .await;
                         });
                     }
                     Err(e) => {
@@ -302,6 +311,7 @@ async fn run_socket_server(
                     None => std::future::pending::<()>().await,
                 }
             }, if idle_timeout_ms.is_some() => {
+                let _ = memory_state.request_cancel();
                 let mut s = state.lock().await;
                 // The timer may have expired while a command held the state
                 // lock. Command completion refreshes the shared activity
@@ -345,6 +355,7 @@ async fn run_socket_server(
                 break;
             }
             _ = shutdown_signal() => {
+                let _ = memory_state.request_cancel();
                 let mut s = state.lock().await;
                 let _ = auto_save_restore_state(&mut s).await;
                 let _ = close_all_browser_backends(&mut s).await;
@@ -393,12 +404,11 @@ async fn run_socket_server(
     } else {
         None
     };
+    let daemon_state =
+        DaemonState::new_with_stream(stream_client, stream_server, idle_activity.clone());
+    let memory_state = daemon_state.memory_state.clone();
     let state: std::sync::Arc<tokio::sync::Mutex<DaemonState>> =
-        std::sync::Arc::new(tokio::sync::Mutex::new(DaemonState::new_with_stream(
-            stream_client,
-            stream_server,
-            idle_activity.clone(),
-        )));
+        std::sync::Arc::new(tokio::sync::Mutex::new(daemon_state));
 
     let close_notify = Arc::new(Notify::new());
 
@@ -420,8 +430,17 @@ async fn run_socket_server(
                         let idle_activity = idle_activity.clone();
                         let sf = stream_file.clone();
                         let cn = close_notify.clone();
+                        let memory_state = memory_state.clone();
                         tokio::spawn(async move {
-                            handle_connection(stream, state, idle_activity, sf, cn).await;
+                            handle_connection(
+                                stream,
+                                state,
+                                memory_state,
+                                idle_activity,
+                                sf,
+                                cn,
+                            )
+                            .await;
                         });
                     }
                     Err(e) => {
@@ -449,6 +468,7 @@ async fn run_socket_server(
                     None => std::future::pending::<()>().await,
                 }
             }, if idle_timeout_ms.is_some() => {
+                let _ = memory_state.request_cancel();
                 let mut s = state.lock().await;
                 if let Some(remaining) =
                     remaining_idle_timeout(&idle_activity, idle_timeout_ms.unwrap_or_default())
@@ -488,6 +508,7 @@ async fn run_socket_server(
                 break;
             }
             _ = shutdown_signal() => {
+                let _ = memory_state.request_cancel();
                 let mut s = state.lock().await;
                 let _ = auto_save_restore_state(&mut s).await;
                 let _ = close_all_browser_backends(&mut s).await;
@@ -503,6 +524,7 @@ async fn run_socket_server(
 async fn handle_connection<S>(
     stream: S,
     state: std::sync::Arc<tokio::sync::Mutex<DaemonState>>,
+    memory_state: MemoryState,
     idle_activity: Arc<IdleActivity>,
     stream_file_cleanup: Option<PathBuf>,
     close_notify: Arc<Notify>,
@@ -549,7 +571,31 @@ async fn handle_connection<S>(
                     .unwrap_or_default()
                     .to_string();
 
-                let response = {
+                let response = if action == "memory_status" {
+                    serde_json::json!({
+                        "id": cmd.get("id").and_then(Value::as_str).unwrap_or(""),
+                        "success": true,
+                        "data": memory::with_api_version(memory_state.status()),
+                    })
+                } else if action == "memory_cancel"
+                    && memory_state
+                        .active_capture()
+                        .is_some_and(|capture| capture.kind == CaptureKind::Snapshot)
+                {
+                    match memory::snapshot_cancel_response(&memory_state) {
+                        Ok(data) => serde_json::json!({
+                            "id": cmd.get("id").and_then(Value::as_str).unwrap_or(""),
+                            "success": true,
+                            "data": memory::with_api_version(data),
+                        }),
+                        Err(error) => serde_json::json!({
+                            "id": cmd.get("id").and_then(Value::as_str).unwrap_or(""),
+                            "success": false,
+                            "errorCode": memory::error_code(&error),
+                            "error": error,
+                        }),
+                    }
+                } else {
                     let mut s = state.lock().await;
                     let response = execute_command(&cmd, &mut s).await;
                     // Refresh while the state lock is still held. An idle
@@ -676,6 +722,58 @@ fn get_port_for_session(session: &str) -> u16 {
 mod tests {
     #[allow(unused_imports)]
     use super::*;
+
+    #[tokio::test]
+    async fn memory_status_and_snapshot_cancel_do_not_wait_for_daemon_state_lock() {
+        let daemon_state = DaemonState::new();
+        let memory_state = daemon_state.memory_state.clone();
+        memory_state.begin_test_capture(CaptureKind::Snapshot);
+        let state = Arc::new(tokio::sync::Mutex::new(daemon_state));
+        let state_guard = state.lock().await;
+        let (client, server) = tokio::io::duplex(16 * 1024);
+        let notify = Arc::new(Notify::new());
+        let connection = tokio::spawn(handle_connection(
+            server,
+            state.clone(),
+            memory_state.clone(),
+            Arc::new(IdleActivity::new()),
+            None,
+            notify,
+        ));
+        let (reader, mut writer) = tokio::io::split(client);
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"id\":\"status\",\"action\":\"memory_status\"}\n")
+            .await
+            .unwrap();
+        let mut line = String::new();
+        tokio::time::timeout(Duration::from_millis(250), reader.read_line(&mut line))
+            .await
+            .expect("memory status should bypass the daemon state lock")
+            .unwrap();
+        let response: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(response["success"], true);
+        assert_eq!(response["data"]["captureType"], "snapshot");
+
+        writer
+            .write_all(b"{\"id\":\"cancel\",\"action\":\"memory_cancel\"}\n")
+            .await
+            .unwrap();
+        line.clear();
+        tokio::time::timeout(Duration::from_millis(250), reader.read_line(&mut line))
+            .await
+            .expect("snapshot cancellation should bypass the daemon state lock")
+            .unwrap();
+        let response: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(response["success"], true);
+        assert_eq!(response["data"]["cancelled"], true);
+        assert_eq!(memory_state.status()["cancelRequested"], true);
+
+        drop(state_guard);
+        connection.abort();
+        let _ = connection.await;
+    }
 
     #[test]
     fn test_resolve_idle_timeout_unset_applies_default() {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -38,8 +38,188 @@ fn native_test_fixture_html(name: &str) -> &'static str {
         "html5_drag_probe" => include_str!("test_fixtures/html5_drag_probe.html"),
         "pointer_capture_probe" => include_str!("test_fixtures/pointer_capture_probe.html"),
         "upload_probe" => include_str!("test_fixtures/upload_probe.html"),
+        "memory_probe" => include_str!("test_fixtures/memory_probe.html"),
         _ => panic!("Unknown native test fixture: {}", name),
     }
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_memory_metrics_sampling_snapshot_and_tab_binding() {
+    let output_dir = tempfile::tempdir().expect("memory artifact directory");
+    let profile_path = output_dir.path().join("allocations.heapprofile");
+    let snapshot_path = output_dir.path().join("page.heapsnapshot");
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "memory-1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "memory-2",
+            "action": "navigate",
+            "url": native_test_fixture_url("memory_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let baseline = execute_command(
+        &json!({ "id": "memory-3", "action": "memory_metrics" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&baseline);
+    assert!(
+        get_data(&baseline)["jsHeapUsedSize"]
+            .as_f64()
+            .unwrap_or(0.0)
+            > 0.0
+    );
+    let original_target = get_data(&baseline)["targetId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let start = execute_command(
+        &json!({
+            "id": "memory-4",
+            "action": "memory_sampling_start",
+            "samplingInterval": 1024
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&start);
+    assert_eq!(get_data(&start)["targetId"], original_target);
+
+    let leak = execute_command(
+        &json!({
+            "id": "memory-5",
+            "action": "evaluate",
+            "script": "for (let i = 0; i < 8; i++) memoryProbeLeak(); 'done'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&leak);
+
+    let new_tab = execute_command(
+        &json!({ "id": "memory-6", "action": "tab_new", "url": "about:blank" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&new_tab);
+
+    let stop = execute_command(
+        &json!({
+            "id": "memory-7",
+            "action": "memory_sampling_stop",
+            "path": profile_path.to_string_lossy(),
+            "top": 50
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&stop);
+    assert_eq!(get_data(&stop)["targetId"], original_target);
+    assert!(profile_path.exists());
+    let profile: Value = serde_json::from_slice(&std::fs::read(&profile_path).unwrap()).unwrap();
+    assert!(profile.get("head").is_some());
+    assert!(
+        get_data(&stop)["topFunctions"]
+            .as_array()
+            .is_some_and(|functions| functions.iter().any(|entry| {
+                entry["functionName"] == "memoryProbeLeak"
+                    || entry["functionName"] == "buildProbeNodes"
+                    || entry["url"]
+                        .as_str()
+                        .is_some_and(|url| url.contains("memory-probe.js"))
+            })),
+        "expected probe allocation frame in {}",
+        serde_json::to_string_pretty(get_data(&stop)).unwrap()
+    );
+
+    let switch = execute_command(
+        &json!({ "id": "memory-8", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&switch);
+
+    let collect = execute_command(
+        &json!({ "id": "memory-9", "action": "memory_collect_garbage" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&collect);
+    let after_leak = execute_command(
+        &json!({ "id": "memory-10", "action": "memory_metrics" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&after_leak);
+    assert!(
+        get_data(&after_leak)["nodes"].as_u64().unwrap_or(0)
+            > get_data(&baseline)["nodes"].as_u64().unwrap_or(0)
+    );
+
+    let temporary = execute_command(
+        &json!({
+            "id": "memory-11",
+            "action": "evaluate",
+            "script": "for (let i = 0; i < 8; i++) memoryProbeTemporary(); 'done'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&temporary);
+    let collect = execute_command(
+        &json!({ "id": "memory-12", "action": "memory_collect_garbage" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&collect);
+    let after_temporary = execute_command(
+        &json!({ "id": "memory-13", "action": "memory_metrics" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&after_temporary);
+    let leak_nodes = get_data(&after_leak)["nodes"].as_u64().unwrap_or(0);
+    let temporary_nodes = get_data(&after_temporary)["nodes"].as_u64().unwrap_or(0);
+    assert!(temporary_nodes <= leak_nodes + 20);
+
+    let snapshot = execute_command(
+        &json!({
+            "id": "memory-14",
+            "action": "memory_snapshot",
+            "path": snapshot_path.to_string_lossy(),
+            "timeout": 120000
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&snapshot);
+    assert_eq!(get_data(&snapshot)["valid"], true);
+    let snapshot_json: Value =
+        serde_json::from_slice(&std::fs::read(&snapshot_path).unwrap()).unwrap();
+    assert!(snapshot_json.get("snapshot").is_some());
+    assert!(snapshot_json.get("nodes").is_some());
+    assert!(snapshot_json.get("edges").is_some());
+    assert!(snapshot_json.get("strings").is_some());
+
+    let _ = execute_command(&json!({ "id": "memory-99", "action": "close" }), &mut state).await;
 }
 
 fn native_test_fixture_url(name: &str) -> String {
@@ -207,6 +387,112 @@ async fn spawn_fake_daemon_socket(
     });
 
     rx
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_coverage_checkpoints_and_tab_binding() {
+    let output_dir = tempfile::tempdir().expect("coverage artifact directory");
+    let first_path = output_dir.path().join("first.coverage.json");
+    let final_path = output_dir.path().join("final.coverage.json");
+    let mut state = DaemonState::new();
+
+    let launch = execute_command(
+        &json!({
+            "id": "coverage-1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&launch);
+
+    let navigate = execute_command(
+        &json!({
+            "id": "coverage-2",
+            "action": "navigate",
+            "url": native_test_fixture_url("memory_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&navigate);
+
+    let start = execute_command(
+        &json!({ "id": "coverage-3", "action": "coverage_start" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&start);
+    let original_target = get_data(&start)["targetId"].as_str().unwrap().to_string();
+
+    let evaluate = execute_command(
+        &json!({
+            "id": "coverage-4",
+            "action": "evaluate",
+            "script": "memoryProbeLeak(); 'covered'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&evaluate);
+
+    let take = execute_command(
+        &json!({
+            "id": "coverage-5",
+            "action": "coverage_take",
+            "path": first_path.to_string_lossy(),
+            "label": "first"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&take);
+    assert_eq!(get_data(&take)["checkpoint"], 1);
+    assert!(first_path.exists());
+    let artifact: Value = serde_json::from_slice(&std::fs::read(&first_path).unwrap()).unwrap();
+    assert!(artifact["scripts"].as_array().is_some_and(|scripts| {
+        scripts.iter().any(|script| {
+            script["url"]
+                .as_str()
+                .is_some_and(|url| url.contains("memory-probe.js"))
+                && script["functions"].as_array().is_some_and(|functions| {
+                    functions.iter().any(|function| {
+                        function["ranges"].as_array().is_some_and(|ranges| {
+                            ranges
+                                .iter()
+                                .any(|range| range["count"].as_u64().unwrap_or(0) > 0)
+                        })
+                    })
+                })
+        })
+    }));
+
+    let new_tab = execute_command(
+        &json!({ "id": "coverage-6", "action": "tab_new", "url": "about:blank" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&new_tab);
+
+    let stop = execute_command(
+        &json!({
+            "id": "coverage-7",
+            "action": "coverage_stop",
+            "path": final_path.to_string_lossy(),
+            "label": "final"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&stop);
+    assert_eq!(get_data(&stop)["targetId"], original_target);
+    assert_eq!(get_data(&stop)["checkpoint"], 2);
+    assert!(final_path.exists());
+
+    close_current_browser(&mut state).await.unwrap();
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/native/memory.rs
+++ b/cli/src/native/memory.rs
@@ -1,0 +1,999 @@
+use serde_json::{json, Value};
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use super::browser::BrowserManager;
+use super::cdp::client::CdpClient;
+
+pub const ERROR_UNSUPPORTED_ENGINE: &str = "memory_unsupported_engine";
+pub const ERROR_CAPTURE_ACTIVE: &str = "memory_capture_active";
+pub const ERROR_NO_CAPTURE: &str = "memory_no_capture";
+pub const ERROR_TARGET_GONE: &str = "memory_target_gone";
+pub const ERROR_CANCELLED: &str = "memory_capture_cancelled";
+pub const ERROR_TIMEOUT: &str = "memory_capture_timeout";
+pub const ERROR_SIZE_LIMIT: &str = "memory_size_limit";
+pub const ERROR_INVALID_ARTIFACT: &str = "memory_invalid_artifact";
+pub const API_VERSION: u64 = 1;
+
+const DEFAULT_SAMPLING_INTERVAL: u64 = 32_768;
+const DEFAULT_TOP_FUNCTIONS: usize = 20;
+const DEFAULT_SNAPSHOT_TIMEOUT_MS: u64 = 120_000;
+const DEFAULT_MAX_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+const DEFAULT_ARTIFACT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaptureKind {
+    Sampling,
+    Snapshot,
+}
+
+impl CaptureKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sampling => "sampling",
+            Self::Snapshot => "snapshot",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ActiveCapture {
+    pub capture_id: String,
+    pub kind: CaptureKind,
+    pub browser_session: String,
+    pub target_id: String,
+    pub cdp_session_id: String,
+    pub url: String,
+    pub started_at: String,
+    pub output_path: Option<PathBuf>,
+    pub sampling_interval: Option<u64>,
+    cancel_requested: Arc<AtomicBool>,
+}
+
+impl ActiveCapture {
+    fn status(&self) -> Value {
+        json!({
+            "active": true,
+            "captureId": self.capture_id,
+            "captureType": self.kind.as_str(),
+            "browserSession": self.browser_session,
+            "targetId": self.target_id,
+            "url": self.url,
+            "startedAt": self.started_at,
+            "outputPath": self.output_path.as_ref().map(|p| p.to_string_lossy().to_string()),
+            "samplingInterval": self.sampling_interval,
+            "cancelRequested": self.cancel_requested.load(Ordering::SeqCst),
+        })
+    }
+
+    fn request_cancel(&self) {
+        self.cancel_requested.store(true, Ordering::SeqCst);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel_requested.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct MemoryState {
+    active: Arc<Mutex<Option<ActiveCapture>>>,
+}
+
+impl MemoryState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn begin(&self, capture: ActiveCapture) -> Result<(), String> {
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(existing) = active.as_ref() {
+            return Err(format!(
+                "A {} memory capture is already active for target {} (captureId: {})",
+                existing.kind.as_str(),
+                existing.target_id,
+                existing.capture_id
+            ));
+        }
+        *active = Some(capture);
+        Ok(())
+    }
+
+    pub fn active_capture(&self) -> Option<ActiveCapture> {
+        self.active
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    pub fn status(&self) -> Value {
+        self.active_capture()
+            .map(|capture| capture.status())
+            .unwrap_or_else(|| json!({ "active": false }))
+    }
+
+    pub fn request_cancel(&self) -> Result<ActiveCapture, String> {
+        let capture = self
+            .active_capture()
+            .ok_or_else(|| "No memory capture is active".to_string())?;
+        capture.request_cancel();
+        Ok(capture)
+    }
+
+    pub fn finish(&self, capture_id: &str) {
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        if active
+            .as_ref()
+            .is_some_and(|capture| capture.capture_id == capture_id)
+        {
+            *active = None;
+        }
+    }
+
+    pub fn cancel_target(&self, target_id: &str) {
+        if let Some(capture) = self.active_capture() {
+            if capture.target_id == target_id {
+                capture.request_cancel();
+                if capture.kind == CaptureKind::Sampling {
+                    self.finish(&capture.capture_id);
+                }
+            }
+        }
+    }
+
+    pub fn cancel_all(&self) {
+        if let Some(capture) = self.active_capture() {
+            capture.request_cancel();
+            if let Some(path) = capture.output_path.as_ref() {
+                let _ = fs::remove_file(path);
+            }
+            self.finish(&capture.capture_id);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn begin_test_capture(&self, kind: CaptureKind) {
+        self.begin(ActiveCapture {
+            capture_id: "test-capture".to_string(),
+            kind,
+            browser_session: "test-session".to_string(),
+            target_id: "test-target".to_string(),
+            cdp_session_id: "test-cdp-session".to_string(),
+            url: "https://example.test".to_string(),
+            started_at: "now".to_string(),
+            output_path: None,
+            sampling_interval: None,
+            cancel_requested: Arc::new(AtomicBool::new(false)),
+        })
+        .unwrap();
+    }
+}
+
+pub fn error_code(message: &str) -> &'static str {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("not supported") || lower.contains("only supported") {
+        ERROR_UNSUPPORTED_ENGINE
+    } else if lower.contains("already active") {
+        ERROR_CAPTURE_ACTIVE
+    } else if lower.contains("no memory capture") || lower.contains("no allocation sampling") {
+        ERROR_NO_CAPTURE
+    } else if lower.contains("target") && (lower.contains("closed") || lower.contains("left")) {
+        ERROR_TARGET_GONE
+    } else if lower.contains("cancel") {
+        ERROR_CANCELLED
+    } else if lower.contains("timed out") {
+        ERROR_TIMEOUT
+    } else if lower.contains("size limit") {
+        ERROR_SIZE_LIMIT
+    } else if lower.contains("invalid heap snapshot") || lower.contains("incomplete heap snapshot")
+    {
+        ERROR_INVALID_ARTIFACT
+    } else {
+        "memory_command_failed"
+    }
+}
+
+pub fn with_api_version(mut data: Value) -> Value {
+    if let Some(object) = data.as_object_mut() {
+        object.insert("memoryApiVersion".to_string(), json!(API_VERSION));
+    }
+    data
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn capture_id() -> String {
+    format!("mem_{}", uuid::Uuid::new_v4().simple())
+}
+
+fn default_artifact_path(session: &str, capture_id: &str, extension: &str) -> PathBuf {
+    let directory = std::env::temp_dir()
+        .join("agent-browser-memory")
+        .join(session);
+    cleanup_expired_artifacts(&directory, DEFAULT_ARTIFACT_RETENTION);
+    directory.join(format!("{}.{}", capture_id, extension))
+}
+
+fn cleanup_expired_artifacts(directory: &Path, retention: Duration) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let expired = entry
+            .metadata()
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age >= retention);
+        if expired {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn prepare_output_path(path: Option<&str>, default: PathBuf) -> Result<PathBuf, String> {
+    let output = path.map(PathBuf::from).unwrap_or(default);
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "Failed to create memory artifact directory {}: {}",
+                parent.display(),
+                e
+            )
+        })?;
+    }
+    Ok(output)
+}
+
+fn partial_artifact_path(output: &Path, capture_id: &str) -> PathBuf {
+    let file_name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("memory-artifact");
+    output.with_file_name(format!(".{}.{}.partial", file_name, capture_id))
+}
+
+fn finalize_artifact(partial: &Path, output: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    if output.exists() {
+        fs::remove_file(output).map_err(|e| {
+            format!(
+                "Failed to replace existing memory artifact {}: {}",
+                output.display(),
+                e
+            )
+        })?;
+    }
+    fs::rename(partial, output).map_err(|e| {
+        format!(
+            "Failed to finalize memory artifact {}: {}",
+            output.display(),
+            e
+        )
+    })
+}
+
+fn active_page(mgr: &BrowserManager) -> Result<(String, String, String), String> {
+    let target_id = mgr.active_target_id()?.to_string();
+    let cdp_session_id = mgr.active_session_id()?.to_string();
+    let url = mgr
+        .pages_list()
+        .into_iter()
+        .find(|page| page.target_id == target_id)
+        .map(|page| page.url)
+        .unwrap_or_default();
+    Ok((target_id, cdp_session_id, url))
+}
+
+pub async fn metrics(mgr: &BrowserManager, browser_session: &str) -> Result<Value, String> {
+    let (target_id, session_id, url) = active_page(mgr)?;
+    let _ = mgr
+        .client
+        .send_command_no_params("Performance.enable", Some(&session_id))
+        .await;
+    let performance = mgr
+        .client
+        .send_command_no_params("Performance.getMetrics", Some(&session_id))
+        .await?;
+    let dom = mgr
+        .client
+        .send_command_no_params("Memory.getDOMCounters", Some(&session_id))
+        .await?;
+
+    let metric = |name: &str| {
+        performance
+            .get("metrics")
+            .and_then(Value::as_array)
+            .and_then(|metrics| {
+                metrics.iter().find_map(|entry| {
+                    (entry.get("name").and_then(Value::as_str) == Some(name))
+                        .then(|| entry.get("value").and_then(Value::as_f64))
+                        .flatten()
+                })
+            })
+    };
+
+    Ok(json!({
+        "browserSession": browser_session,
+        "targetId": target_id,
+        "url": url,
+        "timestamp": now_rfc3339(),
+        "jsHeapUsedSize": metric("JSHeapUsedSize"),
+        "jsHeapTotalSize": metric("JSHeapTotalSize"),
+        "documents": dom.get("documents").and_then(Value::as_u64),
+        "nodes": dom.get("nodes").and_then(Value::as_u64),
+        "jsEventListeners": dom.get("jsEventListeners").and_then(Value::as_u64),
+    }))
+}
+
+pub async fn collect_garbage(mgr: &BrowserManager, browser_session: &str) -> Result<Value, String> {
+    let (target_id, session_id, url) = active_page(mgr)?;
+    mgr.client
+        .send_command_no_params("HeapProfiler.collectGarbage", Some(&session_id))
+        .await?;
+    Ok(json!({
+        "collected": true,
+        "browserSession": browser_session,
+        "targetId": target_id,
+        "url": url,
+        "timestamp": now_rfc3339(),
+    }))
+}
+
+pub async fn sampling_start(
+    mgr: &BrowserManager,
+    state: &MemoryState,
+    browser_session: &str,
+    sampling_interval: Option<u64>,
+) -> Result<Value, String> {
+    let (target_id, cdp_session_id, url) = active_page(mgr)?;
+    let interval = sampling_interval.unwrap_or(DEFAULT_SAMPLING_INTERVAL);
+    if interval == 0 {
+        return Err("Sampling interval must be greater than zero".to_string());
+    }
+
+    let capture = ActiveCapture {
+        capture_id: capture_id(),
+        kind: CaptureKind::Sampling,
+        browser_session: browser_session.to_string(),
+        target_id,
+        cdp_session_id,
+        url,
+        started_at: now_rfc3339(),
+        output_path: None,
+        sampling_interval: Some(interval),
+        cancel_requested: Arc::new(AtomicBool::new(false)),
+    };
+    state.begin(capture.clone())?;
+
+    let start_result = async {
+        mgr.client
+            .send_command_no_params("HeapProfiler.enable", Some(&capture.cdp_session_id))
+            .await?;
+        mgr.client
+            .send_command(
+                "HeapProfiler.startSampling",
+                Some(json!({ "samplingInterval": interval })),
+                Some(&capture.cdp_session_id),
+            )
+            .await
+    }
+    .await;
+
+    if let Err(error) = start_result {
+        state.finish(&capture.capture_id);
+        let _ = mgr
+            .client
+            .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+            .await;
+        return Err(error);
+    }
+
+    Ok(capture.status())
+}
+
+#[derive(Debug)]
+struct FunctionSummary {
+    function_name: String,
+    url: String,
+    line_number: i64,
+    column_number: i64,
+    self_size: u64,
+}
+
+fn collect_function_summaries(node: &Value, output: &mut Vec<FunctionSummary>) {
+    let self_size = node.get("selfSize").and_then(Value::as_u64).unwrap_or(0);
+    if self_size > 0 {
+        let frame = node.get("callFrame").unwrap_or(&Value::Null);
+        output.push(FunctionSummary {
+            function_name: frame
+                .get("functionName")
+                .and_then(Value::as_str)
+                .unwrap_or("(anonymous)")
+                .to_string(),
+            url: frame
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            line_number: frame.get("lineNumber").and_then(Value::as_i64).unwrap_or(0),
+            column_number: frame
+                .get("columnNumber")
+                .and_then(Value::as_i64)
+                .unwrap_or(0),
+            self_size,
+        });
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_function_summaries(child, output);
+        }
+    }
+}
+
+pub async fn sampling_stop(
+    mgr: &BrowserManager,
+    state: &MemoryState,
+    path: Option<&str>,
+    top: Option<usize>,
+    max_size_bytes: Option<u64>,
+) -> Result<Value, String> {
+    let capture = state
+        .active_capture()
+        .filter(|capture| capture.kind == CaptureKind::Sampling)
+        .ok_or_else(|| "No allocation sampling capture is active".to_string())?;
+    if !mgr.has_target(&capture.target_id) {
+        state.finish(&capture.capture_id);
+        return Err(format!(
+            "The target bound to capture {} has left or closed",
+            capture.capture_id
+        ));
+    }
+    if capture.is_cancelled() {
+        state.finish(&capture.capture_id);
+        return Err(format!(
+            "Memory capture {} was cancelled",
+            capture.capture_id
+        ));
+    }
+
+    let stop_result = mgr
+        .client
+        .send_command_no_params("HeapProfiler.stopSampling", Some(&capture.cdp_session_id))
+        .await;
+    let _ = mgr
+        .client
+        .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+        .await;
+    state.finish(&capture.capture_id);
+    let result = stop_result?;
+    let profile = result.get("profile").cloned().unwrap_or(result);
+
+    let output_path = prepare_output_path(
+        path,
+        default_artifact_path(&capture.browser_session, &capture.capture_id, "heapprofile"),
+    )?;
+    let partial_path = partial_artifact_path(&output_path, &capture.capture_id);
+    let file = File::create(&partial_path)
+        .map_err(|e| format!("Failed to create {}: {}", partial_path.display(), e))?;
+    let mut writer = BufWriter::new(file);
+    if let Err(error) = serde_json::to_writer(&mut writer, &profile) {
+        drop(writer);
+        let _ = fs::remove_file(&partial_path);
+        return Err(format!("Failed to write allocation profile: {}", error));
+    }
+    if let Err(error) = writer.flush() {
+        drop(writer);
+        let _ = fs::remove_file(&partial_path);
+        return Err(format!("Failed to finish allocation profile: {}", error));
+    }
+    drop(writer);
+    let file_size = fs::metadata(&partial_path)
+        .map_err(|e| format!("Failed to inspect allocation profile: {}", e))?
+        .len();
+    let max_size = max_size_bytes.unwrap_or(DEFAULT_MAX_SIZE_BYTES);
+    if file_size > max_size {
+        let _ = fs::remove_file(&partial_path);
+        return Err(format!(
+            "Allocation profile exceeded the size limit of {} bytes",
+            max_size
+        ));
+    }
+
+    let mut summaries = Vec::new();
+    if let Some(head) = profile.get("head") {
+        collect_function_summaries(head, &mut summaries);
+    }
+    summaries.sort_by(|a, b| b.self_size.cmp(&a.self_size));
+    let allocation_bytes: u64 = summaries.iter().map(|entry| entry.self_size).sum();
+    let top_functions: Vec<Value> = summaries
+        .into_iter()
+        .take(top.unwrap_or(DEFAULT_TOP_FUNCTIONS))
+        .map(|entry| {
+            json!({
+                "functionName": entry.function_name,
+                "url": entry.url,
+                "lineNumber": entry.line_number,
+                "columnNumber": entry.column_number,
+                "selfSize": entry.self_size,
+            })
+        })
+        .collect();
+    if let Err(error) = finalize_artifact(&partial_path, &output_path) {
+        let _ = fs::remove_file(&partial_path);
+        return Err(error);
+    }
+
+    Ok(json!({
+        "captureId": capture.capture_id,
+        "captureType": "sampling",
+        "browserSession": capture.browser_session,
+        "targetId": capture.target_id,
+        "url": capture.url,
+        "startedAt": capture.started_at,
+        "finishedAt": now_rfc3339(),
+        "samplingInterval": capture.sampling_interval,
+        "path": output_path.to_string_lossy(),
+        "fileSize": file_size,
+        "allocationBytes": allocation_bytes,
+        "topFunctions": top_functions,
+    }))
+}
+
+#[derive(Default)]
+struct SnapshotValidation {
+    snapshot: bool,
+    nodes: bool,
+    edges: bool,
+    strings: bool,
+    starts_with_object: bool,
+    ends_with_object: bool,
+    saw_content: bool,
+    tail: String,
+}
+
+impl SnapshotValidation {
+    fn observe(&mut self, chunk: &str) {
+        if !self.saw_content {
+            if let Some(first) = chunk.chars().find(|character| !character.is_whitespace()) {
+                self.starts_with_object = first == '{';
+                self.saw_content = true;
+            }
+        }
+        if let Some(last) = chunk
+            .chars()
+            .rev()
+            .find(|character| !character.is_whitespace())
+        {
+            self.ends_with_object = last == '}';
+        }
+        let joined = format!("{}{}", self.tail, chunk);
+        self.snapshot |= joined.contains("\"snapshot\"");
+        self.nodes |= joined.contains("\"nodes\"");
+        self.edges |= joined.contains("\"edges\"");
+        self.strings |= joined.contains("\"strings\"");
+        self.tail = joined
+            .chars()
+            .rev()
+            .take(32)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+    }
+
+    fn is_valid(&self) -> bool {
+        self.starts_with_object
+            && self.ends_with_object
+            && self.snapshot
+            && self.nodes
+            && self.edges
+            && self.strings
+    }
+}
+
+fn write_snapshot_chunk<W: Write>(
+    writer: &mut W,
+    validation: &mut SnapshotValidation,
+    bytes_written: &mut u64,
+    chunk_count: &mut u64,
+    chunk: &str,
+    max_size_bytes: u64,
+) -> Result<(), String> {
+    let new_size = bytes_written.saturating_add(chunk.len() as u64);
+    if new_size > max_size_bytes {
+        return Err(format!(
+            "Heap snapshot exceeded the size limit of {} bytes",
+            max_size_bytes
+        ));
+    }
+    writer
+        .write_all(chunk.as_bytes())
+        .map_err(|e| format!("Failed to write heap snapshot: {}", e))?;
+    validation.observe(chunk);
+    *bytes_written = new_size;
+    *chunk_count += 1;
+    Ok(())
+}
+
+pub async fn snapshot(
+    mgr: &BrowserManager,
+    state: &MemoryState,
+    browser_session: &str,
+    path: Option<&str>,
+    collect_garbage_first: bool,
+    timeout_ms: Option<u64>,
+    max_size_bytes: Option<u64>,
+) -> Result<Value, String> {
+    let (target_id, cdp_session_id, url) = active_page(mgr)?;
+    let id = capture_id();
+    let output_path = prepare_output_path(
+        path,
+        default_artifact_path(browser_session, &id, "heapsnapshot"),
+    )?;
+    let partial_path = partial_artifact_path(&output_path, &id);
+    let capture = ActiveCapture {
+        capture_id: id,
+        kind: CaptureKind::Snapshot,
+        browser_session: browser_session.to_string(),
+        target_id,
+        cdp_session_id,
+        url,
+        started_at: now_rfc3339(),
+        output_path: Some(output_path.clone()),
+        sampling_interval: None,
+        cancel_requested: Arc::new(AtomicBool::new(false)),
+    };
+    state.begin(capture.clone())?;
+
+    let result = snapshot_inner(
+        &mgr.client,
+        &capture,
+        &partial_path,
+        collect_garbage_first,
+        timeout_ms.unwrap_or(DEFAULT_SNAPSHOT_TIMEOUT_MS),
+        max_size_bytes.unwrap_or(DEFAULT_MAX_SIZE_BYTES),
+    )
+    .await;
+    let _ = mgr
+        .client
+        .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+        .await;
+    state.finish(&capture.capture_id);
+
+    match result {
+        Ok((file_size, chunk_count, duration)) => {
+            if let Err(error) = finalize_artifact(&partial_path, &output_path) {
+                let _ = fs::remove_file(&partial_path);
+                return Err(error);
+            }
+            Ok(json!({
+                "captureId": capture.capture_id,
+                "captureType": "snapshot",
+                "browserSession": capture.browser_session,
+                "targetId": capture.target_id,
+                "url": capture.url,
+                "startedAt": capture.started_at,
+                "finishedAt": now_rfc3339(),
+                "path": output_path.to_string_lossy(),
+                "fileSize": file_size,
+                "chunkCount": chunk_count,
+                "durationMs": duration.as_millis() as u64,
+                "garbageCollectedFirst": collect_garbage_first,
+                "valid": true,
+            }))
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&partial_path);
+            Err(error)
+        }
+    }
+}
+
+async fn snapshot_inner(
+    client: &CdpClient,
+    capture: &ActiveCapture,
+    output_path: &Path,
+    collect_garbage_first: bool,
+    timeout_ms: u64,
+    max_size_bytes: u64,
+) -> Result<(u64, u64, Duration), String> {
+    let event_matches_session = |event_session: Option<&str>| {
+        if capture.cdp_session_id.is_empty() {
+            event_session.is_none() || event_session == Some("")
+        } else {
+            event_session == Some(capture.cdp_session_id.as_str())
+        }
+    };
+    if collect_garbage_first {
+        client
+            .send_command_no_params("HeapProfiler.collectGarbage", Some(&capture.cdp_session_id))
+            .await?;
+    }
+    client
+        .send_command_no_params("HeapProfiler.enable", Some(&capture.cdp_session_id))
+        .await?;
+
+    let file = File::create(output_path)
+        .map_err(|e| format!("Failed to create {}: {}", output_path.display(), e))?;
+    let mut writer = BufWriter::new(file);
+    let mut events = client.subscribe();
+    let start = Instant::now();
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+    let command = client.send_command_with_timeout(
+        "HeapProfiler.takeHeapSnapshot",
+        Some(json!({ "reportProgress": true, "captureNumericValue": true })),
+        Some(&capture.cdp_session_id),
+        Duration::from_millis(timeout_ms),
+    );
+    tokio::pin!(command);
+
+    let mut command_done = false;
+    let mut bytes_written = 0_u64;
+    let mut chunk_count = 0_u64;
+    let mut validation = SnapshotValidation::default();
+
+    loop {
+        if capture.is_cancelled() {
+            let _ = client
+                .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+                .await;
+            return Err(format!(
+                "Memory capture {} was cancelled",
+                capture.capture_id
+            ));
+        }
+
+        tokio::select! {
+            command_result = &mut command, if !command_done => {
+                command_result?;
+                command_done = true;
+            }
+            event_result = events.recv() => {
+                match event_result {
+                    Ok(event) if event_matches_session(event.session_id.as_deref()) && event.method == "HeapProfiler.addHeapSnapshotChunk" => {
+                        let chunk = event.params.get("chunk").and_then(Value::as_str).ok_or_else(|| "Heap snapshot chunk was missing data".to_string())?;
+                        write_snapshot_chunk(&mut writer, &mut validation, &mut bytes_written, &mut chunk_count, chunk, max_size_bytes)?;
+                    }
+                    Ok(event) if event.method == "Target.targetDestroyed" && event.params.get("targetId").and_then(Value::as_str) == Some(capture.target_id.as_str()) => {
+                        return Err(format!("The target bound to capture {} has left or closed", capture.capture_id));
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        return Err("Heap snapshot event stream overflowed; snapshot is incomplete".to_string());
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        return Err("Heap snapshot event stream closed before completion".to_string());
+                    }
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                return Err(format!("Heap snapshot timed out after {}ms", timeout_ms));
+            }
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+
+        if command_done {
+            while let Ok(event) = events.try_recv() {
+                if event_matches_session(event.session_id.as_deref())
+                    && event.method == "HeapProfiler.addHeapSnapshotChunk"
+                {
+                    let chunk = event
+                        .params
+                        .get("chunk")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "Heap snapshot chunk was missing data".to_string())?;
+                    write_snapshot_chunk(
+                        &mut writer,
+                        &mut validation,
+                        &mut bytes_written,
+                        &mut chunk_count,
+                        chunk,
+                        max_size_bytes,
+                    )?;
+                }
+            }
+            break;
+        }
+    }
+
+    writer
+        .flush()
+        .map_err(|e| format!("Failed to finish heap snapshot: {}", e))?;
+    let _ = client
+        .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+        .await;
+
+    if bytes_written == 0 || chunk_count == 0 {
+        return Err("Heap snapshot is incomplete because no chunks were received".to_string());
+    }
+    if !validation.is_valid() {
+        return Err(
+            "Invalid heap snapshot: required snapshot, nodes, edges, or strings data is missing"
+                .to_string(),
+        );
+    }
+
+    Ok((bytes_written, chunk_count, start.elapsed()))
+}
+
+pub async fn cancel_sampling(mgr: &BrowserManager, state: &MemoryState) -> Result<Value, String> {
+    let capture = state.request_cancel()?;
+    if capture.kind == CaptureKind::Snapshot {
+        return Ok(json!({
+            "cancelled": true,
+            "captureId": capture.capture_id,
+            "captureType": capture.kind.as_str(),
+        }));
+    }
+
+    if mgr.has_target(&capture.target_id) {
+        let _ = mgr
+            .client
+            .send_command_no_params("HeapProfiler.stopSampling", Some(&capture.cdp_session_id))
+            .await;
+        let _ = mgr
+            .client
+            .send_command_no_params("HeapProfiler.disable", Some(&capture.cdp_session_id))
+            .await;
+    }
+    if let Some(path) = capture.output_path.as_ref() {
+        let _ = fs::remove_file(path);
+    }
+    state.finish(&capture.capture_id);
+    Ok(json!({
+        "cancelled": true,
+        "captureId": capture.capture_id,
+        "captureType": capture.kind.as_str(),
+    }))
+}
+
+pub fn snapshot_cancel_response(state: &MemoryState) -> Result<Value, String> {
+    let capture = state.request_cancel()?;
+    Ok(json!({
+        "cancelled": true,
+        "captureId": capture.capture_id,
+        "captureType": capture.kind.as_str(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capture(kind: CaptureKind, id: &str) -> ActiveCapture {
+        ActiveCapture {
+            capture_id: id.to_string(),
+            kind,
+            browser_session: "test".to_string(),
+            target_id: "target-1".to_string(),
+            cdp_session_id: "session-1".to_string(),
+            url: "https://example.test".to_string(),
+            started_at: "now".to_string(),
+            output_path: None,
+            sampling_interval: Some(DEFAULT_SAMPLING_INTERVAL),
+            cancel_requested: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[test]
+    fn memory_state_enforces_one_active_capture() {
+        let state = MemoryState::new();
+        state
+            .begin(capture(CaptureKind::Sampling, "first"))
+            .unwrap();
+        let error = state
+            .begin(capture(CaptureKind::Snapshot, "second"))
+            .unwrap_err();
+        assert!(error.contains("already active"));
+        assert_eq!(state.status()["captureId"], "first");
+    }
+
+    #[test]
+    fn cancel_and_finish_are_stable_transitions() {
+        let state = MemoryState::new();
+        state
+            .begin(capture(CaptureKind::Snapshot, "snapshot"))
+            .unwrap();
+        let cancelled = state.request_cancel().unwrap();
+        assert!(cancelled.is_cancelled());
+        assert_eq!(state.status()["cancelRequested"], true);
+        state.finish("another");
+        assert_eq!(state.status()["active"], true);
+        state.finish("snapshot");
+        assert_eq!(state.status()["active"], false);
+    }
+
+    #[test]
+    fn snapshot_validation_accepts_split_keys() {
+        let mut validation = SnapshotValidation::default();
+        validation.observe("{\"snap");
+        validation.observe("shot\":{},\"nodes\":[],\"ed");
+        validation.observe("ges\":[],\"strings\":[]}");
+        assert!(validation.is_valid());
+    }
+
+    #[test]
+    fn memory_error_codes_are_stable() {
+        assert_eq!(
+            error_code("Memory is not supported"),
+            ERROR_UNSUPPORTED_ENGINE
+        );
+        assert_eq!(error_code("capture already active"), ERROR_CAPTURE_ACTIVE);
+        assert_eq!(error_code("No memory capture is active"), ERROR_NO_CAPTURE);
+        assert_eq!(error_code("target has left or closed"), ERROR_TARGET_GONE);
+        assert_eq!(error_code("snapshot timed out"), ERROR_TIMEOUT);
+    }
+
+    #[test]
+    fn snapshot_chunks_are_written_incrementally_and_limited() {
+        let mut output = Vec::new();
+        let mut validation = SnapshotValidation::default();
+        let mut bytes = 0;
+        let mut chunks = 0;
+        write_snapshot_chunk(
+            &mut output,
+            &mut validation,
+            &mut bytes,
+            &mut chunks,
+            "{\"snapshot\":{},\"nodes\":[]",
+            100,
+        )
+        .unwrap();
+        write_snapshot_chunk(
+            &mut output,
+            &mut validation,
+            &mut bytes,
+            &mut chunks,
+            ",\"edges\":[],\"strings\":[]}",
+            100,
+        )
+        .unwrap();
+        assert_eq!(chunks, 2);
+        assert_eq!(bytes as usize, output.len());
+        assert!(validation.is_valid());
+        let limit = bytes;
+        assert!(write_snapshot_chunk(
+            &mut output,
+            &mut validation,
+            &mut bytes,
+            &mut chunks,
+            "overflow",
+            limit,
+        )
+        .unwrap_err()
+        .contains("size limit"));
+    }
+
+    #[test]
+    fn target_and_daemon_cleanup_clear_capture_state() {
+        let state = MemoryState::new();
+        state
+            .begin(capture(CaptureKind::Sampling, "sampling"))
+            .unwrap();
+        state.cancel_target("another-target");
+        assert_eq!(state.status()["active"], true);
+        state.cancel_target("target-1");
+        assert_eq!(state.status()["active"], false);
+
+        state
+            .begin(capture(CaptureKind::Snapshot, "snapshot"))
+            .unwrap();
+        state.cancel_all();
+        assert_eq!(state.status()["active"], false);
+    }
+}

--- a/cli/src/native/mod.rs
+++ b/cli/src/native/mod.rs
@@ -11,6 +11,8 @@ pub mod cdp;
 #[allow(dead_code)]
 pub mod cookies;
 #[allow(dead_code)]
+pub mod coverage;
+#[allow(dead_code)]
 pub mod daemon;
 #[allow(dead_code)]
 pub mod diff;
@@ -20,6 +22,8 @@ pub mod element;
 pub mod inspect_server;
 #[allow(dead_code)]
 pub mod interaction;
+#[allow(dead_code)]
+pub mod memory;
 #[allow(dead_code)]
 pub mod network;
 #[allow(dead_code)]

--- a/cli/src/native/test_fixtures/memory_probe.html
+++ b/cli/src/native/test_fixtures/memory_probe.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Memory diagnostics probe</title>
+  </head>
+  <body>
+    <main id="root">Memory diagnostics probe</main>
+    <script>
+      window.__memoryProbeLeaks = [];
+
+      function buildProbeNodes() {
+        const nodes = [];
+        for (let index = 0; index < 250; index += 1) {
+          const node = document.createElement("div");
+          node.textContent = `probe-${index}-${"x".repeat(256)}`;
+          nodes.push(node);
+        }
+        return nodes;
+      }
+
+      function memoryProbeLeak() {
+        const nodes = buildProbeNodes();
+        window.__memoryProbeLeaks.push(nodes);
+        return nodes.length;
+      }
+
+      function memoryProbeTemporary() {
+        return buildProbeNodes().length;
+      }
+
+      //# sourceURL=memory-probe.js
+    </script>
+  </body>
+</html>

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -384,6 +384,122 @@ fn format_a11y_target(target: &serde_json::Value) -> Option<String> {
     }
 }
 
+fn format_memory_text(action: Option<&str>, data: &serde_json::Value) -> Option<String> {
+    let bytes = |key: &str| {
+        data.get(key)
+            .and_then(|value| value.as_f64())
+            .map(|value| format!("{:.2} MB", value / 1024.0 / 1024.0))
+            .unwrap_or_else(|| "unknown".to_string())
+    };
+    match action? {
+        "memory_metrics" => Some(format!(
+            "Memory metrics for {}\n  JS heap used: {}\n  JS heap total: {}\n  DOM nodes: {}\n  Documents: {}\n  Event listeners: {}",
+            data.get("url").and_then(|value| value.as_str()).unwrap_or("current page"),
+            bytes("jsHeapUsedSize"),
+            bytes("jsHeapTotalSize"),
+            data.get("nodes").and_then(|value| value.as_u64()).unwrap_or(0),
+            data.get("documents").and_then(|value| value.as_u64()).unwrap_or(0),
+            data.get("jsEventListeners").and_then(|value| value.as_u64()).unwrap_or(0),
+        )),
+        "memory_status" => {
+            if data.get("active").and_then(|value| value.as_bool()).unwrap_or(false) {
+                Some(format!(
+                    "Memory capture active\n  ID: {}\n  Type: {}\n  Page: {}\n  Started: {}",
+                    data.get("captureId").and_then(|value| value.as_str()).unwrap_or("unknown"),
+                    data.get("captureType").and_then(|value| value.as_str()).unwrap_or("unknown"),
+                    data.get("url").and_then(|value| value.as_str()).unwrap_or("unknown"),
+                    data.get("startedAt").and_then(|value| value.as_str()).unwrap_or("unknown"),
+                ))
+            } else {
+                Some("No memory capture is active".to_string())
+            }
+        }
+        "memory_sampling_start" => Some(format!(
+            "{} Allocation sampling started ({})",
+            color::success_indicator(),
+            data.get("captureId").and_then(|value| value.as_str()).unwrap_or("unknown")
+        )),
+        "memory_sampling_stop" => Some(format!(
+            "{} Allocation profile saved to {} ({} sampled bytes)",
+            color::success_indicator(),
+            data.get("path").and_then(|value| value.as_str()).unwrap_or("unknown"),
+            data.get("allocationBytes").and_then(|value| value.as_u64()).unwrap_or(0)
+        )),
+        "memory_snapshot" => Some(format!(
+            "{} Heap snapshot saved to {} ({} bytes)",
+            color::success_indicator(),
+            data.get("path").and_then(|value| value.as_str()).unwrap_or("unknown"),
+            data.get("fileSize").and_then(|value| value.as_u64()).unwrap_or(0)
+        )),
+        "memory_collect_garbage" => Some(format!(
+            "{} Garbage collection requested for {}",
+            color::success_indicator(),
+            data.get("url").and_then(|value| value.as_str()).unwrap_or("current page")
+        )),
+        "memory_cancel" => Some(format!(
+            "{} Memory capture cancelled ({})",
+            color::success_indicator(),
+            data.get("captureId").and_then(|value| value.as_str()).unwrap_or("unknown")
+        )),
+        _ => None,
+    }
+}
+
+fn format_coverage_text(action: Option<&str>, data: &serde_json::Value) -> Option<String> {
+    match action? {
+        "coverage_status" => {
+            if data
+                .get("active")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+            {
+                Some(format!(
+                    "Code coverage active\n  ID: {}\n  Page: {}\n  Checkpoints: {}",
+                    data.get("captureId")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("unknown"),
+                    data.get("url")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("unknown"),
+                    data.get("checkpointCount")
+                        .and_then(|value| value.as_u64())
+                        .unwrap_or(0),
+                ))
+            } else {
+                Some("No code coverage capture is active".to_string())
+            }
+        }
+        "coverage_start" => Some(format!(
+            "{} Code coverage started ({})",
+            color::success_indicator(),
+            data.get("captureId")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown")
+        )),
+        "coverage_take" | "coverage_stop" => Some(format!(
+            "{} Code coverage checkpoint {} saved to {} ({} scripts)",
+            color::success_indicator(),
+            data.get("checkpoint")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(0),
+            data.get("path")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown"),
+            data.get("scriptCount")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(0),
+        )),
+        "coverage_cancel" => Some(format!(
+            "{} Code coverage cancelled ({})",
+            color::success_indicator(),
+            data.get("captureId")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown")
+        )),
+        _ => None,
+    }
+}
+
 pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &OutputOptions) {
     if opts.json {
         if opts.content_boundaries {
@@ -464,6 +580,14 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         }
         if action == Some("a11y") {
             println!("{}", format_a11y_text(data));
+            return;
+        }
+        if let Some(output) = format_memory_text(action, data) {
+            println!("{}", output);
+            return;
+        }
+        if let Some(output) = format_coverage_text(action, data) {
+            println!("{}", output);
             return;
         }
         if action == Some("storage_get") {
@@ -2660,6 +2784,93 @@ The output file can be viewed in:
 "##
         }
 
+        // === Memory diagnostics ===
+        "memory" => {
+            r##"
+agent-browser memory - Capture page memory evidence
+
+Usage: agent-browser memory <operation> [options]
+
+Read lightweight metrics, record allocation call stacks, or stream a Chrome
+heap snapshot directly to a local file. Memory commands use the current
+agent-browser session and do not require a separate CDP address.
+
+Operations:
+  metrics                         Read JS heap and DOM counters
+  status                          Show the active memory capture
+  sampling start                  Start allocation sampling
+  sampling stop [path]            Stop sampling and save the profile
+  snapshot [path]                 Save a heap snapshot
+  collect-garbage                 Request garbage collection
+  cancel                          Cancel the active capture
+
+Sampling options:
+  --sampling-interval <bytes>     Average allocated bytes between samples
+  --top <count>                   Number of top allocation sites to return
+  --max-size <bytes>              Maximum artifact size
+
+Snapshot options:
+  --no-gc                         Skip garbage collection before capture
+  --timeout <ms>                  Capture timeout, default 120000
+  --max-size <bytes>              Maximum artifact size
+
+Global Options:
+  --json                          Output as JSON
+  --session <name>                Use a specific session
+
+Examples:
+  agent-browser memory metrics
+  agent-browser memory sampling start --sampling-interval 65536
+  agent-browser memory sampling stop ./allocations.heapprofile --top 10
+  agent-browser memory snapshot ./page.heapsnapshot
+  agent-browser memory status --json
+
+Memory diagnostics are supported on Chrome and Chromium. Other engines return
+an explicit unsupported-engine error. Heap snapshots can contain page text,
+application data, and credentials. Keep artifacts local and out of source control.
+"##
+        }
+
+        // === JavaScript code coverage ===
+        "coverage" => {
+            r##"
+agent-browser coverage - Record JavaScript code execution
+
+Usage: agent-browser coverage <operation> [options]
+
+Record precise JavaScript execution ranges for the current page. A checkpoint
+resets the counters, so one capture can separate first-screen work from later
+route or interaction work.
+
+Operations:
+  status                          Show the active capture
+  start                           Start recording
+  take [path]                     Save a checkpoint and keep recording
+  stop [path]                     Save the final checkpoint and stop
+  cancel                          Stop without saving another checkpoint
+
+Options:
+  --call-count                    Preserve function call counts when starting
+  --label <name>                  Label a take or stop checkpoint
+  --max-size <bytes>              Maximum artifact size
+
+Global Options:
+  --json                          Output as JSON
+  --session <name>                Use a specific session
+
+Examples:
+  agent-browser coverage start
+  agent-browser goto https://example.com
+  agent-browser coverage take ./first-screen.coverage.json --label first-screen
+  agent-browser click "a[href='/orders']"
+  agent-browser coverage stop ./orders.coverage.json --label orders
+
+Code coverage is supported on Chrome and Chromium. It records generated script
+URLs and byte ranges; source maps can later associate those ranges with project
+files and dependency packages.
+"##
+        }
+
         // === Record (video) ===
         "record" => {
             r##"
@@ -3573,6 +3784,8 @@ Debug:
   trace start                Start Chrome DevTools trace
   trace stop [path]          Stop and save Chrome DevTools trace
   profiler start|stop [path] Record Chrome DevTools profile
+  memory <operation>         Capture page memory metrics and artifacts
+  coverage <operation>       Record JavaScript execution checkpoints
   record start <path> [url]  Start video recording (WebM)
   record stop                Stop and save video
   console [--clear]          View console logs

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -329,6 +329,20 @@ agent-browser inspect                 # Open Chrome DevTools for the active page
 
 See [Debugging](/debugging) for console, error, dialog, trace, highlight, and DevTools workflows. See [Video Recording](/recording) for `record` workflows and [Profiler](/profiler) for performance profiles.
 
+## Memory diagnostics
+
+```bash
+agent-browser memory metrics
+agent-browser memory status
+agent-browser memory sampling start [--sampling-interval <bytes>]
+agent-browser memory sampling stop [path] [--top <count>] [--max-size <bytes>]
+agent-browser memory snapshot [path] [--no-gc] [--timeout <ms>] [--max-size <bytes>]
+agent-browser memory collect-garbage
+agent-browser memory cancel
+```
+
+Memory commands reuse the current Chrome session, keep long-running sampling bound to its original page, and save raw artifacts locally instead of printing them. See [Memory Diagnostics](/memory) for the capture lifecycle, output fields, limits, and privacy guidance.
+
 ## Auth vault
 
 ```bash

--- a/docs/src/app/debugging/page.mdx
+++ b/docs/src/app/debugging/page.mdx
@@ -74,6 +74,7 @@ Use [Profiler](/profiler) when you want curated performance categories and event
   </thead>
   <tbody>
     <tr><td>Performance profile</td><td><a href="/profiler">Profiler</a></td></tr>
+    <tr><td>Heap growth and retained objects</td><td><a href="/memory">Memory Diagnostics</a></td></tr>
     <tr><td>Saved video artifact</td><td><a href="/recording">Video Recording</a></td></tr>
     <tr><td>Live browser stream</td><td><a href="/streaming">Streaming</a></td></tr>
     <tr><td>Install and environment diagnosis</td><td><a href="/installation#doctor">Doctor</a></td></tr>

--- a/docs/src/app/memory/layout.tsx
+++ b/docs/src/app/memory/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("memory");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/memory/page.mdx
+++ b/docs/src/app/memory/page.mdx
@@ -1,0 +1,91 @@
+# Memory Diagnostics
+
+Capture browser-level evidence for JavaScript heap growth, retained DOM nodes, and allocation call sites without configuring a separate CDP address. Memory diagnostics reuse the active agent-browser Chrome session and are available through both CLI and the MCP `debug` tool profile.
+
+## Quick workflow
+
+```bash
+agent-browser open https://example.com
+agent-browser memory metrics
+
+agent-browser memory sampling start --sampling-interval 65536
+# Repeat and verify the suspected user flow several times
+agent-browser memory sampling stop ./allocations.heapprofile --top 20
+
+agent-browser memory collect-garbage
+agent-browser memory snapshot ./after.heapsnapshot
+```
+
+Use `memory metrics` as a lightweight trend signal. Use allocation sampling to find where retained allocations were created. Use heap snapshots when an external analyzer needs object graphs and retaining paths. agent-browser captures generic browser evidence; source-map analysis and application-specific leak conclusions belong in the calling diagnostic system.
+
+## Commands
+
+<table>
+  <thead>
+    <tr><th>Command</th><th>Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>memory metrics</code></td><td>Read JavaScript heap and DOM counters for the active page.</td></tr>
+    <tr><td><code>memory status</code></td><td>Show the current capture ID, type, original page, start time, and cancellation state.</td></tr>
+    <tr><td><code>memory sampling start</code></td><td>Start allocation sampling on the active page.</td></tr>
+    <tr><td><code>memory sampling stop [path]</code></td><td>Stop sampling on its original page, save the full profile, and return the largest allocation sites.</td></tr>
+    <tr><td><code>memory snapshot [path]</code></td><td>Stream a heap snapshot directly to a local file and validate it before success.</td></tr>
+    <tr><td><code>memory collect-garbage</code></td><td>Request garbage collection at a diagnostic boundary.</td></tr>
+    <tr><td><code>memory cancel</code></td><td>Cancel the active capture and remove partial output.</td></tr>
+  </tbody>
+</table>
+
+## Capture lifecycle
+
+Only one allocation sampling or heap snapshot capture can be active in a browser session. Sampling records the target page at start and stops that same page even after a tab switch. If the original page closes, the browser restarts, or the daemon exits, agent-browser clears the capture instead of applying the result to another page.
+
+`memory status --json` includes `memoryApiVersion: 1`. Callers should discover support from the available command or MCP tools and this version field, not from a package name.
+
+```bash
+agent-browser memory status --json
+agent-browser memory cancel
+```
+
+Heap snapshots are synchronous, but `memory status` and `memory cancel` remain responsive from another command while snapshot chunks are being written.
+
+## Allocation sampling options
+
+<table>
+  <thead>
+    <tr><th>Option</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--sampling-interval &lt;bytes&gt;</code></td><td>Average bytes allocated between samples. Default: 32768.</td></tr>
+    <tr><td><code>--top &lt;count&gt;</code></td><td>Number of largest allocation call sites returned in the summary. Default: 20.</td></tr>
+    <tr><td><code>--max-size &lt;bytes&gt;</code></td><td>Maximum saved profile size. Default: 1 GiB.</td></tr>
+  </tbody>
+</table>
+
+The stop summary includes function name, script URL, line, column, sampled bytes, original page identity, output path, and total file size. The full `.heapprofile` remains on disk for later source-map analysis.
+
+## Heap snapshot options
+
+<table>
+  <thead>
+    <tr><th>Option</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--no-gc</code></td><td>Skip the default garbage collection before capture.</td></tr>
+    <tr><td><code>--timeout &lt;ms&gt;</code></td><td>Stop an incomplete capture after this duration. Default: 120000.</td></tr>
+    <tr><td><code>--max-size &lt;bytes&gt;</code></td><td>Cancel and remove the snapshot after this many bytes. Default: 1 GiB.</td></tr>
+  </tbody>
+</table>
+
+Snapshot chunks are appended to the output file as Chrome sends them. agent-browser does not assemble the entire snapshot in its own memory. A successful result confirms that snapshot metadata, nodes, edges, and strings were observed. Cancelled, timed-out, oversized, and incomplete snapshots are removed.
+
+If no path is supplied, artifacts are saved below the runtime temporary directory under `agent-browser-memory/<session>/`. Default artifacts older than 24 hours are cleaned when a new capture starts. Raw profiles and snapshots are never included in terminal or JSON output.
+
+## Engines and errors
+
+Memory diagnostics require Chrome or Chromium. Lightpanda, Safari, iOS, and other unsupported engines return `memory_unsupported_engine` rather than using an unreliable page expression fallback.
+
+JSON errors use stable `errorCode` values for unsupported engines, an already-active capture, missing captures, closed targets, cancellation, timeout, size limit, invalid artifacts, and other command failures.
+
+## Privacy
+
+Heap snapshots and allocation profiles can contain page text, application data, account details, credentials, and tokens. Save them only in a trusted local directory. Do not upload them, commit them, or copy their raw contents into agent context. Delete artifacts when diagnosis is complete.

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -41,6 +41,7 @@ export const navigation: NavSection[] = [
       { name: "WebGPU", href: "/webgpu" },
       { name: "Debugging", href: "/debugging" },
       { name: "Profiler", href: "/profiler" },
+      { name: "Memory Diagnostics", href: "/memory" },
       { name: "React & Web Vitals", href: "/react" },
       { name: "Files & Clipboard", href: "/files" },
       { name: "Init Scripts", href: "/init-scripts" },

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -18,6 +18,7 @@ export const PAGE_TITLES: Record<string, string> = {
   webgpu: "WebGPU",
   debugging: "Debugging",
   profiler: "Profiler",
+  memory: "Memory Diagnostics",
   react: "React & Web Vitals",
   files: "Files & Clipboard",
   "init-scripts": "Init Scripts",

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -367,6 +367,21 @@ agent-browser dialog accept "text"    # accept with prompt input
 agent-browser dialog dismiss          # cancel
 ```
 
+## Capturing page memory evidence
+
+Use the Chrome-only `memory` commands when a page appears to retain JavaScript objects or DOM nodes across a repeatable flow. They reuse the current browser session and do not need a separate CDP address.
+
+```bash
+agent-browser memory metrics
+agent-browser memory sampling start
+# Repeat the suspected flow several times and verify each loop completes
+agent-browser memory sampling stop ./allocations.heapprofile --top 20
+agent-browser memory collect-garbage
+agent-browser memory snapshot ./after.heapsnapshot
+```
+
+Only one capture can be active per session. Sampling remains bound to the page where it started even if another tab becomes active. Use `memory status` to inspect the current capture and `memory cancel` to stop it safely. Keep `.heapprofile` and `.heapsnapshot` files local because they can contain page text, application data, credentials, and tokens. See [references/commands.md](references/commands.md#memory-diagnostics) for every option and output field.
+
 ## Diagnosing install issues
 
 If a command fails unexpectedly (`Unknown command`, `Failed to connect`, stale daemons, version mismatches after `upgrade`, missing Chrome, etc.) run `doctor` before anything else:

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -418,6 +418,34 @@ agent-browser profiler start              # Start Chrome DevTools profiling
 agent-browser profiler stop trace.json    # Stop and save profile
 ```
 
+## Memory diagnostics
+
+Memory commands require Chrome or Chromium. They reuse the current browser session and return `memory_unsupported_engine` on Lightpanda, Safari, or other unsupported engines.
+
+```bash
+agent-browser memory metrics
+agent-browser memory status
+agent-browser memory sampling start [--sampling-interval <bytes>]
+agent-browser memory sampling stop [path] [--top <count>] [--max-size <bytes>]
+agent-browser memory snapshot [path] [--no-gc] [--timeout <ms>] [--max-size <bytes>]
+agent-browser memory collect-garbage
+agent-browser memory cancel
+```
+
+`memory metrics` returns the current JavaScript heap used and total sizes plus document, DOM node, and JavaScript event-listener counts. Use it for a cheap trend signal, not as proof of a leak.
+
+`memory sampling start` records allocation call stacks on the current page. The default average sampling interval is 32768 bytes. `memory sampling stop` always stops the original page, saves the full `.heapprofile`, and returns the largest allocation sites with function name, script URL, line, column, and sampled bytes. Switching tabs does not change the capture target.
+
+`memory snapshot` asks for garbage collection by default, then writes each Chrome snapshot chunk directly to a `.heapsnapshot` file. It validates that the artifact contains snapshot metadata, nodes, edges, and strings before reporting success. The default timeout is 120000 milliseconds and the default size limit is 1 GiB. Pass `--no-gc` only when the pre-collection state itself is relevant.
+
+If no output path is supplied, profiles are saved below the runtime temporary directory under `agent-browser-memory/<session>/`. Default artifacts older than 24 hours are cleaned when a new capture starts. Command output contains only summaries and file paths. Raw artifacts are never printed into agent context.
+
+Only one sampling or snapshot task may be active per session. `memory status` includes the capture ID, type, original target, URL, start time, output path when known, and cancellation state. `memory cancel` stops allocation sampling or interrupts a snapshot and removes partial output. Closing the captured page, closing the browser, or stopping the daemon also clears capture state.
+
+JSON failures include a stable `errorCode`: `memory_unsupported_engine`, `memory_capture_active`, `memory_no_capture`, `memory_target_gone`, `memory_capture_cancelled`, `memory_capture_timeout`, `memory_size_limit`, `memory_invalid_artifact`, or `memory_command_failed`.
+
+Heap snapshots and allocation profiles can contain user-visible text, application data, credentials, and tokens. Save them only on trusted local storage, never commit them, and delete them after diagnosis.
+
 ## React / Web Vitals
 
 Requires `--enable react-devtools` at launch for the `react ...` commands. `vitals` and `pushstate` are framework-agnostic.


### PR DESCRIPTION
## Summary

- Add Chrome memory metrics, allocation sampling, garbage collection, heap snapshots, capture status, and cancellation.
- Add precise JavaScript code coverage checkpoints with optional call counts.
- Keep captures bound to the page where they started, even when the active tab changes.
- Stream large artifacts directly to local files with time and size limits.
- Provide matching CLI and MCP commands, structured errors, documentation, and agent guidance.

## Why

Agents can already operate pages through agent-browser, but diagnosing retained memory or identifying loaded code that never executes currently requires a separate CDP setup.

These commands reuse the daemon’s existing connection to the current Chrome page. Users do not need to provide a debug address, port, or additional browser configuration.

## Safety

Heap snapshots and allocation profiles can contain page text, application data, credentials, and tokens.

Raw artifacts are written directly to local files and are never printed in command output. Snapshot collection supports size limits, timeouts, cancellation, partial-file cleanup, and automatic cleanup of old temporary artifacts.

The commands return a clear unsupported-engine error on browsers that do not provide the required Chrome capabilities.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml` — 971 tests passed
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`
- `e2e_memory_metrics_sampling_snapshot_and_tab_binding`
- `e2e_coverage_checkpoints_and_tab_binding`
