### PR TITLE
perf: execute batches in one daemon request

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ agent-browser wait "#spinner" --state hidden
 
 ### Batch Execution
 
-Execute multiple commands in a single invocation. Commands can be passed as quoted arguments or piped as JSON via stdin. This avoids per-command process startup overhead when running multi-step workflows.
+Execute multiple commands in a single CLI invocation and a single daemon request. Commands are parsed client-side, then the daemon acquires the session once and executes them in order without reconnecting between steps. This avoids per-command process startup and socket lifecycle overhead in multi-step workflows.
+
+`--bail` stops on the first parse or execution error. A confirmation request or successful `close` always stops the remaining commands safely. Nested batches are rejected. The client does not replay a submitted batch after a transport failure because earlier commands may already have changed the page. The daemon performs one final CDP event drain before replying, but it does not add an implicit network-idle wait because no single settle condition is correct for every command; include an explicit `wait` child when the workflow requires one.
 
 ```bash
 # Argument mode: each quoted argument is a full command
@@ -413,7 +415,7 @@ agent-browser pushstate <url>         # SPA client-side nav; auto-detects window
 
 ### Pre-navigation setup
 
-Some flows (SSR debug, auth cookies for protected origins, init scripts) need state set up *before* the first navigation. Use `open` with no URL to launch the browser, then stage cookies / routes / init scripts, then navigate. `batch` sends it all in one CLI call:
+Some flows (SSR debug, auth cookies for protected origins, init scripts) need state set up *before* the first navigation. Use `open` with no URL to launch the browser, then stage cookies / routes / init scripts, then navigate. `batch` sends it all in one CLI call and one daemon request:
 
 ```bash
 agent-browser batch \
@@ -548,6 +550,8 @@ Full parity MCP client config:
 ```
 
 Tool invocations use the same config files and environment variables as the CLI. Use `session` in the tool arguments, or set `AGENT_BROWSER_SESSION`, to isolate browser state.
+
+The `agent_browser_batch` tool delegates to the canonical CLI batch parser and uses the same single daemon request, ordered results, bail, confirmation, close, and no-replay behavior.
 
 ## Authentication
 

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -1032,6 +1032,16 @@ pub fn send_command(cmd: Value, session: &str) -> Result<Response, String> {
     ))
 }
 
+/// Send a command exactly once.
+///
+/// Batch requests use this path because retrying a partially completed batch
+/// could repeat browser side effects. The caller may still recover from an
+/// initial connection failure, which happens before any request bytes are
+/// written, but must not replay read, EOF, or reset failures.
+pub fn send_command_no_retry(cmd: Value, session: &str) -> Result<Response, String> {
+    send_command_once(&cmd, session)
+}
+
 /// Check if an error is transient and worth retrying against the SAME daemon.
 /// Transient errors include:
 /// - EAGAIN/EWOULDBLOCK (os error 35 on macOS, 11 on Linux)
@@ -1086,7 +1096,26 @@ fn has_os_error(error: &str, code: u32) -> bool {
 /// instead of 30s. Only commands that actually carry a `timeout` field get
 /// the extended budget, and that field is set client-side per invocation,
 /// avoiding the daemon's spawn-time env snapshot drifting from the client.
+///
+/// A daemon-side batch is one socket request containing sequential child
+/// requests. Its read budget is therefore the saturating sum of the child
+/// budgets rather than the budget of the outer envelope. This lets the daemon
+/// finish a legitimate long batch without making ordinary commands wait
+/// longer before surfacing an unresponsive daemon.
 fn read_timeout_for(cmd: &Value) -> Duration {
+    if cmd.get("action").and_then(|v| v.as_str()) == Some("batch") {
+        let batch_ms = cmd
+            .get("entries")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.get("request"))
+            .map(|request| read_timeout_for(request).as_millis() as u64)
+            .fold(0_u64, u64::saturating_add)
+            .max(30_000);
+        return Duration::from_millis(batch_ms);
+    }
+
     let op_ms = cmd.get("timeout").and_then(|v| v.as_u64()).unwrap_or(0);
     Duration::from_millis(op_ms.saturating_add(10_000).max(30_000))
 }
@@ -1117,6 +1146,27 @@ fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
 mod tests {
     use super::*;
     use crate::test_utils::EnvGuard;
+
+    #[test]
+    fn test_batch_read_timeout_sums_child_budgets() {
+        let command = json!({
+            "action": "batch",
+            "entries": [
+                { "request": { "action": "url" } },
+                { "parseError": "bad command" },
+                { "request": { "action": "wait", "timeout": 45_000 } }
+            ]
+        });
+
+        assert_eq!(read_timeout_for(&command), Duration::from_secs(85));
+    }
+
+    #[test]
+    fn test_empty_batch_read_timeout_keeps_normal_floor() {
+        let command = json!({ "action": "batch", "entries": [] });
+
+        assert_eq!(read_timeout_for(&command), Duration::from_secs(30));
+    }
 
     #[test]
     fn test_get_socket_dir_explicit_override() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1727,14 +1727,8 @@ fn batch_failed_before_submit(error: &str) -> bool {
     error.starts_with("Failed to connect")
 }
 
-struct PreparedBatch {
-    entries: Vec<serde_json::Value>,
-    actions: Vec<Option<String>>,
-}
-
-fn prepare_batch(commands: &[Vec<String>], flags: &Flags) -> PreparedBatch {
+fn prepare_batch(commands: &[Vec<String>], flags: &Flags) -> Vec<serde_json::Value> {
     let mut entries = Vec::with_capacity(commands.len());
-    let mut actions = Vec::with_capacity(commands.len());
 
     for cmd_args in commands {
         if cmd_args.is_empty() {
@@ -1743,16 +1737,11 @@ fn prepare_batch(commands: &[Vec<String>], flags: &Flags) -> PreparedBatch {
 
         match parse_command(cmd_args, flags) {
             Ok(mut request) => {
-                let action = request
-                    .get("action")
-                    .and_then(|v| v.as_str())
-                    .map(ToString::to_string);
-                if action.as_deref() == Some("batch") {
+                if request.get("action").and_then(|v| v.as_str()) == Some("batch") {
                     entries.push(json!({
                         "command": cmd_args,
                         "parseError": "Nested batch commands are not supported",
                     }));
-                    actions.push(None);
                     continue;
                 }
 
@@ -1762,19 +1751,17 @@ fn prepare_batch(commands: &[Vec<String>], flags: &Flags) -> PreparedBatch {
                     "command": cmd_args,
                     "request": request,
                 }));
-                actions.push(action);
             }
             Err(e) => {
                 entries.push(json!({
                     "command": cmd_args,
                     "parseError": e.format(),
                 }));
-                actions.push(None);
             }
         }
     }
 
-    PreparedBatch { entries, actions }
+    entries
 }
 
 fn run_batch(
@@ -1825,8 +1812,8 @@ fn run_batch(
         return;
     }
 
-    let prepared = prepare_batch(&commands, flags);
-    if prepared.entries.is_empty() {
+    let entries = prepare_batch(&commands, flags);
+    if entries.is_empty() {
         if flags.json {
             println!("[]");
         }
@@ -1837,7 +1824,7 @@ fn run_batch(
         "id": gen_id(),
         "action": "batch",
         "bail": bail,
-        "entries": prepared.entries,
+        "entries": entries,
     });
     let response = match send_batch_with_respawn(batch_request, &flags.session, daemon_opts) {
         Ok(response) => response,
@@ -1887,7 +1874,7 @@ fn run_batch(
                 eprintln!("{} {}", color::error_indicator(), error);
                 continue;
             }
-            let action = prepared.actions.get(index).and_then(|v| v.as_deref());
+            let action = result.get("action").and_then(|value| value.as_str());
             if action.is_none() {
                 let error = result
                     .get("error")
@@ -2107,20 +2094,19 @@ mod tests {
             Vec::new(),
         ];
 
-        let prepared = prepare_batch(&commands, &flags);
+        let entries = prepare_batch(&commands, &flags);
 
-        assert_eq!(prepared.entries.len(), 3);
-        assert_eq!(prepared.entries[0]["request"]["action"], "url");
-        assert_eq!(prepared.entries[0]["command"], json!(["get", "url"]));
-        assert!(prepared.entries[1]["parseError"]
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0]["request"]["action"], "url");
+        assert_eq!(entries[0]["command"], json!(["get", "url"]));
+        assert!(entries[1]["parseError"]
             .as_str()
             .unwrap()
             .contains("Unknown command"));
         assert_eq!(
-            prepared.entries[2]["parseError"],
+            entries[2]["parseError"],
             "Nested batch commands are not supported"
         );
-        assert_eq!(prepared.actions, vec![Some("url".to_string()), None, None]);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ use windows_sys::Win32::System::Threading::OpenProcess;
 use commands::{gen_id, parse_command, ParseError};
 use connection::{
     cleanup_stale_files, daemon_unreachable, ensure_daemon, get_socket_dir, is_pid_alive,
-    send_command, walk_daemons, DaemonOptions, Response,
+    send_command, send_command_no_retry, walk_daemons, DaemonOptions, Response,
 };
 use flags::{clean_args, parse_flags, Flags};
 use install::run_install;
@@ -1688,6 +1688,95 @@ fn send_command_with_respawn(
     }
 }
 
+/// Send a batch envelope without transient retries. A failure to establish
+/// the initial connection is safe to recover because no request bytes were
+/// sent. Once connected, any failure is returned directly so completed child
+/// actions are never replayed.
+fn send_batch_with_respawn(
+    cmd: serde_json::Value,
+    session: &str,
+    daemon_opts: &DaemonOptions,
+) -> Result<connection::Response, String> {
+    send_batch_with_recovery(
+        cmd,
+        |request| send_command_no_retry(request, session),
+        || ensure_daemon(session, daemon_opts).map(|_| ()),
+    )
+}
+
+fn send_batch_with_recovery<Send, Recover>(
+    cmd: serde_json::Value,
+    mut send: Send,
+    mut recover_initial_connection: Recover,
+) -> Result<connection::Response, String>
+where
+    Send: FnMut(serde_json::Value) -> Result<connection::Response, String>,
+    Recover: FnMut() -> Result<(), String>,
+{
+    let first_attempt = send(cmd.clone());
+    match first_attempt {
+        Err(ref e) if batch_failed_before_submit(e) => match recover_initial_connection() {
+            Ok(()) => send(cmd),
+            Err(_) => first_attempt,
+        },
+        other => other,
+    }
+}
+
+fn batch_failed_before_submit(error: &str) -> bool {
+    error.starts_with("Failed to connect")
+}
+
+struct PreparedBatch {
+    entries: Vec<serde_json::Value>,
+    actions: Vec<Option<String>>,
+}
+
+fn prepare_batch(commands: &[Vec<String>], flags: &Flags) -> PreparedBatch {
+    let mut entries = Vec::with_capacity(commands.len());
+    let mut actions = Vec::with_capacity(commands.len());
+
+    for cmd_args in commands {
+        if cmd_args.is_empty() {
+            continue;
+        }
+
+        match parse_command(cmd_args, flags) {
+            Ok(mut request) => {
+                let action = request
+                    .get("action")
+                    .and_then(|v| v.as_str())
+                    .map(ToString::to_string);
+                if action.as_deref() == Some("batch") {
+                    entries.push(json!({
+                        "command": cmd_args,
+                        "parseError": "Nested batch commands are not supported",
+                    }));
+                    actions.push(None);
+                    continue;
+                }
+
+                attach_plugins_to_command(&mut request, &flags.plugins);
+                attach_restore_config_to_command(&mut request, flags);
+                entries.push(json!({
+                    "command": cmd_args,
+                    "request": request,
+                }));
+                actions.push(action);
+            }
+            Err(e) => {
+                entries.push(json!({
+                    "command": cmd_args,
+                    "parseError": e.format(),
+                }));
+                actions.push(None);
+            }
+        }
+    }
+
+    PreparedBatch { entries, actions }
+}
+
 fn run_batch(
     flags: &Flags,
     daemon_opts: &DaemonOptions,
@@ -1736,105 +1825,103 @@ fn run_batch(
         return;
     }
 
-    let output_opts = OutputOptions::from_flags(flags);
-
-    let mut results: Vec<serde_json::Value> = Vec::new();
-    let mut had_error = false;
-
-    for (i, cmd_args) in commands.iter().enumerate() {
-        if cmd_args.is_empty() {
-            continue;
+    let prepared = prepare_batch(&commands, flags);
+    if prepared.entries.is_empty() {
+        if flags.json {
+            println!("[]");
         }
-
-        let mut parsed = match parse_command(cmd_args, flags) {
-            Ok(c) => c,
-            Err(e) => {
-                had_error = true;
-                if flags.json {
-                    results.push(json!({
-                        "command": cmd_args,
-                        "success": false,
-                        "error": e.format(),
-                    }));
-                    if bail {
-                        break;
-                    }
-                } else {
-                    eprintln!(
-                        "{} Command {}: {}",
-                        color::error_indicator(),
-                        i + 1,
-                        e.format()
-                    );
-                    if bail {
-                        exit(1);
-                    }
-                }
-                continue;
-            }
-        };
-
-        let action = parsed
-            .get("action")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        attach_plugins_to_command(&mut parsed, &flags.plugins);
-        attach_restore_config_to_command(&mut parsed, flags);
-
-        match send_command_with_respawn(parsed, &flags.session, daemon_opts) {
-            Ok(resp) => {
-                if flags.json {
-                    results.push(json!({
-                        "command": cmd_args,
-                        "success": resp.success,
-                        "result": resp.data,
-                        "error": resp.error,
-                    }));
-                } else {
-                    if i > 0 {
-                        println!();
-                    }
-                    print_response_with_opts(&resp, action.as_deref(), &output_opts);
-                }
-                if !resp.success {
-                    had_error = true;
-                    if bail {
-                        if !flags.json {
-                            exit(1);
-                        }
-                        break;
-                    }
-                }
-            }
-            Err(e) => {
-                had_error = true;
-                if flags.json {
-                    results.push(json!({
-                        "command": cmd_args,
-                        "success": false,
-                        "error": e.to_string(),
-                    }));
-                    if bail {
-                        break;
-                    }
-                } else {
-                    eprintln!("{} Command {}: {}", color::error_indicator(), i + 1, e);
-                    if bail {
-                        exit(1);
-                    }
-                }
-            }
-        }
+        return;
     }
+
+    let batch_request = json!({
+        "id": gen_id(),
+        "action": "batch",
+        "bail": bail,
+        "entries": prepared.entries,
+    });
+    let response = match send_batch_with_respawn(batch_request, &flags.session, daemon_opts) {
+        Ok(response) => response,
+        Err(e) => {
+            if flags.json {
+                print_json_error(e);
+            } else {
+                eprintln!("{} {}", color::error_indicator(), e);
+            }
+            exit(1);
+        }
+    };
+
+    let Some(results) = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("results"))
+        .and_then(|results| results.as_array())
+    else {
+        let error = response
+            .error
+            .unwrap_or_else(|| "Invalid batch response: missing results".to_string());
+        if flags.json {
+            print_json_error(error);
+        } else {
+            eprintln!("{} {}", color::error_indicator(), error);
+        }
+        exit(1);
+    };
 
     if flags.json {
         println!(
             "{}",
-            serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string())
+            serde_json::to_string(results).unwrap_or_else(|_| "[]".to_string())
         );
+    } else {
+        let output_opts = OutputOptions::from_flags(flags);
+        for (index, result) in results.iter().enumerate() {
+            if index > 0 {
+                println!();
+            }
+            if result.get("batchFinalization").and_then(|v| v.as_bool()) == Some(true) {
+                let error = result
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Batch finalization failed");
+                eprintln!("{} {}", color::error_indicator(), error);
+                continue;
+            }
+            let action = prepared.actions.get(index).and_then(|v| v.as_deref());
+            if action.is_none() {
+                let error = result
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Invalid batch entry");
+                eprintln!(
+                    "{} Command {}: {}",
+                    color::error_indicator(),
+                    index + 1,
+                    error
+                );
+                continue;
+            }
+
+            let child_response = Response {
+                success: result
+                    .get("success")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                data: result.get("result").cloned().filter(|v| !v.is_null()),
+                error: result
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .map(ToString::to_string),
+                warning: result
+                    .get("warning")
+                    .and_then(|v| v.as_str())
+                    .map(ToString::to_string),
+            };
+            print_response_with_opts(&child_response, action, &output_opts);
+        }
     }
 
-    if had_error {
+    if !response.success {
         exit(1);
     }
 }
@@ -2008,6 +2095,85 @@ mod tests {
         attach_plugins_to_command(&mut cmd, &[]);
 
         assert_eq!(cmd["plugins"], json!([]));
+    }
+
+    #[test]
+    fn test_prepare_batch_keeps_parse_errors_ordered_and_rejects_nested_batch() {
+        let flags = neutral_launch_config_flags();
+        let commands = vec![
+            vec!["get".to_string(), "url".to_string()],
+            vec!["definitely-not-a-command".to_string()],
+            vec!["batch".to_string(), "url".to_string()],
+            Vec::new(),
+        ];
+
+        let prepared = prepare_batch(&commands, &flags);
+
+        assert_eq!(prepared.entries.len(), 3);
+        assert_eq!(prepared.entries[0]["request"]["action"], "url");
+        assert_eq!(prepared.entries[0]["command"], json!(["get", "url"]));
+        assert!(prepared.entries[1]["parseError"]
+            .as_str()
+            .unwrap()
+            .contains("Unknown command"));
+        assert_eq!(
+            prepared.entries[2]["parseError"],
+            "Nested batch commands are not supported"
+        );
+        assert_eq!(prepared.actions, vec![Some("url".to_string()), None, None]);
+    }
+
+    #[test]
+    fn test_batch_post_submit_transport_failure_is_never_replayed() {
+        let mut sends = 0;
+        let mut recoveries = 0;
+        let error = match send_batch_with_recovery(
+            json!({ "action": "batch", "entries": [] }),
+            |_| {
+                sends += 1;
+                Err("Failed to read: Connection reset by peer".to_string())
+            },
+            || {
+                recoveries += 1;
+                Ok(())
+            },
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("post-submit failure must be returned"),
+        };
+
+        assert_eq!(sends, 1, "a submitted batch must never be replayed");
+        assert_eq!(recoveries, 0, "post-submit failures must not respawn");
+        assert!(error.contains("Connection reset"));
+    }
+
+    #[test]
+    fn test_batch_initial_connect_failure_can_recover_before_submit() {
+        let mut sends = 0;
+        let mut recoveries = 0;
+        let response = send_batch_with_recovery(
+            json!({ "action": "batch", "entries": [] }),
+            |_| {
+                sends += 1;
+                if sends == 1 {
+                    Err("Failed to connect: connection refused".to_string())
+                } else {
+                    Ok(Response {
+                        success: true,
+                        ..Response::default()
+                    })
+                }
+            },
+            || {
+                recoveries += 1;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert!(response.success);
+        assert_eq!(sends, 2);
+        assert_eq!(recoveries, 1);
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1517,7 +1517,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_BATCH,
             "Batch",
-            "Run multiple commands sequentially.",
+            "Run multiple commands sequentially through one daemon request and connection.",
             json!({ "commands": { "type": "array", "items": { "type": "array", "items": { "type": "string" }, "minItems": 1 }, "minItems": 1 }, "bail": { "type": "boolean" } }),
             &["commands"],
         ),
@@ -3069,7 +3069,7 @@ fn call_diff_url(arguments: &Value) -> Result<Value, ProtocolError> {
     call_cli_tool(arguments, args, None)
 }
 
-fn call_batch(arguments: &Value) -> Result<Value, ProtocolError> {
+fn batch_cli_invocation(arguments: &Value) -> Result<(Vec<String>, String), ProtocolError> {
     let commands_value = optional_value(arguments, "commands")?
         .ok_or_else(|| ProtocolError::invalid_params("commands must be an array"))?;
     let commands = commands_value
@@ -3101,6 +3101,11 @@ fn call_batch(arguments: &Value) -> Result<Value, ProtocolError> {
     }
     let stdin = serde_json::to_string(&parsed_commands)
         .map_err(|e| ProtocolError::invalid_params(format!("commands encode error: {}", e)))?;
+    Ok((args, stdin))
+}
+
+fn call_batch(arguments: &Value) -> Result<Value, ProtocolError> {
+    let (args, stdin) = batch_cli_invocation(arguments)?;
     call_cli_tool(arguments, args, Some(stdin))
 }
 
@@ -3990,6 +3995,35 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, vec!["click", "@e1", "--new-tab"]);
+    }
+
+    #[test]
+    fn batch_mcp_tool_delegates_one_canonical_cli_batch() {
+        let (args, stdin) = batch_cli_invocation(&json!({
+            "commands": [
+                ["open", "https://example.com"],
+                ["snapshot", "-i"]
+            ],
+            "bail": true
+        }))
+        .unwrap();
+
+        assert_eq!(args, vec!["batch", "--bail"]);
+        assert_eq!(
+            serde_json::from_str::<Value>(&stdin).unwrap(),
+            json!([["open", "https://example.com"], ["snapshot", "-i"]])
+        );
+    }
+
+    #[test]
+    fn batch_mcp_tool_rejects_non_string_child_arguments() {
+        let error = batch_cli_invocation(&json!({
+            "commands": [["click", 42]]
+        }))
+        .unwrap_err();
+
+        assert_eq!(error.code, -32602);
+        assert!(error.message.contains("commands[0][1] must be a string"));
     }
 
     #[test]

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -602,10 +602,8 @@ pub(crate) async fn execute_batch_command(cmd: &Value, state: &mut DaemonState) 
     // This is intentionally not an implicit network-idle wait: there is no
     // generic settle condition that is correct for every command, and callers
     // should include an explicit `wait` child when their workflow needs one.
-    let mut final_drain_attempted = false;
     if executed_child && !closed {
         tokio::task::yield_now().await;
-        final_drain_attempted = true;
         if let Err(error) = state.drain_cdp_events_background().await {
             had_error = true;
             results.push(serde_json::json!({
@@ -634,10 +632,8 @@ pub(crate) async fn execute_batch_command(cmd: &Value, state: &mut DaemonState) 
         "success": !had_error,
         "data": {
             "results": results,
-            "stopped": stop_reason.is_some(),
             "stopReason": stop_reason,
             "closed": closed,
-            "finalDrainAttempted": final_drain_attempted,
         },
     })
 }
@@ -860,7 +856,6 @@ mod tests {
             serde_json::json!(["bad-three"])
         );
         assert_eq!(continued["success"], false);
-        assert_eq!(continued["data"]["finalDrainAttempted"], true);
 
         let bailed = execute_batch_command(
             &serde_json::json!({
@@ -874,7 +869,6 @@ mod tests {
         .await;
         assert_eq!(bailed["data"]["results"].as_array().unwrap().len(), 1);
         assert_eq!(bailed["data"]["stopReason"], "error");
-        assert_eq!(bailed["data"]["finalDrainAttempted"], false);
     }
 
     #[tokio::test]
@@ -918,7 +912,6 @@ mod tests {
             serde_json::json!(true)
         );
         assert_eq!(response["data"]["stopReason"], "confirmation");
-        assert_eq!(response["data"]["finalDrainAttempted"], true);
     }
 
     #[tokio::test]
@@ -951,7 +944,6 @@ mod tests {
         assert_eq!(response["success"], true);
         assert_eq!(response["data"]["results"].as_array().unwrap().len(), 1);
         assert_eq!(response["data"]["stopReason"], "confirmation");
-        assert_eq!(response["data"]["finalDrainAttempted"], true);
         assert_eq!(
             response["data"]["results"][0]["result"]["confirmation_required"],
             true
@@ -984,7 +976,6 @@ mod tests {
         assert_eq!(response["success"], false);
         assert_eq!(response["data"]["stopReason"], "close");
         assert_eq!(response["data"]["closed"], true);
-        assert_eq!(response["data"]["finalDrainAttempted"], false);
         assert!(close_completed_response("batch", &response));
     }
 

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -566,6 +566,7 @@ pub(crate) async fn execute_batch_command(cmd: &Value, state: &mut DaemonState) 
             .unwrap_or(false);
         let mut result = serde_json::json!({
             "command": command,
+            "action": child_action,
             "success": success,
             "result": response.get("data").cloned().unwrap_or(Value::Null),
             "error": response.get("error").cloned().unwrap_or(Value::Null),
@@ -668,13 +669,18 @@ fn close_completed_response(action: &str, response: &Value) -> bool {
         data.get("closed").and_then(|v| v.as_bool()) == Some(true)
     }
 
-    if response.get("success").and_then(|v| v.as_bool()) != Some(true) {
-        return false;
-    }
-
     let Some(data) = response.get("data") else {
         return false;
     };
+    // A batch can report earlier child errors and still complete a later
+    // `close`. The outer response is then unsuccessful, but the daemon must
+    // honor the successful close instead of lingering without a browser.
+    if action == "batch" && data_closed(data) {
+        return true;
+    }
+    if response.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return false;
+    }
     if data_closed(data) {
         return true;
     }
@@ -962,6 +968,7 @@ mod tests {
                 "id": "batch-close",
                 "action": "batch",
                 "entries": [
+                    { "command": ["bad"], "parseError": "earlier error" },
                     {
                         "command": ["close"],
                         "request": { "id": "close", "action": "close" }
@@ -973,7 +980,8 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response["data"]["results"].as_array().unwrap().len(), 1);
+        assert_eq!(response["data"]["results"].as_array().unwrap().len(), 2);
+        assert_eq!(response["success"], false);
         assert_eq!(response["data"]["stopReason"], "close");
         assert_eq!(response["data"]["closed"], true);
         assert_eq!(response["data"]["finalDrainAttempted"], false);

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -449,7 +449,11 @@ async fn handle_connection<S>(
 
                 let response = {
                     let mut s = state.lock().await;
-                    execute_command(&cmd, &mut s).await
+                    if action == "batch" {
+                        execute_batch_command(&cmd, &mut s).await
+                    } else {
+                        execute_command(&cmd, &mut s).await
+                    }
                 };
 
                 let mut resp = serde_json::to_string(&response).unwrap_or_default();
@@ -475,6 +479,176 @@ async fn handle_connection<S>(
     }
 }
 
+/// Execute a client-prepared batch while the caller holds the session state.
+///
+/// The CLI parses every child through the canonical command parser before it
+/// builds the envelope. Parse failures remain ordered entries so `--bail`
+/// behaves exactly as it does for daemon command failures. The daemon still
+/// validates the envelope and rejects nested batches so direct protocol
+/// clients cannot recurse indefinitely or bypass the single-envelope model.
+pub(crate) async fn execute_batch_command(cmd: &Value, state: &mut DaemonState) -> Value {
+    let id = cmd.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let bail = cmd.get("bail").and_then(|v| v.as_bool()).unwrap_or(false);
+    let Some(entries) = cmd.get("entries").and_then(|v| v.as_array()) else {
+        return serde_json::json!({
+            "id": id,
+            "success": false,
+            "error": "Invalid batch request: entries must be an array",
+        });
+    };
+
+    let mut results = Vec::with_capacity(entries.len());
+    let mut had_error = false;
+    let mut stop_reason: Option<&str> = None;
+    let mut closed = false;
+    let mut executed_child = false;
+    let mut last_executable_result_index = None;
+
+    for entry in entries {
+        let command = entry
+            .get("command")
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new()));
+
+        if let Some(parse_error) = entry.get("parseError").and_then(|v| v.as_str()) {
+            results.push(serde_json::json!({
+                "command": command,
+                "success": false,
+                "error": parse_error,
+            }));
+            had_error = true;
+            if bail {
+                stop_reason = Some("error");
+                break;
+            }
+            continue;
+        }
+
+        let Some(request) = entry.get("request").filter(|v| v.is_object()) else {
+            results.push(serde_json::json!({
+                "command": command,
+                "success": false,
+                "error": "Invalid batch entry: request must be an object",
+            }));
+            had_error = true;
+            if bail {
+                stop_reason = Some("error");
+                break;
+            }
+            continue;
+        };
+
+        let child_action = request
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if child_action == "batch" {
+            results.push(serde_json::json!({
+                "command": command,
+                "success": false,
+                "error": "Nested batch commands are not supported",
+            }));
+            had_error = true;
+            if bail {
+                stop_reason = Some("error");
+                break;
+            }
+            continue;
+        }
+
+        // Box the future because execute_command can itself resume a pending
+        // confirmed command through an async recursive path.
+        executed_child = true;
+        let response = Box::pin(execute_command(request, state)).await;
+        let success = response
+            .get("success")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let mut result = serde_json::json!({
+            "command": command,
+            "success": success,
+            "result": response.get("data").cloned().unwrap_or(Value::Null),
+            "error": response.get("error").cloned().unwrap_or(Value::Null),
+        });
+        if let Some(warning) = response.get("warning") {
+            result["warning"] = warning.clone();
+        }
+        results.push(result);
+        last_executable_result_index = Some(results.len() - 1);
+
+        if response_requires_confirmation(&response) {
+            stop_reason = Some("confirmation");
+            break;
+        }
+        if close_completed_response(child_action, &response) {
+            closed = true;
+            stop_reason = Some("close");
+            break;
+        }
+        if !success {
+            had_error = true;
+            if bail {
+                stop_reason = Some("error");
+                break;
+            }
+        }
+    }
+
+    // Each child retains its own pre/post event drains because target changes,
+    // dialogs, and navigation state are inputs to the next child. Yield once
+    // and drain again at the outer boundary so events queued immediately after
+    // the final child are applied before the batch response is serialized.
+    // This is intentionally not an implicit network-idle wait: there is no
+    // generic settle condition that is correct for every command, and callers
+    // should include an explicit `wait` child when their workflow needs one.
+    let mut final_drain_attempted = false;
+    if executed_child && !closed {
+        tokio::task::yield_now().await;
+        final_drain_attempted = true;
+        if let Err(error) = state.drain_cdp_events_background().await {
+            had_error = true;
+            results.push(serde_json::json!({
+                "command": [],
+                "success": false,
+                "error": format!(
+                    "Final batch event drain failed: {}",
+                    super::browser::to_ai_friendly_error(&error)
+                ),
+                "batchFinalization": true,
+            }));
+        } else if let (Some(index), Some(dialog)) =
+            (last_executable_result_index, state.pending_dialog.as_ref())
+        {
+            if results[index].get("warning").is_none() {
+                results[index]["warning"] = serde_json::json!(format!(
+                    "A JavaScript {} dialog is blocking the page: \"{}\" — use `dialog accept` or `dialog dismiss` to resolve it",
+                    dialog.dialog_type, dialog.message
+                ));
+            }
+        }
+    }
+
+    serde_json::json!({
+        "id": id,
+        "success": !had_error,
+        "data": {
+            "results": results,
+            "stopped": stop_reason.is_some(),
+            "stopReason": stop_reason,
+            "closed": closed,
+            "finalDrainAttempted": final_drain_attempted,
+        },
+    })
+}
+
+fn response_requires_confirmation(response: &Value) -> bool {
+    response
+        .get("data")
+        .and_then(|v| v.get("confirmation_required"))
+        .and_then(|v| v.as_bool())
+        == Some(true)
+}
+
 fn looks_like_http(line: &str) -> bool {
     let prefixes = [
         "GET ", "POST ", "PUT ", "DELETE ", "PATCH ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ",
@@ -485,7 +659,7 @@ fn looks_like_http(line: &str) -> bool {
 fn close_completed_response(action: &str, response: &Value) -> bool {
     if !matches!(
         action,
-        "close" | "confirm" | INTERNAL_DAEMON_SHUTDOWN_ACTION
+        "close" | "confirm" | "batch" | INTERNAL_DAEMON_SHUTDOWN_ACTION
     ) {
         return false;
     }
@@ -642,6 +816,207 @@ mod tests {
             &direct
         ));
         assert!(close_completed_response("confirm", &confirmed));
+    }
+
+    #[tokio::test]
+    async fn test_batch_preserves_order_and_bail_behavior() {
+        let mut state = DaemonState::new();
+        state.policy = None;
+        state.confirm_actions = None;
+        let entries = serde_json::json!([
+            { "command": ["bad-one"], "parseError": "first error" },
+            {
+                "command": ["stream", "status"],
+                "request": { "id": "child-2", "action": "stream_status" }
+            },
+            { "command": ["bad-three"], "parseError": "third error" }
+        ]);
+
+        let continued = execute_batch_command(
+            &serde_json::json!({
+                "id": "batch-continue",
+                "action": "batch",
+                "entries": entries.clone(),
+                "bail": false,
+            }),
+            &mut state,
+        )
+        .await;
+        let continued_results = continued["data"]["results"].as_array().unwrap();
+        assert_eq!(continued_results.len(), 3);
+        assert_eq!(
+            continued_results[0]["command"],
+            serde_json::json!(["bad-one"])
+        );
+        assert_eq!(continued_results[1]["success"], true);
+        assert_eq!(
+            continued_results[2]["command"],
+            serde_json::json!(["bad-three"])
+        );
+        assert_eq!(continued["success"], false);
+        assert_eq!(continued["data"]["finalDrainAttempted"], true);
+
+        let bailed = execute_batch_command(
+            &serde_json::json!({
+                "id": "batch-bail",
+                "action": "batch",
+                "entries": entries,
+                "bail": true,
+            }),
+            &mut state,
+        )
+        .await;
+        assert_eq!(bailed["data"]["results"].as_array().unwrap().len(), 1);
+        assert_eq!(bailed["data"]["stopReason"], "error");
+        assert_eq!(bailed["data"]["finalDrainAttempted"], false);
+    }
+
+    #[tokio::test]
+    async fn test_batch_rejects_nested_requests_and_stops_for_confirmation() {
+        use crate::native::policy::ConfirmActions;
+        use std::collections::HashSet;
+
+        let mut state = DaemonState::new();
+        state.policy = None;
+        state.confirm_actions = Some(ConfirmActions {
+            categories: HashSet::from(["stream_status".to_string()]),
+        });
+        let response = execute_batch_command(
+            &serde_json::json!({
+                "id": "batch-confirm",
+                "action": "batch",
+                "entries": [
+                    {
+                        "command": ["batch", "url"],
+                        "request": { "id": "nested", "action": "batch", "entries": [] }
+                    },
+                    {
+                        "command": ["stream", "status"],
+                        "request": { "id": "confirm", "action": "stream_status" }
+                    },
+                    { "command": ["not-run"], "parseError": "must not execute" }
+                ]
+            }),
+            &mut state,
+        )
+        .await;
+
+        let results = response["data"]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0]["error"],
+            "Nested batch commands are not supported"
+        );
+        assert_eq!(
+            results[1]["result"]["confirmation_required"],
+            serde_json::json!(true)
+        );
+        assert_eq!(response["data"]["stopReason"], "confirmation");
+        assert_eq!(response["data"]["finalDrainAttempted"], true);
+    }
+
+    #[tokio::test]
+    async fn test_confirmation_stop_is_a_successful_batch_exit() {
+        use crate::native::policy::ConfirmActions;
+        use std::collections::HashSet;
+
+        let mut state = DaemonState::new();
+        state.policy = None;
+        state.confirm_actions = Some(ConfirmActions {
+            categories: HashSet::from(["stream_status".to_string()]),
+        });
+        let response = execute_batch_command(
+            &serde_json::json!({
+                "id": "batch-confirm-success",
+                "action": "batch",
+                "bail": true,
+                "entries": [
+                    {
+                        "command": ["stream", "status"],
+                        "request": { "id": "confirm", "action": "stream_status" }
+                    },
+                    { "command": ["not-run"], "parseError": "must not execute" }
+                ]
+            }),
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(response["success"], true);
+        assert_eq!(response["data"]["results"].as_array().unwrap().len(), 1);
+        assert_eq!(response["data"]["stopReason"], "confirmation");
+        assert_eq!(response["data"]["finalDrainAttempted"], true);
+        assert_eq!(
+            response["data"]["results"][0]["result"]["confirmation_required"],
+            true
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_close_stops_and_marks_outer_response_closed() {
+        let mut state = DaemonState::new();
+        state.policy = None;
+        state.confirm_actions = None;
+        let response = execute_batch_command(
+            &serde_json::json!({
+                "id": "batch-close",
+                "action": "batch",
+                "entries": [
+                    {
+                        "command": ["close"],
+                        "request": { "id": "close", "action": "close" }
+                    },
+                    { "command": ["not-run"], "parseError": "must not execute" }
+                ]
+            }),
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(response["data"]["results"].as_array().unwrap().len(), 1);
+        assert_eq!(response["data"]["stopReason"], "close");
+        assert_eq!(response["data"]["closed"], true);
+        assert_eq!(response["data"]["finalDrainAttempted"], false);
+        assert!(close_completed_response("batch", &response));
+    }
+
+    #[tokio::test]
+    async fn test_one_batch_line_returns_one_ordered_wrapper() {
+        let (mut client, server) = tokio::io::duplex(16 * 1024);
+        let mut daemon_state = DaemonState::new();
+        daemon_state.policy = None;
+        daemon_state.confirm_actions = None;
+        let state = Arc::new(tokio::sync::Mutex::new(daemon_state));
+        let close_notify = Arc::new(Notify::new());
+        let server_task = tokio::spawn(handle_connection(server, state, None, None, close_notify));
+        let request = serde_json::json!({
+            "id": "one-wrapper",
+            "action": "batch",
+            "entries": [
+                { "command": ["bad"], "parseError": "bad command" },
+                {
+                    "command": ["stream", "status"],
+                    "request": { "id": "status", "action": "stream_status" }
+                }
+            ]
+        });
+        let mut wire = serde_json::to_vec(&request).unwrap();
+        wire.push(b'\n');
+        client.write_all(&wire).await.unwrap();
+
+        let mut reader = BufReader::new(client);
+        let mut response_line = String::new();
+        reader.read_line(&mut response_line).await.unwrap();
+        let response: Value = serde_json::from_str(&response_line).unwrap();
+        assert_eq!(response["id"], "one-wrapper");
+        assert_eq!(response["data"]["results"].as_array().unwrap().len(), 2);
+        assert_eq!(response_line.lines().count(), 1);
+
+        drop(reader);
+        tokio::time::timeout(Duration::from_secs(1), server_task)
+            .await
+            .expect("connection task should finish after client closes")
+            .unwrap();
     }
 
     /// Guard against re-introducing `waitpid(-1)` in daemon code.

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -18,6 +18,7 @@ use crate::test_utils::EnvGuard;
 use super::actions::{
     close_current_browser, execute_command, maybe_autosave_restore_state, DaemonState,
 };
+use super::daemon::execute_batch_command;
 
 fn assert_success(resp: &Value) {
     assert_eq!(
@@ -47,6 +48,59 @@ fn native_test_fixture_url(name: &str) -> String {
         "data:text/html;base64,{}",
         STANDARD.encode(native_test_fixture_html(name))
     )
+}
+
+/// Exercises multiple real browser operations through one daemon batch
+/// envelope. Keeping this as one wrapper guards the latency property that the
+/// client performs one socket request instead of reconnecting per child.
+#[tokio::test]
+#[ignore]
+async fn e2e_daemon_batch_runs_real_browser_steps_in_one_wrapper() {
+    let mut state = DaemonState::new();
+    let response = execute_batch_command(
+        &json!({
+            "id": "e2e-batch",
+            "action": "batch",
+            "bail": true,
+            "entries": [
+                {
+                    "command": ["open"],
+                    "request": {
+                        "id": "launch",
+                        "action": "launch",
+                        "headless": true,
+                        "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+                    }
+                },
+                {
+                    "command": ["open", "data:text/html,<title>Daemon Batch</title>"],
+                    "request": {
+                        "id": "navigate",
+                        "action": "navigate",
+                        "url": "data:text/html,<title>Daemon Batch</title>"
+                    }
+                },
+                {
+                    "command": ["get", "title"],
+                    "request": { "id": "title", "action": "title" }
+                },
+                {
+                    "command": ["close"],
+                    "request": { "id": "close", "action": "close" }
+                },
+                { "command": ["not-run"], "parseError": "close must stop the batch" }
+            ]
+        }),
+        &mut state,
+    )
+    .await;
+
+    assert_success(&response);
+    let results = response["data"]["results"].as_array().unwrap();
+    assert_eq!(results.len(), 4, "close must stop the remaining batch");
+    assert_eq!(results[2]["result"]["title"], "Daemon Batch");
+    assert_eq!(response["data"]["stopReason"], "close");
+    assert_eq!(response["data"]["closed"], true);
 }
 
 async fn create_storage_state_with_cookie(path: &str, cookie_name: &str, cookie_value: &str) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3042,9 +3042,16 @@ agent-browser batch - Execute multiple commands sequentially
 Usage: agent-browser batch [options] "<cmd1>" "<cmd2>" ...
        echo '<json>' | agent-browser batch [options]
 
-Runs multiple commands in sequence. Commands can be passed as quoted
-arguments or piped as JSON via stdin. Results are printed in order,
+Runs multiple commands in sequence through one daemon request and socket
+connection. Commands are parsed before submission and can be passed as
+quoted arguments or piped as JSON via stdin. Results are printed in order,
 separated by blank lines (or as a JSON array with --json).
+
+The daemon stops the batch if a command requests confirmation or closes the
+session. Nested batch commands are rejected. A transport failure after the
+request is sent is not retried because earlier commands may have completed.
+Batch performs a final event drain but does not add an implicit network-idle
+wait; include an explicit wait command when the workflow requires settling.
 
 Options:
   --bail               Stop on first error (default: continue all commands)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -580,7 +580,9 @@ See [Configuration](/configuration) for config files and environment variables. 
 
 ## Batch execution
 
-Execute multiple commands in a single invocation. Commands can be passed as quoted arguments or piped as JSON via stdin.
+Execute multiple commands in a single CLI invocation and one daemon request. Commands are parsed client-side, then the daemon acquires the session once and executes them in order without reconnecting between steps. Commands can be passed as quoted arguments or piped as JSON via stdin.
+
+`--bail` stops on the first parse or execution error. A confirmation request or successful `close` always stops the remaining commands safely. Nested batches are rejected. The client does not replay a submitted batch after a transport failure because earlier commands may already have changed the page. The daemon performs one final CDP event drain before replying, but it does not add an implicit network-idle wait because no single settle condition is correct for every command; include an explicit `wait` child when the workflow requires one.
 
 ```bash
 # Argument mode: each quoted argument is a full command
@@ -664,6 +666,8 @@ Common tools include:
 Each tool has typed fields such as `url`, `selector`, `text`, `key`, `session`, and `allowedDomains`, so MCP clients show meaningful approval prompts instead of raw command arrays. The common `allowedDomains` array maps to `--allowed-domains` and activates the same WebRTC containment and launch-mode restrictions. Each tool also accepts `extraArgs` for advanced CLI flags and exact CLI parity. Tool discovery is paginated and includes read-only/open-world annotations so modern MCP clients can load the large typed surface incrementally.
 
 Tool invocations use the same config files and environment variables as the CLI. Use `session` in the tool arguments, or set `AGENT_BROWSER_SESSION`, to isolate browser state.
+
+The `agent_browser_batch` tool delegates to the canonical CLI batch parser and uses the same single daemon request, ordered results, bail, confirmation, close, and no-replay behavior.
 
 ## Command chaining
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -48,6 +48,8 @@ agent-browser screenshot result.png
 
 The browser stays running across commands so these feel like a single session. Use `agent-browser close` (or `close --all`) when you're done.
 
+For a known multi-step sequence, use `agent-browser batch "open https://example.com" "snapshot -i" "screenshot"`. Batch parses the child commands client-side and executes them through one daemon request, avoiding a socket connection per step. Add `--bail` to stop on the first error. Confirmation requests and `close` stop the remaining commands automatically; nested batches are not supported. Batch performs a final CDP event drain but does not add an implicit network-idle wait, so include a `wait` child when the workflow needs a specific settle condition.
+
 ## MCP integration
 
 For tools that support Model Context Protocol servers, start the stdio server:
@@ -59,6 +61,8 @@ agent-browser mcp --tools core,network,react
 ```
 
 Configure the MCP client to launch `agent-browser` with `["mcp"]`. The server defaults to MCP protocol 2025-11-25 and accepts older supported client protocol versions during initialization. The default tools profile is `core`, which keeps MCP context small for everyday browser automation. Use `--tools all` for the full typed CLI parity surface, or combine profiles with commas, such as `--tools core,network,react`. Profiles are `core`, `network`, `state`, `debug`, `tabs`, `react`, `mobile`, and `all`; the `debug` profile includes plugin registry and command.run tools. Each tool accepts typed arguments plus `extraArgs` for advanced CLI flags and exact CLI parity. The common `allowedDomains` array maps to `--allowed-domains` and activates the same WebRTC containment and launch-mode restrictions. Tool discovery is paginated and includes read-only/open-world annotations so modern MCP clients can load the large typed surface incrementally. Use the tool `session` argument or `AGENT_BROWSER_SESSION` to isolate browser sessions.
+
+The `agent_browser_batch` tool delegates through the canonical CLI parser and uses the same single daemon request, ordered results, bail, confirmation, close, and no-replay behavior as `agent-browser batch`.
 
 ## eve agent integration
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -38,6 +38,8 @@ agent-browser batch \
   '["navigate","http://localhost:3000/target"]'
 ```
 
+`batch` parses the child commands first, submits them through one daemon connection, and returns their results in order. Use `--bail` to stop on the first parse or execution error. Confirmation requests and `close` stop the remaining commands automatically; nested batches are not supported. Batch performs one final CDP event drain but does not wait for network idle implicitly, so include a `wait` child when the workflow needs a specific settle condition.
+
 `open` with no URL gives you a clean launch so any interception, cookies, or init scripts you register take effect on the *first* real navigation. Use for SSR-only debug (`--resource-type script`), protected-origin auth, or capturing fresh `react suspense`/`vitals` state without noise from a prior page.
 
 ## Snapshot (page analysis)


### PR DESCRIPTION
## Summary

- add a daemon batch envelope that sends one canonical request over one connection
- parse each subcommand through the existing CLI parser and return ordered parse or execution results
- acquire daemon session state once, execute actions without recursive connection lifecycles, and perform one final yield and CDP drain
- stop safely on confirmation, close, or bail conditions and never replay a batch after submission
- keep each executable result self-describing and honor a successful `close` even when an earlier child made the outer batch unsuccessful
- expose the same batch contract through MCP and update the README, docs, and bundled skill

This removes per-command daemon reconnect and lifecycle overhead while preserving current command semantics. It does not add an implicit `networkidle`; callers can include an explicit wait when that is part of the batch contract they need.

## Prior work and scope

This builds on the single-process batch foundation from #865 by @mvanhorn and #1160 by @ctate. Those changes removed repeated CLI process startup; this PR moves the batch boundary into the daemon protocol itself.

PR #1268 addresses inline screenshot-flag parsing and remains separate. The connection path retains the safe initial-connect recovery from #1432, while completed or submitted batch requests are never automatically replayed.

## Validation

- `cargo fmt --all -- --check`
- strict Clippy across all targets and features
- full Rust suite: 972 unit tests plus 2 doctor integration tests passed
- 17 focused daemon-batch tests passed
- real-browser batch E2E passed
- black-box CLI and daemon smoke test verified one connection, ordered JSON results, action execution, and close
- production docs build completed with all 43 routes

## Full fork CI

- [Fresh post-audit cross-platform validation](https://github.com/tempera-dev/agent-browser/actions/runs/29728240229) passed Linux formatting, Clippy, and the full Rust suite; Apple Silicon; Windows compilation and focused batch runtime tests; Windows integration; package builds; and global installs on Linux, macOS, and Windows. The new real-browser daemon-batch E2E passed on both hosted attempts.
- The hosted native suite passed 83 of 84 tests on both attempts. The sole failure was the pre-existing `e2e_save_state_cross_domain` timing out while navigating to external `https://httpbin.org/html`; that test bypasses the new batch, daemon-connection, and socket-timeout paths, and those underlying action/browser/CDP files are unchanged. The exact published revision passed the complete serial native suite locally with 84 of 84 tests, including both the batch and cross-domain tests. The existing cross-domain collection race is tracked in #1060, so this PR deliberately does not widen timeouts or mix in an unrelated state-collection fix.
- The Intel macOS parity test also timed out on action `launch`. The same test and timeout reproduce on a [fresh untouched upstream `main` validation run](https://github.com/tempera-dev/agent-browser/actions/runs/29728538114).
