### PR TITLE
fix(har): preserve capture after export failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ agent-browser network har start --content none # Metadata only, no bodies
 agent-browser network har stop [output.har]    # Stop and save HAR (temp path if omitted)
 ```
 
+If HAR export fails, the recording and captured requests are retained. Fix the destination and run `network har stop` again without repeating the browser flow.
+
 ### Tabs & Windows
 
 ```bash

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -8789,14 +8789,18 @@ async fn handle_har_start(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     Ok(json!({ "started": true }))
 }
 
-/// Stop HAR recording and write the captured requests to disk.
+/// Stop HAR recording and write the captured requests to disk. Recording state
+/// is cleared only after the file is written so callers can retry a failed
+/// export with another path without losing the capture.
 async fn handle_har_stop(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let path = har_output_path(cmd.get("path").and_then(|v| v.as_str()));
 
-    state.har_recording = false;
-    state.har_body_total_bytes = 0;
-
-    let entries: Vec<Value> = state.har_entries.drain(..).map(har_entry_to_json).collect();
+    let entries: Vec<Value> = state
+        .har_entries
+        .iter()
+        .cloned()
+        .map(har_entry_to_json)
+        .collect();
     let request_count = entries.len();
     let browser = har_browser_metadata(state).await;
 
@@ -8816,6 +8820,10 @@ async fn handle_har_stop(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     let har_str = serde_json::to_string_pretty(&har)
         .map_err(|e| format!("Failed to serialize HAR: {}", e))?;
     std::fs::write(&path, har_str).map_err(|e| format!("Failed to write HAR: {}", e))?;
+
+    state.har_recording = false;
+    state.har_body_total_bytes = 0;
+    state.har_entries.clear();
 
     Ok(json!({ "path": path, "requestCount": request_count }))
 }
@@ -12918,6 +12926,77 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
         assert_eq!(har["log"]["entries"][0]["response"]["content"]["size"], 128);
 
         let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn test_handle_har_stop_write_failure_preserves_capture_for_retry() {
+        let unique = unix_timestamp_millis();
+        let missing_parent = std::env::temp_dir().join(format!(
+            "agent-browser-har-missing-parent-{}-{}",
+            std::process::id(),
+            unique
+        ));
+        let failed_path = missing_parent.join("capture.har");
+        let retry_path = std::env::temp_dir().join(format!(
+            "agent-browser-har-retry-{}-{}.har",
+            std::process::id(),
+            unique
+        ));
+        let mut state = DaemonState::new();
+        state.har_recording = true;
+        state.har_body_total_bytes = 13;
+        state.har_entries.push(HarEntry {
+            request_id: "retry-request".to_string(),
+            wall_time: 1773576000.0,
+            method: "GET".to_string(),
+            url: "https://example.com/api/items".to_string(),
+            request_headers: vec![],
+            post_data: None,
+            request_body_size: 0,
+            resource_type: "Fetch".to_string(),
+            status: Some(200),
+            status_text: "OK".to_string(),
+            http_version: "HTTP/2.0".to_string(),
+            response_headers: vec![("content-type".to_string(), "application/json".to_string())],
+            mime_type: "application/json".to_string(),
+            redirect_url: String::new(),
+            response_body_size: 13,
+            cdp_timing: None,
+            loading_finished_timestamp: None,
+            response_body: Some(r#"{"items":[1]}"#.to_string()),
+            response_body_base64: false,
+        });
+
+        let error = handle_har_stop(
+            &json!({ "action": "har_stop", "path": failed_path }),
+            &mut state,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("Failed to write HAR"));
+        assert!(state.har_recording, "a failed export must remain retryable");
+        assert_eq!(state.har_body_total_bytes, 13);
+        assert_eq!(state.har_entries.len(), 1);
+
+        let result = handle_har_stop(
+            &json!({ "action": "har_stop", "path": &retry_path }),
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["requestCount"], 1);
+        assert!(!state.har_recording);
+        assert_eq!(state.har_body_total_bytes, 0);
+        assert!(state.har_entries.is_empty());
+        let har: Value = serde_json::from_str(&fs::read_to_string(&retry_path).unwrap()).unwrap();
+        assert_eq!(
+            har["log"]["entries"][0]["request"]["url"],
+            "https://example.com/api/items"
+        );
+
+        let _ = fs::remove_file(retry_path);
     }
 
     #[tokio::test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2174,6 +2174,7 @@ Subcommands:
   request <requestId>        View full request/response detail (including body)
   har <start|stop> [path]    Record and export a HAR file
     --content <mode>         Response bodies to embed on start: text (default), all, none
+    Failed exports retain the capture so har stop can be retried with another path.
 
 Global Options:
   --json               Output as JSON

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -216,6 +216,8 @@ agent-browser network har start --content none # Metadata only, no bodies
 agent-browser network har stop [output.har]    # Stop and save HAR (temp path if omitted)
 ```
 
+If HAR export fails, the recording and captured requests remain available for another `network har stop` attempt.
+
 See [Network](/network) for pre-navigation routing, request filters, HAR export, and SSR/no-JavaScript debugging.
 
 ## Tabs & frames

--- a/docs/src/app/network/page.mdx
+++ b/docs/src/app/network/page.mdx
@@ -66,6 +66,8 @@ agent-browser click @e4
 agent-browser network har stop ./trace.har
 ```
 
+If export fails, the recording and captured requests are retained. Correct the destination and run `network har stop` again without repeating the browser flow.
+
 Text response bodies (JSON, HTML, JavaScript, form data) are embedded in the HAR as `content.text` by default, captured while the browser still has them buffered so they survive navigation. The `--content` flag on `har start` controls this:
 
 <table>

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -198,6 +198,8 @@ agent-browser network har start --content none # Sizes and headers only
 agent-browser network har stop [output.har]    # Stop and save HAR
 ```
 
+If HAR export fails, the recording and captured requests remain available. Correct the destination and run `network har stop` again rather than repeating the browser flow.
+
 ## Tabs and Windows
 
 ```bash


### PR DESCRIPTION
## Summary

- preserve the active HAR recording, captured entries, and body budget until export succeeds
- allow `network har stop` to be retried with another destination after a serialization or write failure
- document the recovery behavior across CLI help, README, docs, and the bundled core skill reference

## Problem

`handle_har_stop` cleared recording state and drained every entry before writing the HAR file. A missing parent directory or other write error therefore destroyed the capture even though the command reported failure.

A black-box reproduction recorded local HTTP traffic, stopped to an invalid path, and then retried to a valid path. Before this change the retry succeeded with `requestCount: 0`.

## Implementation

The handler now builds and writes the HAR before clearing recording state. Successful exports retain the existing HAR structure and lifecycle behavior. Failed exports leave the same native state available to both CLI and MCP callers for a later stop attempt.

## Validation

- regression test fails on the prior implementation and verifies failed export, preserved state, successful retry, and original HAR entry
- 25 focused HAR, parser, MCP-schema, and native parity tests passed
- real CLI retry after an invalid destination produced a valid HAR with both captured entries
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets` passed with existing repository warnings
- docs Next.js production build passed
- full serial Rust suite: 940 passed, 83 ignored; the only failure is the existing Windows `download_bytes_connection_refused_includes_details` error-text assertion, which also reproduced before this change