### PR TITLE
refactor(cli): add executable command registry

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -71,92 +71,98 @@ pub fn gen_id() -> String {
     )
 }
 
+/// Every token accepted as a top-level CLI command.
+///
+/// Keep aliases and commands dispatched directly by `main` in this list. The
+/// command-surface contract tests below require every entry to be reachable by
+/// the normal parser or explicitly identified as a standalone command.
+pub const TOP_LEVEL_COMMANDS: &[&str] = &[
+    "open",
+    "goto",
+    "navigate",
+    "back",
+    "forward",
+    "reload",
+    "read",
+    "click",
+    "dblclick",
+    "fill",
+    "type",
+    "hover",
+    "focus",
+    "check",
+    "uncheck",
+    "select",
+    "drag",
+    "upload",
+    "download",
+    "press",
+    "key",
+    "keydown",
+    "keyup",
+    "keyboard",
+    "scroll",
+    "scrollintoview",
+    "scrollinto",
+    "wait",
+    "screenshot",
+    "pdf",
+    "snapshot",
+    "eval",
+    "close",
+    "quit",
+    "exit",
+    "inspect",
+    "auth",
+    "confirm",
+    "deny",
+    "connect",
+    "stream",
+    "get",
+    "is",
+    "find",
+    "mouse",
+    "set",
+    "network",
+    "storage",
+    "cookies",
+    "tab",
+    "window",
+    "frame",
+    "dialog",
+    "trace",
+    "profiler",
+    "record",
+    "console",
+    "errors",
+    "highlight",
+    "clipboard",
+    "state",
+    "tap",
+    "swipe",
+    "device",
+    "diff",
+    "batch",
+    "react",
+    "vitals",
+    "web-vitals",
+    "pushstate",
+    "removeinitscript",
+    "session",
+    "mcp",
+    "doctor",
+    "install",
+    "upgrade",
+    "profiles",
+    "skills",
+    "dashboard",
+    "plugin",
+    "plugins",
+    "chat",
+];
+
 pub fn is_top_level_command(value: &str) -> bool {
-    matches!(
-        value,
-        "open"
-            | "goto"
-            | "navigate"
-            | "back"
-            | "forward"
-            | "reload"
-            | "read"
-            | "click"
-            | "dblclick"
-            | "fill"
-            | "type"
-            | "hover"
-            | "focus"
-            | "check"
-            | "uncheck"
-            | "select"
-            | "drag"
-            | "upload"
-            | "download"
-            | "press"
-            | "key"
-            | "keydown"
-            | "keyup"
-            | "keyboard"
-            | "scroll"
-            | "scrollintoview"
-            | "scrollinto"
-            | "wait"
-            | "screenshot"
-            | "pdf"
-            | "snapshot"
-            | "eval"
-            | "close"
-            | "quit"
-            | "exit"
-            | "inspect"
-            | "auth"
-            | "confirm"
-            | "deny"
-            | "connect"
-            | "stream"
-            | "get"
-            | "is"
-            | "find"
-            | "mouse"
-            | "set"
-            | "network"
-            | "storage"
-            | "cookies"
-            | "tab"
-            | "window"
-            | "frame"
-            | "dialog"
-            | "trace"
-            | "profiler"
-            | "record"
-            | "console"
-            | "errors"
-            | "highlight"
-            | "clipboard"
-            | "state"
-            | "tap"
-            | "swipe"
-            | "device"
-            | "diff"
-            | "batch"
-            | "react"
-            | "vitals"
-            | "web-vitals"
-            | "pushstate"
-            | "removeinitscript"
-            | "session"
-            | "mcp"
-            | "doctor"
-            | "install"
-            | "upgrade"
-            | "profiles"
-            | "skills"
-            | "dashboard"
-            | "plugin"
-            | "plugins"
-            | "chat"
-    )
+    TOP_LEVEL_COMMANDS.contains(&value)
 }
 
 /// Parse a cookies file in one of three auto-detected formats:
@@ -334,6 +340,14 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
     }
 
     let cmd = args[0].as_str();
+    // The registry is the executable command-surface contract. A new parser
+    // arm is intentionally unreachable until its token is registered, which
+    // prevents parse_command and global-flag cleanup from drifting apart.
+    if !is_top_level_command(cmd) {
+        return Err(ParseError::UnknownCommand {
+            command: cmd.to_string(),
+        });
+    }
     let rest: Vec<&str> = args[1..].iter().map(|s| s.as_str()).collect();
     let id = gen_id();
 
@@ -3081,10 +3095,15 @@ pub fn shell_words_split(s: &str) -> Vec<String> {
 }
 
 #[cfg(test)]
+pub(crate) fn command_contract_flags() -> Flags {
+    tests::default_flags()
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
-    fn default_flags() -> Flags {
+    pub(super) fn default_flags() -> Flags {
         Flags {
             session: "test".to_string(),
             json: false,
@@ -3160,6 +3179,75 @@ mod tests {
 
     fn args(s: &str) -> Vec<String> {
         s.split_whitespace().map(String::from).collect()
+    }
+
+    /// Commands routed by `main` before `parse_command` intentionally have no
+    /// parser arm. Keeping this allowlist test-owned makes those exceptions
+    /// visible without turning dispatch metadata into a second runtime router.
+    const STANDALONE_TOP_LEVEL_COMMANDS: &[(&str, &str)] = &[
+        ("session", "handled by the session lifecycle entrypoint"),
+        ("mcp", "starts the MCP stdio server"),
+        ("doctor", "runs diagnostics without a session daemon"),
+        ("install", "runs the browser installer"),
+        ("upgrade", "runs the package upgrade flow"),
+        ("profiles", "lists local Chrome profiles"),
+        ("skills", "manages bundled skills"),
+        ("dashboard", "manages the standalone dashboard process"),
+        ("plugin", "manages the plugin registry"),
+        ("plugins", "aliases the plugin registry command"),
+        ("chat", "runs the AI chat entrypoint"),
+    ];
+
+    #[test]
+    fn top_level_commands_are_unique_and_nonempty() {
+        let commands: std::collections::BTreeSet<_> = TOP_LEVEL_COMMANDS.iter().copied().collect();
+        assert_eq!(
+            commands.len(),
+            TOP_LEVEL_COMMANDS.len(),
+            "top-level command registry contains duplicate tokens"
+        );
+        assert!(
+            TOP_LEVEL_COMMANDS.iter().all(|command| !command.is_empty()),
+            "top-level command registry contains an empty token"
+        );
+    }
+
+    #[test]
+    fn top_level_commands_reach_parser_or_reviewed_standalone_dispatch() {
+        let flags = default_flags();
+        let standalone: std::collections::BTreeMap<_, _> =
+            STANDALONE_TOP_LEVEL_COMMANDS.iter().copied().collect();
+        assert_eq!(
+            standalone.len(),
+            STANDALONE_TOP_LEVEL_COMMANDS.len(),
+            "standalone command allowlist contains duplicate tokens"
+        );
+
+        for (command, reason) in STANDALONE_TOP_LEVEL_COMMANDS {
+            assert!(
+                TOP_LEVEL_COMMANDS.contains(command),
+                "standalone command '{command}' is missing from the top-level registry"
+            );
+            assert!(
+                !reason.trim().is_empty(),
+                "standalone command '{command}' needs a review rationale"
+            );
+        }
+
+        for command in TOP_LEVEL_COMMANDS {
+            let result = parse_command(&[command.to_string()], &flags);
+            if standalone.contains_key(command) {
+                assert!(
+                    matches!(result, Err(ParseError::UnknownCommand { .. })),
+                    "standalone command '{command}' is now parser-reachable; remove its reviewed exception"
+                );
+            } else {
+                assert!(
+                    !matches!(result, Err(ParseError::UnknownCommand { .. })),
+                    "registered command '{command}' is unreachable through parse_command"
+                );
+            }
+        }
     }
 
     // === Cookies Tests ===

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -3746,6 +3746,76 @@ fn write_json_line(stdout: &mut io::Stdout, value: &Value) -> io::Result<()> {
 mod tests {
     use super::*;
 
+    /// Top-level CLI aliases share the canonical command's MCP tools. The MCP
+    /// server command itself cannot be exposed recursively through its own
+    /// tool surface.
+    const INTENTIONAL_MCP_TOP_LEVEL_OMISSIONS: &[(&str, &str)] = &[
+        ("goto", "alias of the open tool"),
+        ("navigate", "alias of the open tool"),
+        ("key", "alias of the press tool"),
+        ("quit", "alias of the close tool"),
+        ("exit", "alias of the close tool"),
+        ("scrollinto", "alias of the scroll-into-view tool"),
+        ("web-vitals", "alias of the vitals tool"),
+        ("plugins", "alias of the plugin tools"),
+        (
+            "mcp",
+            "starts this MCP server and cannot be called recursively",
+        ),
+    ];
+
+    fn top_level_command_for_tool(tool_name: &str) -> Option<&str> {
+        let suffix = tool_name.strip_prefix("agent_browser_")?;
+        match suffix {
+            "scroll_into_view" => Some("scrollintoview"),
+            "remove_init_script" => Some("removeinitscript"),
+            _ => suffix.split('_').next(),
+        }
+    }
+
+    #[test]
+    fn registered_cli_commands_have_mcp_tools_or_reviewed_omissions() {
+        let tool_definitions = tools();
+        let exposed: std::collections::BTreeSet<_> = tool_definitions
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .filter(|tool_name| *tool_name != TOOL_TOOLS_PROFILES)
+            .filter_map(top_level_command_for_tool)
+            .filter(|command| crate::commands::TOP_LEVEL_COMMANDS.contains(command))
+            .collect();
+        let omissions: std::collections::BTreeMap<_, _> = INTENTIONAL_MCP_TOP_LEVEL_OMISSIONS
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(
+            omissions.len(),
+            INTENTIONAL_MCP_TOP_LEVEL_OMISSIONS.len(),
+            "MCP omission list contains duplicate commands"
+        );
+
+        for (command, reason) in INTENTIONAL_MCP_TOP_LEVEL_OMISSIONS {
+            assert!(
+                crate::commands::TOP_LEVEL_COMMANDS.contains(command),
+                "MCP omission '{command}' is not a registered CLI command"
+            );
+            assert!(
+                !exposed.contains(command),
+                "CLI command '{command}' now has a dedicated MCP tool; remove its omission"
+            );
+            assert!(
+                !reason.trim().is_empty(),
+                "MCP omission '{command}' needs a review rationale"
+            );
+        }
+
+        for command in crate::commands::TOP_LEVEL_COMMANDS {
+            assert!(
+                exposed.contains(command) || omissions.contains_key(command),
+                "registered CLI command '{command}' has no dedicated MCP tool or reviewed omission"
+            );
+        }
+    }
+
     #[test]
     fn tools_list_contains_typed_tools() {
         let tools = tools();

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -7,6 +7,8 @@
 
 use serde_json::{json, Value};
 
+use crate::commands::{parse_command, shell_words_split};
+
 use super::actions::{execute_command, DaemonState};
 
 const ENCRYPTION_KEY_ENV: &str = "AGENT_BROWSER_ENCRYPTION_KEY";
@@ -388,6 +390,45 @@ fn minimal_command(action: &str, id: &str) -> Value {
 // ---------------------------------------------------------------------------
 // 1. Action dispatch coverage
 // ---------------------------------------------------------------------------
+
+#[test]
+fn test_representative_cli_commands_reach_native_dispatch_contract() {
+    let samples = [
+        ("open https://example.com", "navigate"),
+        ("read", "read"),
+        ("snapshot -i", "snapshot"),
+        ("click body", "click"),
+        ("network requests", "requests"),
+        ("cookies get", "cookies_get"),
+        ("storage local get key", "storage_get"),
+        ("state list", "state_list"),
+        ("auth list", "auth_list"),
+        ("tab list", "tab_list"),
+        ("dialog status", "dialog"),
+        ("trace start", "trace_start"),
+        ("diff snapshot", "diff_snapshot"),
+        ("device list", "device_list"),
+        ("confirm confirmation-1", "confirm"),
+    ];
+    let flags = crate::commands::command_contract_flags();
+
+    for (invocation, expected_action) in samples {
+        let command = parse_command(&shell_words_split(invocation), &flags)
+            .unwrap_or_else(|error| panic!("'{invocation}' did not parse: {}", error.format()));
+        let action = command["action"]
+            .as_str()
+            .unwrap_or_else(|| panic!("'{invocation}' did not produce a daemon action"));
+
+        assert_eq!(
+            action, expected_action,
+            "unexpected action for '{invocation}'"
+        );
+        assert!(
+            DOCUMENTED_ACTIONS.contains(&action),
+            "'{invocation}' parsed to '{action}', which is absent from the native dispatch contract"
+        );
+    }
+}
 
 #[tokio::test]
 async fn test_all_documented_actions_are_handled() {


### PR DESCRIPTION
## Summary

- make top-level CLI command tokens an enumerable production constant used by parser admission
- prove every registered token is parsed or appears in a reviewed standalone-dispatch allowlist
- add representative daemon-backed invocations and prove each parses to an action accepted by the native dispatch contract
- record MCP aliases and intentional omissions explicitly, then test dedicated-tool parity against the registry

This creates one executable reachability contract for backend adapters without generating help or documentation from metadata in this first slice.

## Issue and overlap

Closes #1575 and is related to the broader drift discussion in #774.

This intentionally does not duplicate the `addinitscript` parser fix in #1522 by @HighSkySky. If #1522 lands first, `addinitscript` will be added to the registry and representative invocation during rebase so the new command is protected by the same contract.

## Validation

- `cargo fmt --all -- --check`
- strict Clippy across all targets and features
- full Rust suite: 964 unit tests plus 2 doctor integration tests passed
- focused registry, parser, native-dispatch, and MCP parity tests passed
- `git diff --check`

## Full fork CI

- [Cross-platform validation run](https://github.com/tempera-dev/agent-browser/actions/runs/29722830884) passed Linux Rust, Apple Silicon, Windows test compilation and focused registry/MCP filters, all 83 native E2Es, Windows integration, and global installs on Linux, macOS, and Windows.
- The only red job is the Intel macOS parity test timing out on action `launch`. The same test and timeout reproduce on a [fresh untouched upstream `main` validation run](https://github.com/tempera-dev/agent-browser/actions/runs/29728538114).
