### PR TITLE
fix(native): allow headed viewports to follow window resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 
 ```bash
 agent-browser set viewport <w> <h> [scale]  # Set viewport size (scale for retina, e.g. 2)
+agent-browser set viewport auto       # Clear emulation and follow browser window resizing
 agent-browser set device <name>       # Emulate device ("iPhone 14")
 agent-browser set geo <lat> <lng>     # Set geolocation
 agent-browser set offline [on|off]    # Toggle offline mode
@@ -283,6 +284,8 @@ agent-browser set headers <json>      # Extra HTTP headers
 agent-browser set credentials <u> <p> # HTTP basic auth
 agent-browser set media [dark|light]  # Emulate color scheme
 ```
+
+`set viewport <w> <h>` enables persistent device metrics emulation. In headed mode, use `set viewport auto` when the visible page should follow manual window resizing again.
 
 ### Cookies & Storage
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2773,25 +2773,34 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
 
     match rest.first().copied() {
         Some("viewport") => {
+            if rest.get(1).copied() == Some("auto") {
+                if rest.len() != 2 {
+                    return Err(ParseError::InvalidValue {
+                        message: "Viewport auto does not accept additional arguments".to_string(),
+                        usage: "set viewport <width> <height> [scale] | auto",
+                    });
+                }
+                return Ok(json!({ "id": id, "action": "viewport", "auto": true }));
+            }
             let w_str = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                 context: "set viewport".to_string(),
-                usage: "set viewport <width> <height> [scale]",
+                usage: "set viewport <width> <height> [scale] | auto",
             })?;
             let h_str = rest.get(2).ok_or_else(|| ParseError::MissingArguments {
                 context: "set viewport".to_string(),
-                usage: "set viewport <width> <height> [scale]",
+                usage: "set viewport <width> <height> [scale] | auto",
             })?;
             let w = w_str
                 .parse::<i32>()
                 .map_err(|_| ParseError::MissingArguments {
                     context: "set viewport".to_string(),
-                    usage: "set viewport <width> <height> [scale]",
+                    usage: "set viewport <width> <height> [scale] | auto",
                 })?;
             let h = h_str
                 .parse::<i32>()
                 .map_err(|_| ParseError::MissingArguments {
                     context: "set viewport".to_string(),
-                    usage: "set viewport <width> <height> [scale]",
+                    usage: "set viewport <width> <height> [scale] | auto",
                 })?;
             let mut cmd = json!({ "id": id, "action": "viewport", "width": w, "height": h });
             if let Some(scale_str) = rest.get(3) {
@@ -2799,7 +2808,7 @@ fn parse_set(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     .parse::<f64>()
                     .map_err(|_| ParseError::MissingArguments {
                         context: "set viewport".to_string(),
-                        usage: "set viewport <width> <height> [scale]",
+                        usage: "set viewport <width> <height> [scale] | auto",
                     })?;
                 cmd["deviceScaleFactor"] = json!(scale);
             }
@@ -4776,6 +4785,21 @@ mod tests {
         assert_eq!(cmd["width"], 1920);
         assert_eq!(cmd["height"], 1080);
         assert!(cmd.get("deviceScaleFactor").is_none());
+    }
+
+    #[test]
+    fn test_set_viewport_auto() {
+        let cmd = parse_command(&args("set viewport auto"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "viewport");
+        assert_eq!(cmd["auto"], true);
+        assert!(cmd.get("width").is_none());
+        assert!(cmd.get("height").is_none());
+    }
+
+    #[test]
+    fn test_set_viewport_auto_rejects_extra_arguments() {
+        let result = parse_command(&args("set viewport auto 800 600"), &default_flags());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1071,13 +1071,7 @@ fn parity_tools() -> Vec<Value> {
             json!({ "dy": number_schema(), "dx": number_schema() }),
             &["dy"],
         ),
-        tool(
-            TOOL_SET_VIEWPORT,
-            "Set viewport",
-            "Set viewport size.",
-            json!({ "width": int_schema(), "height": int_schema(), "scale": number_schema() }),
-            &["width", "height"],
-        ),
+        viewport_tool(),
         tool(
             TOOL_SET_DEVICE,
             "Set device",
@@ -1813,6 +1807,42 @@ fn wait_timeout_schema() -> Value {
         "minimum": 1,
         "description": "Maximum time for the browser wait condition."
     })
+}
+
+fn viewport_tool() -> Value {
+    let mut viewport = tool(
+        TOOL_SET_VIEWPORT,
+        "Set viewport",
+        "Set a fixed viewport size, or clear viewport emulation so a headed page follows manual window resizing.",
+        json!({
+            "width": int_schema(),
+            "height": int_schema(),
+            "scale": number_schema(),
+            "auto": {
+                "type": "boolean",
+                "description": "Clear viewport emulation. Do not combine with width, height, or scale."
+            }
+        }),
+        &[],
+    );
+    viewport["inputSchema"]["oneOf"] = json!([
+        {
+            "properties": { "auto": { "const": true } },
+            "required": ["auto"],
+            "not": {
+                "anyOf": [
+                    { "required": ["width"] },
+                    { "required": ["height"] },
+                    { "required": ["scale"] }
+                ]
+            }
+        },
+        {
+            "not": { "required": ["auto"] },
+            "required": ["width", "height"]
+        }
+    ]);
+    viewport
 }
 
 fn tool(name: &str, title: &str, description: &str, properties: Value, required: &[&str]) -> Value {
@@ -2649,6 +2679,31 @@ fn call_mouse_wheel(arguments: &Value) -> Result<Value, ProtocolError> {
 }
 
 fn call_set_viewport(arguments: &Value) -> Result<Value, ProtocolError> {
+    call_cli_tool(arguments, set_viewport_args(arguments)?, None)
+}
+
+fn set_viewport_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
+    if let Some(auto) = optional_bool(arguments, "auto")? {
+        if !auto {
+            return Err(ProtocolError::invalid_params(
+                "auto must be true when provided",
+            ));
+        }
+        if ["width", "height", "scale"]
+            .iter()
+            .any(|key| arguments.get(key).is_some())
+        {
+            return Err(ProtocolError::invalid_params(
+                "auto cannot be combined with width, height, or scale",
+            ));
+        }
+        return Ok(vec![
+            "set".to_string(),
+            "viewport".to_string(),
+            "auto".to_string(),
+        ]);
+    }
+
     let width = required_u64(arguments, "width")?;
     let height = required_u64(arguments, "height")?;
     let mut args = vec![
@@ -2660,7 +2715,7 @@ fn call_set_viewport(arguments: &Value) -> Result<Value, ProtocolError> {
     if let Some(scale) = optional_number_string(arguments, "scale")? {
         args.push(scale);
     }
-    call_cli_tool(arguments, args, None)
+    Ok(args)
 }
 
 fn call_set_geo(arguments: &Value) -> Result<Value, ProtocolError> {
@@ -4009,6 +4064,61 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, vec!["set", "media", "dark", "reduced-motion"]);
+    }
+
+    #[test]
+    fn set_viewport_tool_exposes_auto_mode() {
+        let tools = tools();
+        let viewport = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some(TOOL_SET_VIEWPORT))
+            .unwrap();
+        let schema = &viewport["inputSchema"];
+
+        assert!(schema["properties"].get("auto").is_some());
+        assert!(schema["required"].as_array().is_none_or(|required| {
+            !required
+                .iter()
+                .any(|field| field == "width" || field == "height")
+        }));
+        assert_eq!(
+            schema["oneOf"],
+            json!([
+                {
+                    "properties": { "auto": { "const": true } },
+                    "required": ["auto"],
+                    "not": {
+                        "anyOf": [
+                            { "required": ["width"] },
+                            { "required": ["height"] },
+                            { "required": ["scale"] }
+                        ]
+                    }
+                },
+                {
+                    "not": { "required": ["auto"] },
+                    "required": ["width", "height"]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn set_viewport_args_require_exactly_one_mode() {
+        assert_eq!(
+            set_viewport_args(&json!({ "auto": true })).unwrap(),
+            vec!["set", "viewport", "auto"]
+        );
+        assert_eq!(
+            set_viewport_args(&json!({ "width": 1280, "height": 720, "scale": 2 })).unwrap(),
+            vec!["set", "viewport", "1280", "720", "2"]
+        );
+        assert!(set_viewport_args(&json!({})).is_err());
+        assert!(set_viewport_args(&json!({ "width": 1280 })).is_err());
+        assert!(set_viewport_args(&json!({ "auto": true, "width": 1280, "height": 720 })).is_err());
+        assert!(
+            set_viewport_args(&json!({ "auto": false, "width": 1280, "height": 720 })).is_err()
+        );
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5948,6 +5948,30 @@ async fn handle_tab_close(cmd: &Value, state: &mut DaemonState) -> Result<Value,
 }
 
 async fn handle_viewport(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    if cmd.get("auto").and_then(|v| v.as_bool()).unwrap_or(false) {
+        let dimensions = {
+            let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+            mgr.clear_viewport().await?;
+            mgr.evaluate("[window.innerWidth,window.innerHeight]", None)
+                .await
+                .ok()
+                .and_then(|value| serde_json::from_value::<Vec<u32>>(value).ok())
+                .filter(|values| values.len() == 2 && values[0] > 0 && values[1] > 0)
+        };
+
+        state.viewport = None;
+
+        let mut result = json!({ "auto": true });
+        if let Some(dimensions) = dimensions {
+            result["width"] = json!(dimensions[0]);
+            result["height"] = json!(dimensions[1]);
+            if let Some(ref server) = state.stream_server {
+                server.set_viewport(dimensions[0], dimensions[1]).await;
+            }
+        }
+        return Ok(result);
+    }
+
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let width = cmd.get("width").and_then(|v| v.as_i64()).unwrap_or(1280) as i32;
     let height = cmd.get("height").and_then(|v| v.as_i64()).unwrap_or(720) as i32;

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1318,6 +1318,20 @@ impl BrowserManager {
         Ok(())
     }
 
+    /// Clear device metrics emulation so the page viewport follows the browser
+    /// content area again, including manual window resizing in headed mode.
+    pub async fn clear_viewport(&self) -> Result<(), String> {
+        let session_id = self.active_session_id()?;
+        self.client
+            .send_command(
+                "Emulation.clearDeviceMetricsOverride",
+                None,
+                Some(session_id),
+            )
+            .await?;
+        Ok(())
+    }
+
     pub async fn set_user_agent(&self, user_agent: &str) -> Result<(), String> {
         let session_id = self.active_session_id()?;
         self.client

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1972,6 +1972,97 @@ async fn e2e_viewport_emulation() {
     assert_success(&resp);
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_viewport_auto_restores_window_tracking() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "about:blank" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "viewport", "width": 1200, "height": 800 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(state.viewport.is_some());
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "viewport", "auto": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["auto"], true);
+    assert_eq!(get_data(&resp)["width"], 1200);
+    assert_eq!(get_data(&resp)["height"], 800);
+    assert!(state.viewport.is_none());
+
+    let mgr = state.browser.as_ref().unwrap();
+    let target_id = mgr.active_target_id().unwrap();
+    let window_info = mgr
+        .client
+        .send_command(
+            "Browser.getWindowForTarget",
+            Some(json!({ "targetId": target_id })),
+            None,
+        )
+        .await
+        .unwrap();
+    let window_id = window_info["windowId"].as_i64().unwrap();
+    mgr.client
+        .send_command(
+            "Browser.setContentsSize",
+            Some(json!({
+                "windowId": window_id,
+                "width": 640,
+                "height": 480,
+            })),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "waitforfunction",
+            "expression": "window.innerWidth === 640",
+            "timeout": 5000,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "window.innerWidth" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        640,
+        "CSS viewport should follow the browser content size after auto mode"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // Hover, scroll, press
 // ---------------------------------------------------------------------------
@@ -5522,9 +5613,158 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
         "should have received a frame with JPEG dimensions 800x600 within the deadline"
     );
 
+    // Disconnect the stream before clearing emulation and resizing. The next
+    // client must get the current CSS viewport even though no listener saw the
+    // resize event.
+    ws.close(None)
+        .await
+        .expect("websocket client should close cleanly");
+    let stream_server = state
+        .stream_server
+        .as_ref()
+        .expect("stream server should remain enabled");
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    while stream_server.is_screencasting().await && tokio::time::Instant::now() < deadline {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !stream_server.is_screencasting().await,
+        "stream server should observe the disconnected client"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "viewport", "auto": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let mgr = state.browser.as_ref().expect("browser should be running");
+    let target_id = mgr
+        .active_target_id()
+        .expect("an active target should exist");
+    let browser_client = Arc::clone(&mgr.client);
+    let window_info = browser_client
+        .send_command(
+            "Browser.getWindowForTarget",
+            Some(json!({ "targetId": target_id })),
+            None,
+        )
+        .await
+        .expect("window should be discoverable");
+    let window_id = window_info["windowId"]
+        .as_i64()
+        .expect("window id should be present");
+    browser_client
+        .send_command(
+            "Browser.setContentsSize",
+            Some(json!({
+                "windowId": window_id,
+                "width": 640,
+                "height": 480,
+            })),
+            None,
+        )
+        .await
+        .expect("window contents should resize");
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "waitforfunction",
+            "expression": "window.innerWidth === 640 && window.innerHeight === 480",
+            "timeout": 5000,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("websocket client should reconnect to runtime stream");
+
+    let mut found_resized_frame = false;
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
+        let Some(Ok(message)) = msg.ok().flatten() else {
+            continue;
+        };
+        if !message.is_text() {
+            continue;
+        }
+        let parsed: Value =
+            serde_json::from_str(message.to_text().expect("text message should be readable"))
+                .expect("stream payload should be valid JSON");
+        if parsed.get("type") == Some(&json!("frame"))
+            && parsed["metadata"]["deviceWidth"] == 640
+            && parsed["metadata"]["deviceHeight"] == 480
+        {
+            found_resized_frame = true;
+            break;
+        }
+    }
+    assert!(
+        found_resized_frame,
+        "stream frame metadata should follow a manual resize after viewport auto"
+    );
+
+    // A resize while connected must also update the active stream.
+    browser_client
+        .send_command(
+            "Browser.setContentsSize",
+            Some(json!({
+                "windowId": window_id,
+                "width": 700,
+                "height": 520,
+            })),
+            None,
+        )
+        .await
+        .expect("window contents should resize while streaming");
+
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "waitforfunction",
+            "expression": "window.innerWidth === 700 && window.innerHeight === 520",
+            "timeout": 5000,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let mut found_live_resized_frame = false;
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
+        let Some(Ok(message)) = msg.ok().flatten() else {
+            continue;
+        };
+        if !message.is_text() {
+            continue;
+        }
+        let parsed: Value =
+            serde_json::from_str(message.to_text().expect("text message should be readable"))
+                .expect("stream payload should be valid JSON");
+        if parsed.get("type") == Some(&json!("frame"))
+            && parsed["metadata"]["deviceWidth"] == 700
+            && parsed["metadata"]["deviceHeight"] == 520
+        {
+            found_live_resized_frame = true;
+            break;
+        }
+    }
+    assert!(
+        found_live_resized_frame,
+        "stream frame metadata should follow a resize while connected"
+    );
+
     // Cleanup
     let resp = execute_command(
-        &json!({ "id": "4", "action": "stream_disable" }),
+        &json!({ "id": "7", "action": "stream_disable" }),
         &mut state,
     )
     .await;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -8,7 +8,7 @@
 //!   cargo test e2e -- --ignored --test-threads=1
 
 use base64::{engine::general_purpose::STANDARD, Engine};
-use futures_util::StreamExt;
+use futures_util::{Stream, StreamExt};
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -30,6 +30,59 @@ fn assert_success(resp: &Value) {
 
 fn get_data(resp: &Value) -> &Value {
     resp.get("data").expect("Missing 'data' in response")
+}
+
+async fn wait_for_stream_frame_dimensions<S, E>(stream: &mut S, width: u32, height: u32) -> bool
+where
+    S: Stream<Item = Result<tokio_tungstenite::tungstenite::Message, E>> + Unpin,
+{
+    let mut last_frame = None;
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        let message =
+            tokio::time::timeout(tokio::time::Duration::from_secs(3), stream.next()).await;
+        let Some(Ok(message)) = message.ok().flatten() else {
+            continue;
+        };
+        if !message.is_text() {
+            continue;
+        }
+
+        let parsed: Value =
+            serde_json::from_str(message.to_text().expect("text message should be readable"))
+                .expect("stream payload should be valid JSON");
+        if parsed.get("type") != Some(&json!("frame")) {
+            continue;
+        }
+
+        let jpeg_size = parsed
+            .get("data")
+            .and_then(Value::as_str)
+            .and_then(|data| STANDARD.decode(data).ok())
+            .and_then(|bytes| jpeg_dimensions(&bytes));
+        last_frame = Some((
+            parsed["metadata"]["deviceWidth"].clone(),
+            parsed["metadata"]["deviceHeight"].clone(),
+            jpeg_size,
+        ));
+        if parsed["metadata"]["deviceWidth"] == width
+            && parsed["metadata"]["deviceHeight"] == height
+            && jpeg_size == Some((width, height))
+        {
+            return true;
+        }
+    }
+
+    eprintln!("last stream frame while waiting for {width}x{height}: {last_frame:?}");
+    false
+}
+
+async fn wait_for_screencast_state(server: &super::stream::StreamServer, expected: bool) -> bool {
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    while server.is_screencasting().await != expected && tokio::time::Instant::now() < deadline {
+        tokio::task::yield_now().await;
+    }
+    server.is_screencasting().await == expected
 }
 
 fn native_test_fixture_html(name: &str) -> &'static str {
@@ -2006,8 +2059,18 @@ async fn e2e_viewport_auto_restores_window_tracking() {
     .await;
     assert_success(&resp);
     assert_eq!(get_data(&resp)["auto"], true);
-    assert_eq!(get_data(&resp)["width"], 1200);
-    assert_eq!(get_data(&resp)["height"], 800);
+    assert!(
+        get_data(&resp)["width"]
+            .as_u64()
+            .is_some_and(|width| width > 0),
+        "auto mode should report the actual positive CSS viewport width"
+    );
+    assert!(
+        get_data(&resp)["height"]
+            .as_u64()
+            .is_some_and(|height| height > 0),
+        "auto mode should report the actual positive CSS viewport height"
+    );
     assert!(state.viewport.is_none());
 
     let mgr = state.browser.as_ref().unwrap();
@@ -5540,7 +5603,7 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
         .as_u64()
         .expect("stream enable should report the bound port");
 
-    // Set a custom viewport before launching the browser
+    // Set a custom viewport before connecting the stream client.
     let resp = execute_command(
         &json!({ "id": "2", "action": "viewport", "width": 800, "height": 600 }),
         &mut state,
@@ -5552,8 +5615,18 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
         .await
         .expect("websocket client should connect to runtime stream");
+    let stream_server = Arc::clone(
+        state
+            .stream_server
+            .as_ref()
+            .expect("stream server should remain enabled"),
+    );
+    assert!(
+        wait_for_screencast_state(&stream_server, true).await,
+        "stream server should start screencasting for the connected client"
+    );
 
-    // Navigate to trigger browser launch and screencast
+    // Navigate after screencast startup so Chrome produces a fresh frame.
     let resp = execute_command(
         &json!({ "id": "3", "action": "navigate", "url": "data:text/html,<h1>Viewport Test</h1>" }),
         &mut state,
@@ -5561,55 +5634,8 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     .await;
     assert_success(&resp);
 
-    // Wait for a frame whose JPEG dimensions match the custom viewport.
-    // Early frames may arrive before Chrome fully applies the viewport resize,
-    // so skip frames with stale dimensions rather than failing immediately.
-    let mut found_frame = false;
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
-    while tokio::time::Instant::now() < deadline {
-        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
-        let Some(Ok(message)) = msg.ok().flatten() else {
-            continue;
-        };
-        if !message.is_text() {
-            continue;
-        }
-        let parsed: Value =
-            serde_json::from_str(message.to_text().expect("text message should be readable"))
-                .expect("stream payload should be valid JSON");
-        if parsed.get("type") == Some(&json!("frame")) {
-            let meta = &parsed["metadata"];
-            assert_eq!(
-                meta["deviceWidth"], 800,
-                "frame metadata deviceWidth should match custom viewport, got: {}",
-                meta
-            );
-            assert_eq!(
-                meta["deviceHeight"], 600,
-                "frame metadata deviceHeight should match custom viewport, got: {}",
-                meta
-            );
-
-            let data_str = parsed
-                .get("data")
-                .and_then(|v| v.as_str())
-                .expect("frame message should include base64-encoded 'data' field");
-            use base64::Engine;
-            let bytes = base64::engine::general_purpose::STANDARD
-                .decode(data_str)
-                .expect("frame data should be valid base64");
-            let (img_w, img_h) =
-                jpeg_dimensions(&bytes).expect("frame data should be a valid JPEG with SOF marker");
-            if img_w != 800 || img_h != 600 {
-                continue;
-            }
-
-            found_frame = true;
-            break;
-        }
-    }
     assert!(
-        found_frame,
+        wait_for_stream_frame_dimensions(&mut ws, 800, 600).await,
         "should have received a frame with JPEG dimensions 800x600 within the deadline"
     );
 
@@ -5619,16 +5645,8 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     ws.close(None)
         .await
         .expect("websocket client should close cleanly");
-    let stream_server = state
-        .stream_server
-        .as_ref()
-        .expect("stream server should remain enabled");
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
-    while stream_server.is_screencasting().await && tokio::time::Instant::now() < deadline {
-        tokio::task::yield_now().await;
-    }
     assert!(
-        !stream_server.is_screencasting().await,
+        wait_for_screencast_state(&stream_server, false).await,
         "stream server should observe the disconnected client"
     );
 
@@ -5684,30 +5702,9 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
         .await
         .expect("websocket client should reconnect to runtime stream");
 
-    let mut found_resized_frame = false;
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
-    while tokio::time::Instant::now() < deadline {
-        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
-        let Some(Ok(message)) = msg.ok().flatten() else {
-            continue;
-        };
-        if !message.is_text() {
-            continue;
-        }
-        let parsed: Value =
-            serde_json::from_str(message.to_text().expect("text message should be readable"))
-                .expect("stream payload should be valid JSON");
-        if parsed.get("type") == Some(&json!("frame"))
-            && parsed["metadata"]["deviceWidth"] == 640
-            && parsed["metadata"]["deviceHeight"] == 480
-        {
-            found_resized_frame = true;
-            break;
-        }
-    }
     assert!(
-        found_resized_frame,
-        "stream frame metadata should follow a manual resize after viewport auto"
+        wait_for_stream_frame_dimensions(&mut ws, 640, 480).await,
+        "stream frame metadata and JPEG dimensions should follow a manual resize after viewport auto"
     );
 
     // A resize while connected must also update the active stream.
@@ -5736,30 +5733,9 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     .await;
     assert_success(&resp);
 
-    let mut found_live_resized_frame = false;
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
-    while tokio::time::Instant::now() < deadline {
-        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
-        let Some(Ok(message)) = msg.ok().flatten() else {
-            continue;
-        };
-        if !message.is_text() {
-            continue;
-        }
-        let parsed: Value =
-            serde_json::from_str(message.to_text().expect("text message should be readable"))
-                .expect("stream payload should be valid JSON");
-        if parsed.get("type") == Some(&json!("frame"))
-            && parsed["metadata"]["deviceWidth"] == 700
-            && parsed["metadata"]["deviceHeight"] == 520
-        {
-            found_live_resized_frame = true;
-            break;
-        }
-    }
     assert!(
-        found_live_resized_frame,
-        "stream frame metadata should follow a resize while connected"
+        wait_for_stream_frame_dimensions(&mut ws, 700, 520).await,
+        "stream frame metadata and JPEG dimensions should follow a resize while connected"
     );
 
     // Cleanup

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, watch, Mutex, RwLock};
 
 use crate::native::cdp::client::CdpClient;
+use crate::native::cdp::types::{EvaluateParams, EvaluateResult};
 use crate::native::network;
 
 use super::timestamp_ms;
@@ -57,6 +58,12 @@ pub(super) async fn cdp_event_loop(
 
                 let session_id = cdp_session_id.read().await.clone();
 
+                if let Some((width, height)) =
+                    current_css_viewport(&client_arc, session_id.as_deref()).await
+                {
+                    *viewport_width.lock().await = width;
+                    *viewport_height.lock().await = height;
+                }
                 let vw = *viewport_width.lock().await;
                 let vh = *viewport_height.lock().await;
 
@@ -137,6 +144,48 @@ pub(super) async fn cdp_event_loop(
                                                     });
                                                     let _ = frame_tx.send(msg.to_string());
                                                 }
+                                            }
+                                        }
+                                    } else if evt.method == "Page.frameResized"
+                                        && is_active_page_session(
+                                            evt.session_id.as_deref(),
+                                            session_id.as_deref(),
+                                        )
+                                    {
+                                        if let Some((width, height)) =
+                                            current_css_viewport(
+                                                &client_arc,
+                                                session_id.as_deref(),
+                                            )
+                                            .await
+                                        {
+                                            let changed = {
+                                                let mut current_width = viewport_width.lock().await;
+                                                let mut current_height = viewport_height.lock().await;
+                                                if *current_width == width && *current_height == height {
+                                                    false
+                                                } else {
+                                                    *current_width = width;
+                                                    *current_height = height;
+                                                    true
+                                                }
+                                            };
+
+                                            if changed {
+                                                if supports_screencast {
+                                                    let _ = client_arc
+                                                        .send_command_no_params(
+                                                            "Page.stopScreencast",
+                                                            session_id.as_deref(),
+                                                        )
+                                                        .await;
+                                                }
+                                                {
+                                                    let mut sc = screencasting.lock().await;
+                                                    *sc = false;
+                                                }
+                                                client_notify.notify_one();
+                                                break;
                                             }
                                         }
                                     } else if evt.method == "Page.screencastFrame" {
@@ -278,6 +327,30 @@ pub(super) async fn cdp_event_loop(
     }
 }
 
+async fn current_css_viewport(client: &CdpClient, session_id: Option<&str>) -> Option<(u32, u32)> {
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: "[window.innerWidth, window.innerHeight]".to_string(),
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            session_id,
+        )
+        .await
+        .ok()?;
+    let dimensions = result.result.value?.as_array()?.clone();
+    let width = u32::try_from(dimensions.first()?.as_u64()?).ok()?;
+    let height = u32::try_from(dimensions.get(1)?.as_u64()?).ok()?;
+    Some((width, height))
+}
+
+fn is_active_page_session(event_session: Option<&str>, active_session: Option<&str>) -> bool {
+    event_session.filter(|session| !session.is_empty())
+        == active_session.filter(|session| !session.is_empty())
+}
+
 pub async fn start_screencast(
     client: &CdpClient,
     session_id: &str,
@@ -322,4 +395,20 @@ pub async fn ack_screencast_frame(
         )
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_active_page_session;
+
+    #[test]
+    fn frame_resize_must_come_from_active_page_session() {
+        assert!(is_active_page_session(Some("page-1"), Some("page-1")));
+        assert!(is_active_page_session(None, None));
+        assert!(is_active_page_session(None, Some("")));
+        assert!(is_active_page_session(Some(""), Some("")));
+        assert!(!is_active_page_session(Some("page-2"), Some("page-1")));
+        assert!(!is_active_page_session(Some("oopif"), Some("page-1")));
+        assert!(!is_active_page_session(None, Some("page-1")));
+    }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2128,7 +2128,8 @@ Usage: agent-browser set <setting> [args]
 Configures various browser settings and emulation options.
 
 Settings:
-  viewport <w> <h> [scale]   Set viewport size (scale = deviceScaleFactor, e.g. 2 for retina)
+  viewport <w> <h> [scale]   Set a fixed viewport size (scale = deviceScaleFactor, e.g. 2 for retina)
+  viewport auto              Clear emulation so viewport follows the browser window
   device <name>              Emulate device (e.g., "iPhone 12")
   geo <lat> <lng>            Set geolocation
   offline [on|off]           Toggle offline mode
@@ -2144,6 +2145,7 @@ Global Options:
 Examples:
   agent-browser set viewport 1920 1080
   agent-browser set viewport 1920 1080 2    # 2x retina
+  agent-browser set viewport auto           # Follow manual headed window resizing
   agent-browser set device "iPhone 12"
   agent-browser set geo 37.7749 -122.4194
   agent-browser set offline on
@@ -3371,7 +3373,7 @@ Mouse:  agent-browser mouse <action> [args]
   move <x> <y>, down [btn], up [btn], wheel <dy> [dx]
 
 Browser Settings:  agent-browser set <setting> [value]
-  viewport <w> <h>, device <name>, geo <lat> <lng>
+  viewport <w> <h> [scale] | auto, device <name>, geo <lat> <lng>
   offline [on|off], headers <json>, credentials <user> <pass>
   media [dark|light] [reduced-motion]
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -167,6 +167,7 @@ See [Files & Clipboard](/files) for clipboard, upload, download, local file, scr
 
 ```bash
 agent-browser set viewport <w> <h> [scale]  # Set viewport size (scale for retina, e.g. 2)
+agent-browser set viewport auto       # Clear emulation and follow browser window resizing
 agent-browser set device <name>       # Emulate device ("iPhone 14")
 agent-browser set geo <lat> <lng>     # Set geolocation
 agent-browser set offline [on|off]    # Toggle offline mode
@@ -174,6 +175,8 @@ agent-browser set headers <json>      # Extra HTTP headers
 agent-browser set credentials <u> <p> # HTTP basic auth
 agent-browser set media [dark|light]  # Emulate color scheme (persists for session)
 ```
+
+`set viewport <w> <h>` enables persistent device metrics emulation. In headed mode, use `set viewport auto` when the visible page should follow manual window resizing again.
 
 Use `--color-scheme` for persistent dark/light mode across all commands:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -391,6 +391,8 @@ agent-browser snapshot -i
 
 **Click does nothing / overlay swallows the click** Some modals and cookie banners block other clicks. If `click` reports `covered by <...>`, interact with that covering element first. Otherwise, snapshot, find the dismiss/close button, click it, then re-snapshot.
 
+**Headed page does not resize with the browser window** `set viewport <w> <h>` enables persistent device metrics emulation, so later manual window resizing does not change the CSS viewport. Run `agent-browser set viewport auto` to clear emulation and make the page follow the visible window again. Prefer auto mode for a headed browser shared with a human; use fixed dimensions for deterministic responsive tests and screenshots.
+
 **Fill / type doesn't work** Some custom input components intercept key events. Try:
 
 ```bash

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -162,6 +162,7 @@ agent-browser find nth 2 "a" hover
 ```bash
 agent-browser set viewport 1920 1080          # Set viewport size
 agent-browser set viewport 1920 1080 2        # 2x retina (same CSS size, higher res screenshots)
+agent-browser set viewport auto               # Clear emulation and follow browser window resizing
 agent-browser set device "iPhone 14"          # Emulate device
 agent-browser set geo 37.7749 -122.4194       # Set geolocation (alias: geolocation)
 agent-browser set offline on                  # Toggle offline mode
@@ -170,6 +171,8 @@ agent-browser set credentials user pass       # HTTP basic auth (alias: auth)
 agent-browser set media dark                  # Emulate color scheme
 agent-browser set media light reduced-motion  # Light mode + reduced motion
 ```
+
+Fixed viewport dimensions remain emulated until changed. In headed mode, use `set viewport auto` when the page should follow manual window resizing.
 
 ## Cookies and Storage
 


### PR DESCRIPTION
## Summary

- add `set viewport auto` to the CLI and MCP surface
- clear CDP device metrics emulation so a headed page follows manual window resizing
- keep stream status, frame metadata, and screencast dimensions synchronized after resizes
- document fixed versus auto viewport behavior and cover both modes with regression tests

## Why

`set viewport <width> <height>` applies a persistent `Emulation.setDeviceMetricsOverride`. Resizing a headed browser window afterward changes the visible window but not the CSS viewport, which makes the page appear clipped or stuck at the old responsive breakpoint.

Auto mode explicitly clears that override with `Emulation.clearDeviceMetricsOverride`. The existing deterministic fixed viewport remains the default and is unchanged.

This restores the manual-resize behavior requested in #592 while preserving fixed dimensions for repeatable responsive tests and screenshots. It also follows the earlier launch-time viewport precedent in #492 and retains the exact fixed stream sizing added in #1033.

## Usage

```bash
agent-browser set viewport 1280 720
agent-browser set viewport auto
```

Use fixed dimensions for deterministic automation. Use auto mode when a human and an agent share a headed browser and the page should follow the visible window.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets`
- `cargo test --manifest-path cli/Cargo.toml --bin agent-browser -- --test-threads=1 --skip download_bytes_connection_refused_includes_details` (`967 passed`, `93 ignored`)
- CLI parser and MCP schema/argument tests
- `e2e_viewport_auto_restores_window_tracking`
- `e2e_stream_frame_metadata_respects_custom_viewport`
- stream resize regression repeated 10 consecutive times after removing the test startup race
- manual side-by-side headed comparison against the unmodified v0.32.4 build

Fixes #592
