### PR TITLE
feat: add post-action observation diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,28 @@ agent-browser snapshot -i -c -d 5         # Combine options
 | `-d, --depth <n>`      | Limit tree depth                                                        |
 | `-s, --selector <sel>` | Scope to CSS selector                                                   |
 
+## Post-action Snapshot Diffs
+
+Use `--snapshot-after-action` on page-changing commands to receive the resulting accessibility change and current element refs in the same response. This removes the extra model turn normally spent requesting another snapshot:
+
+```bash
+agent-browser open https://example.com
+agent-browser snapshot -i
+agent-browser click @e1 --snapshot-after-action
+# ✓ Done
+# Post-action observation diff (+2, -1):
+# ...
+# Current refs:
+#   @e1 button "Continue"
+#   @e2 link "Account"
+```
+
+When an explicit snapshot exists, agent-browser reuses its options and returns a unified diff against it. Without a baseline, the first page-changing command returns a full compact interactive observation. Successful observations become the next baseline. JSON responses expose the same data under `data.observation`, and mutating MCP tools accept `snapshotAfter: true`.
+
+The observation always includes the complete current ref map when the page changed. Snapshot collection still uses the canonical snapshot engine, so this feature reduces model turns and response size rather than browser-side snapshot work. Set `snapshotAfterAction: true` in `agent-browser.json` or `AGENT_BROWSER_SNAPSHOT_AFTER_ACTION=1` to enable it persistently. Pass `--snapshot-after-action false` to override a persistent setting for one command.
+
+This feature does not redefine ref identity or stale-ref safety. That separate work remains covered by [PR #1444](https://github.com/vercel-labs/agent-browser/pull/1444), contributed by [@iddogino](https://github.com/iddogino), and is designed to compose with these observation diffs.
+
 ## Annotated Screenshots
 
 The `--annotate` flag overlays numbered labels on interactive elements in the screenshot. Each label `[N]` corresponds to ref `@eN`, so the same refs work for both visual and text-based workflows.
@@ -911,6 +933,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--color-scheme <scheme>` | Color scheme: `dark`, `light`, `no-preference` (or `AGENT_BROWSER_COLOR_SCHEME` env) |
 | `--download-path <path>` | Default download directory (or `AGENT_BROWSER_DOWNLOAD_PATH` env) |
 | `--content-boundaries` | Wrap page output in boundary markers for LLM safety (or `AGENT_BROWSER_CONTENT_BOUNDARIES` env) |
+| `--snapshot-after-action` | Return a snapshot diff and current refs after page-changing commands (or `AGENT_BROWSER_SNAPSHOT_AFTER_ACTION` env) |
 | `--max-output <chars>` | Truncate page output to N characters (or `AGENT_BROWSER_MAX_OUTPUT` env) |
 | `--allowed-domains <list>` | Comma-separated allowed domain patterns; also disables WebRTC peer connections in supported Chromium sessions and rejects CDP, auto-connect, Chrome profiles, restore/state replay, direct-page provider plugins, unsafe startup `--args`, iOS, and Safari (or `AGENT_BROWSER_ALLOWED_DOMAINS` env) |
 | `--action-policy <path>` | Path to action policy JSON file (or `AGENT_BROWSER_ACTION_POLICY` env) |
@@ -995,6 +1018,7 @@ Create an `agent-browser.json` file to set persistent defaults instead of repeat
   "profile": "./browser-data",
   "userAgent": "my-agent/1.0",
   "hideScrollbars": false,
+  "snapshotAfterAction": true,
   "ignoreHttpsErrors": true,
   "plugins": [
     {

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -149,6 +149,10 @@
       "type": "boolean",
       "description": "Wrap page output in boundary markers for LLM safety."
     },
+    "snapshotAfterAction": {
+      "type": "boolean",
+      "description": "Return a post-action snapshot diff and current element refs after page-changing commands."
+    },
     "maxOutput": {
       "type": "integer",
       "minimum": 0,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -320,9 +320,82 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
                 result["timeout"] = json!(t);
             }
         }
+        if flags.snapshot_after_action && supports_snapshot_after_command(&result) {
+            result["snapshotAfter"] = json!(true);
+        }
     }
 
     Ok(result)
+}
+
+/// Whether a successful command can use `--snapshot-after-action` to return
+/// a page observation. Read-only and lifecycle commands are intentionally
+/// excluded so a persistent config setting does not add snapshot overhead to
+/// unrelated commands.
+pub fn supports_snapshot_after_action(action: &str) -> bool {
+    matches!(
+        action,
+        "navigate"
+            | "back"
+            | "forward"
+            | "reload"
+            | "click"
+            | "dblclick"
+            | "fill"
+            | "type"
+            | "press"
+            | "keydown"
+            | "keyup"
+            | "keyboard"
+            | "hover"
+            | "focus"
+            | "check"
+            | "uncheck"
+            | "select"
+            | "drag"
+            | "upload"
+            | "scroll"
+            | "scrollintoview"
+            | "wait"
+            | "waitforurl"
+            | "waitforloadstate"
+            | "waitforfunction"
+            | "setcontent"
+            | "setvalue"
+            | "dispatch"
+            | "tap"
+            | "swipe"
+            | "dialog"
+            | "getbyrole"
+            | "getbytext"
+            | "getbylabel"
+            | "getbyplaceholder"
+            | "getbyalttext"
+            | "getbytitle"
+            | "getbytestid"
+            | "nth"
+    )
+}
+
+/// Command-level eligibility for post-action observations. Some daemon
+/// actions combine mutating and read-only subcommands, so the action name
+/// alone is not sufficient when a persistent config setting is enabled.
+pub fn supports_snapshot_after_command(command: &Value) -> bool {
+    let Some(action) = command.get("action").and_then(|value| value.as_str()) else {
+        return false;
+    };
+    if !supports_snapshot_after_action(action) {
+        return false;
+    }
+
+    match action {
+        "dialog" => command.get("response").and_then(|value| value.as_str()) != Some("status"),
+        "getbyrole" | "getbytext" | "getbylabel" | "getbyplaceholder" | "getbyalttext"
+        | "getbytitle" | "getbytestid" | "nth" => {
+            command.get("subaction").and_then(|value| value.as_str()) != Some("text")
+        }
+        _ => true,
+    }
 }
 
 fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseError> {
@@ -3139,6 +3212,7 @@ mod tests {
             color_scheme: None,
             download_path: None,
             content_boundaries: false,
+            snapshot_after_action: false,
             max_output: None,
             allowed_domains: None,
             action_policy: None,
@@ -4902,6 +4976,67 @@ mod tests {
         let mut f = default_flags();
         f.default_timeout = Some(ms);
         f
+    }
+
+    #[test]
+    fn test_snapshot_after_action_is_injected_for_page_changes() {
+        let mut flags = default_flags();
+        flags.snapshot_after_action = true;
+
+        let click = parse_command(&args("click @e1"), &flags).unwrap();
+        assert_eq!(click["snapshotAfter"], true);
+
+        let navigate = parse_command(&args("open example.com"), &flags).unwrap();
+        assert_eq!(navigate["snapshotAfter"], true);
+    }
+
+    #[test]
+    fn test_snapshot_after_action_skips_read_only_and_snapshot_commands() {
+        let mut flags = default_flags();
+        flags.snapshot_after_action = true;
+
+        let snapshot = parse_command(&args("snapshot -i"), &flags).unwrap();
+        assert!(snapshot.get("snapshotAfter").is_none());
+
+        let title = parse_command(&args("get title"), &flags).unwrap();
+        assert!(title.get("snapshotAfter").is_none());
+
+        let dialog_status = parse_command(&args("dialog status"), &flags).unwrap();
+        assert!(dialog_status.get("snapshotAfter").is_none());
+
+        let find_text = parse_command(&args("find role button text"), &flags).unwrap();
+        assert!(find_text.get("snapshotAfter").is_none());
+    }
+
+    #[test]
+    fn test_snapshot_after_action_supports_semantic_locator_actions() {
+        let mut flags = default_flags();
+        flags.snapshot_after_action = true;
+
+        let find_click = parse_command(&args("find role button click"), &flags).unwrap();
+        assert_eq!(find_click["action"], "getbyrole");
+        assert_eq!(find_click["snapshotAfter"], true);
+
+        let dialog_accept = parse_command(&args("dialog accept"), &flags).unwrap();
+        assert_eq!(dialog_accept["snapshotAfter"], true);
+    }
+
+    #[test]
+    fn test_snapshot_after_action_supported_action_contract() {
+        for action in [
+            "navigate",
+            "click",
+            "fill",
+            "select",
+            "press",
+            "wait",
+            "getbyrole",
+        ] {
+            assert!(supports_snapshot_after_action(action), "{action}");
+        }
+        for action in ["snapshot", "title", "screenshot", "close", "launch"] {
+            assert!(!supports_snapshot_after_action(action), "{action}");
+        }
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -336,6 +336,7 @@ pub fn supports_snapshot_after_action(action: &str) -> bool {
     matches!(
         action,
         "navigate"
+            | "evaluate"
             | "back"
             | "forward"
             | "reload"
@@ -355,6 +356,10 @@ pub fn supports_snapshot_after_action(action: &str) -> bool {
             | "drag"
             | "upload"
             | "scroll"
+            | "wheel"
+            | "mousemove"
+            | "mousedown"
+            | "mouseup"
             | "scrollintoview"
             | "wait"
             | "waitforurl"
@@ -363,9 +368,25 @@ pub fn supports_snapshot_after_action(action: &str) -> bool {
             | "setcontent"
             | "setvalue"
             | "dispatch"
+            | "viewport"
+            | "device"
+            | "geolocation"
+            | "permissions"
+            | "emulatemedia"
+            | "offline"
+            | "pushstate"
+            | "addscript"
+            | "addstyle"
             | "tap"
             | "swipe"
             | "dialog"
+            | "tab_new"
+            | "tab_switch"
+            | "tab_close"
+            | "window_new"
+            | "frame"
+            | "mainframe"
+            | "clipboard"
             | "getbyrole"
             | "getbytext"
             | "getbylabel"
@@ -390,6 +411,7 @@ pub fn supports_snapshot_after_command(command: &Value) -> bool {
 
     match action {
         "dialog" => command.get("response").and_then(|value| value.as_str()) != Some("status"),
+        "clipboard" => command.get("operation").and_then(|value| value.as_str()) == Some("paste"),
         "getbyrole" | "getbytext" | "getbylabel" | "getbyplaceholder" | "getbyalttext"
         | "getbytitle" | "getbytestid" | "nth" => {
             command.get("subaction").and_then(|value| value.as_str()) != Some("text")
@@ -4988,6 +5010,12 @@ mod tests {
 
         let navigate = parse_command(&args("open example.com"), &flags).unwrap();
         assert_eq!(navigate["snapshotAfter"], true);
+
+        let evaluate = parse_command(&args("eval document.body.dataset.ready=1"), &flags).unwrap();
+        assert_eq!(evaluate["snapshotAfter"], true);
+
+        let tab = parse_command(&args("tab new"), &flags).unwrap();
+        assert_eq!(tab["snapshotAfter"], true);
     }
 
     #[test]
@@ -5006,6 +5034,12 @@ mod tests {
 
         let find_text = parse_command(&args("find role button text"), &flags).unwrap();
         assert!(find_text.get("snapshotAfter").is_none());
+
+        let clipboard_read = parse_command(&args("clipboard read"), &flags).unwrap();
+        assert!(clipboard_read.get("snapshotAfter").is_none());
+
+        let clipboard_paste = parse_command(&args("clipboard paste"), &flags).unwrap();
+        assert_eq!(clipboard_paste["snapshotAfter"], true);
     }
 
     #[test]
@@ -5025,11 +5059,16 @@ mod tests {
     fn test_snapshot_after_action_supported_action_contract() {
         for action in [
             "navigate",
+            "evaluate",
             "click",
             "fill",
             "select",
             "press",
             "wait",
+            "wheel",
+            "viewport",
+            "tab_switch",
+            "frame",
             "getbyrole",
         ] {
             assert!(supports_snapshot_after_action(action), "{action}");
@@ -5037,6 +5076,11 @@ mod tests {
         for action in ["snapshot", "title", "screenshot", "close", "launch"] {
             assert!(!supports_snapshot_after_action(action), "{action}");
         }
+
+        let clipboard_read = json!({ "action": "clipboard", "operation": "read" });
+        let clipboard_paste = json!({ "action": "clipboard", "operation": "paste" });
+        assert!(!supports_snapshot_after_command(&clipboard_read));
+        assert!(supports_snapshot_after_command(&clipboard_paste));
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -88,6 +88,7 @@ pub struct Config {
     pub color_scheme: Option<String>,
     pub download_path: Option<String>,
     pub content_boundaries: Option<bool>,
+    pub snapshot_after_action: Option<bool>,
     pub max_output: Option<usize>,
     pub allowed_domains: Option<Vec<String>>,
     pub action_policy: Option<String>,
@@ -158,6 +159,7 @@ impl Config {
             color_scheme: other.color_scheme.or(self.color_scheme),
             download_path: other.download_path.or(self.download_path),
             content_boundaries: other.content_boundaries.or(self.content_boundaries),
+            snapshot_after_action: other.snapshot_after_action.or(self.snapshot_after_action),
             max_output: other.max_output.or(self.max_output),
             allowed_domains: other.allowed_domains.or(self.allowed_domains),
             action_policy: other.action_policy.or(self.action_policy),
@@ -361,6 +363,8 @@ pub struct Flags {
     pub color_scheme: Option<String>,
     pub download_path: Option<String>,
     pub content_boundaries: bool,
+    /// Capture a ref refresh and snapshot diff after page-changing actions.
+    pub snapshot_after_action: bool,
     pub max_output: Option<usize>,
     pub allowed_domains: Option<Vec<String>>,
     pub action_policy: Option<String>,
@@ -548,6 +552,8 @@ pub fn parse_flags(args: &[String]) -> Flags {
             .or(config.download_path),
         content_boundaries: env_var_is_truthy("AGENT_BROWSER_CONTENT_BOUNDARIES")
             || config.content_boundaries.unwrap_or(false),
+        snapshot_after_action: env_var_is_truthy("AGENT_BROWSER_SNAPSHOT_AFTER_ACTION")
+            || config.snapshot_after_action.unwrap_or(false),
         max_output: env::var("AGENT_BROWSER_MAX_OUTPUT")
             .ok()
             .and_then(|s| s.parse().ok())
@@ -893,6 +899,13 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--snapshot-after-action" => {
+                let (val, consumed) = parse_bool_arg(args, i);
+                flags.snapshot_after_action = val;
+                if consumed {
+                    i += 1;
+                }
+            }
             "--max-output" => {
                 if let Some(s) = args.get(i + 1) {
                     if let Ok(n) = s.parse::<usize>() {
@@ -1023,6 +1036,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--auto-connect",
         "--annotate",
         "--content-boundaries",
+        "--snapshot-after-action",
         "--confirm-interactive",
         "--no-auto-dialog",
         "-v",
@@ -1153,6 +1167,30 @@ mod tests {
     #[test]
     fn test_parse_idle_timeout_hours() {
         assert_eq!(parse_idle_timeout("1h").unwrap(), "3600000");
+    }
+
+    #[test]
+    fn test_snapshot_after_action_flag_accepts_explicit_boolean() {
+        let enabled = parse_flags(&args("--snapshot-after-action open example.com"));
+        assert!(enabled.snapshot_after_action);
+
+        let disabled = parse_flags(&args("--snapshot-after-action false open example.com"));
+        assert!(!disabled.snapshot_after_action);
+    }
+
+    #[test]
+    fn test_snapshot_after_action_env() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_SNAPSHOT_AFTER_ACTION"]);
+        guard.set("AGENT_BROWSER_SNAPSHOT_AFTER_ACTION", "1");
+        assert!(parse_flags(&args("open example.com")).snapshot_after_action);
+    }
+
+    #[test]
+    fn test_clean_args_removes_snapshot_after_action() {
+        let cleaned = clean_args(&args(
+            "--snapshot-after-action true click @e1 --snapshot-after-action false",
+        ));
+        assert_eq!(cleaned, args("click @e1"));
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1898,6 +1898,16 @@ fn tool(name: &str, title: &str, description: &str, properties: Value, required:
             "description": "Maximum time to wait for this tool call."
         }),
     );
+    if supports_snapshot_after_tool(name) {
+        props.insert(
+            "snapshotAfter".to_string(),
+            json!({
+                "type": "boolean",
+                "default": false,
+                "description": "Return a post-action snapshot diff and current element refs."
+            }),
+        );
+    }
 
     let mut schema = serde_json::Map::new();
     schema.insert("type".to_string(), json!("object"));
@@ -1914,6 +1924,45 @@ fn tool(name: &str, title: &str, description: &str, properties: Value, required:
         "inputSchema": Value::Object(schema),
         "annotations": tool_annotations(name),
     })
+}
+
+fn supports_snapshot_after_tool(name: &str) -> bool {
+    matches!(
+        name,
+        TOOL_OPEN
+            | TOOL_CLICK
+            | TOOL_BACK
+            | TOOL_FORWARD
+            | TOOL_RELOAD
+            | TOOL_DBLCLICK
+            | TOOL_FILL
+            | TOOL_TYPE
+            | TOOL_PRESS
+            | TOOL_KEYDOWN
+            | TOOL_KEYUP
+            | TOOL_KEYBOARD_TYPE
+            | TOOL_KEYBOARD_INSERT_TEXT
+            | TOOL_HOVER
+            | TOOL_FOCUS
+            | TOOL_CHECK
+            | TOOL_UNCHECK
+            | TOOL_SELECT
+            | TOOL_DRAG
+            | TOOL_UPLOAD
+            | TOOL_SCROLL
+            | TOOL_SCROLL_INTO_VIEW
+            | TOOL_WAIT_MS
+            | TOOL_WAIT_FOR_SELECTOR
+            | TOOL_WAIT_FOR_TEXT
+            | TOOL_WAIT_FOR_URL
+            | TOOL_WAIT_FOR_LOAD
+            | TOOL_WAIT_FOR_FUNCTION
+            | TOOL_DIALOG_ACCEPT
+            | TOOL_DIALOG_DISMISS
+            | TOOL_TAP
+            | TOOL_SWIPE
+            | TOOL_FIND
+    )
 }
 
 fn tool_annotations(name: &str) -> Value {
@@ -3519,6 +3568,10 @@ fn append_common_global_args(
             args.push(domains.join(","));
         }
     }
+    if let Some(enabled) = optional_bool(arguments, "snapshotAfter")? {
+        args.push("--snapshot-after-action".to_string());
+        args.push(enabled.to_string());
+    }
 
     Ok(())
 }
@@ -3680,6 +3733,9 @@ fn response_text(value: &Value) -> Option<String> {
         }
 
         if let Some(data) = obj.get("data") {
+            if let Some(observation) = data.get("observation") {
+                return Some(crate::output::format_post_action_observation(observation));
+            }
             for key in [
                 "snapshot", "text", "html", "report", "value", "content", "title", "url", "path",
             ] {
@@ -3767,6 +3823,36 @@ mod tests {
         assert!(names.contains(&TOOL_SESSION_ID));
         assert!(names.contains(&TOOL_SESSION_INFO));
         assert!(!names.contains(&"agent_browser_frame_list"));
+    }
+
+    #[test]
+    fn mutating_tools_expose_snapshot_after_without_adding_it_to_snapshot() {
+        let tools = tools();
+        let click = tools
+            .iter()
+            .find(|tool| tool["name"] == TOOL_CLICK)
+            .unwrap();
+        let snapshot = tools
+            .iter()
+            .find(|tool| tool["name"] == TOOL_SNAPSHOT)
+            .unwrap();
+
+        assert_eq!(
+            click["inputSchema"]["properties"]["snapshotAfter"]["type"],
+            "boolean"
+        );
+        assert!(snapshot["inputSchema"]["properties"]
+            .get("snapshotAfter")
+            .is_none());
+
+        let find = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some(TOOL_FIND))
+            .unwrap();
+        assert_eq!(
+            find["inputSchema"]["properties"]["snapshotAfter"]["type"],
+            "boolean"
+        );
     }
 
     #[test]
@@ -4090,6 +4176,15 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, vec!["--allowed-domains", "example.com,*.example.org"]);
+    }
+
+    #[test]
+    fn common_global_args_forward_snapshot_after_explicitly() {
+        let mut args = Vec::new();
+
+        append_common_global_args(&mut args, &json!({ "snapshotAfter": true }), None).unwrap();
+
+        assert_eq!(args, vec!["--snapshot-after-action", "true"]);
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -3751,21 +3751,26 @@ fn response_text(value: &Value) -> Option<String> {
         }
 
         if let Some(data) = obj.get("data") {
-            if let Some(observation) = data.get("observation") {
-                return Some(crate::output::format_post_action_observation(observation));
-            }
-            for key in [
+            let primary = [
                 "snapshot", "text", "html", "report", "value", "content", "title", "url", "path",
-            ] {
-                if let Some(s) = data.get(key).and_then(|v| v.as_str()) {
-                    return Some(s.to_string());
-                }
+            ]
+            .into_iter()
+            .find_map(|key| data.get(key).and_then(|value| value.as_str()))
+            .map(ToString::to_string)
+            .or_else(|| {
+                data.get("result").map(|result| {
+                    serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string())
+                })
+            });
+
+            if let Some(observation) = data.get("observation") {
+                let observation = crate::output::format_post_action_observation(observation);
+                return Some(match primary {
+                    Some(primary) => format!("{}\n\n{}", primary, observation),
+                    None => observation,
+                });
             }
-            if let Some(result) = data.get("result") {
-                return Some(
-                    serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string()),
-                );
-            }
+            return primary;
         }
     }
 
@@ -4093,6 +4098,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(text, "# Docs\n\nReadable content.");
+    }
+
+    #[test]
+    fn response_text_keeps_primary_metadata_with_observation() {
+        let text = response_text(&json!({
+            "success": true,
+            "data": {
+                "url": "https://example.com/next",
+                "observation": {
+                    "mode": "diff",
+                    "changed": false
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            text,
+            "https://example.com/next\n\nPost-action observation: no accessibility changes"
+        );
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1975,6 +1975,7 @@ fn supports_snapshot_after_tool(name: &str) -> bool {
             | TOOL_WINDOW_NEW
             | TOOL_FRAME_SWITCH
             | TOOL_FRAME_MAIN
+            | TOOL_PUSHSTATE
             | TOOL_CLIPBOARD_PASTE
             | TOOL_TAP
             | TOOL_SWIPE
@@ -3857,6 +3858,7 @@ mod tests {
             TOOL_SET_VIEWPORT,
             TOOL_TAB_SWITCH,
             TOOL_FRAME_SWITCH,
+            TOOL_PUSHSTATE,
         ] {
             let tool = tools
                 .iter()

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1930,6 +1930,7 @@ fn supports_snapshot_after_tool(name: &str) -> bool {
     matches!(
         name,
         TOOL_OPEN
+            | TOOL_EVAL
             | TOOL_CLICK
             | TOOL_BACK
             | TOOL_FORWARD
@@ -1951,6 +1952,15 @@ fn supports_snapshot_after_tool(name: &str) -> bool {
             | TOOL_UPLOAD
             | TOOL_SCROLL
             | TOOL_SCROLL_INTO_VIEW
+            | TOOL_MOUSE_MOVE
+            | TOOL_MOUSE_DOWN
+            | TOOL_MOUSE_UP
+            | TOOL_MOUSE_WHEEL
+            | TOOL_SET_VIEWPORT
+            | TOOL_SET_DEVICE
+            | TOOL_SET_GEO
+            | TOOL_SET_OFFLINE
+            | TOOL_SET_MEDIA
             | TOOL_WAIT_MS
             | TOOL_WAIT_FOR_SELECTOR
             | TOOL_WAIT_FOR_TEXT
@@ -1959,6 +1969,13 @@ fn supports_snapshot_after_tool(name: &str) -> bool {
             | TOOL_WAIT_FOR_FUNCTION
             | TOOL_DIALOG_ACCEPT
             | TOOL_DIALOG_DISMISS
+            | TOOL_TAB_NEW
+            | TOOL_TAB_SWITCH
+            | TOOL_TAB_CLOSE
+            | TOOL_WINDOW_NEW
+            | TOOL_FRAME_SWITCH
+            | TOOL_FRAME_MAIN
+            | TOOL_CLIPBOARD_PASTE
             | TOOL_TAP
             | TOOL_SWIPE
             | TOOL_FIND
@@ -3828,19 +3845,28 @@ mod tests {
     #[test]
     fn mutating_tools_expose_snapshot_after_without_adding_it_to_snapshot() {
         let tools = tools();
-        let click = tools
-            .iter()
-            .find(|tool| tool["name"] == TOOL_CLICK)
-            .unwrap();
         let snapshot = tools
             .iter()
             .find(|tool| tool["name"] == TOOL_SNAPSHOT)
             .unwrap();
 
-        assert_eq!(
-            click["inputSchema"]["properties"]["snapshotAfter"]["type"],
-            "boolean"
-        );
+        for name in [
+            TOOL_CLICK,
+            TOOL_EVAL,
+            TOOL_MOUSE_WHEEL,
+            TOOL_SET_VIEWPORT,
+            TOOL_TAB_SWITCH,
+            TOOL_FRAME_SWITCH,
+        ] {
+            let tool = tools
+                .iter()
+                .find(|tool| tool["name"] == name)
+                .unwrap_or_else(|| panic!("missing MCP tool {name}"));
+            assert_eq!(
+                tool["inputSchema"]["properties"]["snapshotAfter"]["type"], "boolean",
+                "{name} must expose the post-action observation option"
+            );
+        }
         assert!(snapshot["inputSchema"]["properties"]
             .get("snapshotAfter")
             .is_none());

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -208,6 +208,15 @@ pub struct MouseState {
     pub buttons: i32,
 }
 
+/// Snapshot text and options used as the baseline for an opt-in post-action
+/// observation. Keeping this in daemon state lets separate CLI and MCP calls
+/// receive a lightweight diff instead of requesting another full snapshot.
+#[derive(Clone)]
+struct ObservationBaseline {
+    snapshot: String,
+    options: SnapshotOptions,
+}
+
 #[derive(Default)]
 struct DrainedEvents {
     pending_acks: Vec<i64>,
@@ -318,6 +327,9 @@ pub struct DaemonState {
     pub webdriver_backend: Option<super::webdriver::backend::WebDriverBackend>,
     pub backend_type: BackendType,
     pub ref_map: RefMap,
+    /// Most recent explicit or post-action snapshot for diffing the next
+    /// `--snapshot-after-action` observation.
+    last_observation: Option<ObservationBaseline>,
     pub domain_filter: Arc<RwLock<Option<DomainFilter>>>,
     pub event_tracker: EventTracker,
     pub session_name: Option<String>,
@@ -417,6 +429,7 @@ impl DaemonState {
             webdriver_backend: None,
             backend_type: BackendType::Cdp,
             ref_map: RefMap::new(),
+            last_observation: None,
             domain_filter: Arc::new(RwLock::new(
                 env::var("AGENT_BROWSER_ALLOWED_DOMAINS")
                     .ok()
@@ -1875,6 +1888,7 @@ pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(),
     state.launch_hash = None;
     state.network_auto_attach_installed = false;
     state.screencasting = false;
+    state.last_observation = None;
     state.reset_input_state();
     state.update_stream_client().await;
 
@@ -2402,6 +2416,36 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         validate_restore_if_pending(state).await;
     }
 
+    // An explicit snapshot establishes the baseline for a later opt-in
+    // post-action diff, even when the next command arrives through a separate
+    // CLI process or MCP tool call.
+    if action == "snapshot" {
+        state.last_observation = match &result {
+            Ok(data) => data
+                .get("snapshot")
+                .and_then(|v| v.as_str())
+                .map(|snapshot| ObservationBaseline {
+                    snapshot: snapshot.to_string(),
+                    options: snapshot_options_from_command(cmd),
+                }),
+            // A failed explicit snapshot may have raced a context change. Do
+            // not retain an older baseline that the caller could mistake for
+            // the attempted observation.
+            Err(_) => None,
+        };
+    }
+
+    // A baseline is scoped to the active browsing context. Do not diff a
+    // later action against a snapshot from a different tab, window, or frame.
+    if result.is_ok()
+        && matches!(
+            action,
+            "tab_new" | "tab_switch" | "tab_close" | "window_new" | "frame" | "mainframe"
+        )
+    {
+        state.last_observation = None;
+    }
+
     // Stamp browser-touching commands so periodic autosave waits for an
     // active command burst to settle before collecting state. Stamped even on
     // error: a failed click can still have navigated.
@@ -2432,6 +2476,46 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             lifecycle_launched,
             lifecycle_relaunched_browser,
         );
+    }
+
+    // Capture only after the action's CDP events have been applied. This
+    // avoids racing a navigation or dynamic render and lets us skip a
+    // renderer-blocking JavaScript dialog without changing the successful
+    // action result into an error.
+    if cmd
+        .get("snapshotAfter")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+        && crate::commands::supports_snapshot_after_command(cmd)
+        && resp.get("success").and_then(|v| v.as_bool()) == Some(true)
+    {
+        let observation = if let Some(dialog) = state.pending_dialog.as_ref() {
+            Err(format!(
+                "A JavaScript {} dialog is blocking the page. Resolve it, then take a snapshot.",
+                dialog.dialog_type
+            ))
+        } else {
+            capture_post_action_observation(state).await
+        };
+
+        let observation = match observation {
+            Ok(value) => value,
+            Err(error) => {
+                // The page may have changed even though optional observation
+                // capture failed, so the old baseline must not be reused.
+                state.last_observation = None;
+                json!({ "mode": "error", "error": error })
+            }
+        };
+
+        if let Some(data) = resp.get_mut("data") {
+            if let Some(obj) = data.as_object_mut() {
+                obj.insert("observation".to_string(), observation);
+            } else {
+                let result = std::mem::replace(data, Value::Null);
+                *data = json!({ "result": result, "observation": observation });
+            }
+        }
     }
 
     // Auto-report pending JavaScript dialog so agents know why commands may hang
@@ -4471,6 +4555,102 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .collect();
 
     Ok(json!({ "snapshot": tree, "origin": url, "refs": refs }))
+}
+
+fn snapshot_options_from_command(cmd: &Value) -> SnapshotOptions {
+    SnapshotOptions {
+        selector: cmd
+            .get("selector")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        interactive: cmd
+            .get("interactive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        compact: cmd
+            .get("compact")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        depth: cmd
+            .get("maxDepth")
+            .and_then(|v| v.as_u64())
+            .map(|d| d as usize),
+        urls: cmd.get("urls").and_then(|v| v.as_bool()).unwrap_or(false),
+    }
+}
+
+fn snapshot_command_from_options(options: &SnapshotOptions) -> Value {
+    let mut cmd = json!({
+        "action": "snapshot",
+        "interactive": options.interactive,
+        "compact": options.compact,
+        "urls": options.urls,
+    });
+    if let Some(ref selector) = options.selector {
+        cmd["selector"] = json!(selector);
+    }
+    if let Some(depth) = options.depth {
+        cmd["maxDepth"] = json!(depth);
+    }
+    cmd
+}
+
+/// Capture the post-action observation requested by
+/// `--snapshot-after-action`. When an explicit snapshot established a
+/// baseline, only its unified diff is returned. The complete current ref map
+/// is always included so agents can continue without a separate snapshot
+/// turn. If there is no baseline, the first observation contains the full
+/// compact interactive snapshot and becomes the baseline for the next action.
+async fn capture_post_action_observation(state: &mut DaemonState) -> Result<Value, String> {
+    let baseline = state.last_observation.clone();
+    let options = baseline
+        .as_ref()
+        .map(|baseline| baseline.options.clone())
+        .unwrap_or(SnapshotOptions {
+            interactive: true,
+            compact: true,
+            ..SnapshotOptions::default()
+        });
+
+    // Delegate through the canonical snapshot handler. Besides avoiding two
+    // subtly different snapshot paths, this composes with stable-ref work in
+    // upstream PR #1444 without copying or superseding that contribution.
+    let snapshot_cmd = snapshot_command_from_options(&options);
+    let captured = handle_snapshot(&snapshot_cmd, state).await?;
+    let current = captured
+        .get("snapshot")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let origin = captured.get("origin").cloned().unwrap_or(Value::Null);
+    let refs = captured.get("refs").cloned().unwrap_or_else(|| json!({}));
+
+    state.last_observation = Some(ObservationBaseline {
+        snapshot: current.clone(),
+        options,
+    });
+
+    if let Some(baseline) = baseline {
+        let result = diff::diff_snapshots(&baseline.snapshot, &current);
+        Ok(json!({
+            "mode": "diff",
+            "origin": origin,
+            "diff": result.diff,
+            "changed": result.changed,
+            "additions": result.additions,
+            "removals": result.removals,
+            "unchanged": result.unchanged,
+            "refs": refs,
+        }))
+    } else {
+        Ok(json!({
+            "mode": "full",
+            "origin": origin,
+            "snapshot": current,
+            "changed": true,
+            "refs": refs,
+        }))
+    }
 }
 
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -10662,6 +10842,20 @@ mod tests {
         assert!(!should_validate_restore_after_action("launch"));
         assert!(should_validate_restore_after_action("navigate"));
         assert!(should_validate_restore_after_action("click"));
+    }
+
+    #[test]
+    fn test_post_action_snapshot_options_round_trip() {
+        let options = SnapshotOptions {
+            selector: Some("#main".to_string()),
+            interactive: true,
+            compact: true,
+            depth: Some(4),
+            urls: true,
+        };
+
+        let command = snapshot_command_from_options(&options);
+        assert_eq!(snapshot_options_from_command(&command), options);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2477,6 +2477,12 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         );
     }
 
+    // The caller never received this explicit snapshot if final event
+    // processing failed, so it cannot be a valid baseline for a later diff.
+    if action == "snapshot" && resp.get("success").and_then(|value| value.as_bool()) != Some(true) {
+        state.last_observation = None;
+    }
+
     // Capture only after the action's CDP events have been applied. This
     // avoids racing a navigation or dynamic render and lets us skip a
     // renderer-blocking JavaScript dialog without changing the successful

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -211,7 +211,6 @@ pub struct MouseState {
 /// Snapshot text and options used as the baseline for an opt-in post-action
 /// observation. Keeping this in daemon state lets separate CLI and MCP calls
 /// receive a lightweight diff instead of requesting another full snapshot.
-#[derive(Clone)]
 struct ObservationBaseline {
     snapshot: String,
     options: SnapshotOptions,
@@ -4602,7 +4601,7 @@ fn snapshot_command_from_options(options: &SnapshotOptions) -> Value {
 /// turn. If there is no baseline, the first observation contains the full
 /// compact interactive snapshot and becomes the baseline for the next action.
 async fn capture_post_action_observation(state: &mut DaemonState) -> Result<Value, String> {
-    let baseline = state.last_observation.clone();
+    let baseline = state.last_observation.take();
     let options = baseline
         .as_ref()
         .map(|baseline| baseline.options.clone())
@@ -4616,23 +4615,23 @@ async fn capture_post_action_observation(state: &mut DaemonState) -> Result<Valu
     // subtly different snapshot paths, this composes with stable-ref work in
     // upstream PR #1444 without copying or superseding that contribution.
     let snapshot_cmd = snapshot_command_from_options(&options);
-    let captured = handle_snapshot(&snapshot_cmd, state).await?;
-    let current = captured
-        .get("snapshot")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default()
-        .to_string();
-    let origin = captured.get("origin").cloned().unwrap_or(Value::Null);
-    let refs = captured.get("refs").cloned().unwrap_or_else(|| json!({}));
+    let mut captured = handle_snapshot(&snapshot_cmd, state).await?;
+    let captured = captured
+        .as_object_mut()
+        .ok_or("Snapshot handler returned a non-object response")?;
+    let current = match captured.remove("snapshot") {
+        Some(Value::String(snapshot)) => snapshot,
+        _ => return Err("Snapshot handler returned no snapshot text".to_string()),
+    };
+    let origin = captured.remove("origin").unwrap_or(Value::Null);
+    let refs = match captured.remove("refs") {
+        Some(Value::Object(refs)) => Value::Object(refs),
+        _ => return Err("Snapshot handler returned no current ref map".to_string()),
+    };
 
-    state.last_observation = Some(ObservationBaseline {
-        snapshot: current.clone(),
-        options,
-    });
-
-    if let Some(baseline) = baseline {
+    let observation = if let Some(baseline) = baseline {
         let result = diff::diff_snapshots(&baseline.snapshot, &current);
-        Ok(json!({
+        json!({
             "mode": "diff",
             "origin": origin,
             "diff": result.diff,
@@ -4641,16 +4640,22 @@ async fn capture_post_action_observation(state: &mut DaemonState) -> Result<Valu
             "removals": result.removals,
             "unchanged": result.unchanged,
             "refs": refs,
-        }))
+        })
     } else {
-        Ok(json!({
+        json!({
             "mode": "full",
             "origin": origin,
-            "snapshot": current,
+            "snapshot": current.clone(),
             "changed": true,
             "refs": refs,
-        }))
-    }
+        })
+    };
+
+    state.last_observation = Some(ObservationBaseline {
+        snapshot: current,
+        options,
+    });
+    Ok(observation)
 }
 
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2415,25 +2415,6 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         validate_restore_if_pending(state).await;
     }
 
-    // An explicit snapshot establishes the baseline for a later opt-in
-    // post-action diff, even when the next command arrives through a separate
-    // CLI process or MCP tool call.
-    if action == "snapshot" {
-        state.last_observation = match &result {
-            Ok(data) => data
-                .get("snapshot")
-                .and_then(|v| v.as_str())
-                .map(|snapshot| ObservationBaseline {
-                    snapshot: snapshot.to_string(),
-                    options: snapshot_options_from_command(cmd),
-                }),
-            // A failed explicit snapshot may have raced a context change. Do
-            // not retain an older baseline that the caller could mistake for
-            // the attempted observation.
-            Err(_) => None,
-        };
-    }
-
     // A baseline is scoped to the active browsing context. Do not diff a
     // later action against a snapshot from a different tab, window, or frame.
     if result.is_ok()
@@ -2477,10 +2458,17 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         );
     }
 
-    // The caller never received this explicit snapshot if final event
-    // processing failed, so it cannot be a valid baseline for a later diff.
-    if action == "snapshot" && resp.get("success").and_then(|value| value.as_bool()) != Some(true) {
-        state.last_observation = None;
+    // Only a snapshot returned successfully after final event processing can
+    // establish a baseline for a later opt-in diff.
+    if action == "snapshot" {
+        state.last_observation = resp
+            .get("data")
+            .and_then(|data| data.get("snapshot"))
+            .and_then(|value| value.as_str())
+            .map(|snapshot| ObservationBaseline {
+                snapshot: snapshot.to_string(),
+                options: snapshot_options_from_command(cmd),
+            });
     }
 
     // Capture only after the action's CDP events have been applied. This

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -753,6 +753,121 @@ async fn e2e_snapshot_after_action_without_baseline_returns_full_observation() {
     assert_success(&resp);
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_after_action_discards_unusable_and_cross_context_baselines() {
+    let mut state = DaemonState::new();
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+
+    let html = r#"<!doctype html><html><body>
+        <button id="remove" onclick="this.remove()">Remove</button>
+        <button id="keep">Keep</button>
+    </body></html>"#;
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+    assert_success(
+        &execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": url }),
+            &mut state,
+        )
+        .await,
+    );
+
+    // A failed explicit snapshot must discard the previous successful
+    // baseline rather than diffing a later action against hidden old state.
+    assert_success(
+        &execute_command(
+            &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+            &mut state,
+        )
+        .await,
+    );
+    let failed = execute_command(
+        &json!({ "id": "4", "action": "snapshot", "selector": "[" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(failed["success"], false, "invalid selector must fail");
+
+    let recovered = execute_command(
+        &json!({
+            "id": "5",
+            "action": "click",
+            "selector": "#keep",
+            "snapshotAfter": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&recovered);
+    assert_eq!(get_data(&recovered)["observation"]["mode"], "full");
+
+    // If the optional post-action capture fails after the action succeeded,
+    // preserve action success, report the observation error, and make the
+    // following observation start from a fresh full baseline.
+    assert_success(
+        &execute_command(
+            &json!({ "id": "6", "action": "snapshot", "selector": "#remove" }),
+            &mut state,
+        )
+        .await,
+    );
+    let removed = execute_command(
+        &json!({
+            "id": "7",
+            "action": "click",
+            "selector": "#remove",
+            "snapshotAfter": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&removed);
+    assert_eq!(get_data(&removed)["observation"]["mode"], "error");
+
+    let after_capture_error = execute_command(
+        &json!({
+            "id": "8",
+            "action": "click",
+            "selector": "#keep",
+            "snapshotAfter": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&after_capture_error);
+    assert_eq!(
+        get_data(&after_capture_error)["observation"]["mode"],
+        "full"
+    );
+
+    // Switching browsing contexts invalidates the old document baseline. The
+    // context-changing command itself can request the first full observation.
+    let new_tab = execute_command(
+        &json!({
+            "id": "9",
+            "action": "tab_new",
+            "url": "data:text/html,<button>Other tab</button>",
+            "snapshotAfter": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&new_tab);
+    assert_eq!(get_data(&new_tab)["observation"]["mode"], "full");
+    assert!(get_data(&new_tab)["observation"]["snapshot"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("Other tab"));
+
+    assert_success(&execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await);
+}
+
 // ---------------------------------------------------------------------------
 // Screenshot
 // ---------------------------------------------------------------------------

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -634,6 +634,126 @@ async fn e2e_snapshot_and_click_ref() {
 }
 
 // ---------------------------------------------------------------------------
+// Opt-in post-action observation and ref refresh (#1351)
+// ---------------------------------------------------------------------------
+
+fn post_action_observation_url() -> String {
+    let html = r#"<!doctype html><html><body>
+        <button id="add" onclick="const b=document.createElement('button');b.textContent='New';document.body.appendChild(b)">Add</button>
+    </body></html>"#;
+    format!("data:text/html;base64,{}", STANDARD.encode(html))
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_after_action_returns_diff_and_current_refs() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": post_action_observation_url() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "snapshot",
+            "interactive": true,
+            "compact": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(get_data(&resp)["snapshot"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("button \"Add\" [ref=e1]"));
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "click",
+            "selector": "@e1",
+            "snapshotAfter": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let observation = &get_data(&resp)["observation"];
+    assert_eq!(observation["mode"], "diff");
+    assert_eq!(observation["changed"], true);
+    assert!(observation["additions"].as_u64().unwrap_or(0) > 0);
+    assert!(observation["diff"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("New"));
+    assert!(observation["refs"]
+        .as_object()
+        .unwrap()
+        .values()
+        .any(|entry| entry["name"] == "New"));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_after_action_without_baseline_returns_full_observation() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": post_action_observation_url() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "click",
+            "selector": "#add",
+            "snapshotAfter": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let observation = &get_data(&resp)["observation"];
+    assert_eq!(observation["mode"], "full");
+    let snapshot = observation["snapshot"].as_str().unwrap_or_default();
+    assert!(snapshot.contains("button \"Add\""), "{snapshot}");
+    assert!(snapshot.contains("button \"New\""), "{snapshot}");
+    assert!(observation["refs"]
+        .as_object()
+        .is_some_and(|refs| refs.len() == 2));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+// ---------------------------------------------------------------------------
 // Screenshot
 // ---------------------------------------------------------------------------
 

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -74,7 +74,7 @@ const INVISIBLE_CHARS: &[char] = &[
     '\u{00A0}', // Non-Breaking Space (&nbsp;)
 ];
 
-#[derive(Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SnapshotOptions {
     pub selector: Option<String>,
     pub interactive: bool,

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -304,6 +304,33 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         return;
     }
 
+    // Keep the normal action output, then append the opt-in observation. The
+    // daemon nests it in `data.observation` so JSON consumers retain a stable,
+    // structured response while human and skill-driven CLI users receive the
+    // diff and ref refresh in the same command turn.
+    if resp.success {
+        if let Some(data) = resp.data.as_ref() {
+            if let Some(observation) = data.get("observation") {
+                let mut primary_data = data.clone();
+                if let Some(obj) = primary_data.as_object_mut() {
+                    obj.remove("observation");
+                }
+                let primary = Response {
+                    success: true,
+                    data: Some(primary_data),
+                    error: None,
+                    warning: resp.warning.clone(),
+                };
+                print_response_with_opts(&primary, action, opts);
+
+                let rendered = format_post_action_observation(observation);
+                let origin = observation.get("origin").and_then(|v| v.as_str());
+                print_with_boundaries(&rendered, origin, opts);
+                return;
+            }
+        }
+    }
+
     if !resp.success {
         eprintln!(
             "{} {}",
@@ -1197,6 +1224,74 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
     }
 
     print_warning(resp);
+}
+
+/// Format the structured `data.observation` payload shared by CLI and MCP
+/// output. Diff mode includes a full ref-only refresh when the page changed;
+/// full mode already carries refs inline in the snapshot text.
+pub(crate) fn format_post_action_observation(observation: &serde_json::Value) -> String {
+    match observation.get("mode").and_then(|v| v.as_str()) {
+        Some("error") => format!(
+            "Post-action observation unavailable: {}",
+            observation
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error")
+        ),
+        Some("full") => {
+            let snapshot = observation
+                .get("snapshot")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(empty page)");
+            format!(
+                "Post-action observation (full; no prior snapshot):\n{}",
+                snapshot
+            )
+        }
+        Some("diff") => {
+            let additions = observation
+                .get("additions")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let removals = observation
+                .get("removals")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let changed = observation
+                .get("changed")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !changed {
+                return "Post-action observation: no accessibility changes".to_string();
+            }
+
+            let diff = observation
+                .get("diff")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let mut rendered = format!(
+                "Post-action observation diff (+{}, -{}):\n{}",
+                additions,
+                removals,
+                diff.trim_end()
+            );
+
+            if let Some(refs) = observation.get("refs").and_then(|v| v.as_object()) {
+                rendered.push_str("\nCurrent refs:");
+                for (ref_id, entry) in refs {
+                    let role = entry.get("role").and_then(|v| v.as_str()).unwrap_or("");
+                    let name = entry.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                    if name.is_empty() {
+                        rendered.push_str(&format!("\n  @{} {}", ref_id, role));
+                    } else {
+                        rendered.push_str(&format!("\n  @{} {} {:?}", ref_id, role, name));
+                    }
+                }
+            }
+            rendered
+        }
+        _ => "Post-action observation unavailable: malformed response".to_string(),
+    }
 }
 
 fn print_lifecycle_note(data: &serde_json::Value) {
@@ -3485,6 +3580,13 @@ Snapshot Options:
   -d, --depth <n>            Limit tree depth
   -s, --selector <sel>       Scope to CSS selector
 
+Post-action Observation:
+  --snapshot-after-action    After page-changing commands, return a snapshot diff
+                             and current refs in the same response
+  Example:
+    agent-browser snapshot -i
+    agent-browser click @e1 --snapshot-after-action
+
 Authentication:
   --profile <name|path>      Chrome profile name (e.g., Default) to reuse login state,
                              or a directory path for a persistent custom profile
@@ -3538,6 +3640,7 @@ Options:
   --color-scheme <scheme>    Color scheme: dark, light, no-preference (or AGENT_BROWSER_COLOR_SCHEME)
   --download-path <path>     Default download directory (or AGENT_BROWSER_DOWNLOAD_PATH)
   --content-boundaries       Wrap page output in boundary markers (or AGENT_BROWSER_CONTENT_BOUNDARIES)
+  --snapshot-after-action    Return post-action snapshot diffs and current refs (or AGENT_BROWSER_SNAPSHOT_AFTER_ACTION)
   --max-output <chars>       Truncate page output to N chars (or AGENT_BROWSER_MAX_OUTPUT)
   --allowed-domains <list>   Restrict network domains; rejects CDP, auto-connect, profiles, restore/state replay, direct-page providers, unsafe startup args, iOS/Safari (or AGENT_BROWSER_ALLOWED_DOMAINS)
   --action-policy <path>     Action policy JSON file (or AGENT_BROWSER_ACTION_POLICY)
@@ -3614,6 +3717,7 @@ Environment:
   AGENT_BROWSER_IOS_DEVICE       Default iOS device name
   AGENT_BROWSER_IOS_UDID         Default iOS device UDID
   AGENT_BROWSER_CONTENT_BOUNDARIES Wrap page output in boundary markers
+  AGENT_BROWSER_SNAPSHOT_AFTER_ACTION Return post-action snapshot diffs and current refs
   AGENT_BROWSER_MAX_OUTPUT       Max characters for page output
   AGENT_BROWSER_ALLOWED_DOMAINS  Comma-separated allowed domain patterns; requires a fresh controllable browser context without profile/session startup args, restore/state replay, or direct-page provider plugins
   AGENT_BROWSER_ACTION_POLICY    Path to action policy JSON file
@@ -3763,8 +3867,8 @@ pub fn print_version() {
 #[cfg(test)]
 mod tests {
     use super::{
-        boundary_origin, format_storage_text, format_vitals_text, format_with_boundaries,
-        OutputOptions,
+        boundary_origin, format_post_action_observation, format_storage_text, format_vitals_text,
+        format_with_boundaries, OutputOptions,
     };
     use serde_json::json;
 
@@ -3935,6 +4039,61 @@ hydration: -  phases: 0  hydratedComponents: 0"
         assert_eq!(
             boundary_origin(&json!({ "url": "https://example.com/source" })),
             Some("https://example.com/source")
+        );
+    }
+
+    #[test]
+    fn test_format_post_action_observation_diff_includes_ref_refresh() {
+        let rendered = format_post_action_observation(&json!({
+            "mode": "diff",
+            "changed": true,
+            "additions": 1,
+            "removals": 0,
+            "diff": "@@ -1 +1,2 @@\n button [ref=e1]\n+button \"New\" [ref=e2]\n",
+            "refs": {
+                "e1": { "role": "button", "name": "Existing" },
+                "e2": { "role": "button", "name": "New" }
+            }
+        }));
+
+        assert!(rendered.contains("Post-action observation diff (+1, -0)"));
+        assert!(rendered.contains("Current refs:"));
+        assert!(rendered.contains("@e2 button \"New\""));
+    }
+
+    #[test]
+    fn test_format_post_action_observation_unchanged_stays_lightweight() {
+        let rendered = format_post_action_observation(&json!({
+            "mode": "diff",
+            "changed": false,
+            "additions": 0,
+            "removals": 0,
+            "diff": "",
+            "refs": { "e1": { "role": "button", "name": "Existing" } }
+        }));
+
+        assert_eq!(
+            rendered,
+            "Post-action observation: no accessibility changes"
+        );
+        assert!(!rendered.contains("Current refs"));
+    }
+
+    #[test]
+    fn test_format_post_action_observation_full_and_error_modes() {
+        assert_eq!(
+            format_post_action_observation(&json!({
+                "mode": "full",
+                "snapshot": "button \"Submit\" [ref=e1]"
+            })),
+            "Post-action observation (full; no prior snapshot):\nbutton \"Submit\" [ref=e1]"
+        );
+        assert_eq!(
+            format_post_action_observation(&json!({
+                "mode": "error",
+                "error": "dialog blocked the page"
+            })),
+            "Post-action observation unavailable: dialog blocked the page"
         );
     }
 }

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -526,6 +526,19 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 
 See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime scripts, built-in React DevTools, and extensions.
 
+## Post-action observations
+
+Add `--snapshot-after-action` to a navigation, interaction, or wait command to receive a lightweight observation in the same response:
+
+```bash
+agent-browser snapshot -i
+agent-browser --snapshot-after-action click @e2
+```
+
+The first explicit snapshot establishes a baseline. Each successful supported action then returns a unified accessibility-tree diff and the complete current ref map; if no baseline exists, the first action returns a full compact interactive snapshot. JSON callers receive this under `data.observation`, and supported MCP tools expose the equivalent `snapshotAfter: true` input.
+
+This removes a separate agent round trip, but it still uses the canonical snapshot engine after each action. It does not make refs stable across snapshots: use the refreshed refs from every observation. Stable node identity remains the scope of [PR #1444](https://github.com/vercel-labs/agent-browser/pull/1444) by [@iddogino](https://github.com/iddogino), which this path is designed to compose with rather than replace.
+
 ## Global options
 
 ```bash
@@ -561,6 +574,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --color-scheme <scheme>  # Color scheme: dark, light, no-preference
 --download-path <path>   # Default download directory
 --content-boundaries     # Wrap page output in boundary markers for LLM safety
+--snapshot-after-action  # Return an observation diff and current refs after supported actions
 --max-output <chars>     # Truncate page output to N characters
 --allowed-domains <list> # Allowed domains; rejects restore/state replay, profile/session startup args, and direct-page providers
 --action-policy <path>   # Path to action policy JSON file

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -36,7 +36,8 @@ AGENT_BROWSER_CONFIG=./ci-config.json agent-browser open example.com
   "profile": "./browser-data",
   "userAgent": "my-agent/1.0",
   "hideScrollbars": false,
-  "ignoreHttpsErrors": true
+  "ignoreHttpsErrors": true,
+  "snapshotAfterAction": true
 }
 ```
 
@@ -91,6 +92,7 @@ Global launch, output, provider, and chat options can be set in the config file 
     <tr><td><code>colorScheme</code></td><td><code>--color-scheme</code></td><td>string (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>downloadPath</code></td><td><code>--download-path</code></td><td>string</td></tr>
     <tr><td><code>contentBoundaries</code></td><td><code>--content-boundaries</code></td><td>boolean</td></tr>
+    <tr><td><code>snapshotAfterAction</code></td><td><code>--snapshot-after-action</code></td><td>boolean</td></tr>
     <tr><td><code>maxOutput</code></td><td><code>--max-output</code></td><td>number</td></tr>
     <tr><td><code>allowedDomains</code></td><td><code>--allowed-domains</code></td><td>string[]; also disables WebRTC in supported Chromium sessions and requires a fresh controllable browser context without profile/session startup args, restore/state replay, or direct-page provider plugins</td></tr>
     <tr><td><code>actionPolicy</code></td><td><code>--action-policy</code></td><td>string</td></tr>
@@ -173,7 +175,7 @@ agent-browser --headed open example.com       # same as --headed true
 agent-browser --headed true open example.com  # explicit
 ```
 
-This applies to boolean flags such as `--headed`, `--debug`, `--json`, `--ignore-https-errors`, `--allow-file-access`, `--hide-scrollbars`, `--auto-connect`, `--annotate`, `--content-boundaries`, `--confirm-interactive`, and `--no-auto-dialog`.
+This applies to boolean flags such as `--headed`, `--debug`, `--json`, `--ignore-https-errors`, `--allow-file-access`, `--hide-scrollbars`, `--auto-connect`, `--annotate`, `--content-boundaries`, `--snapshot-after-action`, `--confirm-interactive`, and `--no-auto-dialog`.
 
 ## Extensions Merging
 
@@ -282,6 +284,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_IOS_UDID</code></td><td>Default iOS device UDID for the <code>ios</code> provider.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_DEBUG</code></td><td>Enable debug output (<code>1</code> to enable).</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_CONTENT_BOUNDARIES</code></td><td>Wrap page output in boundary markers for LLM safety.</td><td>(disabled)</td></tr>
+    <tr><td><code>AGENT_BROWSER_SNAPSHOT_AFTER_ACTION</code></td><td>Return a post-action accessibility observation and current refs after supported actions.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_MAX_OUTPUT</code></td><td>Max characters for page output (truncates beyond limit).</td><td>(unlimited)</td></tr>
     <tr><td><code>AGENT_BROWSER_ALLOWED_DOMAINS</code></td><td>Comma-separated allowed domain patterns (e.g., <code>example.com,*.example.com</code>). Requires a fresh controllable browser context without profile/session startup args, restore/state replay, or direct-page provider plugins.</td><td>(unrestricted)</td></tr>
     <tr><td><code>AGENT_BROWSER_ACTION_POLICY</code></td><td>Path to action policy JSON file.</td><td>(none)</td></tr>

--- a/docs/src/app/selectors/page.mdx
+++ b/docs/src/app/selectors/page.mdx
@@ -26,6 +26,19 @@ agent-browser hover @e4                   # Hover the link
 - **Fast** - No DOM re-query needed
 - **AI-friendly** - LLMs can reliably parse and use refs
 
+### Refresh refs after an action
+
+Use `--snapshot-after-action` when an agent should act and receive the resulting accessibility change without a second snapshot command:
+
+```bash
+agent-browser snapshot -i
+agent-browser --snapshot-after-action click @e2
+```
+
+The response contains the accessibility diff plus the complete current ref map. Always replace previously held refs with this refreshed map, including when the diff itself is small. Without an earlier snapshot baseline, the first post-action observation contains a full compact interactive snapshot.
+
+This feature does not change ref identity semantics. Stable node-backed refs remain the scope of [PR #1444](https://github.com/vercel-labs/agent-browser/pull/1444) by [@iddogino](https://github.com/iddogino); the post-action path delegates to the canonical snapshot handler so it can inherit that work when it lands.
+
 ## CSS selectors
 
 ```bash

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -21,6 +21,16 @@ agent-browser snapshot -i       # 4. Re-snapshot after any page change
 
 Refs (`@e1`, `@e2`, ...) are assigned fresh on every snapshot. They become **stale the moment the page changes** — after clicks that navigate, form submits, dynamic re-renders, dialog opens. Always re-snapshot before your next ref interaction.
 
+To combine steps 3 and 4 into one model turn, add `--snapshot-after-action` to a page-changing command:
+
+```bash
+agent-browser snapshot -i
+agent-browser click @e3 --snapshot-after-action
+# Returns the accessibility diff plus a complete Current refs list
+```
+
+Use refs from `Current refs` after a changed observation. If there is no earlier snapshot baseline, the command returns a full compact interactive observation instead. This reduces model turns and response size; it still runs the canonical snapshot engine. It does not change ref identity or stale-ref safety, which is separate work in upstream PR #1444 by @iddogino.
+
 ## Quickstart
 
 ```bash
@@ -58,7 +68,7 @@ agent-browser mcp --tools all
 agent-browser mcp --tools core,network,react
 ```
 
-Configure the MCP client to launch `agent-browser` with `["mcp"]`. The server defaults to MCP protocol 2025-11-25 and accepts older supported client protocol versions during initialization. The default tools profile is `core`, which keeps MCP context small for everyday browser automation. Use `--tools all` for the full typed CLI parity surface, or combine profiles with commas, such as `--tools core,network,react`. Profiles are `core`, `network`, `state`, `debug`, `tabs`, `react`, `mobile`, and `all`; the `debug` profile includes plugin registry and command.run tools. Each tool accepts typed arguments plus `extraArgs` for advanced CLI flags and exact CLI parity. The common `allowedDomains` array maps to `--allowed-domains` and activates the same WebRTC containment and launch-mode restrictions. Tool discovery is paginated and includes read-only/open-world annotations so modern MCP clients can load the large typed surface incrementally. Use the tool `session` argument or `AGENT_BROWSER_SESSION` to isolate browser sessions.
+Configure the MCP client to launch `agent-browser` with `["mcp"]`. The server defaults to MCP protocol 2025-11-25 and accepts older supported client protocol versions during initialization. The default tools profile is `core`, which keeps MCP context small for everyday browser automation. Use `--tools all` for the full typed CLI parity surface, or combine profiles with commas, such as `--tools core,network,react`. Profiles are `core`, `network`, `state`, `debug`, `tabs`, `react`, `mobile`, and `all`; the `debug` profile includes plugin registry and command.run tools. Each tool accepts typed arguments plus `extraArgs` for advanced CLI flags and exact CLI parity. Page-changing tools accept `snapshotAfter: true`, matching the CLI's `--snapshot-after-action` behavior. The common `allowedDomains` array maps to `--allowed-domains` and activates the same WebRTC containment and launch-mode restrictions. Tool discovery is paginated and includes read-only/open-world annotations so modern MCP clients can load the large typed surface incrementally. Use the tool `session` argument or `AGENT_BROWSER_SESSION` to isolate browser sessions.
 
 ## eve agent integration
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -50,6 +50,13 @@ agent-browser snapshot -d 3       # Limit depth to 3
 agent-browser snapshot -s "#main" # Scope to CSS selector
 ```
 
+Add `--snapshot-after-action` to a page-changing command to return its snapshot diff and current refs in the same response. With MCP tools, use `snapshotAfter: true`:
+
+```bash
+agent-browser snapshot -i
+agent-browser click @e1 --snapshot-after-action
+```
+
 ## Interactions (use @refs from snapshot)
 
 ```bash

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -95,6 +95,30 @@ agent-browser snapshot -i
 # @e1 [h1] "Page 2"  ← Different element now!
 ```
 
+## One-turn Post-action Observation
+
+Use `--snapshot-after-action` when an action is likely to change the page and you need updated refs immediately:
+
+```bash
+agent-browser snapshot -i
+# @e1 [button] "Open menu"
+
+agent-browser click @e1 --snapshot-after-action
+# ✓ Done
+# Post-action observation diff (+3, -0):
+# ...
+# Current refs:
+#   @e1 [button] "Open menu"
+#   @e2 [menuitem] "Profile"
+#   @e3 [menuitem] "Sign out"
+```
+
+An explicit snapshot establishes the baseline and its filtering options are reused. Each successful post-action observation becomes the next baseline. When no baseline exists, the first action returns a full compact interactive observation. When the page changed, the response includes the complete current ref map so the next interaction does not require another snapshot turn.
+
+The flag applies to page-changing navigation, interaction, and wait commands. Set `snapshotAfterAction: true` in `agent-browser.json` or `AGENT_BROWSER_SNAPSHOT_AFTER_ACTION=1` for persistent behavior. Pass `--snapshot-after-action false` for an individual command that should skip it. In MCP, pass `snapshotAfter: true` to a page-changing tool.
+
+Snapshot collection still uses the normal snapshot engine. The lightweight part is the returned diff and ref refresh, not the browser-side collection cost. This feature does not change ref identity or stale-ref safety; that work is separately covered by upstream PR #1444 from @iddogino.
+
 ## Best Practices
 
 ### 1. Always Snapshot Before Interacting


### PR DESCRIPTION
## Summary

- add opt-in post-action observations through `--snapshot-after-action`, configuration, environment, and MCP
- baseline observations on explicit snapshots and return a unified accessibility-tree diff, change counters, and the complete current ref map after page-changing actions
- invalidate baselines across context changes, failed explicit snapshots, and snapshots whose final response fails, while keeping post-action capture failures nonfatal to the requested action
- cover script evaluation, history updates, raw input, emulation, clipboard paste, tab, window, and frame changes consistently across CLI and MCP
- preserve normal MCP action metadata alongside the appended observation text
- move snapshot payloads out of the canonical response instead of cloning large trees on the steady-state diff path
- document the JSON contract and agent workflow across the README, docs, schema, and bundled skill

## Issue and overlap

Closes #1351.

This PR deliberately does not claim to solve stale refs in #1443 or #1504. PR #1444 by @iddogino is the dedicated stable-ref implementation and is more complete for that problem. I tested this observation work rebased with #1444: all observation E2Es and all three stable-ref E2Es passed together, with only an adjacent documentation conflict resolved by retaining both sections.

## Validation

- `cargo fmt --all -- --check`
- strict Clippy across all targets and features
- full Rust suite: 974 unit tests plus 2 doctor integration tests passed
- all 87 ignored serial browser E2Es passed
- focused post-action unit and E2E coverage, including failed explicit snapshots, nonfatal capture errors, recovery, and context changes
- real multi-process CLI smoke test verified `snapshot`, ref action, unified diff, refreshed refs, JSON output, and close
- production docs build completed with all 43 routes

## Full fork CI

- [Fresh post-audit cross-platform validation](https://github.com/tempera-dev/agent-browser/actions/runs/29728078637) passed Linux formatting, Clippy, and the full Rust suite; Apple Silicon; Windows compilation and focused runtime tests; all native E2Es; Windows integration; package builds; and global installs on Linux, macOS, and Windows.
- The only red job is the Intel macOS parity test timing out on action `launch`. The same test and timeout reproduce on a [fresh untouched upstream `main` validation run](https://github.com/tempera-dev/agent-browser/actions/runs/29728538114).
