### PR TITLE
docs: add Remote Agent Browser provider guide

### DIFF
--- a/docs/src/app/providers/remote-agent-browser/layout.tsx
+++ b/docs/src/app/providers/remote-agent-browser/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("providers/remote-agent-browser");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/providers/remote-agent-browser/page.mdx
+++ b/docs/src/app/providers/remote-agent-browser/page.mdx
@@ -1,0 +1,91 @@
+# Remote Agent Browser
+
+[Remote Agent Browser](https://github.com/vercel-labs/remote-agent-browser) runs agent-browser inside an isolated [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox). Use it when a TypeScript application needs to provision a browser on demand without managing a local Chrome process.
+
+Remote Agent Browser is a library rather than an agent-browser `-p` provider. Import it in your application and use the returned client to run agent-browser commands.
+
+## Setup
+
+```bash
+pnpm add remote-agent-browser
+```
+
+Authentication is automatic on Vercel through `VERCEL_OIDC_TOKEN`. For local development, link a Vercel project and pull its environment:
+
+```bash
+vercel link
+vercel env pull .env.local
+```
+
+## Create a browser
+
+```ts
+import { AgentBrowser } from "remote-agent-browser";
+
+const browser = await AgentBrowser.create();
+
+try {
+  await browser.exec("open", {
+    args: ["https://example.com"],
+  });
+
+  const result = await browser.snapshot();
+  console.log(result.results.at(-1)?.stdout);
+} finally {
+  await browser.close();
+}
+```
+
+Commands issued through the same client share the same page, cookies, tabs, and element references. Always close disposable clients when the work is complete.
+
+## Stable browser sessions
+
+Use a stable ID when browser identity needs to survive process boundaries:
+
+```ts
+const browser = AgentBrowser.session({
+  id: `chat:${chatId}`,
+});
+
+const stopKeepalive = browser.keepalive();
+
+try {
+  await browser.exec("open", {
+    args: ["https://example.com"],
+  });
+} finally {
+  stopKeepalive();
+}
+```
+
+The first command finds or creates the named Sandbox. A later process using the same ID can attach to it. If an expired Sandbox resumes, Chromium starts fresh and in-memory page state is reset.
+
+## Custom browser image
+
+The default image is `remote-agent-browser:latest`. Pass a Vercel Container Registry repository, tag, digest, or fully qualified reference to use a custom image:
+
+```ts
+const browser = await AgentBrowser.create({
+  image: "vcr.vercel.com/my-team/my-project/my-browser:v1",
+});
+```
+
+You can also set `REMOTE_AGENT_BROWSER_IMAGE` to configure the image for every client.
+
+## Options
+
+<table>
+  <thead>
+    <tr><th>Option</th><th>Description</th><th>Default</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>image</code></td><td>Vercel Container Registry image containing agent-browser and Chromium</td><td><code>remote-agent-browser:latest</code></td></tr>
+    <tr><td><code>timeoutMs</code></td><td>Sandbox wall-clock timeout in milliseconds</td><td><code>600000</code></td></tr>
+    <tr><td><code>vcpus</code></td><td>Number of Sandbox vCPUs</td><td><code>2</code></td></tr>
+    <tr><td><code>env</code></td><td>Additional environment variables for commands in the Sandbox</td><td><code>{}</code></td></tr>
+    <tr><td><code>args</code></td><td>Global agent-browser CLI arguments applied to each command</td><td><code>[]</code></td></tr>
+    <tr><td><code>proxy</code></td><td>Proxy URL or proxy configuration for the browser client</td><td>(none)</td></tr>
+  </tbody>
+</table>
+
+See the [Remote Agent Browser repository](https://github.com/vercel-labs/remote-agent-browser) for file transfer, proxy configuration, typed JSON output, keepalive, and stable-session examples.

--- a/docs/src/app/providers/remote-agent-browser/page.mdx
+++ b/docs/src/app/providers/remote-agent-browser/page.mdx
@@ -29,8 +29,8 @@ try {
     args: ["https://example.com"],
   });
 
-  const result = await browser.snapshot();
-  console.log(result.results.at(-1)?.stdout);
+  const snapshot = await browser.exec("snapshot");
+  console.log(snapshot.stdout);
 } finally {
   await browser.close();
 }

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -60,6 +60,10 @@ export const navigation: NavSection[] = [
       { name: "Browserbase", href: "/providers/browserbase" },
       { name: "Browserless", href: "/providers/browserless" },
       { name: "Kernel", href: "/providers/kernel" },
+      {
+        name: "Remote Agent Browser",
+        href: "/providers/remote-agent-browser",
+      },
     ],
   },
   {

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -34,6 +34,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "providers/browserbase": "Browserbase",
   "providers/browserless": "Browserless",
   "providers/kernel": "Kernel",
+  "providers/remote-agent-browser": "Remote Agent Browser",
   changelog: "Changelog",
 };
 


### PR DESCRIPTION
## Summary

- add a Remote Agent Browser page alongside the existing cloud provider guides
- document setup, Vercel authentication, disposable and stable sessions, and custom VCR images
- register the route in docs navigation and page metadata

## Testing

- pnpm build from docs