### PR TITLE
Prepare v0.33.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### New Features
 
 - Added **input priority and per-client delivery settings** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+- Added **configurable stream encoding**: frames were hardcoded to jpeg quality 80 at the session viewport, so frame rate was the only bandwidth lever. `AGENT_BROWSER_STREAM_QUALITY`, `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT` are read once per daemon and cut bytes without dropping frames: on a busy page at 1280x720, quality 20 takes a frame from 54 KB to 25 KB, and quality 20 at 640x360 takes it to 9 KB, frame rate unchanged in both. Width and height default to the session viewport, so a larger viewport is never downscaled unless both are set (#1626)
 
 ### Behavior Changes
 
@@ -22,6 +23,7 @@
 
 - @Railly
 - @kevingatera
+- @WebCloud
 <!-- release:end -->
 
 ## 0.33.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # agent-browser
 
-## 0.33.1
+## 0.33.2
 
 <!-- release:start -->
+### New Features
+
+- Added **input priority and latest-frame-wins delivery** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write, and frames move to a latest-value channel so a client that falls behind skips stale frames instead of draining them. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+
+### Bug Fixes
+
+- Fixed **keyboard input over the stream**, which worked in none of the three shapes the docs publish: an absent `key`, `code`, or `text` reached CDP as an explicit null, which rejects the whole command, so every key release and every non-printable key was silently dropped, the dashboard's own payloads included (#1594)
+- Fixed **click latency behind mouse movement**: input dispatch awaited Chrome's reply before reading the next message, so a click sat one round trip behind every queued mouse move. After a 300-event sweep a click landed 2471ms late; it now lands in 6ms (#1627)
+- Fixed **frame timestamps**, which were always 0 because CDP sends the capture time as a float in seconds and the code read it as an integer. `metadata.timestamp` is now epoch milliseconds, so a client can measure how stale the frame it is drawing is (#1594)
+- Fixed **`stream disable`** returning while a slow client's input reader was still running (#1594)
+
+### Contributors
+
+- @Railly
+- @kevingatera
+<!-- release:end -->
+
+## 0.33.1
+
 ### Behavior Changes
 
 - The daemon now ships a **default idle timeout of 1 hour**: after an hour with no commands or dashboard input it saves configured restore state, closes the browser, and exits, so integrations that die without calling `close` no longer leak the daemon and its Chrome tree indefinitely. Sessions without `--restore` or another restore key discard transient browser state and open tabs when they shut down. Set `AGENT_BROWSER_IDLE_TIMEOUT_MS=0` to restore the old always-persist behavior, or any other value to tune it. Dashboard mouse, keyboard, and touch input reset the timer. The default never closes headed browsers, including Safari and iOS WebDriver sessions, or user-attached browsers that may be in direct human use. Provider-owned cloud browsers remain eligible for cleanup, and an explicitly configured timeout applies to all browsers, as before (#1605)
@@ -18,7 +37,6 @@
 - @Railly
 - @joelhooks
 - @jadenfix
-<!-- release:end -->
 
 ## 0.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@
 <!-- release:start -->
 ### New Features
 
-- Added **input priority and latest-frame-wins delivery** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write, and frames move to a latest-value channel so a client that falls behind skips stale frames instead of draining them. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+- Added **input priority and per-client delivery settings** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+
+### Behavior Changes
+
+- **Frame delivery is now latest-wins.** The stream server holds only the newest frame and reads it at send time, so frames produced while an earlier one is still being written are skipped. A client that assumed it received every frame from the WebSocket now receives fewer. Nothing in this repo consumes the stream that way, since `record` captures through CDP and the dashboard is a viewer, so this affects external consumers only (#1594)
+- **`metadata.timestamp` now carries a real value.** It was always 0, because CDP sends the capture time as a float in seconds and the code read it as an integer. It is now epoch milliseconds, so a client can measure how stale the frame it is drawing is. A client that treated 0 as unknown is unaffected (#1594)
 
 ### Bug Fixes
 
 - Fixed **keyboard input over the stream**, which worked in none of the three shapes the docs publish: an absent `key`, `code`, or `text` reached CDP as an explicit null, which rejects the whole command, so every key release and every non-printable key was silently dropped, the dashboard's own payloads included (#1594)
 - Fixed **click latency behind mouse movement**: input dispatch awaited Chrome's reply before reading the next message, so a click sat one round trip behind every queued mouse move. After a 300-event sweep a click landed 2471ms late; it now lands in 6ms (#1627)
-- Fixed **frame timestamps**, which were always 0 because CDP sends the capture time as a float in seconds and the code read it as an integer. `metadata.timestamp` is now epoch milliseconds, so a client can measure how stale the frame it is drawing is (#1594)
 - Fixed **`stream disable`** returning while a slow client's input reader was still running (#1594)
 
 ### Contributors

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.33.1"
+version = "0.33.2"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.33.2
+
+<p className="text-[#888] text-sm">July 30, 2026</p>
+
+### New Features
+
+- Added **input priority and latest-frame-wins delivery** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write, and frames move to a latest-value channel so a client that falls behind skips stale frames instead of draining them. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+
+### Bug Fixes
+
+- Fixed **keyboard input over the stream**, which worked in none of the three shapes the docs publish: an absent `key`, `code`, or `text` reached CDP as an explicit null, which rejects the whole command, so every key release and every non-printable key was silently dropped, the dashboard's own payloads included (#1594)
+- Fixed **click latency behind mouse movement**: input dispatch awaited Chrome's reply before reading the next message, so a click sat one round trip behind every queued mouse move. After a 300-event sweep a click landed 2471ms late; it now lands in 6ms (#1627)
+- Fixed **frame timestamps**, which were always 0 because CDP sends the capture time as a float in seconds and the code read it as an integer. `metadata.timestamp` is now epoch milliseconds, so a client can measure how stale the frame it is drawing is (#1594)
+- Fixed **`stream disable`** returning while a slow client's input reader was still running (#1594)
+
+---
+
 ## v0.33.1
 
 <p className="text-[#888] text-sm">July 28, 2026</p>

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -6,13 +6,17 @@
 
 ### New Features
 
-- Added **input priority and latest-frame-wins delivery** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write, and frames move to a latest-value channel so a client that falls behind skips stale frames instead of draining them. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+- Added **input priority and per-client delivery settings** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+
+### Behavior Changes
+
+- **Frame delivery is now latest-wins.** The stream server holds only the newest frame and reads it at send time, so frames produced while an earlier one is still being written are skipped. A client that assumed it received every frame from the WebSocket now receives fewer. Nothing in this repo consumes the stream that way, since `record` captures through CDP and the dashboard is a viewer, so this affects external consumers only (#1594)
+- **`metadata.timestamp` now carries a real value.** It was always 0, because CDP sends the capture time as a float in seconds and the code read it as an integer. It is now epoch milliseconds, so a client can measure how stale the frame it is drawing is. A client that treated 0 as unknown is unaffected (#1594)
 
 ### Bug Fixes
 
 - Fixed **keyboard input over the stream**, which worked in none of the three shapes the docs publish: an absent `key`, `code`, or `text` reached CDP as an explicit null, which rejects the whole command, so every key release and every non-printable key was silently dropped, the dashboard's own payloads included (#1594)
 - Fixed **click latency behind mouse movement**: input dispatch awaited Chrome's reply before reading the next message, so a click sat one round trip behind every queued mouse move. After a 300-event sweep a click landed 2471ms late; it now lands in 6ms (#1627)
-- Fixed **frame timestamps**, which were always 0 because CDP sends the capture time as a float in seconds and the code read it as an integer. `metadata.timestamp` is now epoch milliseconds, so a client can measure how stale the frame it is drawing is (#1594)
 - Fixed **`stream disable`** returning while a slow client's input reader was still running (#1594)
 
 ---

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -2,11 +2,12 @@
 
 ## v0.33.2
 
-<p className="text-[#888] text-sm">July 30, 2026</p>
+<p className="text-[#888] text-sm">July 31, 2026</p>
 
 ### New Features
 
 - Added **input priority and per-client delivery settings** to the stream server: each WebSocket connection now splits into a reader task and a writer loop, so clicks and keystrokes dispatch to the browser without queueing behind a frame write. Adds a per-client `{"type":"config","maxFps":N}` cap (1 to 120, `0` uncapped) and opt-in ack pacing via `{"type":"config","pacing":"ack"}` with `{"type":"ack","seq":N}`, which keeps one frame in flight so a stalled client never drains a backlog. Both settings can also be declared on the connection URL (`?pacing=ack&maxFps=10`), the only way to cover the opening frame. Every frame now carries a monotonic `seq` (#1594)
+- Added **configurable stream encoding**: frames were hardcoded to jpeg quality 80 at the session viewport, so frame rate was the only bandwidth lever. `AGENT_BROWSER_STREAM_QUALITY`, `AGENT_BROWSER_STREAM_MAX_WIDTH` and `AGENT_BROWSER_STREAM_MAX_HEIGHT` are read once per daemon and cut bytes without dropping frames: on a busy page at 1280x720, quality 20 takes a frame from 54 KB to 25 KB, and quality 20 at 640x360 takes it to 9 KB, frame rate unchanged in both. Width and height default to the session viewport, so a larger viewport is never downscaled unless both are set (#1626)
 
 ### Behavior Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.33.1";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.33.2";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Synchronize package and Rust crate versions to 0.33.2
- Publish matching release notes and contributor credits

Covers #1594, #1626 and #1627.
