### PR TITLE
feat(stream): configurable screencast quality and frame size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1420,6 +1420,25 @@ To bind to a specific port, set `AGENT_BROWSER_STREAM_PORT`:
 AGENT_BROWSER_STREAM_PORT=9223 agent-browser open example.com
 ```
 
+Frame encoding is daemon-wide:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_BROWSER_STREAM_FORMAT` | `jpeg` | `jpeg` or `png`. png is roughly 3x larger |
+| `AGENT_BROWSER_STREAM_QUALITY` | `80` | JPEG quality, 0 to 100 |
+| `AGENT_BROWSER_STREAM_MAX_WIDTH` | the viewport | Caps frame width in pixels |
+| `AGENT_BROWSER_STREAM_MAX_HEIGHT` | the viewport | Caps frame height in pixels |
+
+Width and height cap the encoded frame and leave the page size alone, so a portrait or HiDPI viewport keeps its resolution unless you cap it. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
+
+```bash
+# Cheaper frames for a constrained link
+AGENT_BROWSER_STREAM_QUALITY=20 \
+AGENT_BROWSER_STREAM_MAX_WIDTH=640 \
+AGENT_BROWSER_STREAM_MAX_HEIGHT=360 \
+agent-browser open example.com
+```
+
 You can also manage streaming at runtime with `stream enable`, `stream disable`, and `stream status`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1428,7 +1428,7 @@ Frame encoding is daemon-wide:
 | `AGENT_BROWSER_STREAM_MAX_WIDTH` | the viewport | Caps frame width in pixels |
 | `AGENT_BROWSER_STREAM_MAX_HEIGHT` | the viewport | Caps frame height in pixels |
 
-Width and height cap the encoded frame and leave the page size alone, so a portrait or HiDPI viewport keeps its resolution unless you cap it. Stream frames are always jpeg; `screencast_start` takes an explicit `format` when a caller needs png. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
+Width and height cap the encoded frame and leave the page size alone, so a portrait or HiDPI viewport keeps its resolution unless you cap it. The live stream requests jpeg. An explicit `screencast_start` reconfigures the same screencast, so a client can see the format change mid-stream. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
 
 ```bash
 # Cheaper frames for a constrained link

--- a/README.md
+++ b/README.md
@@ -1424,12 +1424,11 @@ Frame encoding is daemon-wide:
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENT_BROWSER_STREAM_FORMAT` | `jpeg` | `jpeg` or `png`. png is roughly 3x larger |
 | `AGENT_BROWSER_STREAM_QUALITY` | `80` | JPEG quality, 0 to 100 |
 | `AGENT_BROWSER_STREAM_MAX_WIDTH` | the viewport | Caps frame width in pixels |
 | `AGENT_BROWSER_STREAM_MAX_HEIGHT` | the viewport | Caps frame height in pixels |
 
-Width and height cap the encoded frame and leave the page size alone, so a portrait or HiDPI viewport keeps its resolution unless you cap it. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
+Width and height cap the encoded frame and leave the page size alone, so a portrait or HiDPI viewport keeps its resolution unless you cap it. Stream frames are always jpeg; `screencast_start` takes an explicit `format` when a caller needs png. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
 
 ```bash
 # Cheaper frames for a constrained link

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7771,10 +7771,7 @@ async fn handle_screencast_start(cmd: &Value, state: &mut DaemonState) -> Result
     };
     let default_w = env_cfg.max_width.unwrap_or(viewport_w);
     let default_h = env_cfg.max_height.unwrap_or(viewport_h);
-    let format = cmd
-        .get("format")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&env_cfg.format);
+    let format = cmd.get("format").and_then(|v| v.as_str()).unwrap_or("jpeg");
     let quality = cmd
         .get("quality")
         .and_then(|v| v.as_i64())

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7762,15 +7762,16 @@ async fn handle_screencast_start(cmd: &Value, state: &mut DaemonState) -> Result
     }
 
     // Use stored viewport as default for screencast dimensions
-    // Env defaults, so the explicit command and the live stream encode alike.
+    // Quality only. The frame-size env vars are deliberately not applied here:
+    // this command reports its dimensions as the viewport in the status
+    // broadcast, and clients scale pointer coordinates by that, so a smaller
+    // encode would move every click.
     let env_cfg = stream::ScreencastConfig::from_env();
-    let (viewport_w, viewport_h) = if let Some(ref server) = state.stream_server {
+    let (default_w, default_h) = if let Some(ref server) = state.stream_server {
         server.viewport().await
     } else {
         (1280, 720)
     };
-    let default_w = env_cfg.max_width.unwrap_or(viewport_w);
-    let default_h = env_cfg.max_height.unwrap_or(viewport_h);
     let format = cmd.get("format").and_then(|v| v.as_str()).unwrap_or("jpeg");
     let quality = cmd
         .get("quality")

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7762,13 +7762,24 @@ async fn handle_screencast_start(cmd: &Value, state: &mut DaemonState) -> Result
     }
 
     // Use stored viewport as default for screencast dimensions
-    let (default_w, default_h) = if let Some(ref server) = state.stream_server {
+    // Env defaults, so the explicit command and the live stream encode alike.
+    let env_cfg = stream::ScreencastConfig::from_env();
+    let (viewport_w, viewport_h) = if let Some(ref server) = state.stream_server {
         server.viewport().await
     } else {
         (1280, 720)
     };
-    let format = cmd.get("format").and_then(|v| v.as_str()).unwrap_or("jpeg");
-    let quality = cmd.get("quality").and_then(|v| v.as_i64()).unwrap_or(80) as i32;
+    let default_w = env_cfg.max_width.unwrap_or(viewport_w);
+    let default_h = env_cfg.max_height.unwrap_or(viewport_h);
+    let format = cmd
+        .get("format")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&env_cfg.format);
+    let quality = cmd
+        .get("quality")
+        .and_then(|v| v.as_i64())
+        .map(|q| q as i32)
+        .unwrap_or(env_cfg.quality);
     let max_width = cmd
         .get("maxWidth")
         .and_then(|v| v.as_i64())

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -29,6 +29,7 @@ fn frame_timestamp_ms(meta: Option<&Value>) -> u64 {
 pub(super) async fn cdp_event_loop(
     frame_tx: broadcast::Sender<String>,
     frame_watch: watch::Sender<Option<Arc<super::StreamFrame>>>,
+    screencast_config: Arc<super::ScreencastConfig>,
     client_slot: Arc<RwLock<Option<Arc<CdpClient>>>>,
     client_notify: Arc<tokio::sync::Notify>,
     screencasting: Arc<Mutex<bool>>,
@@ -83,10 +84,10 @@ pub(super) async fn cdp_event_loop(
                         .send_command(
                             "Page.startScreencast",
                             Some(json!({
-                                "format": "jpeg",
-                                "quality": 80,
-                                "maxWidth": vw,
-                                "maxHeight": vh,
+                                "format": screencast_config.format,
+                                "quality": screencast_config.quality,
+                                "maxWidth": screencast_config.max_width.unwrap_or(vw),
+                                "maxHeight": screencast_config.max_height.unwrap_or(vh),
                                 "everyNthFrame": 1,
                             })),
                             session_id.as_deref(),

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -84,7 +84,7 @@ pub(super) async fn cdp_event_loop(
                         .send_command(
                             "Page.startScreencast",
                             Some(json!({
-                                "format": screencast_config.format,
+                                "format": "jpeg",
                                 "quality": screencast_config.quality,
                                 "maxWidth": screencast_config.max_width.unwrap_or(vw),
                                 "maxHeight": screencast_config.max_height.unwrap_or(vh),

--- a/cli/src/native/stream/mod.rs
+++ b/cli/src/native/stream/mod.rs
@@ -23,10 +23,12 @@ use super::cdp::client::CdpClient;
 /// session viewport. Defaulting them to a fixed size would downscale every
 /// viewport larger than it.
 ///
-/// Frame format stays jpeg here on purpose. A `frame` message carries no format
-/// field, so a daemon-wide switch would leave every connected client decoding
-/// blind, and png measures about 3x larger. The `screencast_start` command
-/// still takes an explicit format, where the caller knows what it asked for.
+/// No format knob here on purpose: a `frame` message carries no format field, so
+/// a daemon-wide switch would leave connected clients decoding blind, and png
+/// measures about 3x larger.
+///
+/// Not an invariant, though. `screencast_start` reconfigures the same shared
+/// screencast, so an explicit png request does reach stream clients mid-flight.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScreencastConfig {
     pub quality: i32,
@@ -66,9 +68,12 @@ impl ScreencastConfig {
     /// stream that silently stops is worse than one that ignores a typo.
     fn parse(quality: Option<&str>, max_width: Option<&str>, max_height: Option<&str>) -> Self {
         let d = Self::default();
+        // CDP types these as signed, so a value past i32::MAX makes it reject
+        // the whole command. The caller discards that error, so the stream
+        // would stop with no frames and no signal.
         let dimension = |v: Option<&str>| {
             v.and_then(|s| s.trim().parse::<u32>().ok())
-                .filter(|n| *n > 0)
+                .filter(|n| *n > 0 && *n <= i32::MAX as u32)
         };
         Self {
             // Clamped, since CDP accepts an out-of-range quality and ignores it,
@@ -654,8 +659,9 @@ mod tests {
             ScreencastConfig::parse(Some("high"), None, None).quality,
             d.quality
         );
-        // Zero and negative dimensions are dropped, so the viewport is used.
-        for bad in ["0", "-100", "wide"] {
+        // Dropped, so the viewport is used: zero, negative, non-numeric, and
+        // anything past i32::MAX, which CDP rejects outright.
+        for bad in ["0", "-100", "wide", "4294967295", "2147483648"] {
             assert_eq!(
                 ScreencastConfig::parse(None, Some(bad), Some(bad)).max_width,
                 None

--- a/cli/src/native/stream/mod.rs
+++ b/cli/src/native/stream/mod.rs
@@ -17,6 +17,79 @@ use tokio::sync::{broadcast, watch, Mutex, Notify, RwLock};
 
 use super::cdp::client::CdpClient;
 
+/// Screencast encoding, from `AGENT_BROWSER_STREAM_*`.
+///
+/// Invariant: `max_width` and `max_height` are overrides, so `None` keeps the
+/// session viewport. Defaulting them to a fixed size would downscale every
+/// viewport larger than it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreencastConfig {
+    pub format: String,
+    pub quality: i32,
+    pub max_width: Option<u32>,
+    pub max_height: Option<u32>,
+}
+
+impl Default for ScreencastConfig {
+    fn default() -> Self {
+        Self {
+            format: "jpeg".to_string(),
+            quality: 80,
+            max_width: None,
+            max_height: None,
+        }
+    }
+}
+
+impl ScreencastConfig {
+    pub fn from_env() -> Self {
+        Self::parse(
+            std::env::var("AGENT_BROWSER_STREAM_FORMAT").ok().as_deref(),
+            std::env::var("AGENT_BROWSER_STREAM_QUALITY")
+                .ok()
+                .as_deref(),
+            std::env::var("AGENT_BROWSER_STREAM_MAX_WIDTH")
+                .ok()
+                .as_deref(),
+            std::env::var("AGENT_BROWSER_STREAM_MAX_HEIGHT")
+                .ok()
+                .as_deref(),
+        )
+    }
+
+    /// Split from `from_env` so the parsing rules are testable without mutating
+    /// process environment, which races across parallel tests.
+    ///
+    /// Invariant: an unset or unusable value leaves the default in place. A
+    /// stream that silently stops is worse than one that ignores a typo.
+    fn parse(
+        format: Option<&str>,
+        quality: Option<&str>,
+        max_width: Option<&str>,
+        max_height: Option<&str>,
+    ) -> Self {
+        let d = Self::default();
+        let dimension = |v: Option<&str>| {
+            v.and_then(|s| s.trim().parse::<u32>().ok())
+                .filter(|n| *n > 0)
+        };
+        Self {
+            format: format
+                .map(|s| s.trim().to_ascii_lowercase())
+                .filter(|s| s == "jpeg" || s == "png")
+                .unwrap_or(d.format),
+            // Clamped, since CDP accepts an out-of-range quality and ignores it,
+            // which reads as "the setting does nothing".
+            quality: quality
+                .and_then(|s| s.trim().parse::<i32>().ok())
+                .map(|q| q.clamp(0, 100))
+                .unwrap_or(d.quality),
+            max_width: dimension(max_width),
+            max_height: dimension(max_height),
+        }
+    }
+}
+
 /// Invariant: frame ids are process-wide, never per server. A per-server
 /// counter restarts on browser relaunch, and an ack pacing client that banked a
 /// higher id would never receive another frame.
@@ -110,6 +183,7 @@ pub struct StreamServer {
     port: u16,
     session_name: String,
     frame_tx: broadcast::Sender<String>,
+    screencast_config: Arc<ScreencastConfig>,
     /// Latest-value channel for screencast frames. Slow clients skip straight
     /// to the newest frame instead of draining a stale ordered backlog.
     frame_watch: watch::Sender<Option<Arc<StreamFrame>>>,
@@ -258,6 +332,7 @@ impl StreamServer {
 
         let (frame_tx, _) = broadcast::channel::<String>(64);
         let (frame_watch_tx, frame_watch_rx) = watch::channel::<Option<Arc<StreamFrame>>>(None);
+        let screencast_config = Arc::new(ScreencastConfig::from_env());
         let client_count = Arc::new(Mutex::new(0usize));
         let client_notify = Arc::new(Notify::new());
         let screencasting = Arc::new(Mutex::new(false));
@@ -319,10 +394,12 @@ impl StreamServer {
         let last_engine_bg = last_engine.clone();
         let recording_bg = recording.clone();
         let frame_watch_bg = frame_watch_tx.clone();
+        let screencast_cfg_bg = screencast_config.clone();
         let cdp_task = tokio::spawn(async move {
             cdp_loop::cdp_event_loop(
                 frame_tx_bg,
                 frame_watch_bg,
+                screencast_cfg_bg,
                 client_slot_bg,
                 client_notify_bg,
                 screencasting_bg,
@@ -344,6 +421,7 @@ impl StreamServer {
                 session_name: session_id,
                 frame_tx,
                 frame_watch: frame_watch_tx,
+                screencast_config,
                 client_count,
                 client_slot: client_slot.clone(),
                 cdp_session_id,
@@ -539,6 +617,74 @@ pub fn is_allowed_origin(origin: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_screencast_config_defaults_when_unset() {
+        let c = ScreencastConfig::parse(None, None, None, None);
+        assert_eq!(c, ScreencastConfig::default());
+        // Dimensions stay unset so the session viewport wins.
+        assert_eq!(c.max_width, None);
+        assert_eq!(c.max_height, None);
+    }
+
+    #[test]
+    fn test_screencast_config_reads_values() {
+        let c = ScreencastConfig::parse(Some("png"), Some("30"), Some("640"), Some("360"));
+        assert_eq!(c.format, "png");
+        assert_eq!(c.quality, 30);
+        assert_eq!(c.max_width, Some(640));
+        assert_eq!(c.max_height, Some(360));
+        assert_eq!(
+            ScreencastConfig::parse(Some(" JPEG "), Some(" 55 "), None, None).format,
+            "jpeg"
+        );
+    }
+
+    /// CDP accepts an out-of-range quality and then ignores it, so the setting
+    /// would look like it does nothing. Clamp instead.
+    #[test]
+    fn test_screencast_config_clamps_quality() {
+        assert_eq!(
+            ScreencastConfig::parse(None, Some("500"), None, None).quality,
+            100
+        );
+        assert_eq!(
+            ScreencastConfig::parse(None, Some("-5"), None, None).quality,
+            0
+        );
+        assert_eq!(
+            ScreencastConfig::parse(None, Some("0"), None, None).quality,
+            0
+        );
+    }
+
+    /// An unusable value leaves the default. A stream that silently stops is
+    /// worse than one that ignores a typo.
+    #[test]
+    fn test_screencast_config_ignores_unusable_values() {
+        let d = ScreencastConfig::default();
+        for bad in ["webp", "", "gif"] {
+            assert_eq!(
+                ScreencastConfig::parse(Some(bad), None, None, None).format,
+                d.format
+            );
+        }
+        assert_eq!(
+            ScreencastConfig::parse(None, Some("high"), None, None).quality,
+            d.quality
+        );
+        // Zero and negative dimensions are dropped, so the viewport is used.
+        for bad in ["0", "-100", "wide"] {
+            assert_eq!(
+                ScreencastConfig::parse(None, None, Some(bad), Some(bad)).max_width,
+                None
+            );
+            assert_eq!(
+                ScreencastConfig::parse(None, None, Some(bad), Some(bad)).max_height,
+                None
+            );
+        }
+    }
 
     #[test]
     fn test_allowed_origin_none() {

--- a/cli/src/native/stream/mod.rs
+++ b/cli/src/native/stream/mod.rs
@@ -17,14 +17,18 @@ use tokio::sync::{broadcast, watch, Mutex, Notify, RwLock};
 
 use super::cdp::client::CdpClient;
 
-/// Screencast encoding, from `AGENT_BROWSER_STREAM_*`.
+/// Screencast encoding for the live stream, from `AGENT_BROWSER_STREAM_*`.
 ///
 /// Invariant: `max_width` and `max_height` are overrides, so `None` keeps the
 /// session viewport. Defaulting them to a fixed size would downscale every
 /// viewport larger than it.
+///
+/// Frame format stays jpeg here on purpose. A `frame` message carries no format
+/// field, so a daemon-wide switch would leave every connected client decoding
+/// blind, and png measures about 3x larger. The `screencast_start` command
+/// still takes an explicit format, where the caller knows what it asked for.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScreencastConfig {
-    pub format: String,
     pub quality: i32,
     pub max_width: Option<u32>,
     pub max_height: Option<u32>,
@@ -33,7 +37,6 @@ pub struct ScreencastConfig {
 impl Default for ScreencastConfig {
     fn default() -> Self {
         Self {
-            format: "jpeg".to_string(),
             quality: 80,
             max_width: None,
             max_height: None,
@@ -44,7 +47,6 @@ impl Default for ScreencastConfig {
 impl ScreencastConfig {
     pub fn from_env() -> Self {
         Self::parse(
-            std::env::var("AGENT_BROWSER_STREAM_FORMAT").ok().as_deref(),
             std::env::var("AGENT_BROWSER_STREAM_QUALITY")
                 .ok()
                 .as_deref(),
@@ -62,22 +64,13 @@ impl ScreencastConfig {
     ///
     /// Invariant: an unset or unusable value leaves the default in place. A
     /// stream that silently stops is worse than one that ignores a typo.
-    fn parse(
-        format: Option<&str>,
-        quality: Option<&str>,
-        max_width: Option<&str>,
-        max_height: Option<&str>,
-    ) -> Self {
+    fn parse(quality: Option<&str>, max_width: Option<&str>, max_height: Option<&str>) -> Self {
         let d = Self::default();
         let dimension = |v: Option<&str>| {
             v.and_then(|s| s.trim().parse::<u32>().ok())
                 .filter(|n| *n > 0)
         };
         Self {
-            format: format
-                .map(|s| s.trim().to_ascii_lowercase())
-                .filter(|s| s == "jpeg" || s == "png")
-                .unwrap_or(d.format),
             // Clamped, since CDP accepts an out-of-range quality and ignores it,
             // which reads as "the setting does nothing".
             quality: quality
@@ -620,7 +613,7 @@ mod tests {
 
     #[test]
     fn test_screencast_config_defaults_when_unset() {
-        let c = ScreencastConfig::parse(None, None, None, None);
+        let c = ScreencastConfig::parse(None, None, None);
         assert_eq!(c, ScreencastConfig::default());
         // Dimensions stay unset so the session viewport wins.
         assert_eq!(c.max_width, None);
@@ -629,14 +622,14 @@ mod tests {
 
     #[test]
     fn test_screencast_config_reads_values() {
-        let c = ScreencastConfig::parse(Some("png"), Some("30"), Some("640"), Some("360"));
-        assert_eq!(c.format, "png");
+        let c = ScreencastConfig::parse(Some("30"), Some("640"), Some("360"));
         assert_eq!(c.quality, 30);
         assert_eq!(c.max_width, Some(640));
         assert_eq!(c.max_height, Some(360));
+        // Whitespace is tolerated.
         assert_eq!(
-            ScreencastConfig::parse(Some(" JPEG "), Some(" 55 "), None, None).format,
-            "jpeg"
+            ScreencastConfig::parse(Some(" 55 "), None, None).quality,
+            55
         );
     }
 
@@ -645,17 +638,11 @@ mod tests {
     #[test]
     fn test_screencast_config_clamps_quality() {
         assert_eq!(
-            ScreencastConfig::parse(None, Some("500"), None, None).quality,
+            ScreencastConfig::parse(Some("500"), None, None).quality,
             100
         );
-        assert_eq!(
-            ScreencastConfig::parse(None, Some("-5"), None, None).quality,
-            0
-        );
-        assert_eq!(
-            ScreencastConfig::parse(None, Some("0"), None, None).quality,
-            0
-        );
+        assert_eq!(ScreencastConfig::parse(Some("-5"), None, None).quality, 0);
+        assert_eq!(ScreencastConfig::parse(Some("0"), None, None).quality, 0);
     }
 
     /// An unusable value leaves the default. A stream that silently stops is
@@ -663,24 +650,18 @@ mod tests {
     #[test]
     fn test_screencast_config_ignores_unusable_values() {
         let d = ScreencastConfig::default();
-        for bad in ["webp", "", "gif"] {
-            assert_eq!(
-                ScreencastConfig::parse(Some(bad), None, None, None).format,
-                d.format
-            );
-        }
         assert_eq!(
-            ScreencastConfig::parse(None, Some("high"), None, None).quality,
+            ScreencastConfig::parse(Some("high"), None, None).quality,
             d.quality
         );
         // Zero and negative dimensions are dropped, so the viewport is used.
         for bad in ["0", "-100", "wide"] {
             assert_eq!(
-                ScreencastConfig::parse(None, None, Some(bad), Some(bad)).max_width,
+                ScreencastConfig::parse(None, Some(bad), Some(bad)).max_width,
                 None
             );
             assert_eq!(
-                ScreencastConfig::parse(None, None, Some(bad), Some(bad)).max_height,
+                ScreencastConfig::parse(None, Some(bad), Some(bad)).max_height,
                 None
             );
         }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3795,6 +3795,10 @@ Environment:
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete saved states older than N days (default: 30)
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM session encryption
   AGENT_BROWSER_STREAM_PORT      Override WebSocket streaming port (default: OS-assigned)
+  AGENT_BROWSER_STREAM_FORMAT    Frame format: jpeg or png (default: jpeg)
+  AGENT_BROWSER_STREAM_QUALITY   JPEG quality 0-100 (default: 80)
+  AGENT_BROWSER_STREAM_MAX_WIDTH  Cap frame width in pixels (default: the viewport)
+  AGENT_BROWSER_STREAM_MAX_HEIGHT Cap frame height in pixels (default: the viewport)
   AGENT_BROWSER_IDLE_TIMEOUT_MS  Auto-shutdown daemon after N ms of inactivity (default: 3600000 = 1h; 0 disables)
                                  Dashboard input resets the timer; headed, Safari/iOS WebDriver, and user-attached browsers are exempt from the default
                                  Provider-owned cloud browsers remain eligible for default cleanup

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3795,7 +3795,6 @@ Environment:
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete saved states older than N days (default: 30)
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM session encryption
   AGENT_BROWSER_STREAM_PORT      Override WebSocket streaming port (default: OS-assigned)
-  AGENT_BROWSER_STREAM_FORMAT    Frame format: jpeg or png (default: jpeg)
   AGENT_BROWSER_STREAM_QUALITY   JPEG quality 0-100 (default: 80)
   AGENT_BROWSER_STREAM_MAX_WIDTH  Cap frame width in pixels (default: the viewport)
   AGENT_BROWSER_STREAM_MAX_HEIGHT Cap frame height in pixels (default: the viewport)

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -277,6 +277,9 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_ANNOTATE</code></td><td>Enable annotated screenshots by default.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_CDP</code></td><td>Connect the daemon to a CDP port or WebSocket URL.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_STREAM_PORT</code></td><td>Override the WebSocket streaming port. By default, an OS-assigned port is used. Set this to bind to a specific port (e.g., <code>9223</code>).</td><td>OS-assigned</td></tr>
+    <tr><td><code>AGENT_BROWSER_STREAM_QUALITY</code></td><td>JPEG quality for streamed frames, 0 to 100. Lower values cut bandwidth: quality 20 costs about half the bytes of the default on a busy page.</td><td><code>80</code></td></tr>
+    <tr><td><code>AGENT_BROWSER_STREAM_MAX_WIDTH</code></td><td>Cap the encoded frame width in pixels. Caps the frame only and leaves the page size alone, so pointer coordinates are unaffected.</td><td>the viewport</td></tr>
+    <tr><td><code>AGENT_BROWSER_STREAM_MAX_HEIGHT</code></td><td>Cap the encoded frame height in pixels.</td><td>the viewport</td></tr>
     <tr><td><code>AGENT_BROWSER_IDLE_TIMEOUT_MS</code></td><td>Auto-shutdown the daemon after N ms without commands or dashboard input. Set <code>0</code> to disable. Headed browsers, Safari and iOS WebDriver sessions, and user-attached browsers are exempt from the default. Provider-owned cloud browsers are eligible for cleanup, and an explicit value applies to every browser.</td><td><code>3600000</code> (1 hour)</td></tr>
     <tr><td><code>AGENT_BROWSER_IOS_DEVICE</code></td><td>Default iOS device name for the <code>ios</code> provider.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_IOS_UDID</code></td><td>Default iOS device UDID for the <code>ios</code> provider.</td><td>(none)</td></tr>

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -49,7 +49,7 @@ The lower-level `screencast_start` and `screencast_stop` commands still control 
 
 Connect to `ws://localhost:9223` to receive frames and send input.
 
-Frame encoding is set per daemon with `AGENT_BROWSER_STREAM_FORMAT` (`jpeg` or `png`), `AGENT_BROWSER_STREAM_QUALITY` (0 to 100), `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT`. Width and height cap the frame and default to the session viewport. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
+Frame encoding is set per daemon with `AGENT_BROWSER_STREAM_QUALITY` (0 to 100), `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT`. Stream frames are always jpeg. Width and height cap the frame and default to the session viewport. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
 
 Browser clients must load from `localhost`, `127.0.0.1`, `::1` or `file://`. Any other origin gets a 403 on the upgrade and needs a proxy.
 

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -49,6 +49,8 @@ The lower-level `screencast_start` and `screencast_stop` commands still control 
 
 Connect to `ws://localhost:9223` to receive frames and send input.
 
+Frame encoding is set per daemon with `AGENT_BROWSER_STREAM_FORMAT` (`jpeg` or `png`), `AGENT_BROWSER_STREAM_QUALITY` (0 to 100), `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT`. Width and height cap the frame and default to the session viewport. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
+
 Browser clients must load from `localhost`, `127.0.0.1`, `::1` or `file://`. Any other origin gets a 403 on the upgrade and needs a proxy.
 
 ### Frame messages

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -49,7 +49,7 @@ The lower-level `screencast_start` and `screencast_stop` commands still control 
 
 Connect to `ws://localhost:9223` to receive frames and send input.
 
-Frame encoding is set per daemon with `AGENT_BROWSER_STREAM_QUALITY` (0 to 100), `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT`. Stream frames are always jpeg. Width and height cap the frame and default to the session viewport. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
+Frame encoding is set per daemon with `AGENT_BROWSER_STREAM_QUALITY` (0 to 100), `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT`. The live stream requests jpeg. An explicit `screencast_start` reconfigures the same underlying screencast, so a client can see the format change mid-stream. Width and height cap the frame and default to the session viewport. On a busy page at 1280x720, quality 80 costs about 54 KB per frame, quality 20 about 25 KB, and quality 20 at 640x360 about 9 KB.
 
 Browser clients must load from `localhost`, `127.0.0.1`, `::1` or `file://`. Any other origin gets a 403 on the upgrade and needs a proxy.
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -498,7 +498,7 @@ That pulls in:
 - `references/session-management.md` — persistence, multi-session workflows
 - `references/profiling.md` — Chrome DevTools tracing and profiling
 - `references/video-recording.md` — video capture options
-- `references/streaming.md` covers live viewport streaming, remote input, and per-client frame rate
+- `references/streaming.md` covers live viewport streaming, remote input, per-client frame rate, and the encoding vars that set bandwidth cost
 - `references/proxy-support.md` — proxy configuration
 - `references/webgpu.md` — screenshots/video of WebGPU pages (three.js, Babylon.js), Linux/CI setup
 - `templates/*` — starter shell scripts for auth, capture, form automation

--- a/skill-data/core/references/streaming.md
+++ b/skill-data/core/references/streaming.md
@@ -25,6 +25,17 @@ agent-browser stream disable           # Tear it down
 
 `AGENT_BROWSER_STREAM_PORT` pins the port for the whole daemon instead of passing `--port`.
 
+Frame encoding is daemon-wide, read once at startup:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `AGENT_BROWSER_STREAM_FORMAT` | `jpeg` | `png` is roughly 3x larger |
+| `AGENT_BROWSER_STREAM_QUALITY` | `80` | 0 to 100, clamped |
+| `AGENT_BROWSER_STREAM_MAX_WIDTH` | the viewport | caps the frame, does not resize the page |
+| `AGENT_BROWSER_STREAM_MAX_HEIGHT` | the viewport | same |
+
+Measured on a busy page at 1280x720: quality 80 gives ~54 KB per frame, quality 20 gives ~25 KB, and quality 20 at 640x360 gives ~9 KB. An unusable value leaves the default.
+
 Read the port from `stream status --json` rather than assuming one; the OS-assigned default changes per daemon.
 
 ## Connecting

--- a/skill-data/core/references/streaming.md
+++ b/skill-data/core/references/streaming.md
@@ -29,12 +29,11 @@ Frame encoding is daemon-wide, read once at startup:
 
 | Variable | Default | Notes |
 |---|---|---|
-| `AGENT_BROWSER_STREAM_FORMAT` | `jpeg` | `png` is roughly 3x larger |
 | `AGENT_BROWSER_STREAM_QUALITY` | `80` | 0 to 100, clamped |
 | `AGENT_BROWSER_STREAM_MAX_WIDTH` | the viewport | caps the frame, does not resize the page |
 | `AGENT_BROWSER_STREAM_MAX_HEIGHT` | the viewport | same |
 
-Measured on a busy page at 1280x720: quality 80 gives ~54 KB per frame, quality 20 gives ~25 KB, and quality 20 at 640x360 gives ~9 KB. An unusable value leaves the default.
+Stream frames are always jpeg, since a `frame` message carries no format field and a daemon-wide switch would leave connected clients decoding blind. Measured on a busy page at 1280x720: quality 80 gives ~54 KB per frame, quality 20 gives ~25 KB, and quality 20 at 640x360 gives ~9 KB. An unusable value leaves the default.
 
 Read the port from `stream status --json` rather than assuming one; the OS-assigned default changes per daemon.
 

--- a/skill-data/core/references/streaming.md
+++ b/skill-data/core/references/streaming.md
@@ -33,7 +33,7 @@ Frame encoding is daemon-wide, read once at startup:
 | `AGENT_BROWSER_STREAM_MAX_WIDTH` | the viewport | caps the frame, does not resize the page |
 | `AGENT_BROWSER_STREAM_MAX_HEIGHT` | the viewport | same |
 
-Stream frames are always jpeg, since a `frame` message carries no format field and a daemon-wide switch would leave connected clients decoding blind. Measured on a busy page at 1280x720: quality 80 gives ~54 KB per frame, quality 20 gives ~25 KB, and quality 20 at 640x360 gives ~9 KB. An unusable value leaves the default.
+The live stream requests jpeg, since a `frame` message carries no format field. An explicit `screencast_start` reconfigures the same underlying screencast, so a client can still see the format change mid-stream; sniff the bytes rather than assuming. Measured on a busy page at 1280x720: quality 80 gives ~54 KB per frame, quality 20 gives ~25 KB, and quality 20 at 640x360 gives ~9 KB. An unusable value leaves the default.
 
 Read the port from `stream status --json` rather than assuming one; the OS-assigned default changes per daemon.
 


### PR DESCRIPTION
## New arch

<img width="1120" height="905" alt="stream-arch" src="https://github.com/user-attachments/assets/b2b583af-16df-4ae4-89a7-b607b0a24e7d" />

## What

Encoding was hardcoded to jpeg quality 80 at the session viewport, so `maxFps` was the only bandwidth lever. Adds `AGENT_BROWSER_STREAM_QUALITY`, `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT`, read once per daemon.

Recreates #633 by @WebCloud, per the external-contribution policy. Closes #632.

## Measured

Busy page at 1280x720, frame rate unchanged in every row.

| Setting | KB/frame | Mbps |
|---|---|---|
| default | 54 | 22.1 |
| quality 20 | 25 | 11.0 |
| quality 20, 640x360 | 9 | 3.8 |

## Where this diverges from #633

- Width and height are `Option`, defaulting to the session viewport. A fixed 1280x720 default would downscale every larger viewport, and stays expressible by setting both.
- The `FORMAT` var is dropped. png measures 121 KB against 41 KB, a `frame` message carries no format field, and the dashboard decodes with a hardcoded `image/jpeg`. `screencast_start` still takes an explicit format.
- Quality is clamped to 0-100, and an unusable value keeps the default. CDP accepts an out-of-range quality and ignores it.

## Checks

1058 unit tests, clippy and fmt clean. Env parsing is split from env reading, so the rules are tested without mutating process environment.

Reviewed by codex (gpt-5.6-sol), a different model family. Two findings, both fixed:

- A dimension above `i32::MAX` stopped the stream dead. CDP types the field as signed, rejects the call, and the error is discarded while status still reports a healthy screencast. `MAX_WIDTH=4294967295` delivered zero frames. Now bounded, guard forced red.
- "Stream frames are always jpeg" was false. `screencast_start` reconfigures the same shared screencast, so an explicit png request reaches live clients mid-flight. The comment and three doc surfaces now describe that.

Caught before review: feeding the frame-size vars into `screencast_start` made it broadcast a viewport the page does not have, which would halve every dashboard click. That path takes quality only.

## Out of scope

- `screencast_start` on a session with a live stream restarts the shared screencast and overrides format and frame size for connected clients. Observed. Adjacent to #1358.
- Frame metadata carries the configured viewport (#1613). Input mapping is unaffected: a click at (640,360) under a 640 cap still lands at (640,360).
- No `mcp.rs` change. Encoding is env-only, so there is no CLI flag to mirror: `stream enable` takes `--port` and `stream_enable` exposes exactly that.
