### PR TITLE
fix: dashboard live view recovers when a tab closes itself

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -926,9 +926,25 @@ impl DaemonState {
         }
 
         // Remove destroyed targets
+        let mut removed_tracked_page = false;
         for target_id in &drained.destroyed_targets {
             if let Some(ref mut mgr) = self.browser {
-                mgr.remove_page_by_target_id(target_id);
+                removed_tracked_page |= mgr.remove_page_by_target_id(target_id);
+            }
+        }
+
+        // Tab closes that bypass daemon commands (window.close, crashes,
+        // external CDP) only surface here, via the drain. Without this the
+        // stream keeps targeting the dead session and the dashboard keeps
+        // showing the closed tab until some later command re-syncs it.
+        if removed_tracked_page {
+            if let Some(ref server) = self.stream_server {
+                if let Some(ref mgr) = self.browser {
+                    server.broadcast_tabs(&mgr.tab_list()).await;
+                    let session_id = mgr.active_session_id().ok().map(|s| s.to_string());
+                    server.set_cdp_session_id(session_id).await;
+                    server.notify_client_changed();
+                }
             }
         }
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1781,11 +1781,15 @@ impl BrowserManager {
         update_page_target_info_in_pages(&mut self.pages, target)
     }
 
-    pub fn remove_page_by_target_id(&mut self, target_id: &str) {
+    /// Remove a page by target id. Returns true when a tracked page was
+    /// actually removed (untracked targets like workers are ignored).
+    pub fn remove_page_by_target_id(&mut self, target_id: &str) -> bool {
         if let Some(pos) = self.pages.iter().position(|p| p.target_id == target_id) {
             self.pages.remove(pos);
             self.update_active_page_after_removal(pos);
+            return true;
         }
+        false
     }
 
     pub fn has_target(&self, target_id: &str) -> bool {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5658,6 +5658,160 @@ async fn e2e_stream_click_is_not_queued_behind_a_mouse_sweep() {
     let _ = std::fs::remove_dir_all(&socket_dir);
 }
 
+// ---------------------------------------------------------------------------
+// Stream: a tab that closes itself re-targets the screencast and tab list
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn e2e_stream_self_closed_tab_resyncs_stream() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+    let socket_dir = std::env::temp_dir().join(format!(
+        "agent-browser-e2e-stream-selfclose-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&socket_dir).expect("socket dir should be created");
+    guard.set(
+        "AGENT_BROWSER_SOCKET_DIR",
+        socket_dir.to_str().expect("socket dir should be utf-8"),
+    );
+    guard.set("AGENT_BROWSER_SESSION", "e2e-stream-selfclose");
+
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "stream_enable", "port": 0 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let port = get_data(&resp)["port"]
+        .as_u64()
+        .expect("stream enable should report the bound port");
+
+    // First tab repaints constantly, so a healthy screencast always has new
+    // frames to send after the stream is re-targeted to it.
+    let animated = "data:text/html,<script>setInterval(()=>{document.body.style.background='%23'+Math.floor(Math.random()*16777215).toString(16)},200)</script>";
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": animated }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_new", "url": "data:text/html,<h1>closing</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("websocket client should connect to runtime stream");
+
+    // Wait for the screencast to be flowing on the second tab.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+    let mut flowing = false;
+    while tokio::time::Instant::now() < deadline && !flowing {
+        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
+        let Some(Ok(message)) = msg.ok().flatten() else {
+            continue;
+        };
+        if !message.is_text() {
+            continue;
+        }
+        let parsed: Value =
+            serde_json::from_str(message.to_text().expect("text message should be readable"))
+                .expect("stream payload should be valid JSON");
+        if parsed.get("type") == Some(&json!("frame")) {
+            flowing = true;
+        }
+    }
+    assert!(flowing, "screencast should be flowing before the close");
+
+    // The page closes itself over raw CDP, bypassing execute_command so no
+    // post-command sync can mask the event-driven path. The daemon's only
+    // chance to notice is the periodic drain (the 100ms tick in serve mode).
+    let (client, closing_session_id) = {
+        let mgr = state.browser.as_ref().expect("browser should be running");
+        (
+            mgr.client.clone(),
+            mgr.active_session_id()
+                .expect("an active tab should exist")
+                .to_string(),
+        )
+    };
+    let _ = client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({ "expression": "window.close()" })),
+            Some(closing_session_id.as_str()),
+        )
+        .await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    state
+        .drain_cdp_events_background()
+        .await
+        .expect("drain should succeed");
+
+    // The dashboard must learn the tab is gone, and frames must resume from
+    // the remaining (animated) tab without any further command.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+    let mut saw_single_tab = false;
+    let mut frames_after = 0u32;
+    while tokio::time::Instant::now() < deadline {
+        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next()).await;
+        let Some(Ok(message)) = msg.ok().flatten() else {
+            continue;
+        };
+        if !message.is_text() {
+            continue;
+        }
+        let parsed: Value =
+            serde_json::from_str(message.to_text().expect("text message should be readable"))
+                .expect("stream payload should be valid JSON");
+        match parsed.get("type") {
+            Some(t) if t == &json!("tabs") => {
+                let tabs = parsed["tabs"].as_array().cloned().unwrap_or_default();
+                if tabs.len() == 1 {
+                    saw_single_tab = true;
+                }
+            }
+            Some(t) if t == &json!("frame") && saw_single_tab => {
+                frames_after += 1;
+                if frames_after >= 2 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        saw_single_tab,
+        "dashboard should have received a tab list without the closed tab"
+    );
+    assert!(
+        frames_after >= 2,
+        "screencast should resume from the remaining tab, got {frames_after} frames"
+    );
+
+    // Cleanup
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "stream_disable" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    let _ = std::fs::remove_dir_all(&socket_dir);
+}
+
 /// Extract width and height from a JPEG's SOF0 (0xFFC0) or SOF2 (0xFFC2) marker.
 fn jpeg_dimensions(data: &[u8]) -> Option<(u32, u32)> {
     for i in 0..data.len().saturating_sub(8) {


### PR DESCRIPTION
## Bug

Reported in #1633. When a tab closes without going through a daemon command (window.close, a crash, or an external CDP client), the dashboard's live view never noticed on its own. The screencast kept targeting the dead CDP session, so the dashboard kept showing the closed tab's last frame and a stale tab bar until some later tab command happened to re-sync things.

The only path that observes these closes is the lazy per-command CDP event drain. It removed the destroyed target from the tracked pages but never told the stream server, so nothing re-broadcast the tab list or re-pointed the screencast.

## Fix

- When the drain removes a destroyed target that was a tracked page, the daemon now also broadcasts the updated tab list, re-syncs the stream server's CDP session id to the active tab, and notifies stream clients. That triggers the existing screencast restart, so frames resume from the remaining tab without any further command.
- `BrowserManager::remove_page_by_target_id` now returns whether a tracked page was actually removed, so untracked target deaths (workers, service workers) do not cause spurious broadcasts.

## Verification

- New ignored e2e `e2e_stream_self_closed_tab_resyncs_stream` closes a tab over raw CDP (bypassing execute_command, so no post-command sync can mask the event-driven path) and asserts the dashboard receives a tab list without the closed tab and that frames resume from the remaining tab. Passes on this branch, fails without the fix.
- Suite: `cargo fmt` clean, `cargo clippy --all-targets` clean (only the two pre-existing warnings), `cargo test --bin agent-browser daemon` 23/23, `cargo test --bin agent-browser stream` 77/77, all `e2e_stream` ignored tests 4/4.

Fixes #1633.