### PR TITLE
fix(native): scope semantic find locators to selected frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ agent-browser find nth <n> <sel> <action> [value]     # Nth match
 
 **Options:** `--name <name>` (filter role by accessible name), `--exact` (exact, case-sensitive match; for `role` it applies to the accessible name, whose default is a case-insensitive substring)
 
+The `role`, `text`, `label`, `placeholder`, `alt`, `title`, and `testid` locators honor the current frame context. After selecting an iframe with `agent-browser frame`, use `agent-browser frame main` to return locator searches to the top document.
+
 **Examples:**
 
 ```bash

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1035,7 +1035,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_FIND,
             "Find element",
-            "Find an element with semantic locators and optionally act on it.",
+            "Find an element with semantic locators and optionally act on it. The role, text, label, placeholder, alt, title, and testid locators search the currently selected frame when one is active.",
             json!({
                 "locator": { "type": "string", "enum": ["role", "text", "label", "placeholder", "alt", "title", "testid", "first", "last", "nth"] },
                 "value": { "type": "string", "description": "Role, text, label, selector, or test id." },
@@ -2614,6 +2614,10 @@ fn call_is(arguments: &Value, what: &str) -> Result<Value, ProtocolError> {
 }
 
 fn call_find(arguments: &Value) -> Result<Value, ProtocolError> {
+    call_cli_tool(arguments, find_args(arguments)?, None)
+}
+
+fn find_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
     let locator = required_string(arguments, "locator")?;
     let value = required_string(arguments, "value")?;
     let mut args = vec!["find".to_string(), locator.clone()];
@@ -2641,7 +2645,7 @@ fn call_find(arguments: &Value) -> Result<Value, ProtocolError> {
     if exact {
         args.push("--exact".to_string());
     }
-    call_cli_tool(arguments, args, None)
+    Ok(args)
 }
 
 fn call_mouse_move(arguments: &Value) -> Result<Value, ProtocolError> {
@@ -4091,6 +4095,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, vec!["click", "@e1", "--new-tab"]);
+    }
+
+    #[test]
+    fn find_args_keep_text_locator_cli_parity() {
+        let args = find_args(&json!({
+            "locator": "text",
+            "value": "Next Page",
+            "action": "click",
+            "exact": true,
+        }))
+        .unwrap();
+
+        assert_eq!(args, vec!["find", "text", "Next Page", "click", "--exact"]);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -8568,14 +8568,14 @@ fn find_ax_node_by_role(
     Err(format!("No element found: {}", desc))
 }
 
+/// Locate an element in the selected frame's document, or in the top document
+/// when no frame is selected, then run the requested subaction against it.
 async fn handle_semantic_locator(
     cmd: &Value,
     state: &mut DaemonState,
     strategy: &str,
     param_name: &str,
 ) -> Result<Value, String> {
-    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-    let session_id = mgr.active_session_id()?.to_string();
     let value = cmd
         .get(param_name)
         .and_then(|v| v.as_str())
@@ -8594,7 +8594,7 @@ async fn handle_semantic_locator(
         )
     };
 
-    let query = match strategy {
+    let locate_body = match strategy {
         // Like Playwright's getByLabel: match <label> associations AND
         // aria-label / aria-labelledby. Icon buttons and custom controls
         // are usually labelled via aria-label only.
@@ -8606,64 +8606,64 @@ async fn handle_semantic_locator(
                 format!("(s) => !!s && s.includes({value_json})")
             };
             format!(
-                r#"(() => {{
+                r#"(root) => {{
                 const matches = {matches_fn};
-                const label = Array.from(document.querySelectorAll('label')).find(el => matches(el.textContent));
+                const label = Array.from(root.querySelectorAll('label')).find(el => matches(el.textContent));
                 if (label) {{
                     const forId = label.getAttribute('for');
-                    const target = forId ? document.getElementById(forId) : label.querySelector('input,select,textarea');
+                    const target = forId ? root.getElementById(forId) : label.querySelector('input,select,textarea');
                     if (target) {{ target.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 }}
-                const aria = Array.from(document.querySelectorAll('[aria-label]')).find(el => matches(el.getAttribute('aria-label')));
+                const aria = Array.from(root.querySelectorAll('[aria-label]')).find(el => matches(el.getAttribute('aria-label')));
                 if (aria) {{ aria.setAttribute('data-agent-browser-located', 'true'); return true; }}
-                const referenced = Array.from(document.querySelectorAll('[aria-labelledby]')).find(el => {{
+                const referenced = Array.from(root.querySelectorAll('[aria-labelledby]')).find(el => {{
                     const text = el.getAttribute('aria-labelledby').split(/\s+/)
-                        .map(id => {{ const r = document.getElementById(id); return r ? r.textContent : ''; }})
+                        .map(id => {{ const r = root.getElementById(id); return r ? r.textContent : ''; }})
                         .join(' ');
                     return matches(text);
                 }});
                 if (referenced) {{ referenced.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
-            }})()"#,
+            }}"#,
             )
         }
         "placeholder" => format!(
-            r#"(() => {{
-                const el = document.querySelector('input[placeholder={val}], textarea[placeholder={val}]');
+            r#"(root) => {{
+                const el = root.querySelector('input[placeholder={val}], textarea[placeholder={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
-            }})()"#,
+            }}"#,
             val = serde_json::to_string(value).unwrap_or_default(),
         ),
         "alttext" => format!(
-            r#"(() => {{
-                const el = document.querySelector('img[alt={val}], [alt={val}]');
+            r#"(root) => {{
+                const el = root.querySelector('img[alt={val}], [alt={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
-            }})()"#,
+            }}"#,
             val = serde_json::to_string(value).unwrap_or_default(),
         ),
         "title" => format!(
-            r#"(() => {{
-                const el = document.querySelector('[title={val}]');
+            r#"(root) => {{
+                const el = root.querySelector('[title={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
-            }})()"#,
+            }}"#,
             val = serde_json::to_string(value).unwrap_or_default(),
         ),
         "testid" => format!(
-            r#"(() => {{
-                const el = document.querySelector('[data-testid={val}]');
+            r#"(root) => {{
+                const el = root.querySelector('[data-testid={val}]');
                 if (el) {{ el.setAttribute('data-agent-browser-located', 'true'); return true; }}
                 return false;
-            }})()"#,
+            }}"#,
             val = serde_json::to_string(value).unwrap_or_default(),
         ),
         _ => {
             // "text" strategy
             format!(
-                r#"(() => {{
-                    const all = document.querySelectorAll('*');
+                r#"(root) => {{
+                    const all = root.querySelectorAll('*');
                     for (const el of all) {{
                         if (el.children.length === 0 && {match_fn}) {{
                             el.setAttribute('data-agent-browser-located', 'true');
@@ -8671,45 +8671,45 @@ async fn handle_semantic_locator(
                         }}
                     }}
                     return false;
-                }})()"#,
+                }}"#,
                 match_fn = match_fn,
             )
         }
     };
 
-    let result: super::cdp::types::EvaluateResult = mgr
-        .client
-        .send_command_typed(
-            "Runtime.evaluate",
-            &super::cdp::types::EvaluateParams {
-                expression: query,
-                return_by_value: Some(true),
-                await_promise: Some(false),
-            },
-            Some(&session_id),
+    let located = {
+        let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+        let top_session = mgr.active_session_id()?.to_string();
+        eval_body_in_active_frame(
+            mgr,
+            state.active_frame_id.as_deref(),
+            &top_session,
+            &state.iframe_sessions,
+            &locate_body,
         )
-        .await?;
+        .await?
+    };
 
-    if !result
-        .result
-        .value
-        .as_ref()
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
+    if !located.as_bool().unwrap_or(false) {
         return Err(format!("No element found by {} '{}'", strategy, value));
     }
 
     let selector = "[data-agent-browser-located='true']";
     let action_result = execute_subaction(cmd, state, selector).await;
 
-    if let Some(ref browser) = state.browser {
-        let _ = browser
-            .evaluate(
-                "document.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located')",
-                None,
+    // Clean up the marker in whichever document it was set in.
+    if let Some(mgr) = state.browser.as_ref() {
+        if let Ok(top_session) = mgr.active_session_id() {
+            let top_session = top_session.to_string();
+            let _ = eval_body_in_active_frame(
+                mgr,
+                state.active_frame_id.as_deref(),
+                &top_session,
+                &state.iframe_sessions,
+                "(root) => { root.querySelector('[data-agent-browser-located]')?.removeAttribute('data-agent-browser-located'); }",
             )
             .await;
+        }
     }
 
     action_result

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7958,6 +7958,132 @@ async fn e2e_presentational_role_honors_selected_frame() {
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
 
+/// Semantic `find` locators must search the selected frame instead of always
+/// evaluating in the top document, as reported for `find text` in issue #1460.
+#[tokio::test]
+#[ignore]
+async fn e2e_semantic_find_honors_selected_frame() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let outer = r#"<body><button>Top Page</button><iframe id="f" srcdoc="
+        <button>Next Page</button>
+        <label for='email'>Email</label><input id='email'>
+        <input id='search' placeholder='Search'>
+        <img alt='Logo' src='data:image/gif;base64,R0lGODlhAQABAAAAACw='>
+        <button title='Close'>Close button</button>
+        <div data-testid='panel'>Panel</div>
+    "></iframe></body>"#;
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(outer));
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "getbytext",
+            "text": "Top Page",
+            "exact": true,
+            "subaction": "text"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["text"], "Top Page");
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "frame", "selector": "#f" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "getbytext",
+            "text": "Next Page",
+            "exact": true,
+            "subaction": "text"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["text"], "Next Page");
+
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "getbylabel",
+            "label": "Email",
+            "exact": true,
+            "subaction": "fill",
+            "value": "user@example.com"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "inputvalue", "selector": "#email" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "user@example.com");
+
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "getbyplaceholder",
+            "placeholder": "Search",
+            "exact": true,
+            "subaction": "fill",
+            "value": "frame query"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "inputvalue", "selector": "#search" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "frame query");
+
+    for (id, action, key, value, expected) in [
+        ("10", "getbyalttext", "text", "Logo", ""),
+        ("11", "getbytitle", "text", "Close", "Close button"),
+        ("12", "getbytestid", "testId", "panel", "Panel"),
+    ] {
+        let mut command = json!({
+            "id": id,
+            "action": action,
+            "subaction": "text"
+        });
+        command[key] = json!(value);
+        let resp = execute_command(&command, &mut state).await;
+        assert_success(&resp);
+        assert_eq!(get_data(&resp)["text"], expected);
+    }
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}
+
 /// ARIA presentational-roles conflict resolution: role="none" on a focusable
 /// element (or one with global ARIA props) is ignored, so `find role none` must
 /// skip it but still match a truly presentational element. Force-red: drop the

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2182,6 +2182,8 @@ agent-browser find - Find and interact with elements by locator
 Usage: agent-browser find <locator> <value> [action] [text]
 
 Finds elements using semantic locators and optionally performs an action.
+The role, text, label, placeholder, alt, title, and testid locators honor the
+active frame selected by frame.
 
 Locators:
   role <role>              Find by ARIA role (--name <n>, --exact)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -106,6 +106,8 @@ Options:
 - `--name <name>`: filter role by accessible name
 - `--exact`: exact, case-sensitive match. For `role` it applies to the accessible name, whose default is a case-insensitive substring.
 
+The `role`, `text`, `label`, `placeholder`, `alt`, `title`, and `testid` locators honor the current frame context. After selecting an iframe with `agent-browser frame`, use `agent-browser frame main` to search the top document again.
+
 Examples:
 
 ```bash

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -149,6 +149,8 @@ agent-browser find first ".card" click
 agent-browser find nth 2 ".card" hover
 ```
 
+The `role`, `text`, `label`, `placeholder`, `alt`, `title`, and `testid` locators honor the current frame context. After selecting an iframe with `agent-browser frame`, use `agent-browser frame main` to search the top document again.
+
 Or a raw CSS selector:
 
 ```bash

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -157,6 +157,8 @@ agent-browser find last ".item" click
 agent-browser find nth 2 "a" hover
 ```
 
+The `role`, `text`, `label`, `placeholder`, `alt`, `title`, and `testid` locators honor the current frame context. After selecting an iframe with `agent-browser frame`, use `agent-browser frame main` to search the top document again.
+
 ## Browser Settings
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #1460.

After `agent-browser frame` selects an iframe, the DOM-backed `text`, `label`, `placeholder`, `alt`, `title`, and `testid` locators now search that frame. Top-document behavior remains unchanged.

- Route lookup and marker cleanup through the existing frame-aware evaluator, including its same-origin and OOPIF dispatch paths.
- Add a real Chrome regression test covering every affected locator, plus fill and read subactions inside the selected frame.
- Keep CLI help, MCP guidance and parity coverage, README, core skill content, and the docs site aligned.

## Root cause

`handle_semantic_locator` always ran `Runtime.evaluate` against the active top-level session and queried the global `document`. The `frame` command updated `active_frame_id`, but this handler never used it, so the selected iframe could not affect semantic lookup.

The fix makes each locator query a function of a document root and reuses `eval_body_in_active_frame`, which is already used by the DOM-backed role path. This keeps frame routing in one place and avoids new parser or protocol behavior.

## Reproduction

On the upstream baseline (`93cdda5`) with only the regression test added:

```text
No element found by text 'Next Page'
```

With this change, the committed ignored E2E passes. It retains the reported text scenario and extends coverage to all six affected locator strategies within the selected `srcdoc` iframe.

## Validation

- `cargo +1.97.1 fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo +1.97.1 clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `cargo +1.97.1 test --profile ci --manifest-path cli/Cargo.toml` (1062 unit tests and 2 CLI integration tests passed)
- `cargo test e2e_semantic_find_honors_selected_frame -- --ignored --nocapture --test-threads=1`
- `cargo test e2e -- --ignored --test-threads=1` (97 E2E tests passed)
- `pnpm --dir docs build`
