### PR TITLE
feat(providers): add TestMu AI Browser Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,49 @@ When enabled, agent-browser connects to a Browserbase session instead of launchi
 
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview).
 
+### Browser Cloud
+
+[Browser Cloud](https://testmuai.com) by TestMu AI provides remote Chrome sessions on a managed grid, with video, console, and network capture for every run. Use it when running agent-browser somewhere a local browser isn't feasible, or when you want a replayable recording of what the agent did.
+
+To enable Browser Cloud, use the `-p` flag:
+
+```bash
+export LT_USERNAME="your-username"
+export LT_ACCESS_KEY="your-access-key"
+agent-browser -p browsercloud open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=browsercloud
+export LT_USERNAME="your-username"
+export LT_ACCESS_KEY="your-access-key"
+agent-browser open https://example.com
+```
+
+Optional configuration via environment variables:
+
+| Variable                        | Description                                              | Default              |
+| ------------------------------- | -------------------------------------------------------- | -------------------- |
+| `BROWSER_CLOUD_ENDPOINT`        | CDP host (bare host or full URL)                          | `cdp.lambdatest.com` |
+| `BROWSER_CLOUD_BROWSER_NAME`    | Browser to launch                                         | `Chrome`             |
+| `BROWSER_CLOUD_BROWSER_VERSION` | Browser version                                           | `latest`             |
+| `BROWSER_CLOUD_PLATFORM`        | Operating system for the session                          | `Windows 10`         |
+| `BROWSER_CLOUD_PROJECT`         | Project name in the dashboard                             | `agent-browser`      |
+| `BROWSER_CLOUD_BUILD`           | Build name in the dashboard                               | `agent-browser`      |
+| `BROWSER_CLOUD_SESSION_NAME`    | Session name in the dashboard                             | —                    |
+| `BROWSER_CLOUD_RESOLUTION`      | Viewport, e.g. `1920x1080`                                | —                    |
+| `BROWSER_CLOUD_REGION`          | Region to run in, e.g. `us`, `eu`                         | —                    |
+| `BROWSER_CLOUD_GEO_LOCATION`    | Two-letter country code for geolocation                   | —                    |
+| `BROWSER_CLOUD_STEALTH`         | Humanize interactions and randomize the user agent        | `false`              |
+| `BROWSER_CLOUD_TUNNEL`          | Route traffic through a tunnel to reach private hosts     | `false`              |
+| `BROWSER_CLOUD_TUNNEL_NAME`     | Name of an already-running tunnel                         | —                    |
+
+When enabled, agent-browser connects to a Browser Cloud session instead of launching a local browser. All commands work identically.
+
+Get your username and access key from the [TestMu AI dashboard](https://testmuai.com) under **Account Settings**.
+
 ### Browser Use
 
 [Browser Use](https://browser-use.com) provides cloud browser infrastructure for AI agents. Use it when running agent-browser in environments where a local browser isn't available (serverless, CI/CD, etc.).

--- a/cli/src/doctor/network.rs
+++ b/cli/src/doctor/network.rs
@@ -77,6 +77,18 @@ pub(super) fn check(checks: &mut Vec<Check>) {
                 env::var("BROWSERLESS_API_URL")
                     .unwrap_or_else(|_| "https://production-sfo.browserless.io".to_string()),
             ),
+            "browsercloud" | "browser-cloud" => {
+                let host = env::var("BROWSER_CLOUD_ENDPOINT")
+                    .unwrap_or_else(|_| "cdp.lambdatest.com".to_string());
+                let host = host
+                    .trim()
+                    .trim_start_matches("wss://")
+                    .trim_start_matches("ws://")
+                    .trim_start_matches("https://")
+                    .trim_start_matches("http://")
+                    .trim_end_matches('/');
+                Some(format!("https://{}", host))
+            }
             "browseruse" | "browser-use" => Some("https://api.browser-use.com".to_string()),
             "kernel" => Some(
                 env::var("KERNEL_ENDPOINT")

--- a/cli/src/doctor/providers.rs
+++ b/cli/src/doctor/providers.rs
@@ -12,9 +12,11 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     let category = "Providers";
 
     let active = env::var("AGENT_BROWSER_PROVIDER").ok();
+    // Provider ids below are written without separators, so `browser-use` and
+    // `browser-cloud` normalize onto the same key as their compact spellings.
     let normalized = active
         .as_ref()
-        .map(|s| s.to_lowercase())
+        .map(|s| s.to_lowercase().replace('-', ""))
         .unwrap_or_default();
 
     let active_status = |provider: &str, ok: bool| -> Status {
@@ -32,16 +34,23 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     let providers: &[(&str, &[&str], &str)] = &[
         ("browserless", &["BROWSERLESS_API_KEY"], "Browserless"),
         ("browserbase", &["BROWSERBASE_API_KEY"], "Browserbase"),
+        (
+            "browsercloud",
+            &["LT_USERNAME", "LT_ACCESS_KEY"],
+            "Browser Cloud",
+        ),
         ("browseruse", &["BROWSER_USE_API_KEY"], "Browser Use"),
         ("kernel", &["KERNEL_API_KEY"], "Kernel"),
     ];
 
     for (id, env_keys, label) in providers {
-        let present = env_keys.iter().any(|k| env::var(k).is_ok());
+        // Providers that need more than one variable are only usable when all
+        // of them are set.
+        let present = env_keys.iter().all(|k| env::var(k).is_ok());
         let provider_id = *id;
         let status = active_status(provider_id, present);
         let msg = if present {
-            format!("{}: API key present", label)
+            format!("{}: credentials present", label)
         } else {
             format!("{}: {} not set", label, env_keys.join(" / "))
         };
@@ -49,7 +58,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         if status == Status::Fail {
             check = check.with_fix(format!(
                 "set {} (or unset AGENT_BROWSER_PROVIDER={})",
-                env_keys.first().copied().unwrap_or(""),
+                env_keys.join(" and "),
                 provider_id
             ));
         }

--- a/cli/src/native/providers.rs
+++ b/cli/src/native/providers.rs
@@ -1,6 +1,7 @@
 //! Browser provider connections for remote CDP sessions.
 //!
-//! Supports AgentCore, Browserbase, Browserless, Browser Use, and Kernel providers.
+//! Supports AgentCore, Browserbase, Browser Cloud, Browserless, Browser Use, and
+//! Kernel providers.
 //! Each provider returns a CDP WebSocket URL for connecting via BrowserManager.
 
 use serde_json::{json, Value};
@@ -60,6 +61,15 @@ pub async fn connect_provider_with_plugins_and_options(
         }
         "browserless" => {
             let (url, session) = connect_browserless().await?;
+            Ok(ProviderConnection {
+                ws_url: url,
+                session,
+                direct_page: false,
+                metadata: None,
+            })
+        }
+        "browsercloud" | "browser-cloud" => {
+            let (url, session) = connect_browser_cloud().await?;
             Ok(ProviderConnection {
                 ws_url: url,
                 session,
@@ -192,7 +202,7 @@ pub async fn connect_plugin_provider_with_plugins_and_options(
 ) -> Result<ProviderConnection, String> {
     if crate::plugins::find_plugin(plugins, provider_name).is_none() {
         return Err(format!(
-            "Unknown provider '{}'. Supported: browserbase, browserless, browser-use, kernel, agentcore, or a configured plugin with browser.provider",
+            "Unknown provider '{}'. Supported: browserbase, browsercloud, browserless, browser-use, kernel, agentcore, or a configured plugin with browser.provider",
             provider_name
         ));
     }
@@ -379,6 +389,111 @@ async fn connect_browserless() -> Result<(String, Option<ProviderSession>), Stri
             session_id: stop_url,
         }),
     ))
+}
+
+/// Connects to TestMu AI Browser Cloud.
+///
+/// Browser Cloud has no session-creation REST call: the CDP endpoint accepts
+/// credentials in the URL userinfo and the session capabilities as a
+/// URL-encoded `capabilities` query parameter. The remote session is created
+/// when the WebSocket connects and is torn down when it closes, so there is no
+/// session id to track for cleanup.
+async fn connect_browser_cloud() -> Result<(String, Option<ProviderSession>), String> {
+    let username =
+        env::var("LT_USERNAME").map_err(|_| "LT_USERNAME environment variable is not set")?;
+    let access_key =
+        env::var("LT_ACCESS_KEY").map_err(|_| "LT_ACCESS_KEY environment variable is not set")?;
+
+    // Accept either a bare host or a full URL for the CDP endpoint.
+    let endpoint =
+        env::var("BROWSER_CLOUD_ENDPOINT").unwrap_or_else(|_| "cdp.lambdatest.com".to_string());
+    let host = endpoint
+        .trim()
+        .trim_start_matches("wss://")
+        .trim_start_matches("ws://")
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/');
+    if host.is_empty() {
+        return Err("BROWSER_CLOUD_ENDPOINT is empty".to_string());
+    }
+
+    let mut lt_options = serde_json::Map::new();
+    lt_options.insert(
+        "platformName".to_string(),
+        json!(env::var("BROWSER_CLOUD_PLATFORM").unwrap_or_else(|_| "Windows 10".to_string())),
+    );
+    lt_options.insert(
+        "project".to_string(),
+        json!(env::var("BROWSER_CLOUD_PROJECT").unwrap_or_else(|_| "agent-browser".to_string())),
+    );
+    lt_options.insert(
+        "build".to_string(),
+        json!(env::var("BROWSER_CLOUD_BUILD").unwrap_or_else(|_| "agent-browser".to_string())),
+    );
+    lt_options.insert("console".to_string(), json!(true));
+    lt_options.insert("network".to_string(), json!(true));
+    lt_options.insert("video".to_string(), json!(true));
+    lt_options.insert(
+        "headless".to_string(),
+        json!(!env_var_is_truthy("AGENT_BROWSER_HEADED")),
+    );
+
+    if let Ok(name) = env::var("BROWSER_CLOUD_SESSION_NAME") {
+        if !name.is_empty() {
+            lt_options.insert("name".to_string(), json!(name));
+        }
+    }
+    if let Ok(resolution) = env::var("BROWSER_CLOUD_RESOLUTION") {
+        if !resolution.is_empty() {
+            lt_options.insert("resolution".to_string(), json!(resolution));
+        }
+    }
+    if let Ok(region) = env::var("BROWSER_CLOUD_REGION") {
+        if !region.is_empty() {
+            lt_options.insert("region".to_string(), json!(region));
+        }
+    }
+    if let Ok(geo) = env::var("BROWSER_CLOUD_GEO_LOCATION") {
+        if !geo.is_empty() {
+            lt_options.insert("geoLocation".to_string(), json!(geo));
+        }
+    }
+    if let Ok(user_agent) = env::var("AGENT_BROWSER_USER_AGENT") {
+        if !user_agent.is_empty() {
+            lt_options.insert("user_agent".to_string(), json!(user_agent));
+        }
+    }
+    if env_var_is_truthy("BROWSER_CLOUD_STEALTH") {
+        lt_options.insert("humanizeInteractions".to_string(), json!(true));
+        lt_options.insert("randomizeUserAgent".to_string(), json!(true));
+    }
+    if env_var_is_truthy("BROWSER_CLOUD_TUNNEL") {
+        lt_options.insert("tunnel".to_string(), json!(true));
+        if let Ok(tunnel_name) = env::var("BROWSER_CLOUD_TUNNEL_NAME") {
+            if !tunnel_name.is_empty() {
+                lt_options.insert("tunnelName".to_string(), json!(tunnel_name));
+            }
+        }
+    }
+
+    let capabilities = json!({
+        "browserName": env::var("BROWSER_CLOUD_BROWSER_NAME")
+            .unwrap_or_else(|_| "Chrome".to_string()),
+        "browserVersion": env::var("BROWSER_CLOUD_BROWSER_VERSION")
+            .unwrap_or_else(|_| "latest".to_string()),
+        "LT:Options": Value::Object(lt_options),
+    });
+
+    let ws_url = format!(
+        "wss://{}:{}@{}/puppeteer?capabilities={}",
+        urlencoding::encode(&username),
+        urlencoding::encode(&access_key),
+        host,
+        urlencoding::encode(&capabilities.to_string())
+    );
+
+    Ok((ws_url, None))
 }
 
 async fn connect_browser_use() -> Result<(String, Option<ProviderSession>), String> {
@@ -878,6 +993,95 @@ mod tests {
         let result = rt.block_on(connect_provider("unknown-provider"));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Unknown provider"));
+    }
+
+    #[test]
+    fn test_connect_browser_cloud_requires_credentials() {
+        let guard = EnvGuard::new(&["LT_USERNAME", "LT_ACCESS_KEY"]);
+        guard.remove("LT_USERNAME");
+        guard.remove("LT_ACCESS_KEY");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(connect_browser_cloud()).unwrap_err();
+        assert!(err.contains("LT_USERNAME"));
+
+        guard.set("LT_USERNAME", "user");
+        let err = rt.block_on(connect_browser_cloud()).unwrap_err();
+        assert!(err.contains("LT_ACCESS_KEY"));
+    }
+
+    #[test]
+    fn test_connect_browser_cloud_builds_cdp_url_with_capabilities() {
+        let optional = [
+            "BROWSER_CLOUD_BROWSER_NAME",
+            "BROWSER_CLOUD_BROWSER_VERSION",
+            "BROWSER_CLOUD_PLATFORM",
+            "BROWSER_CLOUD_PROJECT",
+            "BROWSER_CLOUD_BUILD",
+            "BROWSER_CLOUD_SESSION_NAME",
+            "BROWSER_CLOUD_REGION",
+            "BROWSER_CLOUD_GEO_LOCATION",
+            "BROWSER_CLOUD_TUNNEL",
+            "BROWSER_CLOUD_TUNNEL_NAME",
+            "AGENT_BROWSER_USER_AGENT",
+            "AGENT_BROWSER_HEADED",
+        ];
+        let mut names = vec![
+            "LT_USERNAME",
+            "LT_ACCESS_KEY",
+            "BROWSER_CLOUD_ENDPOINT",
+            "BROWSER_CLOUD_RESOLUTION",
+            "BROWSER_CLOUD_STEALTH",
+        ];
+        names.extend_from_slice(&optional);
+        let guard = EnvGuard::new(&names);
+        for name in optional {
+            guard.remove(name);
+        }
+        guard.set("LT_USERNAME", "user@example.com");
+        guard.set("LT_ACCESS_KEY", "key/with+chars");
+        guard.set("BROWSER_CLOUD_ENDPOINT", "wss://cdp.example.com/");
+        guard.set("BROWSER_CLOUD_RESOLUTION", "1920x1080");
+        guard.set("BROWSER_CLOUD_STEALTH", "true");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (url, session) = rt.block_on(connect_browser_cloud()).unwrap();
+
+        // Credentials are percent-encoded in the userinfo, not passed raw.
+        assert!(url.starts_with("wss://user%40example.com:key%2Fwith%2Bchars@cdp.example.com/"));
+        assert!(url.contains("/puppeteer?capabilities="));
+        // Sessions end when the socket closes, so there is nothing to clean up.
+        assert!(session.is_none());
+
+        let query = url.split("capabilities=").nth(1).unwrap();
+        let decoded = urlencoding::decode(query).unwrap();
+        let caps: Value = serde_json::from_str(&decoded).unwrap();
+        assert_eq!(caps["browserName"], "Chrome");
+        assert_eq!(caps["browserVersion"], "latest");
+        assert_eq!(caps["LT:Options"]["platformName"], "Windows 10");
+        assert_eq!(caps["LT:Options"]["resolution"], "1920x1080");
+        assert_eq!(caps["LT:Options"]["humanizeInteractions"], true);
+        assert_eq!(caps["LT:Options"]["randomizeUserAgent"], true);
+        assert_eq!(caps["LT:Options"]["headless"], true);
+        // Unset optional knobs must not leak into the capabilities payload.
+        assert!(caps["LT:Options"].get("region").is_none());
+        assert!(caps["LT:Options"].get("tunnel").is_none());
+    }
+
+    #[test]
+    fn test_connect_browser_cloud_headed_disables_headless() {
+        let guard = EnvGuard::new(&["LT_USERNAME", "LT_ACCESS_KEY", "AGENT_BROWSER_HEADED"]);
+        guard.set("LT_USERNAME", "user");
+        guard.set("LT_ACCESS_KEY", "key");
+        guard.set("AGENT_BROWSER_HEADED", "1");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (url, _) = rt.block_on(connect_browser_cloud()).unwrap();
+
+        let query = url.split("capabilities=").nth(1).unwrap();
+        let decoded = urlencoding::decode(query).unwrap();
+        let caps: Value = serde_json::from_str(&decoded).unwrap();
+        assert_eq!(caps["LT:Options"]["headless"], false);
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3528,7 +3528,7 @@ Options:
   --allow-file-access        Allow file:// URLs to access local files (Chromium only)
   --hide-scrollbars <bool>   Hide native scrollbars in headless Chromium screenshots (default: true)
                              Use --hide-scrollbars false to keep scrollbars visible
-  -p, --provider <name>      Browser provider: ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name
+  -p, --provider <name>      Browser provider: ios, browserbase, browsercloud, kernel, browseruse, browserless, agentcore, or plugin name
   --device <name>            iOS device name (e.g., "iPhone 15 Pro")
   --json                     JSON output
   --annotate                 Annotated screenshot with numbered labels and legend
@@ -3602,7 +3602,7 @@ Environment:
   AGENT_BROWSER_ANNOTATE         Annotated screenshot with numbered labels and legend
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
-  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name)
+  AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, browsercloud, kernel, browseruse, browserless, agentcore, or plugin name)
   AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_HIDE_SCROLLBARS  Hide scrollbars in headless Chromium screenshots (default: true)

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -91,7 +91,7 @@ This enables control of:
   <tbody>
     <tr><td><code>--session &lt;name&gt;</code></td><td>Use isolated session</td></tr>
     <tr><td><code>--profile &lt;path&gt;</code></td><td>Persistent browser profile directory</td></tr>
-    <tr><td><code>-p &lt;provider&gt;</code></td><td>Browser provider (<code>browserbase</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>, <code>agentcore</code>, or a configured <code>browser.provider</code> plugin)</td></tr>
+    <tr><td><code>-p &lt;provider&gt;</code></td><td>Browser provider (<code>browserbase</code>, <code>browsercloud</code>, <code>browseruse</code>, <code>kernel</code>, <code>browserless</code>, <code>agentcore</code>, or a configured <code>browser.provider</code> plugin)</td></tr>
     <tr><td><code>--headers &lt;json&gt;</code></td><td>HTTP headers scoped to origin</td></tr>
     <tr><td><code>--executable-path</code></td><td>Custom browser executable</td></tr>
     <tr><td><code>--args &lt;args&gt;</code></td><td>Browser launch args (comma-separated)</td></tr>

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -252,7 +252,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>NO_PROXY</code></td><td>Standard proxy bypass fallback.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_ARGS</code></td><td>Comma or newline separated browser launch arguments.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_USER_AGENT</code></td><td>Custom User-Agent string.</td><td>(browser default)</td></tr>
-    <tr><td><code>AGENT_BROWSER_PROVIDER</code></td><td>Browser provider such as <code>ios</code>, <code>browserbase</code>, <code>kernel</code>, <code>browseruse</code>, <code>browserless</code>, <code>agentcore</code>, or a configured <code>browser.provider</code> plugin name.</td><td>(local browser)</td></tr>
+    <tr><td><code>AGENT_BROWSER_PROVIDER</code></td><td>Browser provider such as <code>ios</code>, <code>browserbase</code>, <code>browsercloud</code>, <code>kernel</code>, <code>browseruse</code>, <code>browserless</code>, <code>agentcore</code>, or a configured <code>browser.provider</code> plugin name.</td><td>(local browser)</td></tr>
     <tr><td><code>AGENT_BROWSER_HIDE_SCROLLBARS</code></td><td>Hide native scrollbars in headless Chromium screenshots.</td><td><code>true</code></td></tr>
     <tr><td><code>AGENT_BROWSER_COLOR_SCHEME</code></td><td>Color scheme preference (<code>dark</code>, <code>light</code>, <code>no-preference</code>).</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_DOWNLOAD_PATH</code></td><td>Default directory for browser downloads.</td><td>(temp directory)</td></tr>

--- a/docs/src/app/providers/browsercloud/layout.tsx
+++ b/docs/src/app/providers/browsercloud/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("providers/browsercloud");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/providers/browsercloud/page.mdx
+++ b/docs/src/app/providers/browsercloud/page.mdx
@@ -1,0 +1,60 @@
+# Browser Cloud
+
+[Browser Cloud](https://testmuai.com) by TestMu AI provides remote Chrome sessions on a
+managed grid, with video, console, and network capture for every run. Use it when running
+agent-browser somewhere a local browser isn't feasible, or when you want a replayable
+recording of what the agent did.
+
+## Setup
+
+```bash
+export LT_USERNAME="your-username"
+export LT_ACCESS_KEY="your-access-key"
+agent-browser -p browsercloud open https://example.com
+```
+
+Or use environment variables for CI/scripts:
+
+```bash
+export AGENT_BROWSER_PROVIDER=browsercloud
+export LT_USERNAME="your-username"
+export LT_ACCESS_KEY="your-access-key"
+agent-browser open https://example.com
+```
+
+The `-p` flag takes precedence over `AGENT_BROWSER_PROVIDER`.
+
+When enabled, agent-browser connects to a Browser Cloud session instead of launching a
+local browser. All commands work identically. The remote session starts when the CDP
+WebSocket connects and is released when it closes.
+
+Get your username and access key from the [TestMu AI dashboard](https://testmuai.com)
+under **Account Settings**.
+
+## Options
+
+All options are optional and read from the environment.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BROWSER_CLOUD_ENDPOINT` | `cdp.lambdatest.com` | CDP host. Accepts a bare host or a full URL. |
+| `BROWSER_CLOUD_BROWSER_NAME` | `Chrome` | Browser to launch. |
+| `BROWSER_CLOUD_BROWSER_VERSION` | `latest` | Browser version. |
+| `BROWSER_CLOUD_PLATFORM` | `Windows 10` | Operating system for the session. |
+| `BROWSER_CLOUD_PROJECT` | `agent-browser` | Project name in the dashboard. |
+| `BROWSER_CLOUD_BUILD` | `agent-browser` | Build name in the dashboard. |
+| `BROWSER_CLOUD_SESSION_NAME` | — | Session name in the dashboard. |
+| `BROWSER_CLOUD_RESOLUTION` | — | Viewport, e.g. `1920x1080`. |
+| `BROWSER_CLOUD_REGION` | — | Region to run in, e.g. `us`, `eu`. |
+| `BROWSER_CLOUD_GEO_LOCATION` | — | Two-letter country code for geolocation, e.g. `DE`. |
+| `BROWSER_CLOUD_STEALTH` | `false` | Humanize interactions and randomize the user agent. |
+| `BROWSER_CLOUD_TUNNEL` | `false` | Route traffic through a Browser Cloud tunnel to reach local or private hosts. |
+| `BROWSER_CLOUD_TUNNEL_NAME` | — | Name of an already-running tunnel. |
+
+`AGENT_BROWSER_HEADED` and `AGENT_BROWSER_USER_AGENT` are honored as well.
+
+## Session recordings
+
+Video, console logs, and network logs are captured for every session. Open the
+automation dashboard from [testmuai.com](https://testmuai.com) after signing in to
+replay a run.

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -58,6 +58,7 @@ export const navigation: NavSection[] = [
       { name: "AgentCore", href: "/providers/agentcore" },
       { name: "Browser Use", href: "/providers/browser-use" },
       { name: "Browserbase", href: "/providers/browserbase" },
+      { name: "Browser Cloud", href: "/providers/browsercloud" },
       { name: "Browserless", href: "/providers/browserless" },
       { name: "Kernel", href: "/providers/kernel" },
     ],

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -32,6 +32,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "providers/agentcore": "AgentCore",
   "providers/browser-use": "Browser Use",
   "providers/browserbase": "Browserbase",
+  "providers/browsercloud": "Browser Cloud",
   "providers/browserless": "Browserless",
   "providers/kernel": "Kernel",
   changelog: "Changelog",

--- a/packages/dashboard/public/providers/browsercloud.svg
+++ b/packages/dashboard/public/providers/browsercloud.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M477.998 6H344.789V327.922H477.998V6Z" fill="#121212" style="fill:#121212;fill:color(display-p3 0.0706 0.0706 0.0706);fill-opacity:1;"/>
+<path d="M167.209 6H33.9999V189.163L167.209 327.922V6Z" fill="#121212" style="fill:#121212;fill:color(display-p3 0.0706 0.0706 0.0706);fill-opacity:1;"/>
+<path d="M167.209 327.947H33.9999V505.559H167.209V327.947Z" fill="#121212" style="fill:#121212;fill:color(display-p3 0.0706 0.0706 0.0706);fill-opacity:1;"/>
+<path d="M344.756 327.947H167.144L272.601 461.156H344.756V327.947Z" fill="#121212" style="fill:#121212;fill:color(display-p3 0.0706 0.0706 0.0706);fill-opacity:1;"/>
+</svg>

--- a/packages/dashboard/src/components/session-tree.tsx
+++ b/packages/dashboard/src/components/session-tree.tsx
@@ -58,6 +58,7 @@ const ENGINE_LOGOS: Record<string, string> = {
 const PROVIDER_LOGOS: Record<string, string> = {
   agentcore: "/providers/agentcore.svg",
   browserbase: "/providers/browserbase.svg",
+  browsercloud: "/providers/browsercloud.svg",
   browserless: "/providers/browserless.svg",
   "browser-use": "/providers/browser-use.svg",
   kernel: "/providers/kernel.svg",
@@ -70,6 +71,7 @@ const BROWSER_OPTIONS: { id: string; label: string; engine?: string; provider?: 
   { id: "lightpanda", label: "Lightpanda", engine: "lightpanda" },
   { id: "agentcore", label: "AgentCore", provider: "agentcore" },
   { id: "browserbase", label: "Browserbase", provider: "browserbase" },
+  { id: "browsercloud", label: "Browser Cloud", provider: "browsercloud" },
   { id: "browserless", label: "Browserless", provider: "browserless" },
   { id: "browser-use", label: "Browser Use", provider: "browser-use" },
   { id: "kernel", label: "Kernel", provider: "kernel" },


### PR DESCRIPTION
Title:

feat(providers): add TestMu AI Browser Cloud provider

Adds `browsercloud` as a built-in browser provider, alongside Browserbase,
Browserless, Browser Use, Kernel, and AgentCore.

[Browser Cloud](https://testmuai.com) provides remote Chrome sessions on a
managed grid, with video, console, and network capture recorded for every run.

```bash
export LT_USERNAME="..." LT_ACCESS_KEY="..."
agent-browser -p browsercloud open https://example.com

Implementation note

Browser Cloud has no session-creation REST call. The CDP endpoint takes
credentials in the URL userinfo and session capabilities as a URL-encoded
capabilities query parameter; the remote session is created when the
WebSocket connects and torn down when it closes.

So connect_browser_cloud() performs no HTTP request, returns session: None,
and needs no arm in close_provider_session_with_plugins — structurally the
same as the existing browser-use provider. Credentials are percent-encoded,
since LT usernames are commonly email-shaped and access keys may contain /
or +.

Options are environment-driven and match the conventions of the existing
providers: BROWSER_CLOUD_ENDPOINT, _PLATFORM, _BROWSER_NAME,
_BROWSER_VERSION, _PROJECT, _BUILD, _SESSION_NAME, _RESOLUTION,
_REGION, _GEO_LOCATION, _STEALTH, _TUNNEL, _TUNNEL_NAME.
AGENT_BROWSER_HEADED and AGENT_BROWSER_USER_AGENT are honored. Options that
aren't set appear in the capabilities payload.

Registered in

- native/providers.rs — dispatch arm + connect_browser_cloud()
- doctor/providers.rs — credential check
- doctor/network.rs — endpoint reachability probe
- output.rs — -p / AGENT_BROWSER_PROVIDER help text
- README, docs page, docs nav, page titles
- Dashboard browser picker + provider logo

Drive-by fixes

Both are load-bearing for this provider, but are independent bugs — happy to
split them into a separate PR if you'd prefer:

- doctor::providers used .any() over a provider's env vars, so a provider
requiring two variables would report "present" with only one set. Changed to
.all() — identical behavior for every existing single-key provider.
Browser Cloud is the first provider needing two.
- doctor::providers didn't normalize separators when matching
AGENT_BROWSER_PROVIDER against provider ids, so browser-use never matched
the browseruse entry. Now strips dashes, which also covers browser-cloud.

Testing

- Three new unit tests: missing-credential errors, capabilities construction
and credential percent-encoding, and AGENT_BROWSER_HEADED handling
- cargo test — 986 passed, 0 failed
- cargo fmt --check and cargo clippy --all-targets clean
- Verified end-to-end against a live Browser Cloud session: connected over CDP,
navigated, and closed cleanly

Two notes on what I deliberately left out. There's no mention of the Vercel Marketplace integration — a reviewer evaluating a provider PR shouldn't be handed a reason to wait on an unrelated approval, and it can
be added in a one-line docs follow-up later. And the drive-by fixes are surfaced prominently with an explicit offer to split, since burying unrelated changes is the fastest way to slow a review down.

I am the official contact for TestMu AI.