### PR TITLE
fix(snapshot): do not name a container with its truncated descendant text

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -676,7 +676,11 @@ async fn find_cursor_interactive_elements(
             if (parent && getComputedStyle(parent).cursor === 'pointer') continue;
         }
 
-        var text = (el.textContent || '').trim().slice(0, 100);
+        // A control's accessible name is short. When an element's text overflows the cap it is a
+        // container's concatenated descendant text, not a name, and truncating it yields a label that
+        // matches a search for every control nested inside it. Prefer no name over a misleading one.
+        var rawText = (el.textContent || '').trim();
+        var text = rawText.length > 100 ? '' : rawText;
 
         var rect = el.getBoundingClientRect();
         if (rect.width === 0 || rect.height === 0) continue;


### PR DESCRIPTION
## The problem

A cursor interactive element with no ARIA name falls back to its own `textContent`, capped at 100 characters:

```js
var text = (el.textContent || '').trim().slice(0, 100);
```

For a page level container that carries an `onclick`, that cap turns the entire page's concatenated text into the node's name. Observed on a real application, the first line of `snapshot -i` was:

```
- generic "BidNexTenders0Signals3159Proposals0Relevance rubric9Map⌘K NarrowNothing matches this selection. Clea" [ref=e1] clickable [onclick]
  - button "Tenders 0" [ref=e3]
  - button "Relevance rubric 9" [ref=e6]
```

That node's name is exactly 100 characters, truncated mid word, and it contains the text of every control beneath it.

## Why it matters for agents

Any substring search over the snapshot output matches the wrapper before the control being looked for. Searching for `Relevance rubric` returns `e1`, not `e6`. Clicking `e1` is a valid no op on the container, so `click` correctly reports success and nothing happens.

In our evaluation this cost a full session. An agent resolved handles by text, acted on the container repeatedly, saw the page in an unexpected state later, and reported a reproducible application defect that did not exist. Verified three ways afterwards, the application was never at fault.

## The change

```js
var rawText = (el.textContent || '').trim();
var text = rawText.length > 100 ? '' : rawText;
```

A control's accessible name is short. When the text overflows the cap it is a container's descendant text rather than a name, so this prefers no name over a misleading one. The node keeps its ref and stays clickable; only the fabricated label is dropped.

## Verification

I could not build locally, no Rust toolchain on this machine, so I want to be explicit about what is and is not proven here.

**Not verified:** compilation and the test suite. The change is confined to the embedded JS raw string literal, and I checked the literal is still well formed, with no premature `"#` terminator introduced.

**Verified empirically:** I replicated the selection logic from `find_cursor_interactive_elements` in a real browser against the page above and measured every element it selects.

| Element | textContent length | descendants | effect of this change |
|---|---|---|---|
| `div` (the `e1` wrapper) | 935 | 261 | loses its fabricated name |
| `canvas` (a map) | 0 | 0 | unaffected |

Two cursor interactive elements on the page, one affected. 935 characters against a 100 character cap, with 261 descendants, is not a marginal case.

## Alternative considered

Skipping the fallback when the element has interactive descendants would also work and is arguably more semantically direct. I chose the length test because it reuses a value the surrounding code already computes and keeps the diff to two lines. Happy to switch if you prefer the descendant test.

## Notes

No new flag, command, environment variable or parser semantics, so the five location documentation rule in `AGENTS.md` did not apply. Let me know if you would like a `CHANGELOG.md` entry; I left it alone since releases look maintainer controlled.
