### PR TITLE
fix: dashboard stream input latency, keyboard shortcuts, and clipboard bridge

### DIFF
--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5535,6 +5535,197 @@ async fn e2e_stream_frame_metadata_respects_custom_viewport() {
     let _ = std::fs::remove_dir_all(&socket_dir);
 }
 
+// ---------------------------------------------------------------------------
+// Stream: dashboard input dispatch and clipboard bridge
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn e2e_stream_input_dispatch_and_clipboard_bridge() {
+    use futures_util::SinkExt;
+
+    let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+    let socket_dir = std::env::temp_dir().join(format!(
+        "agent-browser-e2e-stream-input-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&socket_dir).expect("socket dir should be created");
+    guard.set(
+        "AGENT_BROWSER_SOCKET_DIR",
+        socket_dir.to_str().expect("socket dir should be utf-8"),
+    );
+    guard.set("AGENT_BROWSER_SESSION", "e2e-stream-input");
+
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "stream_enable", "port": 0 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let port = get_data(&resp)["port"]
+        .as_u64()
+        .expect("stream enable should report the bound port");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("websocket client should connect to runtime stream");
+
+    // The clipboard bridge needs a secure context, so serve the test page
+    // over localhost HTTP instead of a data: URL.
+    let page_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test page listener should bind");
+    let page_port = page_listener
+        .local_addr()
+        .expect("listener should have a local address")
+        .port();
+    let page_body = "<!doctype html><html><body><textarea id='ta'>stream clipboard bridge</textarea></body></html>";
+    let page_server = tokio::spawn(async move {
+        while let Ok((mut sock, _)) = page_listener.accept().await {
+            let mut buf = [0u8; 2048];
+            let _ = sock.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                page_body.len(),
+                page_body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+        }
+    });
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://127.0.0.1:{page_port}/") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    async fn send_ws(
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        msg: Value,
+    ) {
+        let _ = ws
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                msg.to_string(),
+            ))
+            .await;
+    }
+
+    // The first frame implies the screencast and the clipboard permission
+    // grant ran.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+    let mut saw_frame = false;
+    while tokio::time::Instant::now() < deadline && !saw_frame {
+        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
+        let Some(Ok(message)) = msg.ok().flatten() else {
+            continue;
+        };
+        if message.is_text() {
+            let parsed: Value =
+                serde_json::from_str(message.to_text().expect("text message should be readable"))
+                    .expect("stream payload should be valid JSON");
+            saw_frame = parsed.get("type") == Some(&json!("frame"));
+        }
+    }
+    assert!(saw_frame, "should have received a screencast frame");
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "evaluate", "script": "const ta = document.getElementById('ta'); ta.focus(); ta.select(); ta.value" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Copy via the key events the dashboard sends: rawKeyDown with the
+    // uppercase VK for C (67). Pre-fix it sent 99 (numpad 3), a no-op.
+    for msg in [
+        json!({ "type": "input_keyboard", "eventType": "rawKeyDown", "key": "Control", "code": "ControlLeft", "windowsVirtualKeyCode": 17, "modifiers": 2 }),
+        json!({ "type": "input_keyboard", "eventType": "rawKeyDown", "key": "c", "code": "KeyC", "windowsVirtualKeyCode": 67, "modifiers": 2 }),
+        json!({ "type": "input_keyboard", "eventType": "keyUp", "key": "c", "code": "KeyC", "windowsVirtualKeyCode": 67, "modifiers": 2 }),
+        json!({ "type": "input_keyboard", "eventType": "keyUp", "key": "Control", "code": "ControlLeft", "windowsVirtualKeyCode": 17, "modifiers": 0 }),
+    ] {
+        send_ws(&mut ws, msg).await;
+    }
+
+    // Input dispatch is fire-and-forget now, so poll until the copy lands.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(10);
+    let mut copied = String::new();
+    while tokio::time::Instant::now() < deadline && copied != "stream clipboard bridge" {
+        send_ws(&mut ws, json!({ "type": "input_read_clipboard" })).await;
+        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
+        let Some(Ok(message)) = msg.ok().flatten() else {
+            continue;
+        };
+        if !message.is_text() {
+            continue;
+        }
+        let parsed: Value =
+            serde_json::from_str(message.to_text().expect("text message should be readable"))
+                .expect("stream payload should be valid JSON");
+        if parsed.get("type") == Some(&json!("clipboard")) {
+            if let Some(err) = parsed.get("error").and_then(|v| v.as_str()) {
+                panic!("clipboard bridge returned an error: {err}");
+            }
+            if let Some(text) = parsed.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    copied = text.to_string();
+                }
+            }
+        }
+    }
+    assert_eq!(
+        copied, "stream clipboard bridge",
+        "clipboard bridge should return the text copied from the page"
+    );
+
+    // Paste bridge: input_insert_text replaces the selection at the focus.
+    send_ws(
+        &mut ws,
+        json!({ "type": "input_insert_text", "text": "pasted" }),
+    )
+    .await;
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(10);
+    let mut inserted = false;
+    while tokio::time::Instant::now() < deadline && !inserted {
+        let resp = execute_command(
+            &json!({ "id": "4", "action": "evaluate", "script": "document.getElementById('ta').value" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let value = get_data(&resp)["result"].as_str().unwrap_or("");
+        if value == "pasted" {
+            inserted = true;
+        } else {
+            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        }
+    }
+    assert!(
+        inserted,
+        "input_insert_text should replace the textarea value"
+    );
+
+    // Cleanup
+    page_server.abort();
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "stream_disable" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    let _ = std::fs::remove_dir_all(&socket_dir);
+}
+
 /// Extract width and height from a JPEG's SOF0 (0xFFC0) or SOF2 (0xFFC2) marker.
 fn jpeg_dimensions(data: &[u8]) -> Option<(u32, u32)> {
     for i in 0..data.len().saturating_sub(8) {

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -77,6 +77,20 @@ pub(super) async fn cdp_event_loop(
                             session_id.as_deref(),
                         )
                         .await;
+
+                    // Lets the dashboard copy bridge read the remote clipboard.
+                    for name in ["clipboard-read", "clipboard-write"] {
+                        let _ = client_arc
+                            .send_command(
+                                "Browser.setPermission",
+                                Some(json!({
+                                    "permission": { "name": name },
+                                    "setting": "granted",
+                                })),
+                                None,
+                            )
+                            .await;
+                    }
                 }
 
                 {

--- a/cli/src/native/stream/websocket.rs
+++ b/cli/src/native/stream/websocket.rs
@@ -288,6 +288,11 @@ async fn handle_ws_client(
     client_notify.notify_one();
 }
 
+/// Input events are dispatched without awaiting Chrome's response: the
+/// response carries no data, and awaiting it serializes every event behind
+/// a CDP round trip (~one frame tick under software rendering), so a mouse
+/// sweep's `mouseMoved` flood made clicks wait seconds behind the backlog.
+/// Socket writes are ordered, so event ordering is preserved.
 async fn handle_client_message(
     msg: &str,
     client: &CdpClient,
@@ -307,7 +312,7 @@ async fn handle_client_message(
     match msg_type {
         "input_mouse" => {
             let _ = client
-                .send_command(
+                .send_command_no_wait(
                     "Input.dispatchMouseEvent",
                     Some(json!({
                         "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("mouseMoved"),
@@ -325,7 +330,7 @@ async fn handle_client_message(
         }
         "input_keyboard" => {
             let _ = client
-                .send_command(
+                .send_command_no_wait(
                     "Input.dispatchKeyEvent",
                     Some(json!({
                         "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("keyDown"),
@@ -341,7 +346,7 @@ async fn handle_client_message(
         }
         "input_touch" => {
             let _ = client
-                .send_command(
+                .send_command_no_wait(
                     "Input.dispatchTouchEvent",
                     Some(json!({
                         "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("touchStart"),

--- a/cli/src/native/stream/websocket.rs
+++ b/cli/src/native/stream/websocket.rs
@@ -237,6 +237,9 @@ async fn handle_ws_client(
 
     client_notify.notify_one();
 
+    // Replies produced by spawned client-message handlers (clipboard reads).
+    let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel::<String>(8);
+
     loop {
         tokio::select! {
             changed = shutdown_rx.changed() => {
@@ -258,24 +261,27 @@ async fn handle_ws_client(
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
+            reply = reply_rx.recv() => {
+                // reply_tx is held for the whole loop, so None is unreachable.
+                let Some(reply) = reply else { break };
+                if ws_tx.send(Message::Text(reply)).await.is_err() {
+                    break;
+                }
+            }
             msg = ws_rx.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         let guard = client_slot.read().await;
                         if let Some(ref client) = *guard {
                             let sid = cdp_session_id.read().await;
-                            let reply = handle_client_message(
+                            handle_client_message(
                                 &text,
-                                client.as_ref(),
+                                client,
                                 sid.as_deref(),
                                 idle_activity.as_ref(),
+                                &reply_tx,
                             )
                             .await;
-                            if let Some(reply) = reply {
-                                if ws_tx.send(Message::Text(reply)).await.is_err() {
-                                    break;
-                                }
-                            }
                         }
                     }
                     Some(Ok(Message::Close(_))) | None => break,
@@ -293,23 +299,28 @@ async fn handle_ws_client(
     client_notify.notify_one();
 }
 
-/// Handles one dashboard client message. Returns a message to send back to
-/// the client, if any (currently only clipboard read responses).
+/// Handles one dashboard client message.
 ///
 /// Input events are dispatched without awaiting Chrome's response: the
 /// response carries no data, and awaiting it serializes every event behind
 /// a CDP round trip (~one frame tick under software rendering), so a mouse
 /// sweep's `mouseMoved` flood made clicks wait seconds behind the backlog.
 /// Socket writes are ordered, so event ordering is preserved.
+///
+/// `input_read_clipboard` is the one message that needs a CDP response; it
+/// runs in a spawned task and its reply goes out through `reply_tx`, so a
+/// slow read (a busy page main thread stalls Runtime.evaluate) cannot block
+/// this client's frame forwarding or later input messages.
 async fn handle_client_message(
     msg: &str,
-    client: &CdpClient,
+    client: &Arc<CdpClient>,
     session_id: Option<&str>,
     idle_activity: &IdleActivity,
-) -> Option<String> {
+    reply_tx: &tokio::sync::mpsc::Sender<String>,
+) {
     let parsed: Value = match serde_json::from_str(msg) {
         Ok(v) => v,
-        Err(_) => return None,
+        Err(_) => return,
     };
 
     let msg_type = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -381,39 +392,47 @@ async fn handle_client_message(
         }
         "input_read_clipboard" => {
             // Copy bridge: read the remote clipboard after a copy/cut so the
-            // dashboard can mirror it into the local clipboard.
-            let result = client
-                .send_command(
-                    "Runtime.evaluate",
-                    Some(json!({
-                        "expression": "navigator.clipboard.readText().then(t => ({ ok: t }), e => ({ err: String(e) }))",
-                        "awaitPromise": true,
-                        "returnByValue": true,
-                    })),
-                    session_id,
-                )
-                .await;
-            match result {
-                Ok(result) => {
-                    let value = result.get("result").and_then(|r| r.get("value"));
-                    if let Some(text) = value.and_then(|v| v.get("ok")).and_then(|v| v.as_str()) {
-                        return Some(json!({ "type": "clipboard", "text": text }).to_string());
+            // dashboard can mirror it into the local clipboard. Spawned
+            // because Runtime.evaluate waits for the page's main thread;
+            // awaiting it inline would stall this client's frames and input
+            // behind a busy page (up to the 30s CDP command timeout).
+            let client = Arc::clone(client);
+            let session_id = session_id.map(|s| s.to_string());
+            let reply_tx = reply_tx.clone();
+            tokio::spawn(async move {
+                let result = client
+                    .send_command(
+                        "Runtime.evaluate",
+                        Some(json!({
+                            "expression": "navigator.clipboard.readText().then(t => ({ ok: t }), e => ({ err: String(e) }))",
+                            "awaitPromise": true,
+                            "returnByValue": true,
+                        })),
+                        session_id.as_deref(),
+                    )
+                    .await;
+                let reply = match result {
+                    Ok(result) => {
+                        let value = result.get("result").and_then(|r| r.get("value"));
+                        if let Some(text) = value.and_then(|v| v.get("ok")).and_then(|v| v.as_str())
+                        {
+                            json!({ "type": "clipboard", "text": text }).to_string()
+                        } else {
+                            let err = value
+                                .and_then(|v| v.get("err"))
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("clipboard read failed");
+                            json!({ "type": "clipboard", "error": err }).to_string()
+                        }
                     }
-                    let err = value
-                        .and_then(|v| v.get("err"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("clipboard read failed");
-                    return Some(json!({ "type": "clipboard", "error": err }).to_string());
-                }
-                Err(e) => {
-                    return Some(json!({ "type": "clipboard", "error": e }).to_string());
-                }
-            }
+                    Err(e) => json!({ "type": "clipboard", "error": e }).to_string(),
+                };
+                let _ = reply_tx.send(reply).await;
+            });
         }
         "status" => {}
         _ => {}
     }
-    None
 }
 
 fn is_user_input_message_type(msg_type: &str) -> bool {

--- a/cli/src/native/stream/websocket.rs
+++ b/cli/src/native/stream/websocket.rs
@@ -329,19 +329,20 @@ async fn handle_client_message(
                 .await;
         }
         "input_keyboard" => {
+            // Chrome rejects the whole command when `text` is an explicit
+            // null, so only include the string fields that are present.
+            let mut params = json!({
+                "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("keyDown"),
+                "windowsVirtualKeyCode": parsed.get("windowsVirtualKeyCode").and_then(|v| v.as_i64()).unwrap_or(0),
+                "modifiers": parsed.get("modifiers").and_then(|v| v.as_i64()).unwrap_or(0),
+            });
+            for field in ["key", "code", "text"] {
+                if let Some(value) = parsed.get(field).and_then(|v| v.as_str()) {
+                    params[field] = json!(value);
+                }
+            }
             let _ = client
-                .send_command_no_wait(
-                    "Input.dispatchKeyEvent",
-                    Some(json!({
-                        "type": parsed.get("eventType").and_then(|v| v.as_str()).unwrap_or("keyDown"),
-                        "key": parsed.get("key"),
-                        "code": parsed.get("code"),
-                        "text": parsed.get("text"),
-                        "windowsVirtualKeyCode": parsed.get("windowsVirtualKeyCode").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "modifiers": parsed.get("modifiers").and_then(|v| v.as_i64()).unwrap_or(0),
-                    })),
-                    session_id,
-                )
+                .send_command_no_wait("Input.dispatchKeyEvent", Some(params), session_id)
                 .await;
         }
         "input_touch" => {

--- a/cli/src/native/stream/websocket.rs
+++ b/cli/src/native/stream/websocket.rs
@@ -264,13 +264,18 @@ async fn handle_ws_client(
                         let guard = client_slot.read().await;
                         if let Some(ref client) = *guard {
                             let sid = cdp_session_id.read().await;
-                            handle_client_message(
+                            let reply = handle_client_message(
                                 &text,
                                 client.as_ref(),
                                 sid.as_deref(),
                                 idle_activity.as_ref(),
                             )
                             .await;
+                            if let Some(reply) = reply {
+                                if ws_tx.send(Message::Text(reply)).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                     }
                     Some(Ok(Message::Close(_))) | None => break,
@@ -288,6 +293,9 @@ async fn handle_ws_client(
     client_notify.notify_one();
 }
 
+/// Handles one dashboard client message. Returns a message to send back to
+/// the client, if any (currently only clipboard read responses).
+///
 /// Input events are dispatched without awaiting Chrome's response: the
 /// response carries no data, and awaiting it serializes every event behind
 /// a CDP round trip (~one frame tick under software rendering), so a mouse
@@ -298,10 +306,10 @@ async fn handle_client_message(
     client: &CdpClient,
     session_id: Option<&str>,
     idle_activity: &IdleActivity,
-) {
+) -> Option<String> {
     let parsed: Value = match serde_json::from_str(msg) {
         Ok(v) => v,
-        Err(_) => return,
+        Err(_) => return None,
     };
 
     let msg_type = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -358,13 +366,65 @@ async fn handle_client_message(
                 )
                 .await;
         }
+        "input_insert_text" => {
+            // Paste bridge: insert local clipboard text at the focused element.
+            let text = parsed.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if !text.is_empty() {
+                let _ = client
+                    .send_command_no_wait(
+                        "Input.insertText",
+                        Some(json!({ "text": text })),
+                        session_id,
+                    )
+                    .await;
+            }
+        }
+        "input_read_clipboard" => {
+            // Copy bridge: read the remote clipboard after a copy/cut so the
+            // dashboard can mirror it into the local clipboard.
+            let result = client
+                .send_command(
+                    "Runtime.evaluate",
+                    Some(json!({
+                        "expression": "navigator.clipboard.readText().then(t => ({ ok: t }), e => ({ err: String(e) }))",
+                        "awaitPromise": true,
+                        "returnByValue": true,
+                    })),
+                    session_id,
+                )
+                .await;
+            match result {
+                Ok(result) => {
+                    let value = result.get("result").and_then(|r| r.get("value"));
+                    if let Some(text) = value.and_then(|v| v.get("ok")).and_then(|v| v.as_str()) {
+                        return Some(json!({ "type": "clipboard", "text": text }).to_string());
+                    }
+                    let err = value
+                        .and_then(|v| v.get("err"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("clipboard read failed");
+                    return Some(json!({ "type": "clipboard", "error": err }).to_string());
+                }
+                Err(e) => {
+                    return Some(json!({ "type": "clipboard", "error": e }).to_string());
+                }
+            }
+        }
         "status" => {}
         _ => {}
     }
+    None
 }
 
 fn is_user_input_message_type(msg_type: &str) -> bool {
-    matches!(msg_type, "input_mouse" | "input_keyboard" | "input_touch")
+    matches!(
+        msg_type,
+        "input_mouse"
+            | "input_keyboard"
+            | "input_touch"
+            | "input_insert_text"
+            | "input_read_clipboard"
+    )
 }
 
 #[cfg(test)]
@@ -373,7 +433,13 @@ mod tests {
 
     #[test]
     fn dashboard_input_messages_count_as_user_activity() {
-        for msg_type in ["input_mouse", "input_keyboard", "input_touch"] {
+        for msg_type in [
+            "input_mouse",
+            "input_keyboard",
+            "input_touch",
+            "input_insert_text",
+            "input_read_clipboard",
+        ] {
             assert!(is_user_input_message_type(msg_type));
         }
         assert!(!is_user_input_message_type("status"));

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -68,7 +68,53 @@ const KEY_INFO: Record<string, { text?: string; keyCode: number }> = {
   End: { keyCode: 35 },
   PageUp: { keyCode: 33 },
   PageDown: { keyCode: 34 },
+  Shift: { keyCode: 16 },
+  Control: { keyCode: 17 },
+  Alt: { keyCode: 18 },
+  Meta: { keyCode: 91 },
+  CapsLock: { keyCode: 20 },
+  " ": { text: " ", keyCode: 32 },
 };
+
+// Windows virtual-key codes for punctuation, keyed by the layout-independent
+// KeyboardEvent.code (US OEM table, same as Puppeteer).
+const CODE_KEY_INFO: Record<string, number> = {
+  Minus: 189,
+  Equal: 187,
+  BracketLeft: 219,
+  BracketRight: 221,
+  Backslash: 220,
+  Semicolon: 186,
+  Quote: 222,
+  Comma: 188,
+  Period: 190,
+  Slash: 191,
+  Backquote: 192,
+  NumpadAdd: 107,
+  NumpadSubtract: 109,
+  NumpadMultiply: 106,
+  NumpadDivide: 111,
+  NumpadDecimal: 110,
+};
+
+/**
+ * Windows virtual-key code for a keyboard event. Chrome matches editing
+ * shortcuts against this code, and letter VKs are uppercase ASCII:
+ * `key.charCodeAt(0)` on a lowercase letter yields a numpad VK instead,
+ * which silently breaks every Ctrl+letter shortcut.
+ */
+function vkCodeForEvent(e: KeyboardEvent): number {
+  const code = e.code;
+  if (/^Key[A-Z]$/.test(code)) return code.charCodeAt(3);
+  if (/^Digit[0-9]$/.test(code)) return 48 + Number(code[5]);
+  if (/^Numpad[0-9]$/.test(code)) return 96 + Number(code[6]);
+  if (/^F([1-9]|1[0-2])$/.test(code)) return 111 + Number(code.slice(1));
+  const fromCode = CODE_KEY_INFO[code];
+  if (fromCode !== undefined) return fromCode;
+  const info = KEY_INFO[e.key];
+  if (info) return info.keyCode;
+  return e.key.length === 1 ? e.key.toUpperCase().charCodeAt(0) : 0;
+}
 
 function cdpButton(btn: number): string {
   switch (btn) {
@@ -360,10 +406,14 @@ export function Viewport() {
   const dispatchKey = useCallback(
     (e: KeyboardEvent, eventType: string) => {
       const info = KEY_INFO[e.key];
-      const text = eventType === "keyDown"
-        ? (info?.text ?? (e.key.length === 1 ? e.key : undefined))
-        : undefined;
-      const keyCode = info?.keyCode ?? (e.key.length === 1 ? e.key.charCodeAt(0) : 0);
+      const hasShortcutModifier = e.ctrlKey || e.metaKey || e.altKey;
+      // Shortcut combos go out as rawKeyDown with no text, or Chrome treats
+      // them as text input instead of an editing command.
+      const text =
+        eventType === "keyDown" && !hasShortcutModifier
+          ? (info?.text ?? (e.key.length === 1 ? e.key : undefined))
+          : undefined;
+      const keyCode = vkCodeForEvent(e);
       let m = 0;
       if (e.altKey) m |= 1;
       if (e.ctrlKey) m |= 2;
@@ -371,7 +421,8 @@ export function Viewport() {
       if (e.shiftKey) m |= 8;
       sendInput({
         type: "input_keyboard",
-        eventType,
+        eventType:
+          eventType === "keyDown" && text === undefined ? "rawKeyDown" : eventType,
         key: e.key,
         code: e.code,
         text,

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -503,9 +503,15 @@ export function Viewport() {
 
     const forwardPasteShortcut = (e: KeyboardEvent) => {
       // The remote clipboard has no access to the local one, so read the
-      // local clipboard and insert its text directly.
-      navigator.clipboard
-        .readText()
+      // local clipboard and insert its text directly. navigator.clipboard is
+      // undefined in insecure contexts (and readText in some browsers), so
+      // fall back to forwarding the raw paste keystroke.
+      const readText = navigator.clipboard?.readText?.bind(navigator.clipboard);
+      if (!readText) {
+        dispatchKey(e, "rawKeyDown");
+        return;
+      }
+      readText()
         .then((text) => {
           if (text) {
             sendInput({ type: "input_insert_text", text });

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -45,6 +45,9 @@ import { activeSessionNameAtom, activePortAtom } from "@/store/sessions";
 
 const SCREENCAST_ENGINES = new Set(["chrome"]);
 
+// Minimum interval between forwarded mouseMoved events (~25/s).
+const MOUSEMOVE_INTERVAL_MS = 40;
+
 function cdpModifiers(e: React.MouseEvent | React.WheelEvent): number {
   let m = 0;
   if (e.altKey) m |= 1;
@@ -384,6 +387,61 @@ export function Viewport() {
     [toViewport, sendInput],
   );
 
+  // Coalesce mouseMoved events: a sweep fires 60-125 events/s and Chrome
+  // needs ~a frame tick per event, so an unthrottled flood builds a backlog
+  // that a following click waits behind. Only the latest position matters.
+  const moveThrottleRef = useRef<{
+    last: number;
+    timer: ReturnType<typeof setTimeout> | null;
+    pending: { x: number; y: number; modifiers: number } | null;
+  }>({ last: 0, timer: null, pending: null });
+
+  useEffect(() => {
+    const state = moveThrottleRef.current;
+    return () => {
+      if (state.timer) clearTimeout(state.timer);
+    };
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = toViewport(e);
+      if (!pos) return;
+      const modifiers = cdpModifiers(e);
+      const state = moveThrottleRef.current;
+      const send = (p: { x: number; y: number; modifiers: number }) =>
+        sendInput({
+          type: "input_mouse",
+          eventType: "mouseMoved",
+          x: p.x,
+          y: p.y,
+          button: "none",
+          clickCount: 0,
+          modifiers: p.modifiers,
+        });
+      const now = performance.now();
+      const elapsed = now - state.last;
+      if (elapsed >= MOUSEMOVE_INTERVAL_MS) {
+        state.last = now;
+        send({ ...pos, modifiers });
+      } else {
+        state.pending = { ...pos, modifiers };
+        if (!state.timer) {
+          state.timer = setTimeout(() => {
+            state.timer = null;
+            const pending = state.pending;
+            state.pending = null;
+            if (pending) {
+              state.last = performance.now();
+              send(pending);
+            }
+          }, MOUSEMOVE_INTERVAL_MS - elapsed);
+        }
+      }
+    },
+    [toViewport, sendInput],
+  );
+
   const handleWheel = useCallback(
     (e: React.WheelEvent) => {
       const pos = toViewport(e);
@@ -565,7 +623,7 @@ export function Viewport() {
             ref={canvasRef}
             tabIndex={0}
             className="max-h-full max-w-full object-contain outline-none"
-            onMouseMove={(e) => handleMouseEvent(e, "mouseMoved")}
+            onMouseMove={handleMouseMove}
             onMouseDown={(e) => {
               canvasRef.current?.focus();
               handleMouseEvent(e, "mousePressed");

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -492,10 +492,46 @@ export function Viewport() {
   );
 
   useEffect(() => {
+    const forwardCopyShortcut = (e: KeyboardEvent) => {
+      // Copy remotely with the corrected key event, then mirror the remote
+      // clipboard back into the local one.
+      dispatchKey(e, "rawKeyDown");
+      window.setTimeout(() => {
+        sendInput({ type: "input_read_clipboard" });
+      }, 150);
+    };
+
+    const forwardPasteShortcut = (e: KeyboardEvent) => {
+      // The remote clipboard has no access to the local one, so read the
+      // local clipboard and insert its text directly.
+      navigator.clipboard
+        .readText()
+        .then((text) => {
+          if (text) {
+            sendInput({ type: "input_insert_text", text });
+          } else {
+            dispatchKey(e, "rawKeyDown");
+          }
+        })
+        .catch(() => dispatchKey(e, "rawKeyDown"));
+    };
+
     const handler = (e: KeyboardEvent) => {
       if (document.activeElement !== canvasRef.current) return;
       e.preventDefault();
       e.stopPropagation();
+      const isShortcut = (e.ctrlKey || e.metaKey) && !e.altKey && e.key.length === 1;
+      if (e.type === "keydown" && isShortcut) {
+        const key = e.key.toLowerCase();
+        if (key === "v") {
+          forwardPasteShortcut(e);
+          return;
+        }
+        if (key === "c" || key === "x") {
+          forwardCopyShortcut(e);
+          return;
+        }
+      }
       dispatchKey(e, e.type === "keydown" ? "keyDown" : "keyUp");
     };
     window.addEventListener("keydown", handler, true);
@@ -504,7 +540,7 @@ export function Viewport() {
       window.removeEventListener("keydown", handler, true);
       window.removeEventListener("keyup", handler, true);
     };
-  }, [dispatchKey]);
+  }, [dispatchKey, sendInput]);
 
   return (
     <div ref={containerRef} className="flex h-full flex-col">

--- a/packages/dashboard/src/store/stream.ts
+++ b/packages/dashboard/src/store/stream.ts
@@ -214,6 +214,13 @@ export function useStreamSync(port: number) {
           );
           break;
 
+        case "clipboard":
+          // Copy bridge: mirror the remote clipboard into the local one.
+          if (msg.text != null) {
+            navigator.clipboard?.writeText(msg.text).catch(() => {});
+          }
+          break;
+
         case "error":
           break;
       }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -66,6 +66,12 @@ export interface ErrorMessage {
   message: string;
 }
 
+export interface ClipboardMessage {
+  type: "clipboard";
+  text?: string;
+  error?: string;
+}
+
 export interface TabInfo {
   /** Stable tab id like `t1`, `t2`. Never reused within a session. */
   tabId: string;
@@ -92,7 +98,8 @@ export type StreamMessage =
   | PageErrorMessage
   | ErrorMessage
   | UrlMessage
-  | TabsMessage;
+  | TabsMessage
+  | ClipboardMessage;
 
 export type ActivityEvent = CommandMessage | ResultMessage | ConsoleMessage;
 export type ConsoleEntry = ConsoleMessage | PageErrorMessage;


### PR DESCRIPTION
## Bug

Reported in #1615. In the dashboard's live view, clicks could take seconds to register after moving the mouse, and standard editing shortcuts (copy, paste, select all, ...) never reached the page. Three compounding causes:

- Every input event waited for Chrome's reply before the next message was read, and the reply carries no data. A mouse sweep's `mouseMoved` flood (60-125 events/s) serialized a following click behind seconds of backlog.
- Letter virtual-key codes were derived with `charCodeAt` on the lowercase key, which yields numpad VKs instead of the uppercase ASCII codes Chrome matches editing shortcuts against, so every Ctrl+letter shortcut was a no-op. Combos also went out with `text`, which Chrome treats as typing rather than a command, and the native side forwarded absent `key`/`code`/`text` fields as explicit null, which makes Chrome reject the whole `dispatchKeyEvent`.
- There was no clipboard path between the local machine and the remote page at all.

## Fix

- Dispatch stream input without awaiting CDP responses (socket writes stay ordered, so event order is preserved) and coalesce forwarded mouse moves to ~25/s; only the latest position matters.
- Derive VK codes from `KeyboardEvent.code` (uppercase ASCII for letters, US OEM table for punctuation, same as Puppeteer); send shortcut combos as `rawKeyDown` without text; omit absent optional fields on the native side.
- Bridge the clipboard: Ctrl+C/X copies remotely and mirrors the remote clipboard back into the local one; Ctrl+V reads the local clipboard and inserts its text at the focus, falling back to the raw paste keystroke where the local clipboard API is unavailable (insecure LAN origins, Firefox without `readText`). `clipboard-read`/`clipboard-write` permissions are granted at screencast start. Slow clipboard reads run in a spawned task so they can't freeze that client's screencast frames or input.

## Verification

- New (ignored) e2e `e2e_stream_input_dispatch_and_clipboard_bridge` drives copy/paste through the real stream path; unit test for the new input message types. Suite 1028/1028, `cargo fmt`/`clippy` clean, dashboard `tsc` + `next build` clean.
- Live dashboard: 300-event mouse sweep then click went from ~5s to ~35ms; Ctrl+A/C/V round-tripped text between the local clipboard and a textarea in the page, including unicode and a 100k-char paste.
- Adversarial review pass reproduced and fixed two follow-ups on this branch: slow clipboard reads head-of-line blocking frames/input (7e75ffc), and unguarded `navigator.clipboard` killing paste on insecure origins (521fdfe).

Fixes #1615.