### PR TITLE
Fix immediate dialog target attachment

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -18,10 +18,9 @@ use super::browser::{should_track_target, BrowserManager, WaitUntil};
 use super::cdp::chrome::LaunchOptions;
 use super::cdp::client::CdpClient;
 use super::cdp::types::{
-    AttachToTargetParams, AttachToTargetResult, CdpEvent, CreateTargetResult,
-    DispatchMouseEventParams, ExceptionThrownEvent, GetFullAXTreeResult,
-    JavascriptDialogOpeningEvent, TargetCreatedEvent, TargetDestroyedEvent, TargetInfo,
-    TargetInfoChangedEvent,
+    AttachToTargetParams, AttachToTargetResult, CdpEvent, DispatchMouseEventParams,
+    ExceptionThrownEvent, GetFullAXTreeResult, JavascriptDialogOpeningEvent, TargetCreatedEvent,
+    TargetDestroyedEvent, TargetInfo, TargetInfoChangedEvent,
 };
 use super::cookies;
 use super::diff;
@@ -60,6 +59,8 @@ const AUTH_LOGIN_SELECTOR_POLL_INTERVAL_MS: u64 = 100;
 /// Time spent trying targeted username selectors before broad text-input
 /// fallback selectors are allowed.
 const AUTH_LOGIN_PREFERRED_SELECTOR_WINDOW_MS: u64 = 5_000;
+const AUTO_ATTACHED_DIALOG_OBSERVATION_MS: u64 = 500;
+const AUTO_ATTACHED_TARGET_INIT_MS: u64 = 2_000;
 
 pub struct PendingConfirmation {
     pub action: String,
@@ -71,6 +72,13 @@ pub struct PendingConfirmation {
 struct ActiveProviderSession {
     session: providers::ProviderSession,
     plugins: Vec<crate::plugins::PluginConfig>,
+}
+
+#[derive(Clone)]
+enum AutoAttachedTargetState {
+    Preparing,
+    Ready,
+    Failed(String),
 }
 
 /// Captured request/response metadata used to export HAR 1.2 files.
@@ -400,12 +408,17 @@ pub struct DaemonState {
     /// handling domain filtering, route interception, and origin-scoped headers
     /// without deadlocking navigation/evaluate.
     fetch_handler_task: Option<tokio::task::JoinHandle<()>>,
+    /// Preparation state for page targets claimed by the background CDP
+    /// handler. The command lane registers these pages and waits only for this
+    /// bounded handoff instead of trying to initialize them after an opener
+    /// command has already become blocked.
+    auto_attached_target_states: Arc<RwLock<HashMap<String, AutoAttachedTargetState>>>,
     /// Background task that auto-accepts `alert` and `beforeunload` dialogs
     /// so they never block the agent.
     dialog_handler_task: Option<tokio::task::JoinHandle<()>>,
     pub mouse_state: MouseState,
     /// Tracks the currently open JavaScript dialog (alert/confirm/prompt), if any.
-    pub pending_dialog: Option<PendingDialog>,
+    pub pending_dialogs: Vec<PendingDialog>,
     /// A mouse button left logically down because a dialog opened between
     /// mousePressed and mouseReleased; released when the dialog is resolved.
     pub pending_pointer_release: Option<super::interaction::PendingRelease>,
@@ -490,9 +503,10 @@ impl DaemonState {
             origin_headers: Arc::new(RwLock::new(HashMap::new())),
             proxy_credentials: Arc::new(RwLock::new(None)),
             fetch_handler_task: None,
+            auto_attached_target_states: Arc::new(RwLock::new(HashMap::new())),
             dialog_handler_task: None,
             mouse_state: MouseState::default(),
-            pending_dialog: None,
+            pending_dialogs: Vec::new(),
             pending_pointer_release: None,
             auto_dialog: !matches!(
                 env::var("AGENT_BROWSER_NO_AUTO_DIALOG").as_deref(),
@@ -546,6 +560,41 @@ impl DaemonState {
         s
     }
 
+    fn track_pending_dialog(&mut self, dialog: PendingDialog) {
+        if let Some(existing) = self
+            .pending_dialogs
+            .iter_mut()
+            .find(|existing| existing.session_id == dialog.session_id)
+        {
+            *existing = dialog;
+        } else {
+            self.pending_dialogs.push(dialog);
+        }
+    }
+
+    fn pending_dialog_for_active_page(&self) -> Option<&PendingDialog> {
+        let active_session = self
+            .browser
+            .as_ref()
+            .and_then(|manager| manager.active_session_id().ok());
+        self.pending_dialogs.iter().find(|dialog| {
+            matches!(
+                (dialog.session_id.as_deref(), active_session),
+                (Some(dialog_session), Some(active_session)) if dialog_session == active_session
+            ) || dialog.session_id.is_none()
+        })
+    }
+
+    fn pending_dialog_for_command(&self) -> Option<&PendingDialog> {
+        self.pending_dialog_for_active_page()
+            .or_else(|| self.pending_dialogs.first())
+    }
+
+    fn remove_pending_dialog_for_session(&mut self, session_id: Option<&str>) {
+        self.pending_dialogs
+            .retain(|dialog| dialog.session_id.as_deref() != session_id);
+    }
+
     fn subscribe_to_browser_events(&mut self) {
         if let Some(ref browser) = self.browser {
             self.event_rx = Some(browser.client.subscribe());
@@ -572,6 +621,7 @@ impl DaemonState {
         let routes = self.routes.clone();
         let origin_headers = self.origin_headers.clone();
         let proxy_credentials = self.proxy_credentials.clone();
+        let auto_attached_target_states = self.auto_attached_target_states.clone();
 
         self.fetch_handler_task = Some(tokio::spawn(async move {
             loop {
@@ -630,10 +680,88 @@ impl DaemonState {
                         let target_needs_controls = target_info
                             .as_ref()
                             .is_some_and(target_supports_network_controls);
+                        let target_needs_registration =
+                            target_info.as_ref().is_some_and(should_track_target);
 
                         let df = domain_filter.read().await.clone();
                         let has_proxy_creds = proxy_credentials.read().await.is_some();
                         let controls_active = df.is_some() || has_proxy_creds;
+
+                        if target_needs_registration {
+                            auto_attached_target_states
+                                .write()
+                                .await
+                                .insert(sid.clone(), AutoAttachedTargetState::Preparing);
+
+                            let preparation = tokio::time::timeout(
+                                std::time::Duration::from_millis(AUTO_ATTACHED_TARGET_INIT_MS),
+                                async {
+                                    if controls_active {
+                                        if let Some(ref target) = target_info {
+                                            prepare_network_control_target_session(
+                                                &client, &sid, target,
+                                            )
+                                            .await?;
+                                        }
+                                        install_network_controls_for_session(
+                                            &client,
+                                            &sid,
+                                            df.as_ref(),
+                                            has_proxy_creds,
+                                        )
+                                        .await?;
+                                    } else {
+                                        prime_auto_attached_session(&client, &sid).await?;
+                                    }
+                                    if let (Some(filter), Some(target)) =
+                                        (df.as_ref(), target_info.as_ref())
+                                    {
+                                        if should_blank_existing_url(&target.url, filter) {
+                                            client
+                                                .send_command_no_wait(
+                                                    "Page.navigate",
+                                                    Some(json!({ "url": "about:blank" })),
+                                                    Some(&sid),
+                                                )
+                                                .await?;
+                                        }
+                                    }
+                                    client
+                                        .send_command_no_wait(
+                                            "Runtime.runIfWaitingForDebugger",
+                                            None,
+                                            Some(&sid),
+                                        )
+                                        .await
+                                },
+                            )
+                            .await;
+
+                            let state = match preparation {
+                                Ok(Ok(())) => AutoAttachedTargetState::Ready,
+                                Ok(Err(error)) => AutoAttachedTargetState::Failed(error),
+                                Err(_) => AutoAttachedTargetState::Failed(format!(
+                                    "Timed out after {}ms preparing the target",
+                                    AUTO_ATTACHED_TARGET_INIT_MS
+                                )),
+                            };
+                            if matches!(state, AutoAttachedTargetState::Failed(_)) {
+                                if let Some(target_id) =
+                                    target_info.as_ref().map(|target| target.target_id.as_str())
+                                {
+                                    let _ = client
+                                        .send_command_no_wait(
+                                            "Target.closeTarget",
+                                            Some(json!({ "targetId": target_id })),
+                                            None,
+                                        )
+                                        .await;
+                                }
+                            }
+                            auto_attached_target_states.write().await.insert(sid, state);
+                            continue;
+                        }
+
                         let controls_result = if controls_active && target_needs_controls {
                             async {
                                 if let Some(ref target) = target_info {
@@ -880,6 +1008,7 @@ impl DaemonState {
         // target without changing iframe topology. Refresh after either kind
         // of event so network capture stays scoped to the active page.
         let active_frame_scope_changed = active_frame_scope_may_have_changed(&drained);
+        let mut replaced_page_session = false;
         // ACK screencast frames
         if !drained.pending_acks.is_empty() {
             if let Some(ref browser) = self.browser {
@@ -894,8 +1023,19 @@ impl DaemonState {
 
         // Remove destroyed targets
         for target_id in &drained.destroyed_targets {
-            if let Some(ref mut mgr) = self.browser {
+            let removed_session = if let Some(ref mut mgr) = self.browser {
+                let session_id = mgr
+                    .pages_list()
+                    .into_iter()
+                    .find(|page| page.target_id == *target_id)
+                    .map(|page| page.session_id);
                 mgr.remove_page_by_target_id(target_id);
+                session_id
+            } else {
+                None
+            };
+            if let Some(session_id) = removed_session {
+                self.remove_pending_dialog_for_session(Some(&session_id));
             }
         }
 
@@ -946,66 +1086,88 @@ impl DaemonState {
         // Register top-level pages that browser-level auto-attach paused before
         // their first request. Controls must be installed before resuming.
         for (target_info, page_sid) in &drained.attached_page_sessions {
+            if drained
+                .destroyed_targets
+                .iter()
+                .any(|target_id| target_id == &target_info.target_id)
+            {
+                self.auto_attached_target_states
+                    .write()
+                    .await
+                    .remove(page_sid);
+                self.remove_pending_dialog_for_session(Some(page_sid));
+                continue;
+            }
+
             let filter = self.domain_filter.read().await.clone();
-            let has_proxy_creds = self.proxy_credentials.read().await.is_some();
-            let controls_active = filter.is_some() || has_proxy_creds;
-            let setup_result = if let Some(ref mut mgr) = self.browser {
-                async {
-                    mgr.prepare_domains_pub(page_sid).await?;
-                    if controls_active {
-                        install_network_controls_for_session(
-                            &mgr.client,
-                            page_sid,
-                            filter.as_ref(),
-                            has_proxy_creds,
+            let auto_dialog = self.auto_dialog;
+            let mut initial_events = self.browser.as_ref().map(|mgr| mgr.client.subscribe());
+
+            let replaced_session = if let Some(ref mut mgr) = self.browser {
+                let page_url = if filter
+                    .as_ref()
+                    .is_some_and(|filter| should_blank_existing_url(&target_info.url, filter))
+                {
+                    "about:blank".to_string()
+                } else {
+                    target_info.url.clone()
+                };
+                if mgr.has_target(&target_info.target_id) {
+                    mgr.replace_page_session(target_info, page_sid)
+                } else {
+                    let tab_id = mgr.assign_tab_id();
+                    mgr.add_page(super::browser::PageInfo {
+                        tab_id,
+                        label: None,
+                        target_id: target_info.target_id.clone(),
+                        session_id: page_sid.clone(),
+                        url: page_url,
+                        title: target_info.title.clone(),
+                        target_type: target_info.target_type.clone(),
+                    });
+                    None
+                }
+            } else {
+                None
+            };
+            let replaced_existing_session = replaced_session.is_some();
+
+            if let Err(error) =
+                wait_for_auto_attached_target(&self.auto_attached_target_states, page_sid, true)
+                    .await
+            {
+                discard_failed_attached_page(self, &target_info.target_id).await;
+                return Err(format!(
+                    "Failed to initialize new page target {}; it was closed so later browser commands can continue: {}",
+                    target_info.target_id, error
+                ));
+            }
+
+            if let Some(ref mgr) = self.browser {
+                if let Some(replaced_session) = replaced_session {
+                    mgr.client
+                        .send_command(
+                            "Target.detachFromTarget",
+                            Some(json!({ "sessionId": replaced_session })),
+                            None,
                         )
                         .await?;
-                    }
-
-                    let mut page_url = target_info.url.clone();
-                    if let Some(ref filter) = filter {
-                        if should_blank_existing_url(&page_url, filter) {
-                            let _ = mgr
-                                .client
-                                .send_command(
-                                    "Page.navigate",
-                                    Some(json!({ "url": "about:blank" })),
-                                    Some(page_sid),
-                                )
-                                .await;
-                            page_url = "about:blank".to_string();
-                        }
-                    }
-
-                    if mgr.has_target(&target_info.target_id) {
-                        mgr.update_page_target_info(target_info);
-                    } else {
-                        let tab_id = mgr.assign_tab_id();
-                        mgr.add_page(super::browser::PageInfo {
-                            tab_id,
-                            label: None,
-                            target_id: target_info.target_id.clone(),
-                            session_id: page_sid.clone(),
-                            url: page_url,
-                            title: target_info.title.clone(),
-                            target_type: target_info.target_type.clone(),
-                        });
-                    }
-
-                    mgr.resume_if_waiting_pub(page_sid).await
+                    replaced_page_session = true;
                 }
-                .await
-            } else {
-                Ok(())
-            };
-            if let Err(error) = setup_result {
-                if controls_active {
-                    return close_after_network_control_failure(self, error).await;
+                // Detaching the discovery session can reset target-scoped
+                // emulation overrides, so make the canonical session's
+                // configuration the final write.
+                mgr.apply_launch_session_configuration_pub(page_sid).await?;
+            }
+
+            if !replaced_existing_session {
+                if let Some(ref mut events) = initial_events {
+                    if let Some(dialog) =
+                        observe_auto_attached_dialog(events, page_sid, auto_dialog).await?
+                    {
+                        self.track_pending_dialog(dialog);
+                    }
                 }
-                eprintln!(
-                    "Warning: failed to prepare attached page session: {}",
-                    error
-                );
             }
         }
 
@@ -1061,6 +1223,7 @@ impl DaemonState {
         for sid in &drained.detached_iframe_sessions {
             self.iframe_sessions.retain(|_, v| v != sid);
             self.active_iframe_sessions.remove(sid);
+            self.remove_pending_dialog_for_session(Some(sid));
         }
 
         // Attach and register new targets
@@ -1216,6 +1379,9 @@ impl DaemonState {
         if active_frame_scope_changed {
             self.refresh_active_iframe_sessions().await;
         }
+        if replaced_page_session {
+            self.update_stream_client().await;
+        }
 
         Ok(())
     }
@@ -1233,6 +1399,7 @@ impl DaemonState {
         let mut destroyed_targets: Vec<String> = Vec::new();
         let mut attached_page_sessions: Vec<(TargetInfo, String)> = Vec::new();
         let mut attached_page_target_ids: HashSet<String> = HashSet::new();
+        let mut attached_page_session_ids: HashSet<String> = HashSet::new();
         let mut attached_iframe_sessions: Vec<(String, String)> = Vec::new();
         let mut attached_worker_sessions: Vec<(TargetInfo, String)> = Vec::new();
         let mut attached_other_sessions: Vec<String> = Vec::new();
@@ -1313,6 +1480,7 @@ impl DaemonState {
                                     Ok(target_info) if should_track_target(&target_info) => {
                                         attached_page_target_ids
                                             .insert(target_info.target_id.clone());
+                                        attached_page_session_ids.insert(sid.to_string());
                                         attached_page_sessions.push((target_info, sid.to_string()));
                                     }
                                     Ok(target_info) if target_is_worker_like(&target_info) => {
@@ -1339,6 +1507,10 @@ impl DaemonState {
 
                     let session_matches = if let Some(ref browser) = self.browser {
                         event.session_id.as_deref() == browser.active_session_id().ok()
+                            || event
+                                .session_id
+                                .as_ref()
+                                .is_some_and(|sid| attached_page_session_ids.contains(sid))
                     } else {
                         false
                     };
@@ -1647,18 +1819,29 @@ impl DaemonState {
                                         "beforeunload" | "alert"
                                     );
                                 if !auto_handled {
-                                    self.pending_dialog = Some(PendingDialog {
+                                    let dialog = PendingDialog {
                                         dialog_type: dialog_event.dialog_type,
                                         message: dialog_event.message,
                                         url: dialog_event.url,
                                         default_prompt: dialog_event.default_prompt,
                                         session_id: event.session_id.clone(),
-                                    });
+                                    };
+                                    if let Some(existing) = self
+                                        .pending_dialogs
+                                        .iter_mut()
+                                        .find(|existing| existing.session_id == dialog.session_id)
+                                    {
+                                        *existing = dialog;
+                                    } else {
+                                        self.pending_dialogs.push(dialog);
+                                    }
                                 }
                             }
                         }
                         "Page.javascriptDialogClosed" => {
-                            self.pending_dialog = None;
+                            self.pending_dialogs.retain(|dialog| {
+                                dialog.session_id.as_deref() != event.session_id.as_deref()
+                            });
                         }
                         // Fetch.requestPaused is handled by the background
                         // fetch_handler_task — no need to collect here.
@@ -1677,7 +1860,13 @@ impl DaemonState {
             }
         }
 
-        if !attached_page_target_ids.is_empty() {
+        if self.network_auto_attach_installed {
+            // Browser-level auto-attach is canonical once installed.
+            // Target.targetCreated can be drained one tick before the matching
+            // Target.attachedToTarget; retaining it in that gap would create a
+            // second flat session and route dialog state to the wrong one.
+            new_targets.clear();
+        } else if !attached_page_target_ids.is_empty() {
             new_targets.retain(|te| !attached_page_target_ids.contains(&te.target_info.target_id));
         }
 
@@ -1925,6 +2114,14 @@ async fn close_active_provider_session(state: &mut DaemonState) {
 }
 
 pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(), String> {
+    if let Some(task) = state.fetch_handler_task.take() {
+        task.abort();
+    }
+    if let Some(task) = state.dialog_handler_task.take() {
+        task.abort();
+    }
+    state.event_rx = None;
+
     let close_error = if let Some(mut mgr) = state.browser.take() {
         mgr.close().await.err()
     } else {
@@ -1934,6 +2131,8 @@ pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(),
     close_active_provider_session(state).await;
     state.launch_hash = None;
     state.network_auto_attach_installed = false;
+    state.auto_attached_target_states.write().await.clear();
+    state.pending_dialogs.clear();
     state.iframe_sessions.clear();
     state.active_iframe_sessions.clear();
     state.screencasting = false;
@@ -2237,9 +2436,54 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             lifecycle_reused = true;
         }
 
-        if let Some(ref mut mgr) = state.browser {
+        let ensured_auto_session = if let Some(ref mut mgr) = state.browser {
             if mgr.page_count() == 0 {
-                let _ = mgr.ensure_page().await;
+                match mgr.ensure_page().await {
+                    Ok(session_id) => session_id,
+                    Err(error) => {
+                        return error_response(
+                            &id,
+                            &format!("Failed to create a replacement page: {error}"),
+                        );
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if let Some((session_id, target_id)) = ensured_auto_session {
+            if let Err(error) = wait_for_auto_attached_target(
+                &state.auto_attached_target_states,
+                &session_id,
+                false,
+            )
+            .await
+            {
+                state
+                    .auto_attached_target_states
+                    .write()
+                    .await
+                    .remove(&session_id);
+                if let Some(ref mut mgr) = state.browser {
+                    let _ = mgr
+                        .client
+                        .send_command_no_wait(
+                            "Target.closeTarget",
+                            Some(json!({ "targetId": target_id })),
+                            None,
+                        )
+                        .await;
+                    mgr.remove_page_by_target_id(&target_id);
+                }
+                return error_response(
+                    &id,
+                    &format!("Failed to initialize the replacement page: {error}"),
+                );
+            }
+            if let Err(error) = state.drain_cdp_events_background().await {
+                return error_response(&id, &super::browser::to_ai_friendly_error(&error));
             }
         }
     }
@@ -2263,16 +2507,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // never touch the page; dialog/screenshot/url/title are browser-side.
     // Only a dialog on the ACTIVE tab blocks: one on a background tab leaves
     // the active tab's renderer responsive.
-    if let Some(ref dialog) = state.pending_dialog {
-        let active_session = state
-            .browser
-            .as_ref()
-            .and_then(|m| m.active_session_id().ok().map(|s| s.to_string()));
-        let on_active_tab = match (&dialog.session_id, &active_session) {
-            (Some(dialog_sid), Some(active_sid)) => dialog_sid == active_sid,
-            // No session on the event = top-level page dialog; no browser = be safe.
-            _ => true,
-        };
+    if let Some(dialog) = state.pending_dialog_for_active_page() {
         // Tab and session management must stay usable: switching or closing
         // tabs is exactly how an agent escapes a tab blocked by a dialog.
         let read_touches_active_tab = action == "read"
@@ -2294,7 +2529,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                     | "tab_switch"
                     | "tab_close"
             );
-        if on_active_tab && !safe_during_dialog {
+        if !safe_during_dialog {
             return error_response(
                 &id,
                 &format!(
@@ -2512,7 +2747,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 
     // Auto-report pending JavaScript dialog so agents know why commands may hang
     if action != "dialog" {
-        if let Some(ref dialog) = state.pending_dialog {
+        if let Some(dialog) = state.pending_dialog_for_command() {
             if let Some(obj) = resp.as_object_mut() {
                 obj.insert(
                     "warning".to_string(),
@@ -2841,6 +3076,130 @@ async fn prepare_auto_attached_session(client: &CdpClient, session_id: &str) -> 
     Ok(())
 }
 
+async fn prime_auto_attached_session(client: &CdpClient, session_id: &str) -> Result<(), String> {
+    for method in ["Page.enable", "Runtime.enable", "Network.enable"] {
+        client
+            .send_command_no_wait(method, None, Some(session_id))
+            .await?;
+    }
+    client
+        .send_command_no_wait(
+            "Target.setAutoAttach",
+            Some(json!({
+                "autoAttach": true,
+                "waitForDebuggerOnStart": true,
+                "flatten": true
+            })),
+            Some(session_id),
+        )
+        .await
+}
+
+async fn wait_for_auto_attached_target(
+    states: &Arc<RwLock<HashMap<String, AutoAttachedTargetState>>>,
+    session_id: &str,
+    consume: bool,
+) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now()
+        + std::time::Duration::from_millis(AUTO_ATTACHED_TARGET_INIT_MS);
+    loop {
+        let current = states.read().await.get(session_id).cloned();
+        match current {
+            Some(AutoAttachedTargetState::Ready) => {
+                if consume {
+                    states.write().await.remove(session_id);
+                }
+                return Ok(());
+            }
+            Some(AutoAttachedTargetState::Failed(error)) => {
+                if consume {
+                    states.write().await.remove(session_id);
+                }
+                return Err(error);
+            }
+            Some(AutoAttachedTargetState::Preparing) | None => {}
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            states.write().await.remove(session_id);
+            return Err(format!(
+                "Timed out after {}ms waiting for target preparation",
+                AUTO_ATTACHED_TARGET_INIT_MS
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+}
+
+async fn discard_failed_attached_page(state: &mut DaemonState, target_id: &str) {
+    if let Some(ref mut mgr) = state.browser {
+        let _ = mgr
+            .client
+            .send_command_no_wait(
+                "Target.closeTarget",
+                Some(json!({ "targetId": target_id })),
+                None,
+            )
+            .await;
+        mgr.remove_page_by_target_id(target_id);
+    }
+}
+
+async fn observe_auto_attached_dialog(
+    events: &mut broadcast::Receiver<CdpEvent>,
+    session_id: &str,
+    auto_dialog: bool,
+) -> Result<Option<PendingDialog>, String> {
+    let observation = async {
+        loop {
+            match events.recv().await {
+                Ok(event)
+                    if event.method == "Page.javascriptDialogOpening"
+                        && event.session_id.as_deref() == Some(session_id) =>
+                {
+                    let dialog =
+                        serde_json::from_value::<JavascriptDialogOpeningEvent>(event.params)
+                            .map_err(|_| {
+                                "A new page opened a JavaScript dialog whose type could not be determined safely"
+                                    .to_string()
+                            })?;
+                    if auto_dialog
+                        && matches!(dialog.dialog_type.as_str(), "alert" | "beforeunload")
+                    {
+                        return Ok(None);
+                    }
+                    return Ok(Some(PendingDialog {
+                        dialog_type: dialog.dialog_type,
+                        message: dialog.message,
+                        url: dialog.url,
+                        default_prompt: dialog.default_prompt,
+                        session_id: Some(session_id.to_string()),
+                    }));
+                }
+                Ok(event)
+                    if event.method == "Page.loadEventFired"
+                        && event.session_id.as_deref() == Some(session_id) =>
+                {
+                    return Ok(None);
+                }
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return Ok(None),
+            }
+        }
+    };
+
+    match tokio::time::timeout(
+        std::time::Duration::from_millis(AUTO_ATTACHED_DIALOG_OBSERVATION_MS),
+        observation,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Ok(None),
+    }
+}
+
 fn target_is_worker_like(target: &TargetInfo) -> bool {
     matches!(
         target.target_type.as_str(),
@@ -2912,10 +3271,6 @@ async fn install_active_network_controls(
     handle_auth_requests: bool,
 ) -> Result<(), String> {
     let filter = state.domain_filter.read().await.clone();
-    if !network_controls_required(filter.as_ref(), handle_auth_requests) {
-        return Ok(());
-    }
-
     let direct_page = {
         let mgr = state
             .browser
@@ -2927,15 +3282,23 @@ async fn install_active_network_controls(
         return Err(direct_page_allowed_domains_error());
     }
 
-    if !state.network_auto_attach_installed && !direct_page {
+    if !state.network_auto_attach_installed && !direct_page && state.engine == "chrome" {
         {
             let mgr = state
                 .browser
-                .as_ref()
+                .as_mut()
                 .ok_or("Browser is not available for network control installation")?;
             mgr.enable_browser_auto_attach_pub().await?;
         }
         state.network_auto_attach_installed = true;
+        // Chrome also auto-attaches existing targets. Apply those events now so
+        // the first command after launch cannot retain and route through the
+        // superseded manual discovery session.
+        state.drain_cdp_events_background().await?;
+    }
+
+    if !network_controls_required(filter.as_ref(), handle_auth_requests) {
+        return Ok(());
     }
 
     let mgr = state
@@ -3565,7 +3928,7 @@ fn autosave_due(state: &DaemonState, interval_ms: u64) -> bool {
     }
     // A JS dialog blocks the renderer's main thread, so the storage-collection
     // evaluate would hang until its CDP timeout. Wait for the dialog instead.
-    if state.pending_dialog.is_some() {
+    if !state.pending_dialogs.is_empty() {
         return false;
     }
     let now = std::time::Instant::now();
@@ -6017,15 +6380,24 @@ async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value
 }
 
 async fn handle_tab_close(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
-    let tab_id = {
+    let (tab_id, closing_session) = {
         let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-        match cmd.get("tabId").and_then(|v| v.as_str()) {
+        let tab_id = match cmd.get("tabId").and_then(|v| v.as_str()) {
             Some(s) => {
                 let tab_ref = super::browser::TabRef::parse(s)?;
                 Some(mgr.resolve_tab_ref(&tab_ref)?)
             }
             None => None,
-        }
+        };
+        let session_id = match tab_id {
+            Some(tab_id) => mgr
+                .pages_list()
+                .into_iter()
+                .find(|page| page.tab_id == tab_id)
+                .map(|page| page.session_id),
+            None => mgr.active_session_id().ok().map(ToString::to_string),
+        };
+        (tab_id, session_id)
     };
     state.ref_map.clear();
     state.active_iframe_sessions.clear();
@@ -6034,6 +6406,9 @@ async fn handle_tab_close(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
         mgr.tab_close_by_id(tab_id).await?
     };
+    if let Some(session_id) = closing_session {
+        state.remove_pending_dialog_for_session(Some(&session_id));
+    }
     state.refresh_active_iframe_sessions().await;
     Ok(result)
 }
@@ -6312,6 +6687,7 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
     if let Some(url) = recording_url {
         check_url_allowed_by_filter(domain_filter.as_ref(), url)?;
     }
+    let auto_attached_target_states = state.auto_attached_target_states.clone();
 
     let (client, new_session_id, nav_url) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
@@ -6346,29 +6722,18 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
             .to_string();
 
         // Create page in new context
-        let create_result: CreateTargetResult = mgr
-            .client
-            .send_command_typed(
-                "Target.createTarget",
-                &json!({ "url": "about:blank", "browserContextId": context_id }),
-                None,
-            )
+        let (create_result, new_session_id, auto_attached) = mgr
+            .create_target_session(json!({
+                "url": "about:blank",
+                "browserContextId": context_id
+            }))
             .await?;
-
-        let attach_result: AttachToTargetResult = mgr
-            .client
-            .send_command_typed(
-                "Target.attachToTarget",
-                &AttachToTargetParams {
-                    target_id: create_result.target_id.clone(),
-                    flatten: true,
-                },
-                None,
-            )
-            .await?;
-
-        let new_session_id = attach_result.session_id.clone();
-        mgr.prepare_domains_pub(&new_session_id).await?;
+        if auto_attached {
+            wait_for_auto_attached_target(&auto_attached_target_states, &new_session_id, false)
+                .await?;
+        } else {
+            mgr.prepare_domains_pub(&new_session_id).await?;
+        }
 
         // Re-apply download behavior to the recording context.
         // Without this, downloads in the recording context are silently dropped
@@ -6924,7 +7289,7 @@ async fn handle_dialog(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     // dialog status — return pending dialog info
     if response == Some("status") {
-        return Ok(match &state.pending_dialog {
+        return Ok(match state.pending_dialog_for_command() {
             Some(dialog) => {
                 let mut obj = json!({
                     "hasDialog": true,
@@ -6940,6 +7305,9 @@ async fn handle_dialog(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         });
     }
 
+    let dialog_session = state
+        .pending_dialog_for_command()
+        .and_then(|dialog| dialog.session_id.clone());
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let accept = response
         .map(|r| r == "accept")
@@ -6947,12 +7315,9 @@ async fn handle_dialog(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         .unwrap_or(true);
     let prompt_text = cmd.get("promptText").and_then(|v| v.as_str());
 
-    // Clear tracked state even if Chrome reports no dialog (e.g. it was
-    // already resolved and the closed event was missed); otherwise a stale
-    // pending_dialog would make every page command fail fast forever.
-    let result = mgr.handle_dialog(accept, prompt_text).await;
-    state.pending_dialog = None;
-    result?;
+    mgr.handle_dialog(accept, prompt_text, dialog_session.as_deref())
+        .await?;
+    state.remove_pending_dialog_for_session(dialog_session.as_deref());
 
     // If a click's mousedown opened this dialog, the button is still logically
     // down. Release it now that the page is unblocked so the next click does
@@ -9048,6 +9413,7 @@ async fn handle_waitfordownload(cmd: &Value, state: &DaemonState) -> Result<Valu
 }
 
 async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let auto_attached_target_states = state.auto_attached_target_states.clone();
     let (tab_id, session_id) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
 
@@ -9062,40 +9428,29 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
             .ok_or("Failed to create browser context")?
             .to_string();
 
-        let create_result: super::cdp::types::CreateTargetResult = mgr
-            .client
-            .send_command_typed(
-                "Target.createTarget",
-                &json!({ "url": "about:blank", "browserContextId": context_id }),
-                None,
-            )
+        let (create_result, session_id, auto_attached) = mgr
+            .create_target_session(json!({
+                "url": "about:blank",
+                "browserContextId": context_id
+            }))
             .await?;
-
-        let attach: super::cdp::types::AttachToTargetResult = mgr
-            .client
-            .send_command_typed(
-                "Target.attachToTarget",
-                &super::cdp::types::AttachToTargetParams {
-                    target_id: create_result.target_id.clone(),
-                    flatten: true,
-                },
-                None,
-            )
-            .await?;
-
-        mgr.prepare_domains_pub(&attach.session_id).await?;
+        if auto_attached {
+            wait_for_auto_attached_target(&auto_attached_target_states, &session_id, false).await?;
+        } else {
+            mgr.prepare_domains_pub(&session_id).await?;
+        }
 
         let tab_id = mgr.assign_tab_id();
         mgr.add_page(super::browser::PageInfo {
             tab_id,
             label: None,
             target_id: create_result.target_id,
-            session_id: attach.session_id.clone(),
+            session_id: session_id.clone(),
             url: "about:blank".to_string(),
             title: String::new(),
             target_type: "page".to_string(),
         });
-        (tab_id, attach.session_id)
+        (tab_id, session_id)
     };
 
     let has_proxy_creds = state.proxy_credentials.read().await.is_some();
@@ -11637,7 +11992,7 @@ mod tests {
     #[test]
     fn test_autosave_blocked_while_dialog_open() {
         let mut state = DaemonState::new();
-        state.pending_dialog = Some(PendingDialog {
+        state.pending_dialogs.push(PendingDialog {
             dialog_type: "confirm".to_string(),
             message: "Are you sure?".to_string(),
             url: "https://example.com".to_string(),
@@ -14409,5 +14764,34 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
             let auto_handled = auto_dialog && matches!(*dialog_type, "beforeunload" | "alert");
             assert!(!auto_handled, "{dialog_type} should NOT be auto-handled");
         }
+    }
+
+    #[test]
+    fn browser_auto_attach_suppresses_split_batch_manual_target_attachment() {
+        let mut state = DaemonState::new();
+        state.network_auto_attach_installed = true;
+        let (events, receiver) = broadcast::channel(4);
+        state.event_rx = Some(receiver);
+        events
+            .send(CdpEvent {
+                method: "Target.targetCreated".to_string(),
+                params: json!({
+                    "targetInfo": {
+                        "targetId": "popup-target",
+                        "type": "page",
+                        "title": "",
+                        "url": ""
+                    }
+                }),
+                session_id: None,
+            })
+            .unwrap();
+
+        let drained = state.drain_cdp_events();
+
+        assert!(
+            drained.new_targets.is_empty(),
+            "Target.attachedToTarget must remain the sole registration owner even when its event arrives in a later drain"
+        );
     }
 }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -331,17 +331,23 @@ pub struct BrowserManager {
     pub download_path: Option<String>,
     /// Whether to ignore HTTPS certificate errors, re-applied to new contexts (e.g., recording)
     pub ignore_https_errors: bool,
+    launch_user_agent: Option<String>,
+    launch_color_scheme: Option<String>,
     /// Origins visited during this session, used by save_state to collect cross-origin localStorage.
     visited_origins: HashSet<String>,
     next_tab_id: u32,
     /// True when the CDP WebSocket is already scoped to a page target and
     /// browser-level Target.* commands are not available.
     direct_page: bool,
+    /// True after browser-level Target.setAutoAttach becomes the canonical
+    /// owner of new page sessions.
+    browser_auto_attach_enabled: bool,
 }
 
 const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const LIGHTPANDA_CDP_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(10);
+const CHROME_ATTACHED_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(2);
 
 impl BrowserManager {
     pub async fn launch(options: LaunchOptions, engine: Option<&str>) -> Result<Self, String> {
@@ -394,7 +400,7 @@ impl BrowserManager {
             }
         };
 
-        let manager = if engine == "lightpanda" {
+        let mut manager = if engine == "lightpanda" {
             initialize_lightpanda_manager(ws_url, process).await?
         } else {
             let client = Arc::new(CdpClient::connect(&ws_url).await?);
@@ -407,48 +413,25 @@ impl BrowserManager {
                 default_timeout_ms: 25_000,
                 download_path: download_path.clone(),
                 ignore_https_errors,
+                launch_user_agent: user_agent.clone(),
+                launch_color_scheme: color_scheme.clone(),
                 visited_origins: HashSet::new(),
                 next_tab_id: 1,
                 direct_page: false,
+                browser_auto_attach_enabled: false,
             };
             manager.discover_and_attach_targets().await?;
             manager
         };
+        manager.download_path = download_path.clone();
+        manager.ignore_https_errors = ignore_https_errors;
+        manager.launch_user_agent = user_agent;
+        manager.launch_color_scheme = color_scheme;
 
         let session_id = manager.active_session_id()?.to_string();
-
-        if ignore_https_errors {
-            let _ = manager
-                .client
-                .send_command(
-                    "Security.setIgnoreCertificateErrors",
-                    Some(json!({ "ignore": true })),
-                    Some(&session_id),
-                )
-                .await;
-        }
-
-        if let Some(ref ua) = user_agent {
-            let _ = manager
-                .client
-                .send_command(
-                    "Emulation.setUserAgentOverride",
-                    Some(json!({ "userAgent": ua })),
-                    Some(&session_id),
-                )
-                .await;
-        }
-
-        if let Some(ref scheme) = color_scheme {
-            let _ = manager
-                .client
-                .send_command(
-                    "Emulation.setEmulatedMedia",
-                    Some(json!({ "features": [{ "name": "prefers-color-scheme", "value": scheme }] })),
-                    Some(&session_id),
-                )
-                .await;
-        }
+        let _ = manager
+            .apply_launch_session_configuration_pub(&session_id)
+            .await;
 
         if let Some(ref path) = download_path {
             let _ = manager
@@ -497,9 +480,12 @@ impl BrowserManager {
             default_timeout_ms: 25_000,
             download_path: None,
             ignore_https_errors: false,
+            launch_user_agent: None,
+            launch_color_scheme: None,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
             direct_page,
+            browser_auto_attach_enabled: false,
         };
 
         if direct_page {
@@ -583,7 +569,8 @@ impl BrowserManager {
                 target_type: "page".to_string(),
             });
             self.active_page_index = 0;
-            self.enable_domains(&attach_result.session_id).await?;
+            self.enable_initial_attached_page_domains(&attach_result.session_id)
+                .await?;
         } else {
             for target in &page_targets {
                 let attach_result: AttachToTargetResult = self
@@ -596,6 +583,8 @@ impl BrowserManager {
                         },
                         None,
                     )
+                    .await?;
+                self.enable_initial_attached_page_domains(&attach_result.session_id)
                     .await?;
 
                 let tab_id = self.next_tab_id;
@@ -612,11 +601,24 @@ impl BrowserManager {
             }
 
             self.active_page_index = 0;
-            let session_id = self.pages[0].session_id.clone();
-            self.enable_domains(&session_id).await?;
         }
 
         Ok(())
+    }
+
+    async fn enable_initial_attached_page_domains(&self, session_id: &str) -> Result<(), String> {
+        match tokio::time::timeout(
+            CHROME_ATTACHED_TARGET_INIT_TIMEOUT,
+            self.enable_domains(session_id),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(format!(
+                "Timed out after {}ms initializing an attached page. A pre-existing JavaScript dialog may be blocking it; resolve the dialog in Chrome and retry. The dialog was not accepted automatically.",
+                CHROME_ATTACHED_TARGET_INIT_TIMEOUT.as_millis(),
+            )),
+        }
     }
 
     pub async fn enable_domains_pub(&self, session_id: &str) -> Result<(), String> {
@@ -631,7 +633,46 @@ impl BrowserManager {
         self.resume_if_waiting(session_id).await
     }
 
-    pub async fn enable_browser_auto_attach_pub(&self) -> Result<(), String> {
+    pub async fn apply_launch_session_configuration_pub(
+        &self,
+        session_id: &str,
+    ) -> Result<(), String> {
+        if self.ignore_https_errors {
+            self.client
+                .send_command(
+                    "Security.setIgnoreCertificateErrors",
+                    Some(json!({ "ignore": true })),
+                    Some(session_id),
+                )
+                .await?;
+        }
+        if let Some(ref user_agent) = self.launch_user_agent {
+            self.client
+                .send_command(
+                    "Emulation.setUserAgentOverride",
+                    Some(json!({ "userAgent": user_agent })),
+                    Some(session_id),
+                )
+                .await?;
+        }
+        if let Some(ref color_scheme) = self.launch_color_scheme {
+            self.client
+                .send_command(
+                    "Emulation.setEmulatedMedia",
+                    Some(json!({
+                        "features": [{
+                            "name": "prefers-color-scheme",
+                            "value": color_scheme,
+                        }]
+                    })),
+                    Some(session_id),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn enable_browser_auto_attach_pub(&mut self) -> Result<(), String> {
         self.client
             .send_command(
                 "Target.setAutoAttach",
@@ -643,6 +684,7 @@ impl BrowserManager {
                 None,
             )
             .await?;
+        self.browser_auto_attach_enabled = true;
         Ok(())
     }
 
@@ -963,6 +1005,79 @@ impl BrowserManager {
         }
     }
 
+    pub async fn create_target_session(
+        &self,
+        params: Value,
+    ) -> Result<(CreateTargetResult, String, bool), String> {
+        let mut events = self.client.subscribe();
+        let target: CreateTargetResult = self
+            .client
+            .send_command_typed("Target.createTarget", &params, None)
+            .await?;
+
+        if self.browser_auto_attach_enabled {
+            let target_id = target.target_id.clone();
+            let attached_session = async {
+                loop {
+                    match events.recv().await {
+                        Ok(event) if event.method == "Target.attachedToTarget" => {
+                            let matches_target = event.params["targetInfo"]["targetId"].as_str()
+                                == Some(target_id.as_str());
+                            if matches_target {
+                                if let Some(session_id) =
+                                    event.params["sessionId"].as_str().map(ToString::to_string)
+                                {
+                                    return Ok(session_id);
+                                }
+                            }
+                        }
+                        Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => {
+                            return Err(
+                                "CDP event stream closed while waiting for the new page target"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                }
+            };
+
+            return match tokio::time::timeout(CHROME_ATTACHED_TARGET_INIT_TIMEOUT, attached_session)
+                .await
+            {
+                Ok(Ok(session_id)) => Ok((target, session_id, true)),
+                Ok(Err(error)) => Err(error),
+                Err(_) => {
+                    let _ = self
+                        .client
+                        .send_command_no_wait(
+                            "Target.closeTarget",
+                            Some(json!({ "targetId": target.target_id })),
+                            None,
+                        )
+                        .await;
+                    Err(format!(
+                        "Timed out after {}ms waiting for the auto-attached page target; the target was closed so later commands can continue",
+                        CHROME_ATTACHED_TARGET_INIT_TIMEOUT.as_millis(),
+                    ))
+                }
+            };
+        }
+
+        let attach: AttachToTargetResult = self
+            .client
+            .send_command_typed(
+                "Target.attachToTarget",
+                &AttachToTargetParams {
+                    target_id: target.target_id.clone(),
+                    flatten: true,
+                },
+                None,
+            )
+            .await?;
+        Ok((target, attach.session_id, false))
+    }
+
     pub fn get_cdp_url(&self) -> &str {
         &self.ws_url
     }
@@ -994,50 +1109,36 @@ impl BrowserManager {
     }
 
     /// Ensures the browser has at least one page. If `pages` is empty, creates a new
-    /// about:blank page and attaches to it.
-    pub async fn ensure_page(&mut self) -> Result<(), String> {
+    /// about:blank page and attaches to it. Returns the auto-attached session, when
+    /// applicable, so the command lane can wait for background initialization.
+    pub async fn ensure_page(&mut self) -> Result<Option<(String, String)>, String> {
         if !self.pages.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
-        let result: CreateTargetResult = self
-            .client
-            .send_command_typed(
-                "Target.createTarget",
-                &CreateTargetParams {
-                    url: "about:blank".to_string(),
-                },
-                None,
-            )
-            .await?;
-
-        let attach_result: AttachToTargetResult = self
-            .client
-            .send_command_typed(
-                "Target.attachToTarget",
-                &AttachToTargetParams {
-                    target_id: result.target_id.clone(),
-                    flatten: true,
-                },
-                None,
-            )
+        let (result, session_id, auto_attached) = self
+            .create_target_session(json!({ "url": "about:blank" }))
             .await?;
 
         let tab_id = self.next_tab_id;
         self.next_tab_id += 1;
+        let target_id = result.target_id;
         self.pages.push(PageInfo {
             tab_id,
             label: None,
-            target_id: result.target_id,
-            session_id: attach_result.session_id.clone(),
+            target_id: target_id.clone(),
+            session_id: session_id.clone(),
             url: "about:blank".to_string(),
             title: String::new(),
             target_type: "page".to_string(),
         });
         self.active_page_index = 0;
-        self.enable_domains(&attach_result.session_id).await?;
+        if !auto_attached {
+            self.enable_initial_attached_page_domains(&session_id)
+                .await?;
+        }
 
-        Ok(())
+        Ok(auto_attached.then_some((session_id, target_id)))
     }
 
     // -----------------------------------------------------------------------
@@ -1138,30 +1239,14 @@ impl BrowserManager {
 
         let target_url = url.unwrap_or("about:blank");
 
-        let result: CreateTargetResult = self
-            .client
-            .send_command_typed(
-                "Target.createTarget",
-                &CreateTargetParams {
-                    url: target_url.to_string(),
-                },
-                None,
-            )
+        let (result, session_id, auto_attached) = self
+            .create_target_session(json!({ "url": target_url }))
             .await?;
 
-        let attach: AttachToTargetResult = self
-            .client
-            .send_command_typed(
-                "Target.attachToTarget",
-                &AttachToTargetParams {
-                    target_id: result.target_id.clone(),
-                    flatten: true,
-                },
-                None,
-            )
-            .await?;
-
-        self.enable_domains(&attach.session_id).await?;
+        if !auto_attached {
+            self.enable_initial_attached_page_domains(&session_id)
+                .await?;
+        }
 
         let tab_id = self.next_tab_id;
         self.next_tab_id += 1;
@@ -1171,7 +1256,7 @@ impl BrowserManager {
             tab_id,
             label: label.clone(),
             target_id: result.target_id,
-            session_id: attach.session_id,
+            session_id,
             url: target_url.to_string(),
             title: String::new(),
             target_type: "page".to_string(),
@@ -1197,7 +1282,8 @@ impl BrowserManager {
 
         self.active_page_index = index;
         let session_id = self.pages[index].session_id.clone();
-        self.enable_domains(&session_id).await?;
+        self.enable_initial_attached_page_domains(&session_id)
+            .await?;
 
         // Bring tab to front
         let _ = self
@@ -1249,7 +1335,8 @@ impl BrowserManager {
             .await;
 
         let session_id = self.pages[self.active_page_index].session_id.clone();
-        self.enable_domains(&session_id).await?;
+        self.enable_initial_attached_page_domains(&session_id)
+            .await?;
 
         Ok(json!({
             "tabId": format_tab_id(closed_tab_id),
@@ -1421,8 +1508,12 @@ impl BrowserManager {
         &self,
         accept: bool,
         prompt_text: Option<&str>,
+        session_id: Option<&str>,
     ) -> Result<(), String> {
-        let session_id = self.active_session_id()?;
+        let session_id = match session_id {
+            Some(session_id) => session_id,
+            None => self.active_session_id()?,
+        };
         let mut params = json!({ "accept": accept });
         if let Some(text) = prompt_text {
             params["promptText"] = Value::String(text.to_string());
@@ -1544,6 +1635,29 @@ impl BrowserManager {
 
     pub fn update_page_target_info(&mut self, target: &TargetInfo) -> bool {
         update_page_target_info_in_pages(&mut self.pages, target)
+    }
+
+    /// Makes a browser-auto-attached session canonical for an already tracked page.
+    /// Returns the superseded session so the caller can detach it.
+    pub fn replace_page_session(
+        &mut self,
+        target: &TargetInfo,
+        session_id: &str,
+    ) -> Option<String> {
+        let page = self
+            .pages
+            .iter_mut()
+            .find(|page| page.target_id == target.target_id)?;
+        page.url = target.url.clone();
+        page.title = target.title.clone();
+        page.target_type = target.target_type.clone();
+        if page.session_id == session_id {
+            return None;
+        }
+        Some(std::mem::replace(
+            &mut page.session_id,
+            session_id.to_string(),
+        ))
     }
 
     pub fn remove_page_by_target_id(&mut self, target_id: &str) {
@@ -1725,9 +1839,12 @@ async fn initialize_lightpanda_manager(
             default_timeout_ms: 25_000,
             download_path: None,
             ignore_https_errors: false,
+            launch_user_agent: None,
+            launch_color_scheme: None,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
             direct_page: false,
+            browser_auto_attach_enabled: false,
         };
 
         match discover_and_attach_lightpanda_targets(&mut manager, deadline).await {

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -45,6 +45,13 @@ pub struct CdpClient {
     _keepalive_handle: tokio::task::JoinHandle<()>,
 }
 
+impl Drop for CdpClient {
+    fn drop(&mut self) {
+        self._reader_handle.abort();
+        self._keepalive_handle.abort();
+    }
+}
+
 impl CdpClient {
     pub async fn connect(url: &str) -> Result<Self, String> {
         Self::connect_with_headers(url, None).await

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -145,6 +145,7 @@ pub async fn run_daemon(session: &str) {
     }
     let _ = fs::remove_file(&pid_path);
     let _ = fs::remove_file(&version_path);
+    let _ = fs::remove_file(socket_dir.join(format!("{}.config", session)));
     let _ = fs::remove_file(&stream_path);
     let _ = fs::remove_file(socket_dir.join(format!("{}.engine", session)));
     let _ = fs::remove_file(socket_dir.join(format!("{}.provider", session)));

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -18,6 +18,7 @@ use crate::test_utils::EnvGuard;
 use super::actions::{
     close_current_browser, execute_command, maybe_autosave_restore_state, DaemonState,
 };
+use super::browser::BrowserManager;
 
 fn assert_success(resp: &Value) {
     assert_eq!(
@@ -419,7 +420,32 @@ async fn e2e_runtime_stream_enable_before_launch_attaches_and_disables() {
     assert_eq!(initial_status["connected"], false);
 
     let resp = execute_command(
-        &json!({ "id": "3", "action": "navigate", "url": "data:text/html,<h1>Runtime Stream</h1>" }),
+        &json!({ "id": "3", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let active_session = state
+        .browser
+        .as_ref()
+        .unwrap()
+        .active_session_id()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        state
+            .stream_server
+            .as_ref()
+            .unwrap()
+            .cdp_session_id_for_test()
+            .await
+            .as_deref(),
+        Some(active_session.as_str()),
+        "explicit launch must refresh the stream server after the canonical page session replaces the discovery session"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "navigate", "url": "data:text/html,<h1>Runtime Stream</h1>" }),
         &mut state,
     )
     .await;
@@ -454,7 +480,7 @@ async fn e2e_runtime_stream_enable_before_launch_attaches_and_disables() {
     );
 
     let resp = execute_command(
-        &json!({ "id": "4", "action": "stream_disable" }),
+        &json!({ "id": "5", "action": "stream_disable" }),
         &mut state,
     )
     .await;
@@ -5347,6 +5373,1088 @@ async fn e2e_externally_opened_tab_detected() {
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
+}
+
+async fn start_dialog_popup_server() -> (u16, Arc<Mutex<Vec<String>>>, tokio::task::JoinHandle<()>)
+{
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let lifecycle = Arc::new(Mutex::new(Vec::<String>::new()));
+    let lifecycle_by_server = Arc::clone(&lifecycle);
+    let server = tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let lifecycle = Arc::clone(&lifecycle_by_server);
+            tokio::spawn(async move {
+                let mut request = vec![0u8; 8192];
+                let read = stream.read(&mut request).await.unwrap();
+                let request_line = String::from_utf8_lossy(&request[..read])
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                let body = if request_line.contains(" /launcher ") {
+                    format!(
+                        r#"<!doctype html>
+<title>Popup launcher</title>
+<a id="open-popup" href="http://127.0.0.1:{port}/immediate-alert" target="_blank">Alert</a>
+<a id="open-plain" href="http://127.0.0.1:{port}/plain" target="_blank">Plain</a>
+<a id="open-confirm" href="http://127.0.0.1:{port}/confirm" target="_blank">Confirm</a>
+<a id="open-prompt" href="http://127.0.0.1:{port}/prompt" target="_blank">Prompt</a>
+<a id="open-closed" href="http://127.0.0.1:{port}/closed" target="_blank">Closed</a>"#
+                    )
+                } else if request_line.contains(" /immediate-alert ") {
+                    r#"<!doctype html>
+<title>Immediate alert popup</title>
+<script>
+  const started = new XMLHttpRequest();
+  started.open("GET", "/script-started", false);
+  started.send();
+  alert("informational");
+  document.documentElement.dataset.fixtureState = "after-alert";
+</script>
+<p id="marker">after-alert</p>"#
+                        .to_string()
+                } else if request_line.contains(" /plain ") {
+                    r#"<!doctype html><html data-fixture-state="plain"><title>Plain popup</title></html>"#
+                        .to_string()
+                } else if request_line.contains(" /confirm ") {
+                    r#"<!doctype html>
+<script>
+  document.documentElement.dataset.result = String(confirm("proceed?"));
+</script>"#
+                        .to_string()
+                } else if request_line.contains(" /prompt ") {
+                    r#"<!doctype html>
+<script>
+  document.documentElement.dataset.result = prompt("value?", "default") ?? "dismissed";
+</script>"#
+                        .to_string()
+                } else if request_line.contains(" /closed ") {
+                    "<!doctype html><title>Should close</title>".to_string()
+                } else {
+                    if request_line.contains(" /script-started ") {
+                        lifecycle.lock().unwrap().push("script-started".to_string());
+                    }
+                    "started".to_string()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                stream.flush().await.unwrap();
+            });
+        }
+    });
+    (port, lifecycle, server)
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_immediate_alert_popup_is_registered_before_page_script_runs() {
+    let (port, lifecycle, server) = start_dialog_popup_server().await;
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let launcher_url = format!("http://127.0.0.1:{port}/launcher");
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": launcher_url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let popup_url = format!("http://127.0.0.1:{port}/immediate-alert");
+    let browser = state.browser.as_ref().expect("browser should be launched");
+    let mut events = browser.client.subscribe();
+    let lifecycle_by_events = Arc::clone(&lifecycle);
+    let event_observer = tokio::spawn(async move {
+        while let Ok(event) = events.recv().await {
+            if event.method == "Target.attachedToTarget"
+                && event
+                    .params
+                    .get("targetInfo")
+                    .and_then(|target| target.get("type"))
+                    .and_then(Value::as_str)
+                    == Some("page")
+            {
+                lifecycle_by_events
+                    .lock()
+                    .unwrap()
+                    .push("page-attached".to_string());
+            }
+        }
+    });
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#open-popup" }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("Opening and registering the popup should stay bounded");
+    assert_success(&resp);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if lifecycle
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|entry| entry == "script-started")
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("The resumed popup should run its script");
+
+    let lifecycle_snapshot = lifecycle.lock().unwrap().clone();
+    assert_eq!(
+        lifecycle_snapshot.first().map(String::as_str),
+        Some("page-attached"),
+        "agent-browser must attach and pause the popup before its immediate script runs: {lifecycle_snapshot:?}"
+    );
+
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert!(
+        tabs.iter().any(|tab| {
+            tab["active"] == true && tab["url"].as_str().is_some_and(|url| url == popup_url)
+        }),
+        "The immediate-alert popup should be the active registered tab: {tabs:?}"
+    );
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({
+                "id": "5",
+                "action": "getattribute",
+                "selector": "html",
+                "attribute": "data-fixture-state",
+            }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("A command following the auto-handled alert should stay bounded");
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "after-alert");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    event_observer.abort();
+    server.abort();
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_no_dialog_popup_still_auto_targets_and_recovers() {
+    let (port, _lifecycle, server) = start_dialog_popup_server().await;
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://127.0.0.1:{port}/launcher"),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#open-plain" }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("A no-dialog popup should stay bounded");
+    assert_success(&resp);
+    assert_ne!(get_data(&resp)["dialogOpened"], true);
+
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert_eq!(tabs.len(), 2);
+    assert_eq!(tabs[1]["active"], true);
+    assert_eq!(tabs[1]["url"], format!("http://127.0.0.1:{port}/plain"));
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "getattribute",
+            "selector": "html",
+            "attribute": "data-fixture-state",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "plain");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_explicit_tab_new_keeps_one_flat_session_per_target() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let browser = state.browser.as_ref().unwrap();
+    let existing_target_ids: Vec<String> = browser
+        .pages_list()
+        .into_iter()
+        .map(|page| page.target_id)
+        .collect();
+    let mut events = browser.client.subscribe();
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "tab_new",
+            "url": "data:text/html,<script>confirm('tab-new explicit')</script>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let browser = state.browser.as_ref().unwrap();
+    let new_target_id = browser
+        .pages_list()
+        .into_iter()
+        .map(|page| page.target_id)
+        .find(|target_id| !existing_target_ids.contains(target_id))
+        .expect("tab_new should register one new target");
+    let mut attached_sessions = std::collections::HashSet::new();
+    while let Ok(event) = events.try_recv() {
+        if event.method == "Target.attachedToTarget"
+            && event.params["targetInfo"]["targetId"] == new_target_id
+        {
+            if let Some(session_id) = event.params["sessionId"].as_str() {
+                attached_sessions.insert(session_id.to_string());
+            }
+        }
+    }
+    assert_eq!(
+        attached_sessions.len(),
+        1,
+        "tab_new must not retain both an auto-attached and a manual flat session"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "confirm");
+    assert_eq!(get_data(&resp)["message"], "tab-new explicit");
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "dialog", "response": "dismiss" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_launch_keeps_one_flat_session_per_existing_target() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "userAgent": "canonical-launch-session/1.0",
+            "colorScheme": "dark",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "evaluate",
+            "script": "[navigator.userAgent, matchMedia('(prefers-color-scheme: dark)').matches]",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!(["canonical-launch-session/1.0", true]),
+        "launch-scoped emulation must follow the canonical auto-attached session"
+    );
+
+    let browser = state.browser.as_ref().expect("browser should be launched");
+    let page = browser
+        .pages_list()
+        .into_iter()
+        .next()
+        .expect("launch should retain a page");
+    browser
+        .client
+        .send_command(
+            "Target.detachFromTarget",
+            Some(json!({ "sessionId": page.session_id })),
+            None,
+        )
+        .await
+        .expect("the retained page session should be detachable");
+    let target = browser
+        .client
+        .send_command(
+            "Target.getTargetInfo",
+            Some(json!({ "targetId": page.target_id })),
+            None,
+        )
+        .await
+        .expect("the existing page target should remain inspectable");
+    assert_eq!(
+        target["targetInfo"]["attached"], false,
+        "Detaching the retained session must leave no superseded manual flat session attached"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_external_last_tab_close_recovers_with_a_prepared_page() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let browser = state.browser.as_ref().expect("browser should be launched");
+    let target_id = browser.active_target_id().unwrap().to_string();
+    browser
+        .client
+        .send_command(
+            "Target.closeTarget",
+            Some(json!({ "targetId": target_id })),
+            None,
+        )
+        .await
+        .expect("the last page target should close externally");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        execute_command(
+            &json!({
+                "id": "2",
+                "action": "navigate",
+                "url": "data:text/html,<title>replacement-ready</title>",
+            }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("last-tab recovery and its first page command should stay bounded");
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "replacement-ready");
+    assert_eq!(state.browser.as_ref().unwrap().page_count(), 1);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_immediate_confirm_and_prompt_popups_require_explicit_decisions() {
+    let (port, _lifecycle, server) = start_dialog_popup_server().await;
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://127.0.0.1:{port}/launcher"),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#open-confirm" }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("Opening the confirm popup should stay bounded");
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "confirm");
+    assert_eq!(get_data(&resp)["message"], "proceed?");
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "dialog", "response": "dismiss" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "getattribute",
+            "selector": "html",
+            "attribute": "data-result",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "false");
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({ "id": "8", "action": "click", "selector": "#open-prompt" }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("Opening the prompt popup should stay bounded");
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "prompt");
+    assert_eq!(get_data(&resp)["message"], "value?");
+    assert_eq!(get_data(&resp)["defaultPrompt"], "default");
+
+    let resp = execute_command(
+        &json!({
+            "id": "10",
+            "action": "dialog",
+            "response": "accept",
+            "promptText": "approved",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "11",
+            "action": "getattribute",
+            "selector": "html",
+            "attribute": "data-result",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "approved");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_background_confirm_survives_an_active_auto_handled_alert() {
+    let (port, _lifecycle, server) = start_dialog_popup_server().await;
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://127.0.0.1:{port}/launcher"),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#open-confirm" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "#open-popup" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "confirm");
+    assert_eq!(get_data(&resp)["message"], "proceed?");
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "dialog", "response": "dismiss" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "tab_switch", "tabId": "t2" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({
+                "id": "9",
+                "action": "getattribute",
+                "selector": "html",
+                "attribute": "data-result",
+            }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("the explicitly resolved background confirm should unblock its page");
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "false");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_closing_dialog_tab_prunes_its_pending_state() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "tab_new",
+            "url": "data:text/html,<script>confirm('close-me')</script>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["message"], "close-me");
+
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_close" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["hasDialog"], false);
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(&json!({ "id": "6", "action": "title" }), &mut state),
+    )
+    .await
+    .expect("closing the dialog-owning tab must leave following commands bounded");
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_no_auto_dialog_tracks_immediate_alert_for_explicit_resolution() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_NO_AUTO_DIALOG"]);
+    guard.set("AGENT_BROWSER_NO_AUTO_DIALOG", "1");
+    let (port, _lifecycle, server) = start_dialog_popup_server().await;
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://127.0.0.1:{port}/launcher"),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#open-popup" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "dialog", "response": "status" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "alert");
+    assert_eq!(get_data(&resp)["message"], "informational");
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "dialog", "response": "dismiss" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "getattribute",
+            "selector": "html",
+            "attribute": "data-fixture-state",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "after-alert");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
+    drop(guard);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_auto_attached_worker_is_resumed() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let mut events = state.browser.as_ref().unwrap().client.subscribe();
+
+    let worker_page = r#"data:text/html,<script>
+      const source = new Blob(["postMessage('ready')"], {type: "text/javascript"});
+      const worker = new Worker(URL.createObjectURL(source));
+      worker.onmessage = () => document.documentElement.dataset.worker = "ready";
+    </script>"#;
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": worker_page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let worker_session = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match events.recv().await {
+                Ok(event)
+                    if event.method == "Target.attachedToTarget"
+                        && event.params["targetInfo"]["type"] == "worker" =>
+                {
+                    return event.params["sessionId"].as_str().map(ToString::to_string);
+                }
+                Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    })
+    .await
+    .expect("the dedicated worker should be auto-attached")
+    .expect("the worker attachment should have a flat session");
+    assert!(!worker_session.is_empty());
+
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let resp = execute_command(
+                &json!({
+                    "id": "3",
+                    "action": "getattribute",
+                    "selector": "html",
+                    "attribute": "data-worker",
+                }),
+                &mut state,
+            )
+            .await;
+            if get_data(&resp)["value"] == "ready" {
+                return resp;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the auto-attached worker should resume and post its message");
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_preexisting_dialog_attach_fails_bounded_without_accepting_it() {
+    let mut owner = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": "data:text/html,<title>pre-existing dialog</title>",
+        }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+    let browser = owner.browser.as_ref().expect("owner browser should exist");
+    let owner_session = browser.active_session_id().unwrap().to_string();
+    browser
+        .client
+        .send_command_no_wait(
+            "Runtime.evaluate",
+            Some(json!({ "expression": "confirm('pre-existing')" })),
+            Some(&owner_session),
+        )
+        .await
+        .expect("The owner should trigger the dialog");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "dialog", "response": "status" }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "confirm");
+    let cdp_url = owner.browser.as_ref().unwrap().get_cdp_url().to_string();
+    let attach = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        BrowserManager::connect_cdp(&cdp_url),
+    )
+    .await
+    .expect("Pre-existing dialog attach must return within the target initialization bound");
+    let error = match attach {
+        Ok(_) => panic!("A pre-existing dialog must not be accepted blindly"),
+        Err(error) => error,
+    };
+    assert!(
+        error.contains("pre-existing JavaScript dialog") && error.contains("not accepted"),
+        "Attach failure should be actionable and state the safety policy: {error}"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "dialog", "response": "status" }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["type"], "confirm");
+    assert_eq!(get_data(&resp)["message"], "pre-existing");
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "dialog", "response": "dismiss" }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "6", "action": "url" }), &mut owner).await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut owner).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_preexisting_dialog_in_noninitial_tab_is_bounded_and_not_accepted() {
+    let mut owner = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "tab_new",
+            "url": "data:text/html,<title>second tab</title>",
+        }),
+        &mut owner,
+    )
+    .await;
+    assert_success(&resp);
+
+    let browser = owner.browser.as_mut().expect("owner browser should exist");
+    let pages = browser.pages_list();
+    assert_eq!(pages.len(), 2);
+    let targets = browser
+        .client
+        .send_command("Target.getTargets", Some(json!({})), None)
+        .await
+        .expect("target discovery should succeed");
+    let ordered_page_target_ids: Vec<&str> = targets["targetInfos"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|target| target["type"] == "page")
+        .filter_map(|target| target["targetId"].as_str())
+        .filter(|target_id| pages.iter().any(|page| page.target_id == *target_id))
+        .collect();
+    assert_eq!(ordered_page_target_ids.len(), 2);
+
+    let blocked_index = pages
+        .iter()
+        .position(|page| page.target_id == ordered_page_target_ids[1])
+        .unwrap();
+    let safe_index = 1 - blocked_index;
+    let blocked_session = pages[blocked_index].session_id.clone();
+    browser
+        .tab_switch(safe_index)
+        .await
+        .expect("the normal first-discovered tab should remain usable");
+    browser
+        .client
+        .send_command_no_wait(
+            "Runtime.evaluate",
+            Some(json!({ "expression": "confirm('background pre-existing')" })),
+            Some(&blocked_session),
+        )
+        .await
+        .expect("the background tab should open a dialog");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let cdp_url = browser.get_cdp_url().to_string();
+    let attach = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        BrowserManager::connect_cdp(&cdp_url),
+    )
+    .await
+    .expect("Every discovered target must obey the initialization bound");
+    let error = match attach {
+        Ok(_) => panic!("A dialog in a noninitial tab must not be accepted blindly"),
+        Err(error) => error,
+    };
+    assert!(
+        error.contains("pre-existing JavaScript dialog") && error.contains("not accepted"),
+        "Attach failure should identify the bounded safety policy: {error}"
+    );
+
+    browser
+        .client
+        .send_command(
+            "Page.handleJavaScriptDialog",
+            Some(json!({ "accept": false })),
+            Some(&blocked_session),
+        )
+        .await
+        .expect("The failed attach must leave the background confirm unresolved");
+    browser
+        .tab_switch(blocked_index)
+        .await
+        .expect("The owner should recover the same tab after an explicit decision");
+
+    close_current_browser(&mut owner)
+        .await
+        .expect("owner browser should close");
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_failed_popup_target_does_not_wedge_following_commands() {
+    let (port, _lifecycle, server) = start_dialog_popup_server().await;
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://127.0.0.1:{port}/launcher"),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let browser = state.browser.as_ref().unwrap();
+    let client = Arc::clone(&browser.client);
+    let mut events = client.subscribe();
+    let close_popup = tokio::spawn(async move {
+        while let Ok(event) = events.recv().await {
+            if event.method != "Target.attachedToTarget" {
+                continue;
+            }
+            let is_page = event
+                .params
+                .get("targetInfo")
+                .and_then(|target| target.get("type"))
+                .and_then(Value::as_str)
+                == Some("page");
+            let target_id = event
+                .params
+                .get("targetInfo")
+                .and_then(|target| target.get("targetId"))
+                .and_then(Value::as_str);
+            if is_page {
+                if let Some(target_id) = target_id {
+                    let _ = client
+                        .send_command(
+                            "Target.closeTarget",
+                            Some(json!({ "targetId": target_id })),
+                            None,
+                        )
+                        .await;
+                    return;
+                }
+            }
+        }
+    });
+
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#open-closed" }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("A failed popup target must not hold the command lane");
+    tokio::time::timeout(std::time::Duration::from_secs(2), close_popup)
+        .await
+        .expect("The popup failure should be injected")
+        .expect("The popup closer should complete");
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state),
+    )
+    .await
+    .expect("A command after the failed popup must stay usable");
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert_eq!(tabs.len(), 1, "The failed popup must not remain registered");
+    assert_eq!(tabs[0]["active"], true);
+
+    let resp = execute_command(&json!({ "id": "5", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "Popup launcher");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/native/stream/mod.rs
+++ b/cli/src/native/stream/mod.rs
@@ -100,6 +100,11 @@ impl StreamServer {
         *guard = session_id;
     }
 
+    #[cfg(test)]
+    pub async fn cdp_session_id_for_test(&self) -> Option<String> {
+        self.cdp_session_id.read().await.clone()
+    }
+
     /// Check whether the server currently has active screencast running.
     pub async fn is_screencasting(&self) -> bool {
         *self.screencasting.lock().await


### PR DESCRIPTION
Fixes #1602.

## What changed

- enable browser-level flat auto-attach for Chrome page and non-page targets
- pause new page targets before their first request, initialize them in a bounded background handoff, and resume only after controls are installed
- make the auto-attached session canonical without retaining duplicate manual sessions
- track confirm/prompt dialogs by CDP session and route explicit decisions to the owning page
- bound pre-existing-dialog attachment and failed-target recovery paths
- preserve launch emulation and stream ownership when the canonical session changes
- remove the daemon configuration fingerprint alongside its other per-session sidecars on normal exit

## Root cause

New page targets were discovered and attached only after the opener command returned. A popup that opened a synchronous dialog in its first script could therefore block the command lane before the new target was registered. Mixed manual and automatic attachment also allowed duplicate flat sessions and stale dialog routing.

The newer daemon configuration fingerprint was written by the client before startup but omitted from the daemon normal-exit cleanup list, leaving a stale per-session sidecar after an explicit close.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- full non-ignored suite from a short checkout: 1002 passed, 0 failed; integration tests: 2 passed
- real-Chrome regressions for immediate alerts, explicit confirm/prompt handling, no-dialog popups, disabled auto-dialog behavior, cross-tab dialog ownership, target-close cleanup, domain filtering before first request, worker resume, canonical single sessions, zero-tab recovery, pre-existing dialogs, launch emulation, and stream-session refresh
- real CLI teardown regression proving the daemon process exits and leaves no per-session sidecars
