### PR TITLE
fix(proxy): trim trailing slash from proxy URL

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -457,7 +457,7 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
     }
 
     if let Some(ref proxy) = options.proxy {
-        args.push(format!("--proxy-server={}", proxy));
+        args.push(format!("--proxy-server={}", proxy.trim_end_matches('/')));
     }
 
     if let Some(ref bypass) = options.proxy_bypass {
@@ -1691,6 +1691,27 @@ mod tests {
         let dir = result.temp_user_data_dir.unwrap();
         assert!(dir.exists());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_args_trims_trailing_slash_from_proxy() {
+        let opts = LaunchOptions {
+            proxy: Some("http://127.0.0.1:7890/".to_string()),
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        let proxy_arg = result
+            .args
+            .iter()
+            .find(|arg| arg.starts_with("--proxy-server="))
+            .cloned();
+        let dir = result.temp_user_data_dir.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            proxy_arg.as_deref(),
+            Some("--proxy-server=http://127.0.0.1:7890")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Trim trailing slashes from proxy URLs before building Chrome's `--proxy-server` argument.
- Add a regression test covering a common proxy environment value such as `http://127.0.0.1:7890/`.

## Why

Chrome rejects proxy server values with a trailing slash and navigation fails with `ERR_NO_SUPPORTED_PROXIES`. Proxy environment variables and desktop proxy tools commonly provide URLs in that form, so normalizing at the Chrome argument boundary makes those configurations work without changing bypass rules or public CLI behavior.

Fixes #1349.

The issue investigation and initial patch direction were provided by @uraraneko and @TheDerbiedOne.

## Validation

- Regression test failed on unpatched main with `--proxy-server=http://127.0.0.1:7890/` and passes after the fix.
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `cargo test --profile ci --manifest-path cli/Cargo.toml` — 1,009 unit tests and 2 integration tests passed; 96 end-to-end and benchmark tests remained ignored as configured.
- `node scripts/check-version-sync.js`

Some portions of this contribution were developed with assistance from OpenAI Codex (GPT-5). The final diff and test results were reviewed locally.
