### PR TITLE
test(native): raise parity action timeout to 60s

### DIFF
--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -397,8 +397,10 @@ async fn test_all_documented_actions_are_handled() {
     for (i, action) in DOCUMENTED_ACTIONS.iter().enumerate() {
         let id = format!("parity-{}", i);
         let cmd = minimal_command(action, &id);
+        // Generous: `launch` starts a real browser, and the slowest CI target
+        // (x86_64-apple-darwin) runs this suite about 3x slower than aarch64.
         let result = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
+            std::time::Duration::from_secs(60),
             execute_command(&cmd, &mut state),
         )
         .await


### PR DESCRIPTION
## Problem

`test_all_documented_actions_are_handled` has failed on every push to main since July 24, only on `x86_64-apple-darwin`. The `launch` action starts a real browser and exceeds the 10s per-action timeout on that runner.

That target runs the Rust suite about 3x slower than its aarch64 twin on the same image: 197s vs 67s. Locally the same suite takes 15s and `launch` returns in 1.3s, on both arm64 and x86 under Rosetta, so it does not reproduce off CI. A rerun of the failing job on the same commit failed again, so it is not a flake.

## Change

Per-action timeout goes from 10s to 60s. No effect on the passing path, since the timeout only cuts.

## How to check

CI on a pull request does not run this job: `rust-cross` is gated on `github.event_name != 'pull_request'`. Verified by workflow dispatch on the branch instead: https://github.com/vercel-labs/agent-browser/actions/runs/30670400676

## Related

#1342 touches the same test for the same class of slowness, shortening dispatch-only command timeouts. It does not change the 10s wrapper, so it does not cover the `launch` failure. Open since May 9 and unreviewed.

Leaves the deeper issue open: a unit test that launches a real browser stays environment dependent.