### PR TITLE
feat(native): add visible agent cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,25 @@ Each `react ...` subcommand requires `--enable react-devtools` to have been pass
 
 Works on any React app — Next.js, Remix, Vite+React, CRA, TanStack Start, React Native Web, etc. `vitals` and `pushstate` are framework-agnostic. `vitals` prints a summary by default; pass `--json` for the full structured payload.
 
+### Visible agent cursor
+
+Show a smooth, glowing cursor when agent-browser clicks, hovers, drags, or sends coordinate mouse actions. Because the overlay lives inside the page, it appears in screenshots, recordings, and remote browser streams. It does not intercept pointer input or appear in the accessibility tree, and reduced-motion preferences disable its movement animation.
+
+```bash
+agent-browser open --enable agent-cursor https://example.com
+```
+
+MCP clients can pass `enable: ["agent-cursor"]` to `agent_browser_open`. The MCP server inherits `AGENT_BROWSER_CURSOR_THEME` when it starts, so the same bounded theme applies without adding request-level styling data.
+
+The cursor represents actions sent through agent-browser. Input sent directly to a remote browser is intentionally not presented as agent activity. Each high-level pointer trajectory is capped at 430 milliseconds and completes before its input is dispatched. Raw coordinate input first enqueues an exact cursor placement and then dispatches the real event on the same CDP session, without waiting for a cosmetic response. The first action after a navigation snaps into place because the page has a new JavaScript context. Crossing an out-of-process iframe transfers the cursor between page targets instead of inventing cross-frame coordinates.
+
+The renderer has a bounded theme contract—no arbitrary CSS or SVG. Set a partial JSON override through `AGENT_BROWSER_CURSOR_THEME`; omitted fields retain the default. Supported fields are `shape` (`arrow` or `ring`), a six-digit `accent`, `glow` (`none`, `soft`, or `strong`), `scale` (`0.75`–`1.5`), and `motion` (`smooth` or `direct`).
+
+```bash
+AGENT_BROWSER_CURSOR_THEME='{"accent":"#8c264c","glow":"strong"}' \
+  agent-browser --enable agent-cursor open https://example.com
+```
+
 ### Accessibility audits
 
 Run an [axe-core](https://github.com/dequelabs/axe-core) accessibility audit against the current page or a URL. The axe-core engine is embedded in the binary, so it works offline and under strict CSP. It runs private partial audits across the page's frame tree and merges serialized results without page messaging, so page-provided `window.axe` values remain intact and iframe violations retain their frame selector paths. Accessibility audits require a CDP browser and are not available with Safari or iOS WebDriver sessions.
@@ -922,7 +941,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--executable-path <path>` | Custom browser executable (or `AGENT_BROWSER_EXECUTABLE_PATH` env) |
 | `--extension <path>` | Load browser extension (repeatable; or `AGENT_BROWSER_EXTENSIONS` env) |
 | `--init-script <path>` | Register a page init script before the first navigation (repeatable; or `AGENT_BROWSER_INIT_SCRIPTS` env) |
-| `--enable <feature>` | Built-in init scripts: `react-devtools` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
+| `--enable <feature>` | Built-in features: `react-devtools`, `agent-cursor` (repeatable or comma-list; or `AGENT_BROWSER_ENABLE` env) |
 | `--args <args>` | Browser launch args, comma or newline separated (or `AGENT_BROWSER_ARGS` env) |
 | `--user-agent <ua>` | Custom User-Agent string (or `AGENT_BROWSER_USER_AGENT` env) |
 | `--proxy <url>` | Proxy server URL with optional auth (or `AGENT_BROWSER_PROXY` env) |

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -72,7 +72,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["react-devtools"]
+        "enum": ["react-devtools", "agent-cursor"]
       },
       "description": "Built-in launch features to enable."
     },

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -433,6 +433,7 @@ pub struct DaemonOptions<'a> {
     pub extensions: &'a [String],
     pub init_scripts: &'a [String],
     pub enable: &'a [String],
+    pub cursor_theme: Option<&'a str>,
     pub args: Option<&'a str>,
     pub user_agent: Option<&'a str>,
     pub proxy: Option<&'a str>,
@@ -486,6 +487,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if !opts.enable.is_empty() {
         cmd.env("AGENT_BROWSER_ENABLE", opts.enable.join(","));
+    }
+    if let Some(theme) = opts.cursor_theme {
+        cmd.env("AGENT_BROWSER_CURSOR_THEME", theme);
     }
     if let Some(a) = opts.args {
         cmd.env("AGENT_BROWSER_ARGS", a);
@@ -588,6 +592,7 @@ fn daemon_config_fingerprint(opts: &DaemonOptions) -> String {
     opts.idle_timeout.hash(&mut hasher);
     opts.default_timeout.hash(&mut hasher);
     opts.no_auto_dialog.hash(&mut hasher);
+    opts.cursor_theme.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
 
@@ -1241,6 +1246,7 @@ mod tests {
             extensions: &[],
             init_scripts: &[],
             enable: &[],
+            cursor_theme: None,
             args: None,
             user_agent: None,
             proxy: None,
@@ -1281,6 +1287,8 @@ mod tests {
         let idle_changed = test_daemon_options(Some("1000"), false, None);
         let dialog_changed = test_daemon_options(None, true, None);
         let domains_changed = test_daemon_options(None, false, Some(&domains));
+        let mut theme_changed = test_daemon_options(None, false, None);
+        theme_changed.cursor_theme = Some(r##"{"accent":"#8c264c"}"##);
 
         assert_ne!(
             daemon_config_fingerprint(&base),
@@ -1294,6 +1302,11 @@ mod tests {
             daemon_config_fingerprint(&base),
             daemon_config_fingerprint(&domains_changed),
             "allowed domains are browser launch state, not daemon identity"
+        );
+        assert_ne!(
+            daemon_config_fingerprint(&base),
+            daemon_config_fingerprint(&theme_changed),
+            "cursor theme belongs to the daemon that owns cursor rendering"
         );
     }
 

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -57,6 +57,7 @@ pub(super) fn check(checks: &mut Vec<Check>, opts: &DoctorOptions) {
         extensions: &[],
         init_scripts: &[],
         enable: &[],
+        cursor_theme: None,
         args: None,
         user_agent: None,
         proxy: None,

--- a/cli/src/doctor/webgpu.rs
+++ b/cli/src/doctor/webgpu.rs
@@ -197,6 +197,7 @@ pub(super) fn check(checks: &mut Vec<Check>, opts: &DoctorOptions) {
         extensions: &[],
         init_scripts: &[],
         enable: &[],
+        cursor_theme: None,
         args: None,
         user_agent: None,
         proxy: None,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1246,6 +1246,7 @@ fn main() {
     };
     let plugin_registry_json =
         serde_json::to_string(&flags.plugins).unwrap_or_else(|_| "[]".to_string());
+    let cursor_theme = env::var("AGENT_BROWSER_CURSOR_THEME").ok();
     let daemon_opts = DaemonOptions {
         headed: flags.headed,
         debug: flags.debug,
@@ -1253,6 +1254,7 @@ fn main() {
         extensions: &flags.extensions,
         init_scripts: &flags.init_scripts,
         enable: &flags.enable,
+        cursor_theme: cursor_theme.as_deref(),
         args: flags.args.as_deref(),
         user_agent: flags.user_agent.as_deref(),
         proxy: proxy_server.as_deref(),

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -750,11 +750,16 @@ fn tools() -> Vec<Value> {
         tool(
             TOOL_OPEN,
             "Open page",
-            "Launch the browser and optionally navigate to a URL.",
+            "Launch the browser and optionally navigate to a URL. Agent cursor themes use the MCP server's inherited AGENT_BROWSER_CURSOR_THEME environment setting.",
             json!({
                 "url": { "type": "string", "description": "URL to open. Omit to launch about:blank." },
                 "headed": { "type": "boolean", "description": "Show the browser window. Explicit true/false overrides AGENT_BROWSER_HEADED and config; omit to use those defaults." },
-                "webgpu": { "type": "boolean", "description": "Enable WebGPU (SwiftShader software Vulkan on Linux; no GPU required). Explicit true/false overrides AGENT_BROWSER_WEBGPU and config; omit to use those defaults." }
+                "webgpu": { "type": "boolean", "description": "Enable WebGPU (SwiftShader software Vulkan on Linux; no GPU required). Explicit true/false overrides AGENT_BROWSER_WEBGPU and config; omit to use those defaults." },
+                "enable": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["react-devtools", "agent-cursor"] },
+                    "description": "Built-in launch features to enable."
+                }
             }),
             &[],
         ),
@@ -2365,6 +2370,12 @@ fn open_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
         args.push("--webgpu".to_string());
         args.push(webgpu.to_string());
     }
+    if let Some(features) = optional_string_array(arguments, "enable")? {
+        for feature in features {
+            args.push("--enable".to_string());
+            args.push(feature);
+        }
+    }
     args.push("open".to_string());
     if let Some(url) = optional_string(arguments, "url")? {
         if !url.is_empty() {
@@ -3838,6 +3849,7 @@ mod tests {
         let props = &open["inputSchema"]["properties"];
         assert!(props.get("headed").is_some());
         assert!(props.get("webgpu").is_some());
+        assert!(props.get("enable").is_some());
     }
 
     #[test]
@@ -3858,6 +3870,16 @@ mod tests {
         assert_eq!(
             open_args(&json!({ "headed": false })).unwrap(),
             vec!["--headed", "false", "open"]
+        );
+        assert_eq!(
+            open_args(&json!({ "enable": ["react-devtools", "agent-cursor"] })).unwrap(),
+            vec![
+                "--enable",
+                "react-devtools",
+                "--enable",
+                "agent-cursor",
+                "open"
+            ]
         );
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -24,6 +24,7 @@ use super::cdp::types::{
     TargetInfoChangedEvent,
 };
 use super::cookies;
+use super::cursor;
 use super::diff;
 use super::element::RefMap;
 use super::inspect_server::InspectServer;
@@ -404,6 +405,8 @@ pub struct DaemonState {
     /// so they never block the agent.
     dialog_handler_task: Option<tokio::task::JoinHandle<()>>,
     pub mouse_state: MouseState,
+    /// Visual cursor state for the active browser launch.
+    pub cursor_state: cursor::CursorState,
     /// Tracks the currently open JavaScript dialog (alert/confirm/prompt), if any.
     pub pending_dialog: Option<PendingDialog>,
     /// A mouse button left logically down because a dialog opened between
@@ -507,6 +510,7 @@ impl DaemonState {
             fetch_handler_task: None,
             dialog_handler_task: None,
             mouse_state: MouseState::default(),
+            cursor_state: cursor::CursorState::from_env(),
             pending_dialog: None,
             pending_pointer_release: None,
             auto_dialog: !matches!(
@@ -1094,6 +1098,7 @@ impl DaemonState {
         for sid in &drained.detached_iframe_sessions {
             self.iframe_sessions.retain(|_, v| v != sid);
             self.active_iframe_sessions.remove(sid);
+            self.cursor_state.forget_session(sid);
         }
 
         // Attach and register new targets
@@ -1968,6 +1973,7 @@ pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(),
 
     close_active_provider_session(state).await;
     state.launch_hash = None;
+    state.cursor_state.reset();
     state.network_auto_attach_installed = false;
     state.iframe_sessions.clear();
     state.active_iframe_sessions.clear();
@@ -3336,39 +3342,46 @@ fn allowed_domains_from_launch_command(cmd: &Value) -> Option<Vec<String>> {
 }
 
 async fn apply_launch_init_scripts(
-    state: &DaemonState,
+    state: &mut DaemonState,
     enable_features: &[String],
     init_script_paths: &[String],
 ) {
-    let Some(mgr) = state.browser.as_ref() else {
-        return;
-    };
+    {
+        let Some(mgr) = state.browser.as_ref() else {
+            return;
+        };
 
-    for feature in enable_features {
-        match feature.as_str() {
-            "react-devtools" | "react" => {
-                let _ = mgr.add_script_to_evaluate(react::INSTALL_HOOK_JS).await;
+        for feature in enable_features {
+            match feature.as_str() {
+                cursor::FEATURE_NAME => {
+                    let _ = mgr.add_script_to_evaluate(cursor::INSTALL_SCRIPT).await;
+                }
+                "react-devtools" | "react" => {
+                    let _ = mgr.add_script_to_evaluate(react::INSTALL_HOOK_JS).await;
+                }
+                other => {
+                    eprintln!("warning: unknown --enable feature '{}'", other);
+                }
             }
-            other => {
-                eprintln!("warning: unknown --enable feature '{}'", other);
+        }
+
+        for path in init_script_paths {
+            match fs::read_to_string(path) {
+                Ok(source) => {
+                    let _ = mgr.add_script_to_evaluate(&source).await;
+                }
+                Err(e) => {
+                    eprintln!("warning: failed to read --init-script '{}': {}", path, e);
+                }
             }
+        }
+
+        for source in &state.plugin_init_scripts {
+            let _ = mgr.add_script_to_evaluate(source).await;
         }
     }
 
-    for path in init_script_paths {
-        match fs::read_to_string(path) {
-            Ok(source) => {
-                let _ = mgr.add_script_to_evaluate(&source).await;
-            }
-            Err(e) => {
-                eprintln!("warning: failed to read --init-script '{}': {}", path, e);
-            }
-        }
-    }
-
-    for source in &state.plugin_init_scripts {
-        let _ = mgr.add_script_to_evaluate(source).await;
-    }
+    state.cursor_state.configure(enable_features);
 }
 
 async fn apply_launch_mutator_plugins(
@@ -4733,6 +4746,22 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     let new_tab = cmd.get("newTab").and_then(|v| v.as_bool()).unwrap_or(false);
 
     if new_tab {
+        if state.cursor_state.enabled() {
+            let (_, _, pointer_session_id) = interaction::point_to_element(
+                &mgr.client,
+                &session_id,
+                &state.ref_map,
+                &mut state.cursor_state,
+                selector,
+                &state.iframe_sessions,
+            )
+            .await?;
+            cursor::pulse(&mgr.client, &state.cursor_state, &pointer_session_id).await;
+        }
+
+        // Resolve the link after the optional cursor trajectory. The page can
+        // mutate while the cursor moves, so reading href first could open a
+        // stale destination while visibly pointing at the current element.
         use super::element::resolve_element_object_id;
         let (object_id, effective_session_id) = resolve_element_object_id(
             &mgr.client,
@@ -4807,9 +4836,12 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         selector,
-        button,
-        click_count,
+        interaction::ClickOptions {
+            button,
+            count: click_count,
+        },
         &state.iframe_sessions,
     )
     .await?;
@@ -4833,6 +4865,7 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         selector,
         &state.iframe_sessions,
     )
@@ -4971,6 +5004,7 @@ async fn handle_hover(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         selector,
         &state.iframe_sessions,
     )
@@ -5057,6 +5091,7 @@ async fn handle_check(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         selector,
         &state.iframe_sessions,
     )
@@ -5076,6 +5111,7 @@ async fn handle_uncheck(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         selector,
         &state.iframe_sessions,
     )
@@ -5876,7 +5912,7 @@ async fn handle_auth_show(cmd: &Value) -> Result<Value, String> {
     auth::auth_show(name)
 }
 
-async fn handle_mouse(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_mouse(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -5888,6 +5924,12 @@ async fn handle_mouse(cmd: &Value, state: &DaemonState) -> Result<Value, String>
     let y = cmd.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let button = cmd.get("button").and_then(|v| v.as_str()).unwrap_or("none");
     let click_count = cmd.get("clickCount").and_then(|v| v.as_i64()).unwrap_or(0);
+
+    if event_type == "mousePressed" {
+        cursor::press_at(&mgr.client, &mut state.cursor_state, &session_id, x, y).await;
+    } else if event_type == "mouseMoved" {
+        cursor::place_at(&mgr.client, &mut state.cursor_state, &session_id, x, y).await;
+    }
 
     mgr.client
         .send_command(
@@ -6217,9 +6259,12 @@ async fn handle_download(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         selector,
-        "left",
-        1,
+        interaction::ClickOptions {
+            button: "left",
+            count: 1,
+        },
         &state.iframe_sessions,
     )
     .await?;
@@ -8124,9 +8169,12 @@ async fn execute_subaction(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
+                &mut state.cursor_state,
                 selector,
-                "left",
-                1,
+                interaction::ClickOptions {
+                    button: "left",
+                    count: 1,
+                },
                 &state.iframe_sessions,
             )
             .await?;
@@ -8157,6 +8205,7 @@ async fn execute_subaction(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
+                &mut state.cursor_state,
                 selector,
                 &state.iframe_sessions,
             )
@@ -8168,6 +8217,7 @@ async fn execute_subaction(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
+                &mut state.cursor_state,
                 selector,
                 &state.iframe_sessions,
             )
@@ -8869,7 +8919,7 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
         .and_then(|v| v.as_str())
         .ok_or("Missing 'target' parameter")?;
 
-    let (sx, sy, source_session_id) = super::element::resolve_element_center(
+    let (mut sx, mut sy, mut source_session_id) = super::element::resolve_element_center(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -8877,7 +8927,7 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
         &state.iframe_sessions,
     )
     .await?;
-    let (tx, ty, target_session_id) = super::element::resolve_element_center(
+    let (mut tx, mut ty, mut target_session_id) = super::element::resolve_element_center(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -8885,6 +8935,32 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
         &state.iframe_sessions,
     )
     .await?;
+    if state.cursor_state.enabled() {
+        cursor::move_to(
+            &mgr.client,
+            &mut state.cursor_state,
+            &source_session_id,
+            sx,
+            sy,
+        )
+        .await;
+        (sx, sy, source_session_id) = super::element::resolve_element_center(
+            &mgr.client,
+            &session_id,
+            &state.ref_map,
+            source,
+            &state.iframe_sessions,
+        )
+        .await?;
+        (tx, ty, target_session_id) = super::element::resolve_element_center(
+            &mgr.client,
+            &session_id,
+            &state.ref_map,
+            target,
+            &state.iframe_sessions,
+        )
+        .await?;
+    }
 
     // Mouse down at source
     mgr.client
@@ -8901,6 +8977,7 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
             Some(&source_session_id),
         )
         .await?;
+    cursor::pulse(&mgr.client, &state.cursor_state, &source_session_id).await;
 
     // Move in steps to target, keeping the left button held (buttons: 1) so
     // that the browser sees a drag rather than a plain pointer move.
@@ -8908,6 +8985,14 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     for i in 1..=steps {
         let cx = sx + (tx - sx) * (i as f64) / (steps as f64);
         let cy = sy + (ty - sy) * (i as f64) / (steps as f64);
+        cursor::place_at(
+            &mgr.client,
+            &mut state.cursor_state,
+            &target_session_id,
+            cx,
+            cy,
+        )
+        .await;
         mgr.client
             .send_command(
                 "Input.dispatchMouseEvent",
@@ -8915,7 +9000,10 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
                 Some(&target_session_id),
             )
             .await?;
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(
+            if state.cursor_state.enabled() { 16 } else { 10 },
+        ))
+        .await;
     }
 
     // Mouse up at target
@@ -10601,9 +10689,12 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         &mgr.client,
         &session_id,
         &state.ref_map,
+        &mut state.cursor_state,
         &sub_sel,
-        "left",
-        1,
+        interaction::ClickOptions {
+            button: "left",
+            count: 1,
+        },
         &state.iframe_sessions,
     )
     .await?;
@@ -10929,6 +11020,25 @@ async fn handle_input_mouse(cmd: &Value, state: &mut DaemonState) -> Result<Valu
             .map(|v| v as i32),
     );
 
+    if event_type == "mousePressed" {
+        cursor::press_at(
+            &mgr.client,
+            &mut state.cursor_state,
+            &session_id,
+            params.x,
+            params.y,
+        )
+        .await;
+    } else if event_type == "mouseMoved" {
+        cursor::place_at(
+            &mgr.client,
+            &mut state.cursor_state,
+            &session_id,
+            params.x,
+            params.y,
+        )
+        .await;
+    }
     mgr.client
         .send_command_typed::<_, Value>("Input.dispatchMouseEvent", &params, Some(&session_id))
         .await?;
@@ -11049,6 +11159,14 @@ async fn handle_mousemove(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         None,
     );
 
+    cursor::place_at(
+        &mgr.client,
+        &mut state.cursor_state,
+        &session_id,
+        params.x,
+        params.y,
+    )
+    .await;
     mgr.client
         .send_command_typed::<_, Value>("Input.dispatchMouseEvent", &params, Some(&session_id))
         .await?;
@@ -11072,6 +11190,14 @@ async fn handle_mousedown(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         None,
     );
 
+    cursor::press_at(
+        &mgr.client,
+        &mut state.cursor_state,
+        &session_id,
+        params.x,
+        params.y,
+    )
+    .await;
     mgr.client
         .send_command_typed::<_, Value>("Input.dispatchMouseEvent", &params, Some(&session_id))
         .await?;

--- a/cli/src/native/agent_cursor.js
+++ b/cli/src/native/agent_cursor.js
@@ -1,0 +1,294 @@
+(() => {
+  const key = "__agentBrowserCursor";
+  const current = Object.getOwnPropertyDescriptor(globalThis, key)?.value;
+  if (
+    current?.version === 1 &&
+    typeof current.configure === "function" &&
+    typeof current.moveTo === "function" &&
+    typeof current.placeAt === "function" &&
+    typeof current.pulse === "function"
+  ) {
+    return current;
+  }
+
+  const host = document.createElement("div");
+  host.setAttribute("data-agent-browser-cursor", "");
+  host.setAttribute("aria-hidden", "true");
+  host.setAttribute("popover", "manual");
+  host.inert = true;
+  Object.assign(host.style, {
+    position: "fixed",
+    left: "0",
+    top: "0",
+    right: "auto",
+    bottom: "auto",
+    margin: "0",
+    padding: "0",
+    border: "0",
+    background: "transparent",
+    width: "30px",
+    height: "34px",
+    zIndex: "2147483647",
+    pointerEvents: "none",
+    opacity: "0",
+    transform: "translate3d(-100px, -100px, 0)",
+    transformOrigin: "3px 2px",
+    transition: "opacity 80ms linear",
+    willChange: "transform, opacity",
+  });
+  const protect = (property, value) =>
+    host.style.setProperty(property, value, "important");
+  protect("position", "fixed");
+  protect("left", "0px");
+  protect("top", "0px");
+  protect("right", "auto");
+  protect("bottom", "auto");
+  protect("display", "block");
+  protect("visibility", "visible");
+  protect("width", "30px");
+  protect("height", "34px");
+  protect("margin", "0px");
+  protect("padding", "0px");
+  protect("border", "0px");
+  protect("background", "transparent");
+  protect("z-index", "2147483647");
+  protect("pointer-events", "none");
+  protect("opacity", "0");
+  protect("transform-origin", "3px 2px");
+  protect("transition", "opacity 80ms linear");
+
+  const shadow = host.attachShadow({ mode: "closed" });
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 28");
+  svg.setAttribute("width", "24");
+  svg.setAttribute("height", "28");
+  svg.setAttribute("aria-hidden", "true");
+  Object.assign(svg.style, {
+    display: "block",
+    overflow: "visible",
+    filter:
+      "drop-shadow(0 1px 1px rgba(0,0,0,.42)) drop-shadow(0 0 3px rgba(124,58,237,.86)) drop-shadow(0 0 9px rgba(124,58,237,.52))",
+  });
+
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("d", "M3 2.25 20.15 14.1l-7.12 1.3 4.05 7.62-4.2 2.23-4.04-7.6-4.76 5.52L3 2.25Z");
+  path.setAttribute("fill", "rgba(250,248,255,.92)");
+  path.setAttribute("stroke", "#7c3aed");
+  path.setAttribute("stroke-width", "1.45");
+  path.setAttribute("stroke-linejoin", "round");
+  svg.appendChild(path);
+  const ring = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+  ring.setAttribute("cx", "10");
+  ring.setAttribute("cy", "10");
+  ring.setAttribute("r", "5.25");
+  ring.setAttribute("fill", "rgba(250,248,255,.18)");
+  ring.setAttribute("stroke-width", "1.65");
+  ring.setAttribute("display", "none");
+  svg.appendChild(ring);
+  shadow.appendChild(svg);
+
+  const defaults = Object.freeze({
+    shape: "arrow",
+    accent: "#7c3aed",
+    glow: "soft",
+    scale: 1,
+    motion: "smooth",
+  });
+  let theme = { ...defaults };
+  let position = null;
+  let frame = 0;
+  let fallbackTimer = 0;
+  let finishPending = null;
+  let pulseAnimation = null;
+
+  const reducedMotion = () =>
+    matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  const validAccent = (value) =>
+    typeof value === "string" && /^#[0-9a-f]{6}$/i.test(value);
+
+  const applyTheme = () => {
+    const arrow = theme.shape === "arrow";
+    path.setAttribute("display", arrow ? "block" : "none");
+    ring.setAttribute("display", arrow ? "none" : "block");
+    path.setAttribute("stroke", theme.accent);
+    ring.setAttribute("stroke", theme.accent);
+    const shadows = {
+      none: "drop-shadow(0 1px 1px rgba(0,0,0,.42))",
+      soft: `drop-shadow(0 1px 1px rgba(0,0,0,.42)) drop-shadow(0 0 2px ${theme.accent}bb) drop-shadow(0 0 6px ${theme.accent}44)`,
+      strong: `drop-shadow(0 1px 1px rgba(0,0,0,.42)) drop-shadow(0 0 3px ${theme.accent}) drop-shadow(0 0 8px ${theme.accent}66)`,
+    };
+    svg.style.filter = shadows[theme.glow];
+    svg.style.transform = `scale(${theme.scale})`;
+    svg.style.transformOrigin = arrow ? "3px 2px" : "10px 10px";
+    protect("transform-origin", arrow ? "3px 2px" : "10px 10px");
+  };
+
+  const configure = (options = {}) => {
+    const next = { ...theme };
+    if (options.shape === "arrow" || options.shape === "ring") {
+      next.shape = options.shape;
+    }
+    if (validAccent(options.accent)) next.accent = options.accent;
+    if (["none", "soft", "strong"].includes(options.glow)) {
+      next.glow = options.glow;
+    }
+    const scale = Number(options.scale);
+    if (Number.isFinite(scale) && scale >= 0.75 && scale <= 1.5) {
+      next.scale = scale;
+    }
+    if (options.motion === "smooth" || options.motion === "direct") {
+      next.motion = options.motion;
+    }
+    theme = next;
+    applyTheme();
+    return { ...theme };
+  };
+
+  const ensureAttached = (promote = false) => {
+    if (!host.isConnected) {
+      const parent = document.documentElement || document.body;
+      if (parent) parent.appendChild(host);
+    }
+    if (typeof host.showPopover !== "function") return;
+    try {
+      if (promote && host.matches(":popover-open")) host.hidePopover();
+      if (!host.matches(":popover-open")) host.showPopover();
+    } catch {
+      // A detached or unsupported document still gets the stacking fallback.
+    }
+  };
+
+  const place = (x, y) => {
+    position = { x, y };
+    const hotspot = theme.shape === "arrow" ? { x: 3, y: 2 } : { x: 10, y: 10 };
+    protect(
+      "transform",
+      `translate3d(${x - hotspot.x}px, ${y - hotspot.y}px, 0)`,
+    );
+  };
+
+  const settlePending = () => {
+    if (frame) cancelAnimationFrame(frame);
+    frame = 0;
+    if (fallbackTimer) clearTimeout(fallbackTimer);
+    fallbackTimer = 0;
+    if (finishPending) finishPending();
+    finishPending = null;
+  };
+
+  const moveTo = (rawX, rawY, quick = false) => {
+    ensureAttached(true);
+    const x = Number(rawX);
+    const y = Number(rawY);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return Promise.resolve();
+
+    settlePending();
+    protect("opacity", "1");
+    protect("transition", reducedMotion() ? "none" : "opacity 80ms linear");
+    if (!position || reducedMotion() || theme.motion === "direct") {
+      place(x, y);
+      return Promise.resolve();
+    }
+
+    const start = position;
+    const dx = x - start.x;
+    const dy = y - start.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance < 2) {
+      place(x, y);
+      return Promise.resolve();
+    }
+
+    const duration = quick
+      ? Math.min(120, Math.max(60, 35 + distance * 0.1))
+      : Math.min(430, Math.max(150, 125 + distance * 0.16));
+    const controlX = start.x + dx * 0.5;
+    const controlY = start.y + dy * 0.5 - Math.min(quick ? 16 : 56, distance * 0.12);
+    const startedAt = performance.now();
+
+    return new Promise((resolve) => {
+      finishPending = resolve;
+      fallbackTimer = setTimeout(() => {
+        if (!finishPending) return;
+        place(x, y);
+        settlePending();
+      }, duration + 120);
+      const tick = (now) => {
+        const linear = Math.min(1, (now - startedAt) / duration);
+        const t = linear * linear * linear * (linear * (linear * 6 - 15) + 10);
+        const inverse = 1 - t;
+        place(
+          inverse * inverse * start.x + 2 * inverse * t * controlX + t * t * x,
+          inverse * inverse * start.y + 2 * inverse * t * controlY + t * t * y,
+        );
+
+        if (linear < 1) {
+          frame = requestAnimationFrame(tick);
+          return;
+        }
+
+        frame = 0;
+        finishPending = null;
+        clearTimeout(fallbackTimer);
+        fallbackTimer = 0;
+        resolve();
+      };
+      frame = requestAnimationFrame(tick);
+    });
+  };
+
+  const placeAt = (rawX, rawY) => {
+    ensureAttached(true);
+    const x = Number(rawX);
+    const y = Number(rawY);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    settlePending();
+    protect("transition", reducedMotion() ? "none" : "opacity 80ms linear");
+    protect("opacity", "1");
+    place(x, y);
+  };
+
+  const pulse = () => {
+    ensureAttached();
+    pulseAnimation?.cancel();
+    pulseAnimation = null;
+    if (reducedMotion()) return;
+    pulseAnimation = host.animate(
+      [
+        { scale: "1", offset: 0 },
+        { scale: ".88", offset: 0.38 },
+        { scale: "1.04", offset: 0.72 },
+        { scale: "1", offset: 1 },
+      ],
+      { duration: 180, easing: "cubic-bezier(.2,.8,.2,1)" },
+    );
+  };
+
+  const hide = () => {
+    settlePending();
+    protect("transition", reducedMotion() ? "none" : "opacity 80ms linear");
+    protect("opacity", "0");
+  };
+
+  const api = Object.freeze({
+    version: 1,
+    configure,
+    moveTo,
+    placeAt,
+    pulse,
+    hide,
+    get position() {
+      return position ? { ...position } : null;
+    },
+  });
+  Object.defineProperty(globalThis, key, {
+    value: api,
+    configurable: false,
+  });
+
+  if (!document.documentElement) {
+    document.addEventListener("DOMContentLoaded", ensureAttached, { once: true });
+  }
+  return api;
+})()

--- a/cli/src/native/cursor.rs
+++ b/cli/src/native/cursor.rs
@@ -1,0 +1,356 @@
+use std::env;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::cdp::client::CdpClient;
+use super::cdp::types::EvaluateParams;
+
+pub const FEATURE_NAME: &str = "agent-cursor";
+pub const INSTALL_SCRIPT: &str = include_str!("agent_cursor.js");
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CursorShape {
+    #[default]
+    Arrow,
+    Ring,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CursorGlow {
+    None,
+    #[default]
+    Soft,
+    Strong,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CursorMotion {
+    #[default]
+    Smooth,
+    Direct,
+}
+
+fn default_accent() -> String {
+    "#7c3aed".to_string()
+}
+
+fn default_scale() -> f64 {
+    1.0
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct CursorTheme {
+    pub shape: CursorShape,
+    pub accent: String,
+    pub glow: CursorGlow,
+    pub scale: f64,
+    pub motion: CursorMotion,
+}
+
+impl Default for CursorTheme {
+    fn default() -> Self {
+        Self {
+            shape: CursorShape::default(),
+            accent: default_accent(),
+            glow: CursorGlow::default(),
+            scale: default_scale(),
+            motion: CursorMotion::default(),
+        }
+    }
+}
+
+impl CursorTheme {
+    fn validate(self) -> Result<Self, String> {
+        let valid_accent = self.accent.len() == 7
+            && self.accent.starts_with('#')
+            && self.accent[1..]
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit());
+        if !valid_accent {
+            return Err("accent must be a six-digit hex color such as #7c3aed".to_string());
+        }
+        if !(0.75..=1.5).contains(&self.scale) {
+            return Err("scale must be between 0.75 and 1.5".to_string());
+        }
+        Ok(self)
+    }
+
+    fn from_env() -> Self {
+        let Some(raw) = env::var("AGENT_BROWSER_CURSOR_THEME").ok() else {
+            return Self::default();
+        };
+        let parsed = serde_json::from_str::<Self>(&raw)
+            .map_err(|error| error.to_string())
+            .and_then(Self::validate);
+        match parsed {
+            Ok(theme) => theme,
+            Err(error) => {
+                eprintln!(
+                    "warning: invalid AGENT_BROWSER_CURSOR_THEME; using the default: {error}"
+                );
+                Self::default()
+            }
+        }
+    }
+}
+
+fn feature_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|raw| {
+        raw.split([',', '\n'])
+            .map(str::trim)
+            .any(|feature| feature == FEATURE_NAME)
+    })
+}
+
+#[derive(Debug, Default)]
+pub struct CursorState {
+    enabled: bool,
+    visible_session_id: Option<String>,
+    theme: CursorTheme,
+}
+
+impl CursorState {
+    pub fn from_env() -> Self {
+        Self {
+            enabled: feature_enabled(env::var("AGENT_BROWSER_ENABLE").ok().as_deref()),
+            visible_session_id: None,
+            theme: CursorTheme::from_env(),
+        }
+    }
+
+    pub fn configure(&mut self, features: &[String]) {
+        self.enabled = features.iter().any(|feature| feature == FEATURE_NAME);
+        self.visible_session_id = None;
+    }
+
+    pub fn reset(&mut self) {
+        self.enabled = false;
+        self.visible_session_id = None;
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn theme_json(&self) -> String {
+        serde_json::to_string(&self.theme).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    pub fn forget_session(&mut self, session_id: &str) {
+        if self.visible_session_id.as_deref() == Some(session_id) {
+            self.visible_session_id = None;
+        }
+    }
+}
+
+async fn evaluate(
+    client: &CdpClient,
+    session_id: &str,
+    expression: String,
+    await_promise: bool,
+) -> Result<(), String> {
+    tokio::time::timeout(
+        Duration::from_millis(900),
+        client.send_command_typed::<_, Value>(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression,
+                return_by_value: Some(true),
+                await_promise: Some(await_promise),
+            },
+            Some(session_id),
+        ),
+    )
+    .await
+    .map_err(|_| "Agent cursor evaluation timed out".to_string())??;
+    Ok(())
+}
+
+async fn evaluate_no_wait(client: &CdpClient, session_id: &str, expression: String) {
+    let params = serde_json::to_value(EvaluateParams {
+        expression,
+        return_by_value: Some(false),
+        await_promise: Some(false),
+    })
+    .ok();
+    let _ = client
+        .send_command_no_wait("Runtime.evaluate", params, Some(session_id))
+        .await;
+}
+
+async fn hide(client: &CdpClient, session_id: &str) {
+    let expression = "globalThis.__agentBrowserCursor?.hide()".to_string();
+    evaluate_no_wait(client, session_id, expression).await;
+}
+
+/// Transfer the one visible cursor between page or OOPIF sessions.
+async fn claim_session(client: &CdpClient, state: &mut CursorState, input_session_id: &str) {
+    if state.visible_session_id.as_deref() == Some(input_session_id) {
+        return;
+    }
+    if let Some(previous_session_id) = state.visible_session_id.take() {
+        hide(client, &previous_session_id).await;
+    }
+    state.visible_session_id = Some(input_session_id.to_string());
+}
+
+/// Move the visual agent cursor in the same page target that receives input.
+///
+/// OOPIF input coordinates are local to the iframe target, not the outer page.
+/// Rendering in `input_session_id` keeps the overlay aligned without trying to
+/// duplicate Chromium's frame-transform machinery. Only the previously visible
+/// target is hidden when ownership changes.
+pub async fn move_to(
+    client: &CdpClient,
+    state: &mut CursorState,
+    input_session_id: &str,
+    x: f64,
+    y: f64,
+) {
+    if !state.enabled() {
+        return;
+    }
+
+    claim_session(client, state, input_session_id).await;
+
+    let x = serde_json::to_string(&x).unwrap_or_else(|_| "0".to_string());
+    let y = serde_json::to_string(&y).unwrap_or_else(|_| "0".to_string());
+    let theme = state.theme_json();
+    let expression = format!(
+        "{INSTALL_SCRIPT}; globalThis.__agentBrowserCursor.configure({theme}); globalThis.__agentBrowserCursor.moveTo({x}, {y})"
+    );
+    let _ = evaluate(client, input_session_id, expression, true).await;
+}
+
+pub async fn correct_to(client: &CdpClient, state: &CursorState, session_id: &str, x: f64, y: f64) {
+    if !state.enabled() {
+        return;
+    }
+    let x = serde_json::to_string(&x).unwrap_or_else(|_| "0".to_string());
+    let y = serde_json::to_string(&y).unwrap_or_else(|_| "0".to_string());
+    let theme = state.theme_json();
+    let expression = format!(
+        "{INSTALL_SCRIPT}; globalThis.__agentBrowserCursor.configure({theme}); globalThis.__agentBrowserCursor.moveTo({x}, {y}, true)"
+    );
+    let _ = evaluate(client, session_id, expression, true).await;
+}
+
+/// Enqueue a raw press visualization before its input event without waiting
+/// for a Runtime response. CDP preserves command order on the flat session.
+pub async fn press_at(
+    client: &CdpClient,
+    state: &mut CursorState,
+    session_id: &str,
+    x: f64,
+    y: f64,
+) {
+    if !state.enabled() {
+        return;
+    }
+    claim_session(client, state, session_id).await;
+    let x = serde_json::to_string(&x).unwrap_or_else(|_| "0".to_string());
+    let y = serde_json::to_string(&y).unwrap_or_else(|_| "0".to_string());
+    let theme = state.theme_json();
+    let expression = format!(
+        "{INSTALL_SCRIPT}; globalThis.__agentBrowserCursor.configure({theme}); globalThis.__agentBrowserCursor.placeAt({x}, {y}); globalThis.__agentBrowserCursor.pulse()"
+    );
+    evaluate_no_wait(client, session_id, expression).await;
+}
+
+pub async fn place_at(
+    client: &CdpClient,
+    state: &mut CursorState,
+    session_id: &str,
+    x: f64,
+    y: f64,
+) {
+    if !state.enabled() {
+        return;
+    }
+    claim_session(client, state, session_id).await;
+    let x = serde_json::to_string(&x).unwrap_or_else(|_| "0".to_string());
+    let y = serde_json::to_string(&y).unwrap_or_else(|_| "0".to_string());
+    let theme = state.theme_json();
+    let expression = format!(
+        "{INSTALL_SCRIPT}; globalThis.__agentBrowserCursor.configure({theme}); globalThis.__agentBrowserCursor.placeAt({x}, {y})"
+    );
+    evaluate_no_wait(client, session_id, expression).await;
+}
+
+pub async fn pulse(client: &CdpClient, state: &CursorState, session_id: &str) {
+    if !state.enabled() {
+        return;
+    }
+    let theme = state.theme_json();
+    let expression = format!(
+        "{INSTALL_SCRIPT}; globalThis.__agentBrowserCursor.configure({theme}); globalThis.__agentBrowserCursor.pulse()"
+    );
+    evaluate_no_wait(client, session_id, expression).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_exact_feature_in_comma_or_newline_lists() {
+        assert!(feature_enabled(Some("react-devtools,agent-cursor")));
+        assert!(feature_enabled(Some("react-devtools\n agent-cursor ")));
+        assert!(!feature_enabled(Some("agent-cursors")));
+        assert!(!feature_enabled(Some("cursor")));
+        assert!(!feature_enabled(None));
+    }
+
+    #[test]
+    fn daemon_state_uses_the_resolved_launch_features() {
+        let mut state = CursorState::default();
+        state.configure(&["agent-cursor".to_string()]);
+        assert!(state.enabled());
+
+        state.configure(&[]);
+        assert!(!state.enabled());
+        assert!(state.visible_session_id.is_none());
+    }
+
+    #[test]
+    fn cursor_theme_accepts_partial_typed_overrides() {
+        let theme: CursorTheme = serde_json::from_str(
+            r##"{"shape":"ring","accent":"#8c264c","glow":"strong","scale":1.2}"##,
+        )
+        .unwrap();
+        let theme = theme.validate().unwrap();
+        assert!(matches!(theme.shape, CursorShape::Ring));
+        assert_eq!(theme.accent, "#8c264c");
+        assert!(matches!(theme.glow, CursorGlow::Strong));
+        assert!(matches!(theme.motion, CursorMotion::Smooth));
+        assert_eq!(theme.scale, 1.2);
+    }
+
+    #[test]
+    fn cursor_theme_rejects_unbounded_values() {
+        let invalid_color: CursorTheme = serde_json::from_str(r##"{"accent":"red"}"##).unwrap();
+        assert!(invalid_color.validate().is_err());
+
+        let invalid_scale: CursorTheme = serde_json::from_str(r#"{"scale":2}"#).unwrap();
+        assert!(invalid_scale.validate().is_err());
+
+        assert!(serde_json::from_str::<CursorTheme>(r#"{"shape":"custom-svg"}"#).is_err());
+        assert!(serde_json::from_str::<CursorTheme>(r#"{"css":"display:none"}"#).is_err());
+    }
+
+    #[test]
+    fn overlay_is_non_interactive_and_reduced_motion_aware() {
+        assert!(INSTALL_SCRIPT.contains("pointerEvents: \"none\""));
+        assert!(INSTALL_SCRIPT.contains("prefers-reduced-motion: reduce"));
+        assert!(INSTALL_SCRIPT.contains("requestAnimationFrame"));
+        assert!(INSTALL_SCRIPT.contains("showPopover"));
+        assert!(INSTALL_SCRIPT.contains("configurable: false"));
+        assert!(INSTALL_SCRIPT.contains("style.setProperty(property, value, \"important\")"));
+    }
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7106,6 +7106,406 @@ async fn e2e_react_tree_with_enable_hook() {
 
 #[tokio::test]
 #[ignore]
+async fn e2e_agent_cursor_tracks_pointer_actions_across_navigation() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_ENABLE", "AGENT_BROWSER_CURSOR_THEME"]);
+    guard.remove("AGENT_BROWSER_ENABLE");
+    guard.set(
+        "AGENT_BROWSER_CURSOR_THEME",
+        r##"{"accent":"#8c264c","glow":"strong"}"##,
+    );
+    let mut state = DaemonState::new();
+    let first_page = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode(
+            "<!doctype html><style>[data-agent-browser-cursor]{pointer-events:auto!important;opacity:0!important;transform:none!important}</style><button id='target' style='position:fixed;left:180px;top:120px;width:120px;height:60px' onclick='window.__clicked=true;document.querySelector(\"dialog\").showModal()'>Click me</button><dialog><button id='modal' style='width:140px;height:70px'>Modal action</button></dialog>"
+        )
+    );
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "enable": ["agent-cursor"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(state.cursor_state.enabled());
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": first_page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "#target" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "({ clicked: window.__clicked, position: globalThis.__agentBrowserCursor?.position, theme: globalThis.__agentBrowserCursor?.configure({}), host: (() => { const el = document.querySelector('[data-agent-browser-cursor]'); const computed = getComputedStyle(el); return el && { pointerEvents: computed.pointerEvents, ariaHidden: el.getAttribute('aria-hidden'), inert: el.inert, inlineOpacity: el.style.opacity, opacityPriority: el.style.getPropertyPriority('opacity'), transformPriority: el.style.getPropertyPriority('transform'), popoverOpen: el.matches(':popover-open') }; })(), target: (() => { const r = document.querySelector('#target').getBoundingClientRect(); return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; })() })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let result = &get_data(&resp)["result"];
+    assert_eq!(result["clicked"], true);
+    assert_eq!(result["host"]["pointerEvents"], "none");
+    assert_eq!(result["host"]["ariaHidden"], "true");
+    assert_eq!(result["host"]["inert"], true);
+    assert_eq!(result["host"]["inlineOpacity"], "1");
+    assert_eq!(result["host"]["opacityPriority"], "important");
+    assert_eq!(result["host"]["transformPriority"], "important");
+    assert_eq!(result["host"]["popoverOpen"], true);
+    assert_eq!(result["theme"]["accent"], "#8c264c");
+    assert_eq!(result["theme"]["glow"], "strong");
+    assert_eq!(result["theme"]["shape"], "arrow");
+    assert_eq!(result["position"]["x"], result["target"]["x"]);
+    assert_eq!(result["position"]["y"], result["target"]["y"]);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "#modal" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "(() => { const p = globalThis.__agentBrowserCursor.position; const r = document.querySelector('#modal').getBoundingClientRect(); const host = document.querySelector('[data-agent-browser-cursor]'); return { dx: Math.abs(p.x - (r.x + r.width / 2)), dy: Math.abs(p.y - (r.y + r.height / 2)), popoverOpen: host.matches(':popover-open') }; })()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(get_data(&resp)["result"]["dx"].as_f64().unwrap() < 0.01);
+    assert!(get_data(&resp)["result"]["dy"].as_f64().unwrap() < 0.01);
+    assert_eq!(get_data(&resp)["result"]["popoverOpen"], true);
+
+    let second_page = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode("<!doctype html><button id='next'>Next page</button>")
+    );
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "navigate", "url": &second_page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "evaluate",
+            "script": "Boolean(globalThis.__agentBrowserCursor) && Boolean(document.querySelector('[data-agent-browser-cursor]'))"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], true);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "launch", "headless": true, "enable": [] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(!state.cursor_state.enabled());
+
+    let resp = execute_command(
+        &json!({ "id": "10", "action": "navigate", "url": second_page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "11",
+            "action": "evaluate",
+            "script": "typeof globalThis.__agentBrowserCursor === 'undefined' && !document.querySelector('[data-agent-browser-cursor]')"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], true);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_agent_cursor_transfers_to_the_active_oopif_only() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_ENABLE"]);
+    guard.remove("AGENT_BROWSER_ENABLE");
+    let (port, server) = start_a11y_frame_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "enable": ["agent-cursor"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://localhost:{port}/top")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(!state.active_iframe_sessions.is_empty());
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "click", "selector": "h1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let outer_frame_id = state
+        .iframe_sessions
+        .iter()
+        .find(|(_, session_id)| state.active_iframe_sessions.contains(*session_id))
+        .map(|(frame_id, _)| frame_id.clone())
+        .expect("outer OOPIF should have a frame id");
+    state.active_frame_id = Some(outer_frame_id);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "h1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let mgr = state.browser.as_ref().unwrap();
+    let top_session_id = mgr.active_session_id().unwrap().to_string();
+    let top = mgr
+        .client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({
+                "expression": "document.querySelector('[data-agent-browser-cursor]')?.style.opacity || null",
+                "returnByValue": true
+            })),
+            Some(&top_session_id),
+        )
+        .await
+        .unwrap();
+    assert_eq!(top["result"]["value"], "0");
+
+    let mut visible_iframe_count = 0;
+    for iframe_session_id in &state.active_iframe_sessions {
+        let result = mgr
+            .client
+            .send_command(
+                "Runtime.evaluate",
+                Some(json!({
+                    "expression": "document.querySelector('[data-agent-browser-cursor]')?.style.opacity || null",
+                    "returnByValue": true
+                })),
+                Some(iframe_session_id),
+            )
+            .await
+            .unwrap();
+        if result["result"]["value"] == "1" {
+            visible_iframe_count += 1;
+        }
+    }
+    assert_eq!(visible_iframe_count, 1);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_agent_cursor_keeps_raw_input_and_drag_truthful() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_ENABLE"]);
+    guard.remove("AGENT_BROWSER_ENABLE");
+    let mut state = DaemonState::new();
+    let page = format!(
+        "data:text/html;base64,{}",
+        STANDARD.encode(
+            r#"<!doctype html>
+<div id="source" style="position:fixed;left:80px;top:90px;width:80px;height:60px;background:red"></div>
+<div id="target" style="position:fixed;left:600px;top:420px;width:100px;height:70px;background:blue"></div>
+<dialog><button style="width:180px;height:90px">Modal target</button></dialog>
+<script>
+window.__pointerEvents = [];
+window.__allPointerEvents = [];
+for (const type of ['mousedown', 'mousemove', 'mouseup']) {
+  document.addEventListener(type, event => {
+    const position = globalThis.__agentBrowserCursor?.position;
+    const sample = { type, x: event.clientX, y: event.clientY, cursorX: position?.x, cursorY: position?.y };
+    window.__allPointerEvents.push(sample);
+    if (type !== 'mousemove' || event.buttons === 1) window.__pointerEvents.push(sample);
+  });
+}
+</script>"#,
+        )
+    );
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "enable": ["agent-cursor"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "drag",
+            "source": "#source",
+            "target": "#target"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "({ count: window.__pointerEvents.length, mismatches: window.__pointerEvents.filter(e => Math.abs(e.x-e.cursorX) > .51 || Math.abs(e.y-e.cursorY) > .51).length })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(get_data(&resp)["result"]["count"].as_u64().unwrap() >= 12);
+    assert_eq!(get_data(&resp)["result"]["mismatches"], 0);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "input_mouse",
+            "type": "mouseMoved",
+            "x": 40,
+            "y": 50
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "({ position: globalThis.__agentBrowserCursor.position, event: window.__allPointerEvents.at(-1) })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let result = &get_data(&resp)["result"];
+    assert_eq!(result["position"]["x"], 40);
+    assert_eq!(result["position"]["y"], 50);
+    assert_eq!(result["event"]["x"], result["event"]["cursorX"]);
+    assert_eq!(result["event"]["y"], result["event"]["cursorY"]);
+
+    let resp = execute_command(
+        &json!({
+            "id": "9",
+            "action": "evaluate",
+            "script": "document.querySelector('dialog').showModal()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "10",
+            "action": "input_mouse",
+            "type": "mouseMoved",
+            "x": 400,
+            "y": 300
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "11",
+            "action": "evaluate",
+            "script": "({ modal: document.querySelector('dialog').open, popoverOpen: document.querySelector('[data-agent-browser-cursor]').matches(':popover-open'), position: globalThis.__agentBrowserCursor.position })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let result = &get_data(&resp)["result"];
+    assert_eq!(result["modal"], true);
+    assert_eq!(result["popoverOpen"], true);
+    assert_eq!(result["position"]["x"], 400);
+    assert_eq!(result["position"]["y"], 300);
+
+    let resp = execute_command(
+        &json!({
+            "id": "7",
+            "action": "input_mouse",
+            "type": "mousePressed",
+            "x": 75,
+            "y": 85,
+            "button": "left"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "evaluate",
+            "script": "({ position: globalThis.__agentBrowserCursor.position, event: window.__allPointerEvents.at(-1) })"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let result = &get_data(&resp)["result"];
+    assert_eq!(result["position"]["x"], 75);
+    assert_eq!(result["position"]["y"], 85);
+    assert_eq!(result["event"]["x"], result["event"]["cursorX"]);
+    assert_eq!(result["event"]["y"], result["event"]["cursorY"]);
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
+#[tokio::test]
+#[ignore]
 async fn e2e_relaunch_when_enable_changes_installs_react_hook() {
     let mut state = DaemonState::new();
 

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
+use super::cursor;
 use super::element::{resolve_element_center, resolve_element_object_id, RefMap};
 
 /// Outcome of a click. `dialog_opened` is true if a JavaScript dialog opened
@@ -25,16 +26,20 @@ pub struct PendingRelease {
     pub button: String,
 }
 
-pub async fn click(
+pub struct ClickOptions<'a> {
+    pub button: &'a str,
+    pub count: i32,
+}
+
+pub async fn point_to_element(
     client: &CdpClient,
     session_id: &str,
     ref_map: &RefMap,
+    cursor_state: &mut cursor::CursorState,
     selector_or_ref: &str,
-    button: &str,
-    click_count: i32,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<ClickResult, String> {
-    let (x, y, effective_session_id) = resolve_element_center(
+) -> Result<(f64, f64, String), String> {
+    let (mut x, mut y, mut effective_session_id) = resolve_element_center(
         client,
         session_id,
         ref_map,
@@ -42,6 +47,51 @@ pub async fn click(
         iframe_sessions,
     )
     .await?;
+    if !cursor_state.enabled() {
+        return Ok((x, y, effective_session_id));
+    }
+
+    let initial_x = x;
+    let initial_y = y;
+    let initial_session_id = effective_session_id.clone();
+    cursor::move_to(client, cursor_state, &effective_session_id, x, y).await;
+    (x, y, effective_session_id) = resolve_element_center(
+        client,
+        session_id,
+        ref_map,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await?;
+    if effective_session_id != initial_session_id {
+        cursor::move_to(client, cursor_state, &effective_session_id, x, y).await;
+    } else if (x - initial_x).abs() > 1.0 || (y - initial_y).abs() > 1.0 {
+        cursor::correct_to(client, cursor_state, &effective_session_id, x, y).await;
+    }
+    Ok((x, y, effective_session_id))
+}
+
+pub async fn click(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    cursor_state: &mut cursor::CursorState,
+    selector_or_ref: &str,
+    options: ClickOptions<'_>,
+    iframe_sessions: &HashMap<String, String>,
+) -> Result<ClickResult, String> {
+    let (x, y, effective_session_id) = point_to_element(
+        client,
+        session_id,
+        ref_map,
+        cursor_state,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await?;
+    if cursor_state.enabled() {
+        cursor::pulse(client, cursor_state, &effective_session_id).await;
+    }
     // A click-triggered dialog can fire on the frame's own session (OOPIF) or
     // on the top-level page session; both count as "ours". A dialog on any
     // other session belongs to a background tab and must not abort this click.
@@ -51,8 +101,8 @@ pub async fn click(
         &[effective_session_id.as_str(), session_id],
         x,
         y,
-        button,
-        click_count,
+        options.button,
+        options.count,
     )
     .await
 }
@@ -61,6 +111,7 @@ pub async fn dblclick(
     client: &CdpClient,
     session_id: &str,
     ref_map: &RefMap,
+    cursor_state: &mut cursor::CursorState,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<ClickResult, String> {
@@ -68,9 +119,12 @@ pub async fn dblclick(
         client,
         session_id,
         ref_map,
+        cursor_state,
         selector_or_ref,
-        "left",
-        2,
+        ClickOptions {
+            button: "left",
+            count: 2,
+        },
         iframe_sessions,
     )
     .await
@@ -80,13 +134,15 @@ pub async fn hover(
     client: &CdpClient,
     session_id: &str,
     ref_map: &RefMap,
+    cursor_state: &mut cursor::CursorState,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<(), String> {
-    let (x, y, effective_session_id) = resolve_element_center(
+    let (x, y, effective_session_id) = point_to_element(
         client,
         session_id,
         ref_map,
+        cursor_state,
         selector_or_ref,
         iframe_sessions,
     )
@@ -490,6 +546,7 @@ pub async fn check(
     client: &CdpClient,
     session_id: &str,
     ref_map: &RefMap,
+    cursor_state: &mut cursor::CursorState,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<(), String> {
@@ -506,9 +563,12 @@ pub async fn check(
             client,
             session_id,
             ref_map,
+            cursor_state,
             selector_or_ref,
-            "left",
-            1,
+            ClickOptions {
+                button: "left",
+                count: 1,
+            },
             iframe_sessions,
         )
         .await?;
@@ -542,6 +602,7 @@ pub async fn uncheck(
     client: &CdpClient,
     session_id: &str,
     ref_map: &RefMap,
+    cursor_state: &mut cursor::CursorState,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<(), String> {
@@ -558,9 +619,12 @@ pub async fn uncheck(
             client,
             session_id,
             ref_map,
+            cursor_state,
             selector_or_ref,
-            "left",
-            1,
+            ClickOptions {
+                button: "left",
+                count: 1,
+            },
             iframe_sessions,
         )
         .await?;

--- a/cli/src/native/mod.rs
+++ b/cli/src/native/mod.rs
@@ -11,6 +11,8 @@ pub mod cdp;
 #[allow(dead_code)]
 pub mod cookies;
 #[allow(dead_code)]
+pub mod cursor;
+#[allow(dead_code)]
 pub mod daemon;
 #[allow(dead_code)]
 pub mod diff;

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1403,7 +1403,7 @@ Global Options:
   --session <name>     Use specific session
   --headers <json>     Set HTTP headers (scoped to this origin)
   --headed             Show browser window
-  --enable react-devtools   Inject the React DevTools hook before any page JS
+  --enable <feature>        Enable react-devtools or the visible agent-cursor
   --init-script <path>      Register a page init script (repeatable)
 
 Examples:
@@ -3696,7 +3696,7 @@ Options:
   --extension <path>         Load browser extensions (repeatable)
   --init-script <path>       Register a page init script before the first navigation (repeatable)
                              (or AGENT_BROWSER_INIT_SCRIPTS env, comma-separated)
-  --enable <feature>         Built-in init scripts: react-devtools (repeatable or comma-separated)
+  --enable <feature>         Built-in features: react-devtools, agent-cursor (repeatable or comma-separated)
                              (or AGENT_BROWSER_ENABLE env)
   --args <args>              Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
                              e.g., --args "--no-sandbox,--disable-blink-features=AutomationControlled"
@@ -3777,7 +3777,8 @@ Environment:
   AGENT_BROWSER_EXECUTABLE_PATH  Custom browser executable path
   AGENT_BROWSER_EXTENSIONS       Comma-separated browser extension paths
   AGENT_BROWSER_INIT_SCRIPTS     Comma-separated paths to page init scripts
-  AGENT_BROWSER_ENABLE           Comma-separated built-in init script features (e.g. react-devtools)
+  AGENT_BROWSER_ENABLE           Comma-separated built-in features (react-devtools, agent-cursor)
+  AGENT_BROWSER_CURSOR_THEME     Bounded JSON theme for agent-cursor appearance
   AGENT_BROWSER_HEADED           Show browser window (not headless)
   AGENT_BROWSER_NO_XVFB          Disable automatic Xvfb for headed mode on displayless Linux hosts
   AGENT_BROWSER_WEBGPU           Enable WebGPU (SwiftShader software Vulkan on Linux)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -508,6 +508,7 @@ React commands require `--enable react-devtools` at launch (installs the React D
 
 ```bash
 agent-browser open --enable react-devtools <url>   # Launch with React hook installed
+agent-browser open --enable agent-cursor <url>     # Show agent pointer actions in the page
 agent-browser react tree                           # Full component tree
 agent-browser react inspect <fiberId>              # Inspect one component
 agent-browser react renders start                  # Begin fiber render recording
@@ -543,7 +544,7 @@ agent-browser addinitscript <js>                  # Register at runtime (returns
 agent-browser removeinitscript <identifier>       # Remove a previously registered init script
 ```
 
-See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime scripts, built-in React DevTools, and extensions.
+See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime scripts, built-in React DevTools and agent cursor features, and extensions.
 
 ## Global options
 
@@ -558,7 +559,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --executable-path <path> # Custom browser executable
 --extension <path>       # Load browser extension (repeatable)
 --init-script <path>     # Register a page init script before first navigation (repeatable)
---enable <feature>       # Built-in init scripts: react-devtools (repeatable or comma-list)
+--enable <feature>       # Built-in features: react-devtools, agent-cursor (repeatable or comma-list)
 --args <args>            # Browser launch args (comma separated)
 --user-agent <ua>        # Custom User-Agent string
 --proxy <url>            # Proxy server URL

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -269,7 +269,8 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_ENCRYPTION_KEY</code></td><td>64-char hex key for AES-256-GCM session encryption.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_EXTENSIONS</code></td><td>Comma-separated browser extension paths. Extensions work in both headed and headless mode.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_INIT_SCRIPTS</code></td><td>Comma-separated paths to page init scripts.</td><td>(none)</td></tr>
-    <tr><td><code>AGENT_BROWSER_ENABLE</code></td><td>Comma-separated built-in init script features such as <code>react-devtools</code>.</td><td>(none)</td></tr>
+    <tr><td><code>AGENT_BROWSER_ENABLE</code></td><td>Comma-separated built-in features: <code>react-devtools</code> and <code>agent-cursor</code>.</td><td>(none)</td></tr>
+    <tr><td><code>AGENT_BROWSER_CURSOR_THEME</code></td><td>Bounded JSON appearance override for <code>agent-cursor</code>: shape, six-digit accent, glow, scale, and motion.</td><td>(built-in theme)</td></tr>
     <tr><td><code>AGENT_BROWSER_HEADED</code></td><td>Show browser window instead of running headless (<code>1</code> to enable).</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_WEBGPU</code></td><td>Enable WebGPU; SwiftShader software Vulkan on Linux, no GPU required (<code>1</code> to enable).</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_NO_XVFB</code></td><td>Disable automatic Xvfb virtual display for headed mode on displayless Linux hosts (<code>1</code> to disable).</td><td>(auto-Xvfb enabled)</td></tr>

--- a/docs/src/app/init-scripts/page.mdx
+++ b/docs/src/app/init-scripts/page.mdx
@@ -22,9 +22,33 @@ Launch-time scripts are applied when the browser starts. If the daemon is alread
 
 ```bash
 agent-browser --enable react-devtools open http://localhost:3000
+agent-browser --enable agent-cursor open https://example.com
 ```
 
-`react-devtools` is the built-in feature currently available. It installs the React DevTools hook before application code runs and is required for `react tree`, `react inspect`, `react renders`, and `react suspense`.
+`react-devtools` installs the React DevTools hook before application code runs and is required for `react tree`, `react inspect`, `react renders`, and `react suspense`.
+
+`agent-cursor` shows an animated cursor for agent-driven click, hover, drag, and coordinate mouse actions. The overlay is installed inside each page, so it is visible in screenshots, recordings, and remote browser streams. It ignores pointer input and accessibility APIs, respects reduced-motion preferences, and survives navigation. Human input sent directly to a remote browser is not represented as agent input.
+
+MCP clients enable the same feature at launch:
+
+```json
+{
+  "name": "agent_browser_open",
+  "arguments": {
+    "url": "https://example.com",
+    "enable": ["agent-cursor"]
+  }
+}
+```
+
+Each high-level pointer trajectory is capped at 430 milliseconds and completes before its input is dispatched. Raw coordinate input enqueues an exact cursor placement before the real event on the same CDP session without waiting for a cosmetic response. The first action in a new document snaps into place, and crossing an out-of-process iframe transfers the cursor to that frame's page target.
+
+Cursor appearance is configurable through the bounded `AGENT_BROWSER_CURSOR_THEME` JSON object. It accepts `shape` (`arrow` or `ring`), a six-digit `accent`, `glow` (`none`, `soft`, or `strong`), `scale` (`0.75`–`1.5`), and `motion` (`smooth` or `direct`). Omitted fields use the default; arbitrary CSS and SVG are rejected.
+
+```bash
+AGENT_BROWSER_CURSOR_THEME='{"shape":"arrow","accent":"#8c264c","glow":"strong"}' \
+  agent-browser --enable agent-cursor open https://example.com
+```
 
 ## Runtime scripts
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -438,6 +438,8 @@ EOF
 --namespace <name>      # isolate daemon sockets and restore-state directories
 ```
 
+When a person is watching a headed browser, recording, or remote browser stream, launch with `--enable agent-cursor` to make agent click, hover, drag, and coordinate mouse actions visible. It is presentation-only and should not be enabled for unattended work where nobody will see it.
+
 ## When to load another skill
 
 - **Electron desktop app** (VS Code, Slack desktop, Discord, Figma, etc.): `agent-browser skills get electron`

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -436,6 +436,14 @@ agent-browser pushstate <url>                       # SPA client-side nav (auto-
 
 `vitals` prints a summary by default and uses the same fields as the structured `--json` response.
 
+## Visible agent cursor
+
+```bash
+agent-browser open --enable agent-cursor <url>      # Show agent pointer actions in the page
+```
+
+MCP clients pass `enable: ["agent-cursor"]` to `agent_browser_open`. Set `AGENT_BROWSER_CURSOR_THEME` on the MCP server process to apply the same bounded appearance contract.
+
 ## Accessibility audit
 
 Runs an embedded axe-core audit with no CDN fetch. The vendored engine runs private partial audits through CDP across the page's frame tree and merges serialized results without page messaging, so page CSP does not block it, page-provided `window.axe` values remain intact, and iframe violations retain their frame selector paths. Accessibility audits require a CDP browser and are not available with Safari or iOS WebDriver sessions. Reports WCAG violations with impact, rule id, fix guidance URL, and failing-node selectors.
@@ -481,7 +489,8 @@ AGENT_BROWSER_SESSION="mysession"            # Default session name
 AGENT_BROWSER_EXECUTABLE_PATH="/path/chrome" # Custom browser path
 AGENT_BROWSER_EXTENSIONS="/ext1,/ext2"       # Comma-separated extension paths
 AGENT_BROWSER_INIT_SCRIPTS="/a.js,/b.js"     # Comma-separated init script paths
-AGENT_BROWSER_ENABLE="react-devtools"        # Comma-separated built-in init script features
+AGENT_BROWSER_ENABLE="agent-cursor"          # Comma-separated built-in features
+AGENT_BROWSER_CURSOR_THEME='{"accent":"#8c264c","glow":"strong"}' # Optional bounded cursor theme
 AGENT_BROWSER_HIDE_SCROLLBARS="false"        # Keep native scrollbars visible in headless Chromium screenshots
 AGENT_BROWSER_WEBGPU="1"                     # Enable the WebGPU launch preset (see references/webgpu.md)
 AGENT_BROWSER_NO_XVFB="1"                    # Disable automatic Xvfb for headed mode on displayless Linux

--- a/skill-data/core/references/trust-boundaries.md
+++ b/skill-data/core/references/trust-boundaries.md
@@ -39,7 +39,9 @@ If the user gave you a dev server URL, stay on that origin. Dev-only endpoints o
 
 ## Init scripts and `--enable` features inject code
 
-`--init-script <path>` and `--enable <feature>` register scripts that run before any page JS. That's exactly why they work, and it's also why you should only pass scripts you wrote or have reviewed. The built-in `--enable react-devtools` is a vendored MIT-licensed hook from facebook/react and is safe; custom `--init-script` files are the user's responsibility.
+`--init-script <path>` and some `--enable <feature>` options register scripts that run before any page JS. That's exactly why they work, and it's also why you should only pass scripts you wrote or have reviewed. The built-in `--enable react-devtools` is a vendored MIT-licensed hook from facebook/react and is safe; custom `--init-script` files are the user's responsibility.
+
+`--enable agent-cursor` injects agent-browser's own non-interactive visual overlay. Sites can detect injected page objects, and screenshots, recordings, or remote streams include the cursor. The overlay does not receive pointer events or appear in the accessibility tree.
 
 The hook in particular exposes `window.__REACT_DEVTOOLS_GLOBAL_HOOK__` to every page in the browsing context, including third-party iframes. For production-auditing tasks against sites that handle secrets, consider whether you want that global exposed during the session.
 


### PR DESCRIPTION
## Summary

- add an opt-in `agent-cursor` launch feature for visible click, hover, drag, and raw coordinate actions
- render inside the page so the cursor appears in screenshots, recordings, and remote browser streams
- provide a bounded, daemon-owned theme contract through `AGENT_BROWSER_CURSOR_THEME` with arrow/ring shape, accent, glow, scale, and motion
- preserve input truthfulness across navigation, OOPIFs, top-layer UI, moving targets, and reduced-motion preferences
- add CLI/MCP parity plus README, docs, skill, schema, and help coverage

The overlay is presentation-only: it is inert, omitted from the accessibility tree, cannot capture pointer input, and never represents direct human input as agent activity. No external runtime dependency is added.

## Verification

- `cargo fmt --check`
- `cargo test`: 1064 passed, 100 ignored; doctor integration tests: 2 passed
- `cargo clippy --all-targets -- -D warnings`
- focused real-Chrome cursor E2Es: 3 passed (navigation/top-layer/theme, OOPIF ownership, raw input/drag truthfulness)
- `pnpm --dir docs build`
- `git diff --check`

No duplicate open cursor/overlay PR was found before opening this contribution.