### PR TITLE
fix(wait): stop the global --state flag from swallowing `wait <sel> --state hidden`

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -693,6 +693,29 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 })?);
                 rest.drain(idx..=idx + 1);
             }
+            // `--state` is wait-scoped here (the element state to wait FOR),
+            // not the global auth-state file. Extract it before the variants so
+            // its value can never be misread as a selector.
+            let mut element_state: Option<String> = None;
+            if let Some(idx) = rest.iter().position(|&s| s == "--state") {
+                let raw = rest
+                    .get(idx + 1)
+                    .ok_or_else(|| ParseError::MissingArguments {
+                        context: "wait --state".to_string(),
+                        usage: "wait <selector> --state <visible|hidden|attached|detached>",
+                    })?;
+                if !matches!(*raw, "visible" | "hidden" | "attached" | "detached") {
+                    return Err(ParseError::InvalidValue {
+                        message: format!(
+                            "--state expects visible, hidden, attached, or detached, got '{}'",
+                            raw
+                        ),
+                        usage: "wait <selector> --state <visible|hidden|attached|detached>",
+                    });
+                }
+                element_state = Some((*raw).to_string());
+                rest.drain(idx..=idx + 1);
+            }
             let with_timeout = |mut cmd: Value| {
                 if let Some(ms) = timeout_ms {
                     cmd["timeout"] = json!(ms);
@@ -773,9 +796,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 if let Ok(timeout) = arg.parse::<u64>() {
                     Ok(json!({ "id": id, "action": "wait", "timeout": timeout }))
                 } else {
-                    Ok(with_timeout(
-                        json!({ "id": id, "action": "wait", "selector": arg }),
-                    ))
+                    let mut cmd = json!({ "id": id, "action": "wait", "selector": arg });
+                    if let Some(ref st) = element_state {
+                        cmd["state"] = json!(st);
+                    }
+                    Ok(with_timeout(cmd))
                 }
             } else {
                 Err(ParseError::MissingArguments {
@@ -4456,6 +4481,47 @@ mod tests {
         let cmd = parse_command(&args("wait #element"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "wait");
         assert_eq!(cmd["selector"], "#element");
+    }
+
+    #[test]
+    fn test_wait_state_hidden_reaches_the_daemon() {
+        // The daemon has always honored cmd["state"] (visible/hidden/attached/
+        // detached); only the CLI never sent it, while the help text documented
+        // this exact invocation.
+        let cmd = parse_command(&args("wait #spinner --state hidden"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "wait");
+        assert_eq!(cmd["selector"], "#spinner");
+        assert_eq!(cmd["state"], "hidden");
+    }
+
+    #[test]
+    fn test_wait_state_detached_with_ref() {
+        let cmd = parse_command(&args("wait @e5 --state detached"), &default_flags()).unwrap();
+        assert_eq!(cmd["selector"], "@e5");
+        assert_eq!(cmd["state"], "detached");
+    }
+
+    #[test]
+    fn test_wait_state_combines_with_timeout() {
+        let cmd = parse_command(
+            &args("wait #spinner --state hidden --timeout 9000"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["state"], "hidden");
+        assert_eq!(cmd["timeout"], 9000);
+    }
+
+    #[test]
+    fn test_wait_state_rejects_unknown_value() {
+        // Better a clear parse error than silently treating "gone" as a selector.
+        assert!(parse_command(&args("wait #spinner --state gone"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_wait_selector_without_state_is_unchanged() {
+        let cmd = parse_command(&args("wait #element"), &default_flags()).unwrap();
+        assert!(cmd.get("state").is_none());
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -616,10 +616,14 @@ pub fn parse_flags(args: &[String]) -> Flags {
 
     let mut i = 0;
     let mut seen_command = false;
+    let mut command_name: Option<String> = None;
     while i < args.len() {
         let arg = args[i].as_str();
         if !arg.starts_with('-') && looks_like_command(arg) {
             seen_command = true;
+            if command_name.is_none() {
+                command_name = Some(arg.to_string());
+            }
         }
         match arg {
             s if s.starts_with("--restore=") => {
@@ -783,7 +787,14 @@ pub fn parse_flags(args: &[String]) -> Flags {
                 }
             }
             "--state" => {
-                if let Some(s) = args.get(i + 1) {
+                // `wait <selector> --state hidden` is a wait-scoped element
+                // state, not an auth-state file. Consuming it here made the CLI
+                // try to read a state file literally named "hidden", which fails
+                // and leaves the session on about:blank, even though the help
+                // text documents that exact invocation.
+                if command_name.as_deref() == Some("wait") {
+                    // Leave the flag and its value for the wait parser.
+                } else if let Some(s) = args.get(i + 1) {
                     flags.state = Some(s.clone());
                     flags.cli_state = true;
                     i += 1;
@@ -1075,6 +1086,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
 
     let mut i = 0;
     let mut seen_command = false;
+    let mut command_name: Option<String> = None;
     while i < args.len() {
         let arg = &args[i];
         if skip_next {
@@ -1083,6 +1095,13 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
             continue;
         }
         if arg.starts_with("--restore=") {
+            i += 1;
+            continue;
+        }
+        // `wait --state <element state>` must survive into the command args;
+        // it is not the global auth-state file flag.
+        if arg == "--state" && command_name.as_deref() == Some("wait") {
+            result.push(arg.clone());
             i += 1;
             continue;
         }
@@ -1113,6 +1132,9 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         }
         if !arg.starts_with('-') && looks_like_command(arg) {
             seen_command = true;
+            if command_name.is_none() {
+                command_name = Some(arg.clone());
+            }
         }
         result.push(arg.clone());
         i += 1;
@@ -1127,6 +1149,43 @@ mod tests {
 
     fn args(s: &str) -> Vec<String> {
         s.split_whitespace().map(String::from).collect()
+    }
+
+    #[test]
+    fn test_wait_state_is_not_swallowed_as_an_auth_state_file() {
+        // Regression: `--state` is a global auth-state file flag, but the help
+        // text also documents `wait <sel> --state hidden`. The global parser won,
+        // so the CLI tried to read a state file named "hidden", failed, and left
+        // the session on about:blank.
+        let flags = parse_flags(&args("wait #spinner --state hidden"));
+        assert_eq!(flags.state, None);
+        assert!(!flags.cli_state);
+    }
+
+    #[test]
+    fn test_global_state_flag_still_works_for_other_commands() {
+        let flags = parse_flags(&args("open example.com --state /tmp/auth.json"));
+        assert_eq!(flags.state, Some("/tmp/auth.json".to_string()));
+        assert!(flags.cli_state);
+    }
+
+    #[test]
+    fn test_global_state_flag_before_a_wait_command_still_loads_auth() {
+        // `--state` ahead of the command is unambiguously the auth-state file.
+        let flags = parse_flags(&args("--state /tmp/auth.json wait #spinner"));
+        assert_eq!(flags.state, Some("/tmp/auth.json".to_string()));
+    }
+
+    #[test]
+    fn test_clean_args_keeps_wait_state_for_the_command_parser() {
+        let cleaned = clean_args(&args("wait #spinner --state hidden"));
+        assert_eq!(cleaned, args("wait #spinner --state hidden"));
+    }
+
+    #[test]
+    fn test_clean_args_still_strips_global_state_for_other_commands() {
+        let cleaned = clean_args(&args("open example.com --state /tmp/auth.json"));
+        assert_eq!(cleaned, args("open example.com"));
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`wait <selector> --state hidden` is documented in `--help`:

```
Wait for text to disappear:
  Use --fn or --state hidden to wait for text or elements to go away:
  wait --fn "!document.body.innerText.includes('Loading...')"
  wait "#spinner" --state hidden
  wait @e5 --state detached
```

It does not work. On 0.33.0:

```
$ agent-browser wait "#spinner" --state hidden
✗ Failed to read state from hidden: No such file or directory (os error 2)

$ agent-browser get url
about:blank
```

The global `--state <path>` auth-state flag is parsed unconditionally, so it
consumes `hidden` as a state file path before the `wait` parser ever sees it. The
read fails, and the session is left on `about:blank`.

## Why it is worth fixing rather than documenting away

The failure is silent downstream. Once the session is on `about:blank`, every
subsequent `eval` returns nulls and `snapshot` reports `(no interactive
elements)`. That reads like the page under test broke, not like the CLI rejected
an argument. It cost me two full acceptance runs that looked like application
defects before I traced it here.

The feature is also already implemented at both ends:

- `handle_wait` reads `cmd["state"]` (`cli/src/native/actions.rs`)
- `wait_for_selector` implements `attached`, `detached`, `hidden`, and visible

Only the argument plumbing between the CLI and the daemon was missing, so this
change touches no daemon code.

## The change

- `cli/src/flags.rs` tracks the command name and leaves `--state` for the `wait`
  parser, in both `parse_flags` and `clean_args`. This follows the existing
  `--restore` precedent for command-aware parsing. `--state` before the command,
  and `--state` on any other command, keep their current auth-state meaning.
- `cli/src/commands.rs` parses `--state` in the `wait` arm next to `--timeout`,
  validates it against the four supported values, and forwards it as
  `cmd["state"]`.

An unknown value is now a parse error instead of being silently reinterpreted as
a selector.

## Verification

- `cargo fmt --manifest-path cli/Cargo.toml -- --check` clean.
- `cargo test --bin agent-browser`: same result as the unmodified tree, plus the
  10 new tests. Baseline on a pristine clone was 1025 passed / 3 failed; with
  this change 1035 passed / 3 failed, the same 3. Those 3 are pre-existing and
  environment-dependent on my machine (two `stream::http` tests and one
  `plugins` test fail via a poisoned `EnvGuard` mutex), and they fail identically
  without this patch.
- Behaviour end to end on a local page that hides an element after 1.5s: before,
  the command errors and the session drops to `about:blank`; after, the wait
  resolves and `is visible #spinner` goes from `true` to `false`.

New tests cover the fix, `--state detached` with an `@ref`, combination with
`--timeout`, rejection of an unknown value, that a selector without `--state` is
unchanged, and that the global `--state` still loads an auth file for other
commands and when it precedes the command.

## Note

One pre-existing `clippy -D warnings` failure exists in
`cli/src/native/cdp/chrome.rs:337` (`is_none_or` on an untouched line) with my
local toolchain. It is unrelated to this change and present without it; I left
it alone rather than widen the diff.
