### PR TITLE
chore(build): ignore agent-browser.exe native binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 # Native binaries (keep the launcher scripts)
 bin/agent-browser-*
+bin/agent-browser*.exe
 bin/.install-method
 !bin/agent-browser
 !bin/agent-browser.cmd


### PR DESCRIPTION
## Summary

The existing gitignore rule `bin/agent-browser-*` did not cover `bin/agent-browser.exe`, so the compiled Windows binary showed up as an untracked file in `git status`.

## Changes

- Broaden the native binary ignore rule to `bin/agent-browser*.exe`, covering both `agent-browser.exe` and `agent-browser-win32-x64.exe`
- Launcher scripts (`bin/agent-browser`, `bin/agent-browser.cmd`) remain tracked via the existing negated patterns