### PR TITLE
fix(cli): reject unknown command options

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -372,9 +372,26 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             // scripts before the first real navigation (see `batch`).
             // `goto` and `navigate` still require a URL since those verbs
             // imply the navigation itself.
-            let first_url = rest.iter().find(|a| !a.starts_with("--"));
+            let mut first_url = None;
+            let mut options_ended = false;
+            for arg in &rest {
+                if !options_ended && *arg == "--" {
+                    options_ended = true;
+                } else if !options_ended && arg.starts_with('-') {
+                    return Err(ParseError::InvalidValue {
+                        message: format!("Unknown option '{}' for {}", arg, cmd),
+                        usage: if cmd == "open" {
+                            "open [url]"
+                        } else {
+                            "goto <url>"
+                        },
+                    });
+                } else if first_url.is_none() {
+                    first_url = Some(*arg);
+                }
+            }
             let url = match first_url {
-                Some(u) => *u,
+                Some(u) => u,
                 None if cmd == "open" => {
                     return Ok(json!({ "id": id, "action": "launch", "headless": !flags.headed }));
                 }
@@ -791,24 +808,30 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             // selector: @ref or CSS selector
             // path: file path (contains / or . or ends with known extension)
             let mut full_page = false;
-            let positional: Vec<&str> = rest
-                .iter()
-                .filter(|arg| match **arg {
-                    "--full" | "-f" => {
-                        full_page = true;
-                        false
-                    }
-                    _ => true,
-                })
-                .copied()
-                .collect();
+            let mut options_ended = false;
+            let mut positional = Vec::new();
+            for arg in &rest {
+                if !options_ended && *arg == "--" {
+                    options_ended = true;
+                } else if !options_ended && matches!(*arg, "--full" | "-f") {
+                    full_page = true;
+                } else if !options_ended && arg.starts_with('-') {
+                    return Err(ParseError::InvalidValue {
+                        message: format!("Unknown option '{}' for screenshot", arg),
+                        usage: "screenshot [selector] [path] [--full/-f]",
+                    });
+                } else {
+                    positional.push((*arg, options_ended));
+                }
+            }
             let (selector, path) = match (positional.first(), positional.get(1)) {
                 (Some(first), Some(second)) => {
                     // Two args: first is selector, second is path
-                    (Some(*first), Some(*second))
+                    (Some(first.0), Some(second.0))
                 }
                 (Some(first), None) => {
                     // One arg: determine if it's a selector or a path
+                    let (first, escaped) = *first;
                     let is_relative_path = first.starts_with("./") || first.starts_with("../");
                     let is_selector = !is_relative_path
                         && (first.starts_with('.')
@@ -818,11 +841,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         || first.ends_with(".jpg")
                         || first.ends_with(".jpeg")
                         || first.ends_with(".webp");
-                    let is_path = is_relative_path || first.contains('/') || has_path_extension;
+                    let is_path =
+                        escaped || is_relative_path || first.contains('/') || has_path_extension;
                     if is_selector || !is_path {
-                        (Some(*first), None)
+                        (Some(first), None)
                     } else {
-                        (None, Some(*first))
+                        (None, Some(first))
                     }
                 }
                 _ => (None, None),
@@ -3779,6 +3803,24 @@ mod tests {
     }
 
     #[test]
+    fn test_open_rejects_unknown_option() {
+        let result = parse_command(
+            &args("open --totally-bogus-flag https://example.com"),
+            &default_flags(),
+        );
+        let error = result.unwrap_err().format();
+        assert!(error.contains("Unknown option '--totally-bogus-flag' for open"));
+    }
+
+    #[test]
+    fn test_open_accepts_dash_prefixed_url_after_double_dash() {
+        let cmd =
+            parse_command(&args("open -- --totally-bogus-flag"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "navigate");
+        assert_eq!(cmd["url"], "https://--totally-bogus-flag");
+    }
+
+    #[test]
     fn test_read_command() {
         let cmd = parse_command(&args("read example.com/docs"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "read");
@@ -4388,6 +4430,26 @@ mod tests {
         assert_eq!(cmd["action"], "screenshot");
         assert_eq!(cmd["selector"], ".btn");
         assert_eq!(cmd["path"], "./button.png");
+    }
+
+    #[test]
+    fn test_screenshot_rejects_unknown_option() {
+        let result = parse_command(&args("screenshot --full-page"), &default_flags());
+        let error = result.unwrap_err().format();
+        assert!(error.contains("Unknown option '--full-page' for screenshot"));
+    }
+
+    #[test]
+    fn test_screenshot_rejects_unknown_option_after_selector() {
+        let result = parse_command(&args("screenshot body --full-page"), &default_flags());
+        assert!(matches!(result, Err(ParseError::InvalidValue { .. })));
+    }
+
+    #[test]
+    fn test_screenshot_accepts_dash_prefixed_path_after_double_dash() {
+        let cmd = parse_command(&args("screenshot -- --full-page"), &default_flags()).unwrap();
+        assert_eq!(cmd["selector"], serde_json::Value::Null);
+        assert_eq!(cmd["path"], "--full-page");
     }
 
     // === Snapshot ===


### PR DESCRIPTION
Closes #1622

## Summary

- reject unknown dash-prefixed options for `open`, `goto`, `navigate`, and `screenshot`
- preserve an explicit `--` separator for dash-prefixed navigation targets and screenshot paths
- add regression coverage for the reported `--full-page` cases and the navigation typo case

## Root cause

Global argument cleanup intentionally leaves command-specific arguments in place. The navigation parser then skipped every `--`-prefixed argument, while the screenshot parser treated every option other than `--full`/`-f` as positional input. That allowed typos to be silently ignored or used as selectors and output paths.

## Validation

- added parser unit tests for unknown options before and after screenshot positionals
- added parser unit tests for navigation rejection and explicit `--` escaping
- `git diff --check`
- Rust build, formatting, and test execution are left to CI because a complete local Rust toolchain was unavailable