### PR TITLE
feat: right-click, middle-click, and modifier keys for click and dblclick

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4142,6 +4142,70 @@ mod tests {
     }
 
     #[test]
+    fn test_click_button_and_modifiers() {
+        let cmd = parse_command(
+            &args("click #item --button right --modifiers ctrl,shift"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "click");
+        assert_eq!(cmd["selector"], "#item");
+        assert_eq!(cmd["button"], "right");
+        assert_eq!(cmd["modifiers"], 2 | 8);
+    }
+
+    #[test]
+    fn test_click_flags_before_selector() {
+        let cmd = parse_command(&args("click --button middle #item"), &default_flags()).unwrap();
+        assert_eq!(cmd["selector"], "#item");
+        assert_eq!(cmd["button"], "middle");
+    }
+
+    #[test]
+    fn test_click_new_tab_with_button() {
+        let cmd = parse_command(
+            &args("click @e3 --new-tab --button left --modifiers meta"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["newTab"], true);
+        assert_eq!(cmd["button"], "left");
+        assert_eq!(cmd["modifiers"], 4);
+    }
+
+    #[test]
+    fn test_click_invalid_button_rejected() {
+        let result = parse_command(&args("click #b --button back"), &default_flags());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_click_unknown_modifier_rejected() {
+        let result = parse_command(&args("click #b --modifiers ctrl,super"), &default_flags());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_click_missing_flag_value_rejected() {
+        assert!(parse_command(&args("click #b --button"), &default_flags()).is_err());
+        assert!(parse_command(&args("click #b --modifiers"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_dblclick_button() {
+        let cmd = parse_command(&args("dblclick #b --button right"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "dblclick");
+        assert_eq!(cmd["selector"], "#b");
+        assert_eq!(cmd["button"], "right");
+    }
+
+    #[test]
+    fn test_dblclick_invalid_button_rejected() {
+        let result = parse_command(&args("dblclick #b --button back"), &default_flags());
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_fill() {
         let cmd = parse_command(&args("fill #input hello world"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "fill");

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -415,26 +415,94 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Core Actions ===
         "click" => {
-            let new_tab = rest.contains(&"--new-tab");
-            let sel = rest
-                .iter()
-                .find(|arg| **arg != "--new-tab")
-                .ok_or_else(|| ParseError::MissingArguments {
-                    context: "click".to_string(),
-                    usage: "click <selector> [--new-tab]",
-                })?;
-            if new_tab {
-                Ok(json!({ "id": id, "action": "click", "selector": sel, "newTab": true }))
-            } else {
-                Ok(json!({ "id": id, "action": "click", "selector": sel }))
+            const USAGE: &str =
+                "click <selector> [--button left|right|middle] [--modifiers ctrl,shift] [--new-tab]";
+            let mut new_tab = false;
+            let mut button: Option<&str> = None;
+            let mut modifiers: Option<i32> = None;
+            let mut sel: Option<&str> = None;
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i] {
+                    "--new-tab" => new_tab = true,
+                    "--button" => {
+                        let raw = rest
+                            .get(i + 1)
+                            .ok_or_else(|| ParseError::MissingArguments {
+                                context: "click --button".to_string(),
+                                usage: USAGE,
+                            })?;
+                        button = Some(parse_mouse_button(raw, USAGE)?);
+                        i += 1;
+                    }
+                    "--modifiers" => {
+                        let raw = rest
+                            .get(i + 1)
+                            .ok_or_else(|| ParseError::MissingArguments {
+                                context: "click --modifiers".to_string(),
+                                usage: USAGE,
+                            })?;
+                        modifiers = Some(parse_modifier_mask(raw, USAGE)?);
+                        i += 1;
+                    }
+                    other => {
+                        if sel.is_none() {
+                            sel = Some(other);
+                        }
+                    }
+                }
+                i += 1;
             }
+            let sel = sel.ok_or_else(|| ParseError::MissingArguments {
+                context: "click".to_string(),
+                usage: USAGE,
+            })?;
+            let mut cmd = json!({ "id": id, "action": "click", "selector": sel });
+            if new_tab {
+                cmd["newTab"] = json!(true);
+            }
+            if let Some(b) = button {
+                cmd["button"] = json!(b);
+            }
+            if let Some(m) = modifiers {
+                cmd["modifiers"] = json!(m);
+            }
+            Ok(cmd)
         }
         "dblclick" => {
-            let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
+            const USAGE: &str = "dblclick <selector> [--button left|right|middle]";
+            let mut button: Option<&str> = None;
+            let mut sel: Option<&str> = None;
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i] {
+                    "--button" => {
+                        let raw = rest
+                            .get(i + 1)
+                            .ok_or_else(|| ParseError::MissingArguments {
+                                context: "dblclick --button".to_string(),
+                                usage: USAGE,
+                            })?;
+                        button = Some(parse_mouse_button(raw, USAGE)?);
+                        i += 1;
+                    }
+                    other => {
+                        if sel.is_none() {
+                            sel = Some(other);
+                        }
+                    }
+                }
+                i += 1;
+            }
+            let sel = sel.ok_or_else(|| ParseError::MissingArguments {
                 context: "dblclick".to_string(),
-                usage: "dblclick <selector>",
+                usage: USAGE,
             })?;
-            Ok(json!({ "id": id, "action": "dblclick", "selector": sel }))
+            let mut cmd = json!({ "id": id, "action": "dblclick", "selector": sel });
+            if let Some(b) = button {
+                cmd["button"] = json!(b);
+            }
+            Ok(cmd)
         }
         "fill" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -3156,6 +3224,46 @@ pub fn shell_words_split(s: &str) -> Vec<String> {
         args.push(current);
     }
     args
+}
+
+/// Validate a --button value for click/dblclick.
+fn parse_mouse_button(raw: &str, usage: &'static str) -> Result<&'static str, ParseError> {
+    match raw.to_lowercase().as_str() {
+        "left" => Ok("left"),
+        "right" => Ok("right"),
+        "middle" => Ok("middle"),
+        other => Err(ParseError::InvalidValue {
+            message: format!(
+                "Invalid --button '{}': expected left, right, or middle",
+                other
+            ),
+            usage,
+        }),
+    }
+}
+
+/// Parse a comma-separated modifier list into the CDP bitmask:
+/// Alt=1, Ctrl=2, Meta (Cmd)=4, Shift=8 (same mapping as key chords).
+fn parse_modifier_mask(raw: &str, usage: &'static str) -> Result<i32, ParseError> {
+    let mut mask = 0i32;
+    for part in raw.split(',') {
+        match part.trim().to_lowercase().as_str() {
+            "alt" => mask |= 1,
+            "ctrl" | "control" => mask |= 2,
+            "meta" | "cmd" | "command" => mask |= 4,
+            "shift" => mask |= 8,
+            other => {
+                return Err(ParseError::InvalidValue {
+                    message: format!(
+                        "Unknown modifier '{}': expected alt, ctrl, meta, or shift",
+                        other
+                    ),
+                    usage,
+                })
+            }
+        }
+    }
+    Ok(mask)
 }
 
 #[cfg(test)]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4802,6 +4802,10 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
 
     let button = cmd.get("button").and_then(|v| v.as_str()).unwrap_or("left");
     let click_count = cmd.get("clickCount").and_then(|v| v.as_i64()).unwrap_or(1) as i32;
+    let modifiers = cmd
+        .get("modifiers")
+        .and_then(|v| v.as_i64())
+        .map(|m| m as i32);
 
     let result = interaction::click(
         &mgr.client,
@@ -4810,6 +4814,7 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         selector,
         button,
         click_count,
+        modifiers,
         &state.iframe_sessions,
     )
     .await?;
@@ -4828,12 +4833,14 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .get("selector")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'selector' parameter")?;
+    let button = cmd.get("button").and_then(|v| v.as_str()).unwrap_or("left");
 
     let result = interaction::dblclick(
         &mgr.client,
         &session_id,
         &state.ref_map,
         selector,
+        button,
         &state.iframe_sessions,
     )
     .await?;
@@ -6220,6 +6227,7 @@ async fn handle_download(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         selector,
         "left",
         1,
+        None,
         &state.iframe_sessions,
     )
     .await?;
@@ -8127,6 +8135,7 @@ async fn execute_subaction(
                 selector,
                 "left",
                 1,
+                None,
                 &state.iframe_sessions,
             )
             .await?;
@@ -10604,6 +10613,7 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         &sub_sel,
         "left",
         1,
+        None,
         &state.iframe_sessions,
     )
     .await?;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -2346,9 +2346,207 @@ async fn e2e_drag_action_sends_buttons_during_move() {
     assert_success(&resp);
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_drag_action_completes_html5_drop() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": native_test_fixture_url("html5_drag_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "drag",
+            "source": "#source",
+            "target": "#dest"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "window.__html5DragProbe" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let probe = &get_data(&resp)["result"];
+    let events = probe["events"]
+        .as_array()
+        .expect("html5 drag probe should expose events");
+
+    // The full HTML5 DnD sequence must complete: dragstart on the source, a
+    // drop on the destination carrying the data set in dragstart, and dragend.
+    assert!(
+        events.iter().any(|event| event["type"] == "dragstart"),
+        "Expected dragstart to fire on the source element"
+    );
+    let drop = events
+        .iter()
+        .find(|event| event["type"] == "drop" && event["target"] == "dest")
+        .expect("Expected drop to fire on the #dest drop zone");
+    assert_eq!(
+        drop["dropped"].as_str(),
+        Some("probe"),
+        "Drop should deliver the data set in dragstart"
+    );
+    assert!(
+        events.iter().any(|event| event["type"] == "dragend"),
+        "Expected dragend after the drop"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
-// State save/load, state management
+// Click buttons and modifiers
 // ---------------------------------------------------------------------------
+
+const CLICK_BUTTONS_PROBE_HTML: &str = r#"<!doctype html>
+<html><body>
+<div id="target" style="width:100px;height:100px">target</div>
+<script>
+window.__clicks = [];
+const t = document.getElementById('target');
+for (const type of ['click', 'contextmenu', 'auxclick', 'mousedown', 'mouseup']) {
+  t.addEventListener(type, e => window.__clicks.push({
+    type: e.type, button: e.button,
+    ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, altKey: e.altKey, metaKey: e.metaKey
+  }));
+}
+</script>
+</body></html>"#;
+
+async fn click_probe_events(state: &mut DaemonState) -> Vec<Value> {
+    let resp = execute_command(
+        &json!({ "id": "ev", "action": "evaluate", "script": "window.__clicks" }),
+        state,
+    )
+    .await;
+    assert_success(&resp);
+    get_data(&resp)["result"]
+        .as_array()
+        .expect("click probe should expose an events array")
+        .clone()
+}
+
+async fn launch_click_probe() -> DaemonState {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let url = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode(CLICK_BUTTONS_PROBE_HTML)
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    state
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_click_right_button_fires_contextmenu_not_click() {
+    let mut state = launch_click_probe().await;
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#target", "button": "right" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let events = click_probe_events(&mut state).await;
+    assert!(
+        events.iter().any(|e| e["type"] == "contextmenu"),
+        "Right-click should fire contextmenu, got: {:?}",
+        events
+    );
+    assert!(
+        !events.iter().any(|e| e["type"] == "click"),
+        "Right-click should not fire a normal click, got: {:?}",
+        events
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_click_middle_button_fires_auxclick() {
+    let mut state = launch_click_probe().await;
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#target", "button": "middle" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let events = click_probe_events(&mut state).await;
+    let aux = events
+        .iter()
+        .find(|e| e["type"] == "auxclick")
+        .expect("Middle-click should fire auxclick");
+    assert_eq!(aux["button"].as_i64(), Some(1));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_click_with_modifiers_reports_modifier_state() {
+    let mut state = launch_click_probe().await;
+
+    // Ctrl(2) | Shift(8) = 10
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#target", "modifiers": 10 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let events = click_probe_events(&mut state).await;
+    let click = events
+        .iter()
+        .find(|e| e["type"] == "click")
+        .expect("Ctrl+Shift click should fire a normal click");
+    assert_eq!(click["ctrlKey"].as_bool(), Some(true));
+    assert_eq!(click["shiftKey"].as_bool(), Some(true));
+    assert_eq!(click["altKey"].as_bool(), Some(false));
+    assert_eq!(click["metaKey"].as_bool(), Some(false));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
 
 #[tokio::test]
 #[ignore]

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -25,6 +25,7 @@ pub struct PendingRelease {
     pub button: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn click(
     client: &CdpClient,
     session_id: &str,
@@ -32,6 +33,7 @@ pub async fn click(
     selector_or_ref: &str,
     button: &str,
     click_count: i32,
+    modifiers: Option<i32>,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<ClickResult, String> {
     let (x, y, effective_session_id) = resolve_element_center(
@@ -53,6 +55,7 @@ pub async fn click(
         y,
         button,
         click_count,
+        modifiers,
     )
     .await
 }
@@ -62,6 +65,7 @@ pub async fn dblclick(
     session_id: &str,
     ref_map: &RefMap,
     selector_or_ref: &str,
+    button: &str,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<ClickResult, String> {
     click(
@@ -69,8 +73,9 @@ pub async fn dblclick(
         session_id,
         ref_map,
         selector_or_ref,
-        "left",
+        button,
         2,
+        None,
         iframe_sessions,
     )
     .await
@@ -509,6 +514,7 @@ pub async fn check(
             selector_or_ref,
             "left",
             1,
+            None,
             iframe_sessions,
         )
         .await?;
@@ -561,6 +567,7 @@ pub async fn uncheck(
             selector_or_ref,
             "left",
             1,
+            None,
             iframe_sessions,
         )
         .await?;
@@ -987,6 +994,7 @@ async fn dispatch_mouse_or_dialog(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_click(
     client: &CdpClient,
     session_id: &str,
@@ -995,6 +1003,7 @@ async fn dispatch_click(
     y: f64,
     button: &str,
     click_count: i32,
+    modifiers: Option<i32>,
 ) -> Result<ClickResult, String> {
     // Move
     if dispatch_mouse_or_dialog(
@@ -1042,7 +1051,7 @@ async fn dispatch_click(
             click_count: Some(click_count),
             delta_x: None,
             delta_y: None,
-            modifiers: None,
+            modifiers,
         },
     )
     .await?
@@ -1076,7 +1085,7 @@ async fn dispatch_click(
             click_count: Some(click_count),
             delta_x: None,
             delta_y: None,
-            modifiers: None,
+            modifiers,
         },
     )
     .await?;

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1521,7 +1521,7 @@ Examples:
             r##"
 agent-browser click - Click an element
 
-Usage: agent-browser click <selector> [--new-tab]
+Usage: agent-browser click <selector> [--button left|right|middle] [--modifiers ctrl,shift] [--new-tab]
 
 Clicks on the specified element. The selector can be a CSS selector,
 XPath, or an element reference from snapshot (e.g., @e1).
@@ -1530,6 +1530,9 @@ If another element covers the click point, agent-browser reports the
 covering element instead of dispatching a click to the wrong target.
 
 Options:
+  --button <name>      Mouse button: left (default), right, or middle
+  --modifiers <list>   Comma-separated modifiers held during the click:
+                       alt, ctrl, meta, shift
   --new-tab            Open link in a new tab instead of navigating current tab
                        (only works on elements with href attribute)
 
@@ -1543,16 +1546,21 @@ Examples:
   agent-browser click "button.primary"
   agent-browser click "//button[@type='submit']"
   agent-browser click @e3 --new-tab
+  agent-browser click "#menu-item" --button right
+  agent-browser click "#row" --modifiers ctrl,shift
 "##
         }
         "dblclick" => {
             r##"
 agent-browser dblclick - Double-click an element
 
-Usage: agent-browser dblclick <selector>
+Usage: agent-browser dblclick <selector> [--button left|right|middle]
 
 Double-clicks on the specified element. Useful for text selection
 or triggering double-click handlers.
+
+Options:
+  --button <name>      Mouse button: left (default), right, or middle
 
 Global Options:
   --json               Output as JSON


### PR DESCRIPTION
## What

Reported in #1630. `agent-browser click` only ever performed a plain left click, and `dblclick` the same. There was no way to open a page's context menu, middle-click a link, or hold Ctrl/Shift while clicking. The daemon already dispatched non-left buttons, but the CLI had no way to request them, and modifier state never reached `dispatchMouseEvent`.

## Fix

- Add `--button left|right|middle` and `--modifiers ctrl,shift,alt,meta` to `click`, and `--button` to `dblclick`, parsed in `commands.rs` via new `parse_mouse_button`/`parse_modifier_mask` helpers.
- Plumb the CDP modifier bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8, same mapping as key chords) through `handle_click` into `interaction::click` so both `mousePressed` and `mouseReleased` carry it.
- Document the new flags in `agent-browser help click` / `help dblclick`.

## Verification

- 8 new parse tests lock in flag validation (button/modifier values, flags before selector, rejection of invalid values and missing flag arguments). Parse suite 283/283 green.
- New (ignored) e2e tests prove the behavior end to end: right-click fires `contextmenu` and not `click`, middle-click fires `auxclick` with `button == 1`, a Ctrl+Shift click reports `ctrlKey`/`shiftKey` on the resulting event, and a stepped-mouse drag completes a real HTML5 drop delivering the `dragstart` data. All green.
- `cargo fmt` and `cargo clippy --all-targets` clean (no new warnings).

Fixes #1630.
