### PR TITLE
fix(doctor): stop hanging on the Chrome version query

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ rust-embed = "8"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.52", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/doctor/chrome.rs
+++ b/cli/src/doctor/chrome.rs
@@ -114,15 +114,125 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     }
 }
 
+/// Longest we wait for a browser to report its own version before giving up.
+#[cfg(not(windows))]
+const VERSION_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Read the version from the binary's own resource table. Windows Chrome does
+/// not write a version to a redirected stdout, and `chrome.exe --version`
+/// leaves a process tree whose inherited stdout handle never closes, so the
+/// caller would wait forever.
+#[cfg(windows)]
 fn query_chrome_version(path: &Path) -> Option<String> {
-    let output = std::process::Command::new(path)
-        .arg("--version")
-        .output()
-        .ok()?;
-    if !output.status.success() {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
+    };
+
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // SAFETY: `wide` is a NUL-terminated path and stays alive for the call.
+    let size = unsafe { GetFileVersionInfoSizeW(wide.as_ptr(), std::ptr::null_mut()) };
+    if size == 0 {
         return None;
     }
-    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    let mut buffer = vec![0u8; size as usize];
+    // SAFETY: `buffer` is `size` bytes, the size the call above asked for.
+    let ok = unsafe {
+        GetFileVersionInfoW(
+            wide.as_ptr(),
+            0,
+            size,
+            buffer.as_mut_ptr() as *mut std::ffi::c_void,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+
+    let root: Vec<u16> = "\\".encode_utf16().chain(std::iter::once(0)).collect();
+    let mut info: *mut std::ffi::c_void = std::ptr::null_mut();
+    let mut info_len: u32 = 0;
+    // SAFETY: `buffer` holds a version-info block produced by the call above.
+    let ok = unsafe {
+        VerQueryValueW(
+            buffer.as_ptr() as *const std::ffi::c_void,
+            root.as_ptr(),
+            &mut info,
+            &mut info_len,
+        )
+    };
+    if ok == 0 || info.is_null() || (info_len as usize) < std::mem::size_of::<VS_FIXEDFILEINFO>() {
+        return None;
+    }
+
+    // SAFETY: VerQueryValue reported at least a VS_FIXEDFILEINFO at `info`.
+    let fixed = unsafe { &*(info as *const VS_FIXEDFILEINFO) };
+    Some(format!(
+        "{}.{}.{}.{}",
+        fixed.dwFileVersionMS >> 16,
+        fixed.dwFileVersionMS & 0xFFFF,
+        fixed.dwFileVersionLS >> 16,
+        fixed.dwFileVersionLS & 0xFFFF,
+    ))
+}
+
+#[cfg(not(windows))]
+fn query_chrome_version(path: &Path) -> Option<String> {
+    let mut cmd = std::process::Command::new(path);
+    cmd.arg("--version");
+    run_version_command(cmd, VERSION_QUERY_TIMEOUT)
+}
+
+/// Run a version command, giving up after `timeout` and killing the child so
+/// doctor's liveness never depends on the browser exiting.
+#[cfg(not(windows))]
+fn run_version_command(
+    mut cmd: std::process::Command,
+    timeout: std::time::Duration,
+) -> Option<String> {
+    use std::io::Read;
+
+    let mut child = cmd
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = std::time::Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+
+    if !status.success() {
+        return None;
+    }
+
+    let mut stdout = String::new();
+    child.stdout.take()?.read_to_string(&mut stdout).ok()?;
+    let s = stdout.trim().to_string();
     if s.is_empty() {
         None
     } else {
@@ -152,5 +262,37 @@ mod tests {
             assert!(s.contains(".cache"));
             assert!(s.ends_with("puppeteer"));
         }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn version_query_gives_up_on_a_command_that_never_exits() {
+        use std::time::{Duration, Instant};
+
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.arg("-c").arg("sleep 60");
+
+        let started = Instant::now();
+        let result = run_version_command(cmd, Duration::from_millis(300));
+        let elapsed = started.elapsed();
+
+        assert!(result.is_none());
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "took {:?}, so the deadline did not fire",
+            elapsed
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn version_query_returns_trimmed_stdout() {
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.arg("-c").arg("echo '  Google Chrome 150.0.0.0  '");
+
+        assert_eq!(
+            run_version_command(cmd, std::time::Duration::from_secs(5)).as_deref(),
+            Some("Google Chrome 150.0.0.0")
+        );
     }
 }


### PR DESCRIPTION
## Problem

`agent-browser doctor` hangs forever on Windows when system Chrome is installed, and leaves orphan chrome.exe behind.

`query_chrome_version` runs `chrome.exe --version` and blocks on `Command::output`. Chrome's child processes inherit the stdout handle, so the read waits for an EOF that never arrives. `chrome::check` runs unconditionally, so neither `--offline` nor `--quick` avoids it.

Traced on CI, since it does not reproduce on macOS or Linux:

```
PROBE enter environment
PROBE exit  environment
PROBE enter chrome          <- never exits
HUNG after 180s
ProcessId   : 8836
Name        : chrome.exe
CommandLine : "C:\Program Files\Google\Chrome\Application\chrome.exe" --version
```

A second probe ruled out the obvious fix. Windows Chrome writes nothing to a redirected stdout, so bounding the call would report "version unknown" on every run and still pay the timeout. The same probe found the version in the binary's own resource table: `ProductVersion : 150.0.7871.115`.

## Change

On Windows, read the version from the PE resource table. No process is started, so nothing can be orphaned.

Everywhere else, keep `--version` but bound it: spawn, poll to a 10s deadline, then kill and reap. Doctor's liveness no longer depends on the browser exiting.

Two tests cover the deadline and the unchanged stdout parsing.

## How to check

CI on a pull request does not run `rust-cross`, which is gated on `github.event_name != 'pull_request'`. Verified by workflow dispatch instead: https://github.com/vercel-labs/agent-browser/actions/runs/30768308257

All four Rust jobs pass. On Windows, `doctor_offline_quick_json_emits_valid_payload` now completes in 0.03s. It previously ran until GitHub cancelled the job at the 6 hour limit.

## Related

Fixes #1461.

#1478 fixes a different hang in the same command, during browser close inside `launch::check`, which `--quick` skips. Both are needed. That PR is currently conflicting with main.

Out of scope: `cli/src/doctor/helpers.rs` and `cli/src/doctor/fix.rs` spawn subprocesses with no deadline either. Neither is a known hang.