### PR TITLE
fix: drag and drop and touchpad two-finger tap in the dashboard live view

### DIFF
--- a/cli/src/native/stream/websocket.rs
+++ b/cli/src/native/stream/websocket.rs
@@ -629,6 +629,7 @@ async fn dispatch_input(
                         "x": parsed.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0),
                         "y": parsed.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0),
                         "button": parsed.get("button").and_then(|v| v.as_str()).unwrap_or("none"),
+                        "buttons": mouse_buttons_param(parsed),
                         "clickCount": parsed.get("clickCount").and_then(|v| v.as_i64()).unwrap_or(0),
                         "deltaX": parsed.get("deltaX").and_then(|v| v.as_f64()).unwrap_or(0.0),
                         "deltaY": parsed.get("deltaY").and_then(|v| v.as_f64()).unwrap_or(0.0),
@@ -662,6 +663,29 @@ async fn dispatch_input(
         }
         "status" => {}
         _ => {}
+    }
+}
+
+/// CDP `buttons` bitmask for a dashboard `input_mouse` message. Current
+/// dashboards send `MouseEvent.buttons` directly; when absent, derive the
+/// bit from `button` on press/release so drag state still works with
+/// clients that predate the field.
+fn mouse_buttons_param(parsed: &Value) -> i64 {
+    if let Some(buttons) = parsed.get("buttons").and_then(|v| v.as_i64()) {
+        return buttons;
+    }
+    let event_type = parsed
+        .get("eventType")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !matches!(event_type, "mousePressed" | "mouseReleased") {
+        return 0;
+    }
+    match parsed.get("button").and_then(|v| v.as_str()) {
+        Some("left") => 1,
+        Some("right") => 2,
+        Some("middle") => 4,
+        _ => 0,
     }
 }
 
@@ -940,5 +964,33 @@ mod tests {
             deadline_from(Some(now), 10),
             now + Duration::from_millis(100)
         );
+    }
+
+    #[test]
+    fn mouse_buttons_uses_explicit_bitmask() {
+        let msg = json!({ "eventType": "mouseMoved", "buttons": 1 });
+        assert_eq!(mouse_buttons_param(&msg), 1);
+        let msg = json!({ "eventType": "mousePressed", "button": "left", "buttons": 3 });
+        assert_eq!(mouse_buttons_param(&msg), 3);
+    }
+
+    #[test]
+    fn mouse_buttons_falls_back_to_button_on_press_release() {
+        let msg = json!({ "eventType": "mousePressed", "button": "left" });
+        assert_eq!(mouse_buttons_param(&msg), 1);
+        let msg = json!({ "eventType": "mouseReleased", "button": "right" });
+        assert_eq!(mouse_buttons_param(&msg), 2);
+        let msg = json!({ "eventType": "mousePressed", "button": "middle" });
+        assert_eq!(mouse_buttons_param(&msg), 4);
+        let msg = json!({ "eventType": "mousePressed", "button": "none" });
+        assert_eq!(mouse_buttons_param(&msg), 0);
+    }
+
+    #[test]
+    fn mouse_buttons_defaults_to_zero_on_moves() {
+        let msg = json!({ "eventType": "mouseMoved", "button": "none" });
+        assert_eq!(mouse_buttons_param(&msg), 0);
+        let msg = json!({ "eventType": "mouseWheel", "button": "left" });
+        assert_eq!(mouse_buttons_param(&msg), 0);
     }
 }

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -325,12 +325,27 @@ export function Viewport() {
     (e: React.MouseEvent, eventType: string) => {
       const pos = toViewport(e);
       if (!pos) return;
+      // Held-button state from the browser. Chrome needs both fields on
+      // moves during a drag: it reads `button` (not just the bitmask) to
+      // start an HTML5 drag session.
+      const buttons = e.buttons;
+      const button =
+        eventType === "mouseMoved"
+          ? buttons & 1
+            ? "left"
+            : buttons & 2
+              ? "right"
+              : buttons & 4
+                ? "middle"
+                : "none"
+          : cdpButton(e.button);
       sendInput({
         type: "input_mouse",
         eventType,
         x: pos.x,
         y: pos.y,
-        button: cdpButton(e.button),
+        button,
+        buttons,
         clickCount: eventType === "mousePressed" ? 1 : 0,
         modifiers: cdpModifiers(e),
       });

--- a/packages/dashboard/src/components/viewport.tsx
+++ b/packages/dashboard/src/components/viewport.tsx
@@ -135,6 +135,7 @@ export function Viewport() {
   const sendInput = useSetAtom(sendInputAtom);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const lastRightPressRef = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasAreaRef = useRef<HTMLDivElement>(null);
   const addressRef = useRef<HTMLInputElement>(null);
@@ -325,6 +326,9 @@ export function Viewport() {
     (e: React.MouseEvent, eventType: string) => {
       const pos = toViewport(e);
       if (!pos) return;
+      if (eventType === "mousePressed" && e.button === 2) {
+        lastRightPressRef.current = Date.now();
+      }
       // Held-button state from the browser. Chrome needs both fields on
       // moves during a drag: it reads `button` (not just the bitmask) to
       // start an HTML5 drag session.
@@ -349,6 +353,27 @@ export function Viewport() {
         clickCount: eventType === "mousePressed" ? 1 : 0,
         modifiers: cdpModifiers(e),
       });
+    },
+    [toViewport, sendInput],
+  );
+
+  // A two-finger tap on a touchpad often arrives as a lone contextmenu event
+  // with no right mousedown/mouseup pair. Forward the pair ourselves unless a
+  // real right press just went through, so the remote page gets one menu.
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const pos = toViewport(e);
+      if (!pos || Date.now() - lastRightPressRef.current < 500) return;
+      const base = {
+        type: "input_mouse",
+        x: pos.x,
+        y: pos.y,
+        button: "right",
+        modifiers: cdpModifiers(e),
+      };
+      sendInput({ ...base, eventType: "mousePressed", buttons: 2, clickCount: 1 });
+      sendInput({ ...base, eventType: "mouseReleased", buttons: 0, clickCount: 0 });
     },
     [toViewport, sendInput],
   );
@@ -536,7 +561,7 @@ export function Viewport() {
             }}
             onMouseUp={(e) => handleMouseEvent(e, "mouseReleased")}
             onWheel={handleWheel}
-            onContextMenu={(e) => e.preventDefault()}
+            onContextMenu={handleContextMenu}
           />
         ) : (
           <div className="text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Bug

Reported in #1631 and #1632. In the dashboard's live view, HTML5 drag and drop never starts, and a two-finger tap on a touchpad never opens the page's right-click menu. Two causes:

- The stream's `input_mouse` messages carried no `buttons` bitmask, and moves always sent `button: "none"`. Chrome's `Input.dispatchMouseEvent` treats held-button moves as plain hovers without the bitmask, and Chromium reads `button` (not just the bitmask) on moves to start an HTML5 drag session, so a press-drag-release sequence from the dashboard could never drag.
- A two-finger tap on a touchpad typically delivers only a `contextmenu` DOM event, with no right mousedown/mouseup pair. The dashboard just called `preventDefault()` on it, so nothing reached the remote page.

## Fix

- Forward the `buttons` bitmask on every `input_mouse` dispatch, via a `mouse_buttons_param()` helper: an explicit `buttons` value wins, and absent it the bit is derived from `button` on press/release (0 otherwise) so older clients keep working. Dispatch stays fire-and-forget inside `dispatch_input`.
- The dashboard sends `MouseEvent.buttons` on press, release, and moves, and derives `button` from the held bitmask on moves (left > right > middle) so Chrome sees a consistent drag state.
- `onContextMenu` synthesizes a right press/release pair at the event position, unless a real right press went through within 500ms (tracked with a `lastRightPressRef` timestamp in the mouse-press handler), so a lone touchpad `contextmenu` produces one remote right click and real right clicks do not double-fire.

## Verification

- 3 new unit tests for `mouse_buttons_param` (explicit bitmask wins, press/release fallback, moves default to 0). Suite passes, `cargo fmt`/`clippy` clean (only the 2 pre-existing warnings), dashboard `tsc` + `next build` clean.
- Live websocket proof against a page with a draggable element, a drop zone, and a contextmenu listener, driven with the exact message shapes the dashboard now sends: the synthesized right press/release pair fires `contextmenu`, a held-left move sequence (`button: "left"`, `buttons: 1`) fires `dragstart`, `dragover`, and `drop`, and a ctrl press reports `ctrlKey` through the modifiers bitmask.

Fixes #1631.
Fixes #1632.
