### PR TITLE
fix: upgrade browser-use API v4 + clean up cloud sessions on `close`

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -153,6 +153,18 @@ fn get_config_path(session: &str) -> PathBuf {
     get_socket_dir().join(format!("{}.config", session))
 }
 
+fn get_provider_session_path(session: &str) -> PathBuf {
+    get_socket_dir().join(format!("{}.provider-session", session))
+}
+
+/// Read the provider session ID saved by the daemon for cleanup on crash.
+pub fn read_provider_session_id(session: &str) -> Option<String> {
+    fs::read_to_string(get_provider_session_path(session))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Clean up stale socket and PID files for a session
 pub fn cleanup_stale_files(session: &str) {
     let pid_path = get_pid_path(session);
@@ -163,6 +175,8 @@ pub fn cleanup_stale_files(session: &str) {
     let _ = fs::remove_file(&config_path);
     let stream_path = get_socket_dir().join(format!("{}.stream", session));
     let _ = fs::remove_file(&stream_path);
+    let provider_session_path = get_provider_session_path(session);
+    let _ = fs::remove_file(&provider_session_path);
 
     #[cfg(unix)]
     {
@@ -229,6 +243,7 @@ pub enum CleanReason {
 pub struct CleanedSession {
     pub name: String,
     pub reason: CleanReason,
+    pub provider_session_id: Option<String>,
 }
 
 /// Information about the standalone dashboard process, if any.
@@ -289,6 +304,7 @@ pub fn walk_daemons() -> DaemonInventory {
                         inventory.cleaned.push(CleanedSession {
                             name: "dashboard".to_string(),
                             reason: CleanReason::DashboardGone,
+                            provider_session_id: None,
                         });
                     }
                 }
@@ -307,20 +323,24 @@ pub fn walk_daemons() -> DaemonInventory {
         {
             Some(p) => p,
             None => {
+                let provider_session_id = read_provider_session_id(&session_name);
                 cleanup_stale_files(&session_name);
                 inventory.cleaned.push(CleanedSession {
                     name: session_name,
                     reason: CleanReason::UnreadablePidFile,
+                    provider_session_id,
                 });
                 continue;
             }
         };
 
         if !is_pid_alive(pid) {
+            let provider_session_id = read_provider_session_id(&session_name);
             cleanup_stale_files(&session_name);
             inventory.cleaned.push(CleanedSession {
                 name: session_name,
                 reason: CleanReason::ProcessGone,
+                provider_session_id,
             });
             continue;
         }
@@ -344,10 +364,12 @@ pub fn walk_daemons() -> DaemonInventory {
                 }
                 let pid_path = socket_dir.join(format!("{}.pid", session_name));
                 if !pid_path.exists() {
+                    let provider_session_id = read_provider_session_id(session_name);
                     cleanup_stale_files(session_name);
                     inventory.cleaned.push(CleanedSession {
                         name: session_name.to_string(),
                         reason: CleanReason::OrphanedSocket,
+                        provider_session_id,
                     });
                 }
             }

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -165,7 +165,10 @@ pub fn read_provider_session_id(session: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Clean up stale socket and PID files for a session
+/// Clean up stale socket and PID files for a session.
+///
+/// The `.provider-session` sidecar is preserved so a later `close --all`
+/// can still release the remote provider session after a crash.
 pub fn cleanup_stale_files(session: &str) {
     let pid_path = get_pid_path(session);
     let _ = fs::remove_file(&pid_path);
@@ -175,8 +178,6 @@ pub fn cleanup_stale_files(session: &str) {
     let _ = fs::remove_file(&config_path);
     let stream_path = get_socket_dir().join(format!("{}.stream", session));
     let _ = fs::remove_file(&stream_path);
-    let provider_session_path = get_provider_session_path(session);
-    let _ = fs::remove_file(&provider_session_path);
 
     #[cfg(unix)]
     {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7586,7 +7586,21 @@ fn write_provider_file(session_id: &str, provider: &str) {
 
 fn write_provider_session_file(session_id: &str, provider_session_id: &str) {
     let path = get_socket_dir().join(format!("{}.provider-session", session_id));
-    let _ = fs::write(path, provider_session_id);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let _ = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .and_then(|mut f| f.write_all(provider_session_id.as_bytes()));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = fs::write(&path, provider_session_id);
+    }
 }
 
 fn remove_provider_file(session_id: &str) {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3156,6 +3156,9 @@ async fn auto_launch(
                     state.start_dialog_handler();
                     state.update_stream_client().await;
                     write_provider_file(&state.session_id, &p);
+                    if let Some(ref ps) = conn.session {
+                        write_provider_session_file(&state.session_id, &ps.session_id);
+                    }
                     install_network_controls_or_close(state, has_proxy_auth).await?;
                     apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
                     try_auto_restore_state(state).await;
@@ -4051,6 +4054,9 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
                         state.start_dialog_handler();
                         state.update_stream_client().await;
                         write_provider_file(&state.session_id, provider);
+                        if let Some(ref ps) = conn.session {
+                            write_provider_session_file(&state.session_id, &ps.session_id);
+                        }
                         install_network_controls_or_close(state, has_proxy_auth).await?;
                         apply_launch_init_scripts(state, &enable_features, &init_script_paths)
                             .await;
@@ -7578,8 +7584,15 @@ fn write_provider_file(session_id: &str, provider: &str) {
     let _ = fs::write(provider_file_path(session_id), provider);
 }
 
+fn write_provider_session_file(session_id: &str, provider_session_id: &str) {
+    let path = get_socket_dir().join(format!("{}.provider-session", session_id));
+    let _ = fs::write(path, provider_session_id);
+}
+
 fn remove_provider_file(session_id: &str) {
     let _ = fs::remove_file(provider_file_path(session_id));
+    let path = get_socket_dir().join(format!("{}.provider-session", session_id));
+    let _ = fs::remove_file(path);
 }
 
 fn extensions_file_path(session_id: &str) -> PathBuf {

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -141,7 +141,7 @@ pub async fn close_provider_session_with_plugins(
             if let Ok(api_key) = env::var("BROWSER_USE_API_KEY") {
                 let _ = client
                     .patch(format!(
-                        "https://api.browser-use.com/api/v2/browsers/{}",
+                        "https://api.browser-use.com/api/v4/browsers/{}",
                         session.session_id
                     ))
                     .header("X-Browser-Use-API-Key", &api_key)
@@ -385,9 +385,86 @@ async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), Stri
     let api_key = env::var("BROWSER_USE_API_KEY")
         .map_err(|_| "BROWSER_USE_API_KEY environment variable is not set")?;
 
-    let ws_url = format!("wss://connect.browser-use.com?apiKey={}", api_key);
+    let client = reqwest::Client::new();
 
-    Ok((ws_url, None))
+    let response = client
+        .post("https://api.browser-use.com/api/v4/browsers")
+        .header("X-Browser-Use-API-Key", &api_key)
+        .header("Content-Type", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| format!("Browser Use request failed: {}", e))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Browser Use response: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "Browser Use API error ({}): {}",
+            status.as_u16(),
+            body
+        ));
+    }
+
+    let json: Value =
+        serde_json::from_str(&body).map_err(|e| format!("Invalid Browser Use response: {}", e))?;
+
+    let session_id = json
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let cdp_url = json
+        .get("cdpUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Browser Use response missing cdpUrl".to_string())?;
+
+    let version_url = format!(
+        "{}/json/version",
+        cdp_url.trim_end_matches('/')
+    );
+    let version_response = client
+        .get(&version_url)
+        .send()
+        .await
+        .map_err(|e| format!("Browser Use CDP version request failed: {}", e))?;
+
+    let version_status = version_response.status();
+    let version_body = version_response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Browser Use CDP version response: {}", e))?;
+
+    if !version_status.is_success() {
+        return Err(format!(
+            "Browser Use CDP version error ({}): {}",
+            version_status.as_u16(),
+            version_body
+        ));
+    }
+
+    let version_json: Value = serde_json::from_str(&version_body)
+        .map_err(|e| format!("Invalid Browser Use CDP version response: {}", e))?;
+
+    let ws_url = version_json
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Browser Use CDP version response missing webSocketDebuggerUrl".to_string())?;
+
+    Ok((
+        ws_url,
+        Some(ProviderSession {
+            provider: "browser-use".to_string(),
+            session_id,
+        }),
+    ))
 }
 
 async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -122,7 +122,7 @@ pub async fn close_provider_session_with_plugins(
     }
 
     let client = reqwest::Client::new();
-    match session.provider.as_str() {
+    match session.provider.to_lowercase().as_str() {
         "browserbase" => {
             if let Ok(api_key) = env::var("BROWSERBASE_API_KEY") {
                 let _ = client
@@ -137,18 +137,9 @@ pub async fn close_provider_session_with_plugins(
                     .await;
             }
         }
-        "browser-use" => {
+        "browser-use" | "browseruse" => {
             if let Ok(api_key) = env::var("BROWSER_USE_API_KEY") {
-                let _ = client
-                    .patch(format!(
-                        "https://api.browser-use.com/api/v4/browsers/{}",
-                        session.session_id
-                    ))
-                    .header("X-Browser-Use-API-Key", &api_key)
-                    .header("Content-Type", "application/json")
-                    .json(&json!({ "action": "stop" }))
-                    .send()
-                    .await;
+                stop_browser_use_session(&client, &api_key, &session.session_id).await;
             }
         }
         "browserless" => {
@@ -381,6 +372,60 @@ async fn connect_browserless() -> Result<(String, Option<ProviderSession>), Stri
     ))
 }
 
+async fn stop_browser_use_session(client: &reqwest::Client, api_key: &str, session_id: &str) {
+    let _ = client
+        .patch(format!(
+            "https://api.browser-use.com/api/v4/browsers/{}",
+            session_id
+        ))
+        .header("X-Browser-Use-API-Key", api_key)
+        .header("Content-Type", "application/json")
+        .json(&json!({ "action": "stop" }))
+        .send()
+        .await;
+}
+
+async fn finish_browser_use_session(
+    client: &reqwest::Client,
+    json: &Value,
+) -> Result<String, String> {
+    let cdp_url = json
+        .get("cdpUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Browser Use response missing cdpUrl".to_string())?;
+
+    let version_url = format!("{}/json/version", cdp_url.trim_end_matches('/'));
+    let version_response = client
+        .get(&version_url)
+        .send()
+        .await
+        .map_err(|e| format!("Browser Use CDP version request failed: {}", e))?;
+
+    let version_status = version_response.status();
+    let version_body = version_response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Browser Use CDP version response: {}", e))?;
+
+    if !version_status.is_success() {
+        return Err(format!(
+            "Browser Use CDP version error ({}): {}",
+            version_status.as_u16(),
+            version_body
+        ));
+    }
+
+    let version_json: Value = serde_json::from_str(&version_body)
+        .map_err(|e| format!("Invalid Browser Use CDP version response: {}", e))?;
+
+    version_json
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "Browser Use CDP version response missing webSocketDebuggerUrl".to_string())
+}
+
 async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), String> {
     let api_key = env::var("BROWSER_USE_API_KEY")
         .map_err(|_| "BROWSER_USE_API_KEY environment variable is not set")?;
@@ -419,52 +464,19 @@ async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), Stri
         .unwrap_or("")
         .to_string();
 
-    let cdp_url = json
-        .get("cdpUrl")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .ok_or_else(|| "Browser Use response missing cdpUrl".to_string())?;
-
-    let version_url = format!(
-        "{}/json/version",
-        cdp_url.trim_end_matches('/')
-    );
-    let version_response = client
-        .get(&version_url)
-        .send()
-        .await
-        .map_err(|e| format!("Browser Use CDP version request failed: {}", e))?;
-
-    let version_status = version_response.status();
-    let version_body = version_response
-        .text()
-        .await
-        .map_err(|e| format!("Failed to read Browser Use CDP version response: {}", e))?;
-
-    if !version_status.is_success() {
-        return Err(format!(
-            "Browser Use CDP version error ({}): {}",
-            version_status.as_u16(),
-            version_body
-        ));
+    match finish_browser_use_session(&client, &json).await {
+        Ok(ws_url) => Ok((
+            ws_url,
+            Some(ProviderSession {
+                provider: "browser-use".to_string(),
+                session_id,
+            }),
+        )),
+        Err(e) => {
+            stop_browser_use_session(&client, &api_key, &session_id).await;
+            Err(e)
+        }
     }
-
-    let version_json: Value = serde_json::from_str(&version_body)
-        .map_err(|e| format!("Invalid Browser Use CDP version response: {}", e))?;
-
-    let ws_url = version_json
-        .get("webSocketDebuggerUrl")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .ok_or_else(|| "Browser Use CDP version response missing webSocketDebuggerUrl".to_string())?;
-
-    Ok((
-        ws_url,
-        Some(ProviderSession {
-            provider: "browser-use".to_string(),
-            session_id,
-        }),
-    ))
 }
 
 async fn connect_kernel() -> Result<(String, Option<ProviderSession>), String> {


### PR DESCRIPTION
I don't usually open PRs on big projects, so please don't just merge blindly. Give a careful look first.
Also, I've only tested this on Browser Use, so I haven't tried it with other cloud browser providers like Kernel or others.

Reference: [Browser Use API v4 reference](https://docs.browser-use.com/cloud/api-v4-overview)
Closes: #1514 #1520