### PR TITLE
fix(cli): dispatch mouse wheel at the current mouse position

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,10 @@ agent-browser clipboard paste                     # Paste from clipboard (Ctrl+V
 agent-browser mouse move <x> <y>      # Move mouse
 agent-browser mouse down [button]     # Press button (left/right/middle)
 agent-browser mouse up [button]       # Release button
-agent-browser mouse wheel <dy> [dx]   # Scroll wheel
+agent-browser mouse wheel <dy> [dx]   # Scroll wheel at the current mouse position
 ```
+
+The wheel is dispatched at the current mouse position, which starts at `0,0`. Move the mouse over the element first when the page listens for `wheel` on a specific element rather than on the document.
 
 ### Browser Settings
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7306,29 +7306,35 @@ async fn handle_clipboard(cmd: &Value, state: &DaemonState) -> Result<Value, Str
     }
 }
 
-async fn handle_wheel(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+/// Dispatches a wheel event at the tracked mouse position, so `mouse move x y`
+/// followed by `mouse wheel dy` scrolls whatever sits under the cursor rather
+/// than whatever sits at the viewport origin. An explicit `x`/`y` in the command
+/// overrides the tracked position and becomes the new position, matching the
+/// other mouse handlers.
+async fn handle_wheel(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
-    let x = cmd.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let y = cmd.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let delta_x = cmd.get("deltaX").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let delta_y = cmd.get("deltaY").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let params = build_mouse_event_params(
+        &mut state.mouse_state,
+        "mouseWheel",
+        cmd.get("x").and_then(|v| v.as_f64()),
+        cmd.get("y").and_then(|v| v.as_f64()),
+        None,
+        None,
+        None,
+        Some(delta_x),
+        Some(delta_y),
+        None,
+    );
+    let (x, y) = (params.x, params.y);
 
     mgr.client
-        .send_command(
-            "Input.dispatchMouseEvent",
-            Some(json!({
-                "type": "mouseWheel",
-                "x": x,
-                "y": y,
-                "deltaX": delta_x,
-                "deltaY": delta_y,
-            })),
-            Some(&session_id),
-        )
+        .send_command_typed::<_, Value>("Input.dispatchMouseEvent", &params, Some(&session_id))
         .await?;
 
-    Ok(json!({ "scrolled": true, "deltaX": delta_x, "deltaY": delta_y }))
+    Ok(json!({ "scrolled": true, "x": x, "y": y, "deltaX": delta_x, "deltaY": delta_y }))
 }
 
 async fn handle_device(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -38,6 +38,7 @@ fn native_test_fixture_html(name: &str) -> &'static str {
         "html5_drag_probe" => include_str!("test_fixtures/html5_drag_probe.html"),
         "pointer_capture_probe" => include_str!("test_fixtures/pointer_capture_probe.html"),
         "upload_probe" => include_str!("test_fixtures/upload_probe.html"),
+        "wheel_probe" => include_str!("test_fixtures/wheel_probe.html"),
         _ => panic!("Unknown native test fixture: {}", name),
     }
 }
@@ -7094,4 +7095,167 @@ async fn e2e_removeinitscript_roundtrip() {
     assert_eq!(get_data(&resp)["removed"], true);
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_mouse_wheel_targets_element_under_cursor() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": native_test_fixture_url("wheel_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": r#"(() => {
+                const rect = document.getElementById('viewport').getBoundingClientRect();
+                return {
+                    x: Math.round(rect.left + rect.width / 2),
+                    y: Math.round(rect.top + rect.height / 2)
+                };
+            })()"#
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let center = &get_data(&resp)["result"];
+    let target_x = center["x"].as_i64().expect("viewport x should be numeric");
+    let target_y = center["y"].as_i64().expect("viewport y should be numeric");
+    assert!(
+        target_x > 0 && target_y > 0,
+        "Fixture should place the wheel target away from the viewport origin"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "mousemove", "x": target_x, "y": target_y }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "wheel", "deltaX": 0, "deltaY": 240 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["x"].as_f64(), Some(target_x as f64));
+    assert_eq!(get_data(&resp)["y"].as_f64(), Some(target_y as f64));
+
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "wait",
+            "function": "window.__wheelProbe.onWindow.length === 1",
+            "timeout": 5000
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "7",
+            "action": "evaluate",
+            "script": "JSON.stringify(window.__wheelProbe)"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let probe: Value = serde_json::from_str(
+        get_data(&resp)["result"]
+            .as_str()
+            .expect("probe should serialize to a string"),
+    )
+    .expect("probe should be valid JSON");
+
+    let on_viewport = probe["onViewport"]
+        .as_array()
+        .expect("probe should record viewport wheel events");
+    assert_eq!(
+        on_viewport.len(),
+        1,
+        "Wheel should land on the element under the cursor, got: {}",
+        probe
+    );
+    assert_eq!(on_viewport[0]["deltaY"].as_f64(), Some(240.0));
+    assert_eq!(on_viewport[0]["x"].as_f64(), Some(target_x as f64));
+    assert_eq!(on_viewport[0]["y"].as_f64(), Some(target_y as f64));
+    assert_eq!(on_viewport[0]["target"], "viewport");
+
+    // An explicit x/y overrides the tracked position and moves the cursor there.
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "wheel", "x": 1, "y": 1, "deltaX": 0, "deltaY": 120 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "9",
+            "action": "wait",
+            "function": "window.__wheelProbe.onWindow.length === 2",
+            "timeout": 5000
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "10",
+            "action": "evaluate",
+            "script": "JSON.stringify(window.__wheelProbe)"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let probe: Value = serde_json::from_str(
+        get_data(&resp)["result"]
+            .as_str()
+            .expect("probe should serialize to a string"),
+    )
+    .expect("probe should be valid JSON");
+
+    assert_eq!(
+        probe["onViewport"].as_array().map(|events| events.len()),
+        Some(1),
+        "Explicit coordinates should not reach the element, got: {}",
+        probe
+    );
+    let on_window = probe["onWindow"]
+        .as_array()
+        .expect("probe should record window wheel events");
+    assert_eq!(on_window.len(), 2);
+    assert_eq!(on_window[1]["x"].as_f64(), Some(1.0));
+    assert_eq!(on_window[1]["y"].as_f64(), Some(1.0));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
 }

--- a/cli/src/native/test_fixtures/wheel_probe.html
+++ b/cli/src/native/test_fixtures/wheel_probe.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Wheel Probe</title>
+  <style>
+    body {
+      margin: 0;
+      font: 14px/1.4 sans-serif;
+    }
+    #header {
+      height: 200px;
+      background: rgba(0, 0, 0, 0.1);
+    }
+    #viewport {
+      width: 300px;
+      height: 200px;
+      margin-left: 200px;
+      background: rgba(0, 0, 255, 0.15);
+    }
+    pre {
+      white-space: pre-wrap;
+      font-family: ui-monospace, monospace;
+    }
+  </style>
+</head>
+<body>
+  <div id="header" aria-label="header strip"></div>
+  <div id="viewport" aria-label="wheel target"></div>
+  <pre id="log"></pre>
+  <script>
+    const viewport = document.getElementById("viewport");
+    const logEl = document.getElementById("log");
+
+    const state = { onViewport: [], onWindow: [] };
+    window.__wheelProbe = state;
+
+    function record(bucket, event) {
+      bucket.push({
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        x: event.clientX,
+        y: event.clientY,
+        target: event.target.id || event.target.tagName,
+      });
+      logEl.textContent = JSON.stringify(state, null, 2);
+    }
+
+    viewport.addEventListener("wheel", (event) => record(state.onViewport, event));
+    window.addEventListener("wheel", (event) => record(state.onWindow, event));
+  </script>
+</body>
+</html>

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2099,7 +2099,7 @@ Subcommands:
   move <x> <y>         Move mouse to coordinates
   down [button]        Press mouse button (left, right, middle)
   up [button]          Release mouse button
-  wheel <dy> [dx]      Scroll mouse wheel
+  wheel <dy> [dx]      Scroll mouse wheel at the current mouse position
 
 Global Options:
   --json               Output as JSON
@@ -2112,6 +2112,7 @@ Examples:
   agent-browser mouse down right
   agent-browser mouse wheel 100
   agent-browser mouse wheel -50 0
+  agent-browser mouse move 400 300 && agent-browser mouse wheel 240
 "##
         }
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -148,7 +148,14 @@ See [Files & Clipboard](/files) for upload, download, local file, screenshot, PD
 agent-browser mouse move <x> <y>      # Move mouse
 agent-browser mouse down [button]     # Press button
 agent-browser mouse up [button]       # Release button
-agent-browser mouse wheel <dy> [dx]   # Scroll wheel
+agent-browser mouse wheel <dy> [dx]   # Scroll wheel at the current mouse position
+```
+
+The wheel is dispatched at the current mouse position, which starts at `0,0`. Move the mouse over the element first when the page listens for `wheel` on a specific element rather than on the document.
+
+```bash
+agent-browser mouse move 640 400
+agent-browser mouse wheel 240
 ```
 
 ## Clipboard

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -137,7 +137,15 @@ agent-browser wait --fn "window.ready"     # Wait for JS condition (or -f)
 agent-browser mouse move 100 200      # Move mouse
 agent-browser mouse down left         # Press button
 agent-browser mouse up left           # Release button
-agent-browser mouse wheel 100         # Scroll wheel
+agent-browser mouse wheel 100         # Scroll wheel at the current mouse position
+```
+
+The wheel dispatches wherever the mouse currently is, so move it over the element first when a component listens for `wheel` on itself rather than on the page. The mouse starts at `0,0`, so a wheel with no preceding move scrolls whatever sits in the top-left corner.
+
+```bash
+agent-browser get box @e1             # or: agent-browser eval "..." to compute a center point
+agent-browser mouse move 640 400      # park the cursor over the element
+agent-browser mouse wheel 240         # wheel lands on that element
 ```
 
 ## Semantic Locators (alternative to refs)


### PR DESCRIPTION
## Problem

`agent-browser mouse wheel <dy>` always dispatches at viewport `(0,0)`. `handle_wheel` reads `x`/`y` off the command and falls back to `0.0`, and the CLI parser never sets them, so a preceding `mouse move <x> <y>` has no effect:

```rust
let x = cmd.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
let y = cmd.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
```

The wheel therefore lands on whatever element sits in the page's top-left corner. Any page that binds `wheel` to a specific element — canvas/image viewers, zoomable panes, virtualised lists — receives nothing and can't be driven through the CLI. Observed on a medical-image viewer: a `wheel` listener on the viewer element got 0 events while a `window` listener recorded `{deltaY: 240, clientX: 0, clientY: 0, target: <top header div>}`.

`mousedown`/`mouseup` don't have this problem because they already route through `build_mouse_event_params`, which reuses the tracked cursor position. `handle_wheel` was the one mouse handler that didn't.

## Fix

Route `handle_wheel` through `build_mouse_event_params` too, so it dispatches at the tracked position and keeps `MouseState` in sync. An explicit `x`/`y` on the command still overrides it, as with the other mouse handlers. This matches Playwright semantics, where `page.mouse.wheel()` dispatches at the current mouse position.

The response now also reports the `x`/`y` the wheel was dispatched at, so the position is visible in `--json` output.

## Test

`e2e_mouse_wheel_targets_element_under_cursor` (in `cli/src/native/e2e_tests.rs`, with a new `wheel_probe.html` fixture) moves the cursor to the centre of an element positioned away from the origin, wheels, and asserts the element's own `wheel` listener fired once with the expected `clientX`/`clientY`. It then wheels with explicit `x: 1, y: 1` and asserts the event reaches the window but not the element.

```
cargo test e2e_mouse_wheel -- --ignored --test-threads=1
test native::e2e_tests::e2e_mouse_wheel_targets_element_under_cursor ... ok
```

The test fails on `main` without the handler change (`onViewport` is empty). `cargo test`, `cargo fmt --check` and `cargo clippy --all-targets` are clean; the three pre-existing failures in `native::stream::http::tests` and `plugins::tests` reproduce on an unmodified checkout.

## Docs

Per `AGENTS.md`, updated `cli/src/output.rs` help, `README.md`, `skill-data/core/references/commands.md`, and `docs/src/app/commands/page.mdx` to state that the wheel dispatches at the current mouse position and to show the move-then-wheel recipe. No MCP change needed — `agent_browser_mouse_wheel` delegates through the CLI parser and its `dy`/`dx` surface is unchanged.