### PR TITLE
feat(stream): AGENT_BROWSER_NO_STREAM, a security opt-out that starts the daemon with no TCP listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,12 @@ To bind to a specific port, set `AGENT_BROWSER_STREAM_PORT`:
 AGENT_BROWSER_STREAM_PORT=9223 agent-browser open example.com
 ```
 
+To start the daemon with no stream server at all, set `AGENT_BROWSER_NO_STREAM=1`. The daemon then holds no TCP listener for the session (the CLI talks to it over a unix socket on macOS/Linux), which matters on multi-user hosts where any local user can connect to a loopback port. The live view and dashboard are unavailable for that session and `stream enable` refuses until the daemon is restarted without the variable:
+
+```bash
+AGENT_BROWSER_NO_STREAM=1 agent-browser open example.com
+```
+
 You can also manage streaming at runtime with `stream enable`, `stream disable`, and `stream status`:
 
 ```bash

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7499,6 +7499,13 @@ async fn current_stream_status(state: &DaemonState) -> Value {
 }
 
 async fn handle_stream_enable(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    if super::daemon::stream_opt_out() {
+        return Err(
+            "Streaming is disabled: this daemon was started with AGENT_BROWSER_NO_STREAM. \
+             Unset it and restart the daemon to use streaming."
+                .to_string(),
+        );
+    }
     if state.stream_server.is_some() {
         return Err("Streaming is already enabled for this session".to_string());
     }
@@ -11465,6 +11472,19 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         let request = fs::read_to_string(request_path).unwrap();
         assert!(request.contains(r#""type":"browser.close""#));
         assert!(request.contains(r#""sessionId":"s1""#));
+    }
+
+    #[tokio::test]
+    async fn test_stream_enable_refuses_under_no_stream_opt_out() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_NO_STREAM"]);
+        guard.set("AGENT_BROWSER_NO_STREAM", "1");
+
+        let mut state = DaemonState::new();
+        let err = handle_stream_enable(&json!({}), &mut state)
+            .await
+            .expect_err("stream enable must refuse under the opt-out");
+        assert!(err.contains("AGENT_BROWSER_NO_STREAM"));
+        assert!(state.stream_server.is_none());
     }
 
     #[tokio::test]

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -20,6 +20,16 @@ use super::state;
 use super::stream::StreamServer;
 use crate::connection::INTERNAL_DAEMON_SHUTDOWN_ACTION;
 
+/// True when AGENT_BROWSER_NO_STREAM=1|true: the daemon must not bind the
+/// stream server's TCP listener (see run_daemon). Read from the daemon's own
+/// environment, inherited from the CLI invocation that spawned it, so the
+/// answer is stable for the daemon's lifetime.
+pub(crate) fn stream_opt_out() -> bool {
+    env::var("AGENT_BROWSER_NO_STREAM")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false)
+}
+
 pub async fn run_daemon(session: &str) {
     let socket_dir = get_daemon_socket_dir();
     if !socket_dir.exists() {
@@ -99,20 +109,31 @@ pub async fn run_daemon(session: &str) {
 
     let mut stream_client: Option<Arc<RwLock<Option<Arc<CdpClient>>>>> = None;
     let mut stream_server_instance: Option<Arc<StreamServer>> = None;
-    let preferred_port = env::var("AGENT_BROWSER_STREAM_PORT")
-        .ok()
-        .and_then(|s| s.parse::<u16>().ok())
-        .unwrap_or(0);
-    match StreamServer::start_without_client(preferred_port, session.to_string(), true).await {
-        Ok((stream_server, client_slot)) => {
-            stream_client = Some(client_slot.clone());
-            if let Err(e) = fs::write(&stream_path, stream_server.port().to_string()) {
-                let _ = writeln!(std::io::stderr(), "Failed to write .stream file: {}", e);
+    // Security opt-out: with AGENT_BROWSER_NO_STREAM=1 the daemon starts no
+    // stream server, so it holds no TCP listener for the session (the CLI IPC
+    // channel is a unix socket on unix platforms). The live view / dashboard
+    // are unavailable and `stream enable` refuses while the daemon runs with
+    // the opt-out. Loopback TCP is reachable by every local user, which some
+    // multi-tenant hosts cannot accept; this restores the pre-#951 off switch
+    // as an explicit security mode rather than a default.
+    if stream_opt_out() {
+        let _ = fs::remove_file(&stream_path);
+    } else {
+        let preferred_port = env::var("AGENT_BROWSER_STREAM_PORT")
+            .ok()
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(0);
+        match StreamServer::start_without_client(preferred_port, session.to_string(), true).await {
+            Ok((stream_server, client_slot)) => {
+                stream_client = Some(client_slot.clone());
+                if let Err(e) = fs::write(&stream_path, stream_server.port().to_string()) {
+                    let _ = writeln!(std::io::stderr(), "Failed to write .stream file: {}", e);
+                }
+                stream_server_instance = Some(Arc::new(stream_server));
             }
-            stream_server_instance = Some(Arc::new(stream_server));
-        }
-        Err(e) => {
-            let _ = writeln!(std::io::stderr(), "Stream server failed to start: {}", e);
+            Err(e) => {
+                let _ = writeln!(std::io::stderr(), "Stream server failed to start: {}", e);
+            }
         }
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2901,6 +2901,9 @@ Notes:
   - 'screencast_start' and 'screencast_stop' still control explicit CDP screencasts.
   - Streaming is always enabled. Set AGENT_BROWSER_STREAM_PORT to bind to a
     specific port instead of the default OS-assigned port.
+  - AGENT_BROWSER_NO_STREAM=1 starts the daemon with no stream server at all
+    (no TCP listener; security opt-out for multi-user hosts). The live view is
+    unavailable and 'stream enable' refuses until the daemon restarts without it.
 
 Global Options:
   --json               Output as JSON
@@ -3610,6 +3613,7 @@ Environment:
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete saved states older than N days (default: 30)
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM session encryption
   AGENT_BROWSER_STREAM_PORT      Override WebSocket streaming port (default: OS-assigned)
+  AGENT_BROWSER_NO_STREAM        Start the daemon with no stream server / TCP listener (security opt-out)
   AGENT_BROWSER_IDLE_TIMEOUT_MS  Auto-shutdown daemon after N ms of inactivity (disabled by default)
   AGENT_BROWSER_IOS_DEVICE       Default iOS device name
   AGENT_BROWSER_IOS_UDID         Default iOS device UDID

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -277,6 +277,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_ANNOTATE</code></td><td>Enable annotated screenshots by default.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_CDP</code></td><td>Connect the daemon to a CDP port or WebSocket URL.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_STREAM_PORT</code></td><td>Override the WebSocket streaming port. By default, an OS-assigned port is used. Set this to bind to a specific port (e.g., <code>9223</code>).</td><td>OS-assigned</td></tr>
+    <tr><td><code>AGENT_BROWSER_NO_STREAM</code></td><td>Set to <code>1</code> to start the daemon with no stream server, so it holds no TCP listener for the session. Security opt-out for multi-user hosts; the live view and dashboard are unavailable and <code>stream enable</code> refuses while the daemon runs with it. See the Security page.</td><td>unset</td></tr>
     <tr><td><code>AGENT_BROWSER_IDLE_TIMEOUT_MS</code></td><td>Auto-shutdown the daemon after N ms of inactivity (no commands received). Useful for ephemeral environments.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_IOS_DEVICE</code></td><td>Default iOS device name for the <code>ios</code> provider.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_IOS_UDID</code></td><td>Default iOS device UDID for the <code>ios</code> provider.</td><td>(none)</td></tr>

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -14,6 +14,7 @@ These features are designed to mitigate the following threats when an LLM-based 
 - **Unauthorized navigation / data exfiltration** — A compromised or manipulated agent could navigate to attacker-controlled domains to exfiltrate data. The domain allowlist (`--allowed-domains`) blocks navigations, sub-resource requests, WebSocket connections, EventSource streams, and `sendBeacon` calls to non-allowed domains. In supported Chromium sessions, it disables WebRTC peer connections so STUN, TURN, and related DNS traffic cannot bypass HTTP interception.
 - **Unauthorized destructive actions** -- Action policy (`--action-policy`) and confirmation gating (`--confirm-actions`) prevent the agent from performing dangerous operations (eval, downloads, uploads) without explicit approval.
 - **Context flooding** -- Large page outputs can overwhelm an LLM's context window. Output truncation (`--max-output`) caps the size of page-sourced content.
+- **Local users reaching the stream server** -- The daemon's live-view stream server listens on 127.0.0.1, and a loopback port is reachable by every local user account, not just yours (WebSocket commands are origin-checked, but the port itself carries no authentication). On multi-user hosts, set `AGENT_BROWSER_NO_STREAM=1` to start the daemon with no stream server and therefore no TCP listener; the CLI-daemon channel is a unix socket on macOS/Linux, gated by filesystem permissions. The live view and dashboard are unavailable for that session and `stream enable` refuses until the daemon restarts without the variable.
 
 ### Known limitations
 
@@ -25,6 +26,7 @@ These features are designed to mitigate the following threats when an LLM-based 
 - **Content boundaries are defense-in-depth.** They rely on the LLM and orchestrator respecting the structural markers. A sufficiently capable adversarial page could attempt to mimic the boundary format, though the per-process CSPRNG nonce makes this impractical to predict.
 - **Plugins are local executables.** Install credential plugins only from maintainers you trust. agent-browser limits the data it sends to plugins and supports policy gates, but it does not sandbox arbitrary local executables.
 - **Plugin config is not secret storage.** Do not put vault tokens or passwords in plugin command args. Use the vendor's own login/session mechanism or environment outside agent-browser config.
+- **The browser's DevTools endpoint remains loopback TCP.** Chrome exposes its automation (CDP) endpoint on a 127.0.0.1 port with no authentication while a session runs; `AGENT_BROWSER_NO_STREAM` does not affect it. Where local-user isolation from the browser endpoint is required, add OS-level isolation (containers, network namespaces) around the session.
 - **Confirmation timeout.** Pending confirmations auto-deny after 60 seconds. Orchestrators must respond within that window.
 - **Non-TTY auto-deny.** When `--confirm-interactive` is set but stdin is not a terminal (e.g., piped input), actions are automatically denied to prevent accidental approval in non-interactive contexts.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -459,6 +459,7 @@ AGENT_BROWSER_WEBGPU="1"                     # Enable the WebGPU launch preset (
 AGENT_BROWSER_NO_XVFB="1"                    # Disable automatic Xvfb for headed mode on displayless Linux
 AGENT_BROWSER_PROVIDER="browserbase"         # Browser provider or configured provider plugin
 AGENT_BROWSER_STREAM_PORT="9223"             # Override WebSocket streaming port (default: OS-assigned)
+AGENT_BROWSER_NO_STREAM="1"                  # Start daemon with no stream server / TCP listener (security opt-out)
 AGENT_BROWSER_CONFIG="./agent-browser.json"  # Custom config file
 AGENT_BROWSER_CDP="9222"                     # Connect daemon to CDP port or WebSocket URL
 AGENT_BROWSER_ALLOWED_DOMAINS="example.com"  # Restrict network domains; requires a fresh controllable browser context without profile/session startup args, restore/state replay, or direct-page provider plugins


### PR DESCRIPTION
## What

`AGENT_BROWSER_NO_STREAM=1` starts the daemon without the stream server, so the daemon holds no TCP listener for the session. While it is set, `stream enable` refuses with a clear error, and any stale `.stream` file is removed at daemon start. Unset it and restart the daemon to get streaming back. Default behavior is completely unchanged.

## Why

The stream server binds 127.0.0.1, and a loopback port is reachable by every local user account, not just the invoking user. WebSocket commands are origin-checked (#1355), but the port itself carries no authentication. On multi-user hosts (shared dev servers, CI runners, remote dev boxes) that is a listener other local users can connect to whenever an agent session is running. The CLI-daemon IPC channel is already a unix socket on macOS/Linux, gated by filesystem permissions, so the stream server is the daemon's only TCP surface; this flag closes it for deployments that need that.

#951 removed the stream on/off toggle in favor of always-on streaming, which is the right default for the interactive use case. This restores an explicit off switch framed as what it now is: a security opt-out, documented on the Security page, not a general configuration knob.

We hit this deploying agent-browser on shared cloud dev boxes where the baseline security posture is "no loopback TCP listeners; unix sockets with 0600 perms only" (context: Tako-Research/devenv#210).

## Changes

- `cli/src/native/daemon.rs`: `stream_opt_out()` helper; skip `StreamServer::start_without_client` and remove any stale `.stream` file when set.
- `cli/src/native/actions.rs`: `handle_stream_enable` refuses under the opt-out; new test `test_stream_enable_refuses_under_no_stream_opt_out` (EnvGuard pattern).
- Docs parity per AGENTS.md: `cli/src/output.rs` (stream help + env list), `README.md`, `docs/src/app/configuration/page.mdx` (env table), `docs/src/app/security/page.mdx` (threat model entry + a known-limitations note that Chrome's own DevTools loopback port is not affected by this flag), `skill-data/core/references/commands.md`.

MCP: no schema change; `agent_browser_stream_enable` surfaces the refusal error as-is.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (961 unit + doctor CLI integration) all pass on linux-x64.
- Manual smoke on Ubuntu 24.04: with the flag, daemon runs with zero TCP listeners (verified with `ss -ltnp`), no `.stream` file is written, `stream enable` refuses, `open`/`snapshot`/`close` work normally; without the flag, behavior is unchanged.