### PR TITLE
fix: reset reference (ref) numbers on `diff snapshot`

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5746,6 +5746,10 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         selector,
         ..SnapshotOptions::default()
     };
+    // Reset ref numbering so an unchanged page produces an identical snapshot
+    // on every run. Without this the counter keeps climbing across commands and
+    // every ref-bearing line shows up as a difference.
+    state.ref_map.clear();
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -5798,6 +5802,9 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     mgr.navigate(url1, wait_until).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let options = SnapshotOptions::default();
+    // Both snapshots must number refs from the same base, otherwise the diff
+    // reports every ref-bearing line as changed.
+    state.ref_map.clear();
     let snap1 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -32,6 +32,13 @@ fn get_data(resp: &Value) -> &Value {
     resp.get("data").expect("Missing 'data' in response")
 }
 
+/// Pages with several interactive elements, so snapshots of them allocate refs.
+/// Kept free of spaces and quotes so they survive as bare `data:` URLs.
+const REF_HEAVY_PAGE: &str =
+    "data:text/html,<button>Alpha</button><button>Beta</button><a href=https://example.com>Gamma</a>";
+const REF_HEAVY_PAGE_ALT: &str =
+    "data:text/html,<button>Delta</button><a href=https://example.com>Epsilon</a>";
+
 fn native_test_fixture_html(name: &str) -> &'static str {
     match name {
         "drag_probe" => include_str!("test_fixtures/drag_probe.html"),
@@ -3392,6 +3399,224 @@ async fn e2e_diff_snapshot() {
     assert_success(&resp);
     let data = get_data(&resp);
     assert_eq!(data["changed"], true, "Diff should detect the h1 change");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// A page with refs, diffed against its own snapshot, must report no changes -
+/// and must keep reporting no changes however many times the diff runs.
+#[tokio::test]
+#[ignore]
+async fn e2e_diff_snapshot_unchanged_page_reports_no_changes() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": REF_HEAVY_PAGE }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let baseline = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
+    assert!(
+        baseline.contains("ref=e1"),
+        "Fixture should allocate refs, got: {}",
+        baseline
+    );
+
+    // Run the same diff repeatedly: ref numbering that leaks across commands
+    // shows up on the second and third runs, not just the first.
+    for i in 0..3 {
+        let resp = execute_command(
+            &json!({ "id": format!("diff-{}", i), "action": "diff_snapshot", "baseline": baseline }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let data = get_data(&resp);
+        assert_eq!(
+            data["changed"], false,
+            "Diff run {} against an unchanged page reported changes:\n{}",
+            i, data["diff"]
+        );
+        assert_eq!(data["additions"], 0, "Diff run {} had additions", i);
+        assert_eq!(data["removals"], 0, "Diff run {} had removals", i);
+    }
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// A real edit must show up as a small diff, not a rewrite of every ref-bearing
+/// line. The existing `e2e_diff_snapshot` asserts only that something changed,
+/// which stays true even when the refs themselves are what changed.
+#[tokio::test]
+#[ignore]
+async fn e2e_diff_snapshot_reports_only_the_changed_element() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": REF_HEAVY_PAGE }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let baseline = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
+
+    // Rename the first button only.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "document.querySelector('button').textContent = 'Omega'",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "diff_snapshot", "baseline": baseline }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let data = get_data(&resp);
+    let diff = data["diff"].as_str().unwrap_or_default();
+    assert_eq!(
+        data["changed"], true,
+        "Diff should detect the button rename"
+    );
+    assert!(
+        diff.contains("Omega"),
+        "Diff should show the new button name:\n{}",
+        diff
+    );
+
+    // One renamed button touches at most its own line and its static text child.
+    let additions = data["additions"].as_u64().unwrap_or(u64::MAX);
+    let removals = data["removals"].as_u64().unwrap_or(u64::MAX);
+    assert!(
+        additions <= 2 && removals <= 2,
+        "One rename should be a small diff, got +{} -{}:\n{}",
+        additions,
+        removals,
+        diff
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Snapshotting an untouched page twice must produce identical text. This is
+/// the invariant every ref-consuming command relies on.
+#[tokio::test]
+#[ignore]
+async fn e2e_repeated_snapshots_are_identical() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": REF_HEAVY_PAGE }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let first = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
+
+    let resp = execute_command(&json!({ "id": "4", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let second = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
+
+    assert_eq!(
+        first, second,
+        "Two snapshots of an unchanged page must be identical"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Both sides of a `diff url` must number their refs from the same base.
+#[tokio::test]
+#[ignore]
+async fn e2e_diff_url_numbers_both_snapshots_from_e1() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Consume some refs first: on a fresh daemon the counter already sits at 1,
+    // so a leaked counter only shows up once an earlier command has moved it.
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": REF_HEAVY_PAGE }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "diff_url",
+            "url1": REF_HEAVY_PAGE,
+            "url2": REF_HEAVY_PAGE_ALT,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let data = get_data(&resp);
+    let snap1 = data["snapshot1"].as_str().unwrap();
+    let snap2 = data["snapshot2"].as_str().unwrap();
+
+    assert!(
+        snap1.contains("ref=e1"),
+        "First snapshot should start at e1, got:\n{}",
+        snap1
+    );
+    assert!(
+        snap2.contains("ref=e1"),
+        "Second snapshot should start at e1, got:\n{}",
+        snap2
+    );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -1343,6 +1343,57 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_ref_map_clear_resets_ref_numbering() {
+        let mut ref_map = RefMap::new();
+        assert_eq!(ref_map.next_ref_num(), 1);
+
+        ref_map.add("e1".to_string(), Some(10), "button", "One", None);
+        ref_map.set_next_ref_num(84);
+
+        ref_map.clear();
+
+        assert_eq!(
+            ref_map.next_ref_num(),
+            1,
+            "clear() must reset the counter so snapshots restart at e1"
+        );
+        assert!(ref_map.get("e1").is_none());
+    }
+
+    #[test]
+    fn test_ref_map_reuses_same_ids_after_clear() {
+        let mut ref_map = RefMap::new();
+
+        let first: Vec<String> = (0..3)
+            .map(|_| {
+                let n = ref_map.next_ref_num();
+                let ref_id = format!("e{}", n);
+                ref_map.add(ref_id.clone(), Some(n as i64), "button", "One", None);
+                ref_map.set_next_ref_num(n + 1);
+                ref_id
+            })
+            .collect();
+
+        ref_map.clear();
+
+        let second: Vec<String> = (0..3)
+            .map(|_| {
+                let n = ref_map.next_ref_num();
+                let ref_id = format!("e{}", n);
+                ref_map.add(ref_id.clone(), Some(n as i64), "button", "One", None);
+                ref_map.set_next_ref_num(n + 1);
+                ref_id
+            })
+            .collect();
+
+        assert_eq!(first, vec!["e1", "e2", "e3"]);
+        assert_eq!(
+            first, second,
+            "a cleared ref map must hand out the same ids again"
+        );
+    }
+
+    #[test]
     fn test_parse_ref_at_prefix() {
         assert_eq!(parse_ref("@e1"), Some("e1".to_string()));
         assert_eq!(parse_ref("@e123"), Some("e123".to_string()));


### PR DESCRIPTION
`diff snapshot` doesn't reset the ref map before taking the new snapshot. The daemon's monotonic ref counter kept climbing across commands. This caused the command to always show differences. You can find an example on #1394 , although I could also reproduce on my side.

Closes #1394 

## Reproduce bug

Running `agent-browser snapshot > base.txt` followed by `agent-browser diff snapshot --baseline base.txt` reported every line as changed, with the offset growing on each subsequent run (`e1 -> e84 -> e167`). `diff url` had the same gap on its first snapshot: it cleared before the second one only, so the two sides were numbered from different bases.

## Implementation

The fix only required to clear the references before taking the new snapshot in the `diff snapshot` command. This reproduces the same behavior of `snapshot`. I tried to minimize the changes in the codebase to keep the PR clean.

## Tests

- Unit coverage for the `RefMap::clear()` contract, 
- E2E tests for a self-diff reporting no changes across repeated runs. The existing `e2e_diff_snapshot` only checked that something changed, which was always true.

## Manual testing

To confirm the fix, I built a development released and tested it manually. You can find the dev release on my fork: https://github.com/endorhq/agent-browser/releases/tag/v0.33.2-fix-dev-v1 . That release contains this and a minor feature related to the `-i / --interactive` argument for `diff snapshot`.

Here you can see how the command only shows the differences now:

```bash
agent-browser diff snapshot -i -c --baseline diff.txt
```

```diff
--- before
+++ after
@@ -9,9 +9,9 @@
 - combobox "Selecciona el tipo de billete. Solo ida" [expanded=false, ref=e72]: Solo ida
 - button "1 pasajero" [ref=e73]
 - combobox "Selecciona la clase de asiento. Turista" [expanded=false, ref=e74]: Turista
-- combobox "¿Desde dónde?" [expanded=false, ref=e75]: Ámsterdam
+- combobox "¿Desde dónde?" [expanded=false, ref=e75]: Madrid
 - button "Intercambiar el origen y el destino." [ref=e35]
-- combobox "¿A dónde quieres ir?" [expanded=false, ref=e82]: Madrid
+- combobox "¿A dónde quieres ir?" [expanded=false, ref=e82]: Ámsterdam
 - textbox "Salida" [ref=e83]: lun, 10 ago
 - button "Buscar" [ref=e28]
 - heading "¿Tienes flexibilidad? Descubre las mejores ofertas de vuelos con la IA." [level=2, ref=e9]
@@ -80,4 +80,4 @@
 - link "Sugerencias" [ref=e20]
 - link "Centro de Ayuda y de información para los consumidores" [ref=e21]
 - button "Sitios internacionales" [expanded=false, ref=e33]
-- button "Explorar vuelos" [expanded=false, ref=e34]
+- button "Explorar vuelos" [expanded=false, ref=e34]
\ No newline at end of file

3 additions, 3 removals, 80 unchanged
```

There's still another issue as the `button "Explorar vuelos" [expanded=false, ref=e34]` was reported as changed. I'll investigate and open a different PR to fix it.

## AI usage

I always like to disclose how I use AI in my contributions. In this case, I used Claude to analyze the codebase, plan, and implement the tests and code. However, I reviewed the code, run the CI, and manually test the result.