### PR TITLE
docs: add Panerelay provider guide

### DIFF
--- a/docs/src/app/providers/panerelay/layout.tsx
+++ b/docs/src/app/providers/panerelay/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("providers/panerelay");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/providers/panerelay/page.mdx
+++ b/docs/src/app/providers/panerelay/page.mdx
@@ -1,0 +1,69 @@
+# Panerelay
+
+[Panerelay](https://github.com/F-loat/panerelay) is an open-source local provider that connects agent-browser to explicitly authorized tabs in an already-running Chrome or Microsoft Edge session. Use it when automation must reuse the browser's existing signed-in state without copying the profile or opening a remote debugging endpoint.
+
+## Requirements
+
+- agent-browser 0.33.0 or newer
+- Node.js 20 or newer for Panerelay setup
+- The [Panerelay Chrome extension](https://chromewebstore.google.com/detail/panerelay/panplnkjlkoceaonlmpdekjphgmbggmi)
+
+Chrome is the verified browser baseline. Microsoft Edge uses the same Chromium integration path; see the [Panerelay compatibility records](https://github.com/F-loat/panerelay/tree/main/docs/compatibility) for the current evidence level.
+
+## Setup
+
+Install the local Native Host and agent-browser provider configuration:
+
+```bash
+npx --yes @panerelay/setup --agent-browser
+```
+
+Open the Panerelay extension and authorize the current tab for focused work or all supported web tabs for a cross-page workflow. Browser focus alone does not grant access.
+
+Verify the exposed tabs:
+
+```bash
+agent-browser -p panerelay tab list
+```
+
+An empty list means no eligible tab is currently authorized. It does not necessarily mean setup failed.
+
+## Run commands
+
+Use a stable agent-browser session and keep the provider explicit:
+
+```bash
+agent-browser --session research -p panerelay tab list
+agent-browser --session research -p panerelay snapshot -i
+agent-browser --session research -p panerelay click @e1
+```
+
+Normal agent-browser page commands keep their usual semantics. The provider handles attachment and routing while the extension owns tab authorization and visible active control.
+
+## Agent Skill
+
+Panerelay also publishes a Skill that can check the installed engine, configure the provider, run targeted diagnostics, and stop when user-owned tab authorization is required:
+
+```bash
+npx skills add F-loat/panerelay --skill panerelay-browser
+```
+
+The Skill does not grant browser access. The user still chooses the authorization scope in the extension.
+
+## Authorization and control
+
+Site permission, tab authorization, and active control are separate decisions. `tab list` exposes only eligible authorized tabs, and mutating commands require the current control lease. Active control remains visible in the extension and can be released without silently changing the selected authorization scope.
+
+## Limitations
+
+Panerelay connects to existing authorized tabs and does not own the browser process. It cannot provide isolated browser contexts, launch flags, profile or executable selection, launch-time proxy configuration, whole-profile cookie access, or browser-wide close. Use a managed or remote provider when those browser ownership features are required.
+
+## Troubleshooting
+
+Run the provider-specific diagnostics:
+
+```bash
+npx --yes @panerelay/setup doctor --agent-browser
+```
+
+If the provider configuration is missing, rerun setup with `--agent-browser`. If the extension is disconnected, reload the installed extension or repair the Native Host as directed by doctor. If `tab list` is empty after setup succeeds, authorize the intended scope in the extension rather than switching to another browser or connection mode.

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -60,6 +60,7 @@ export const navigation: NavSection[] = [
       { name: "Browserbase", href: "/providers/browserbase" },
       { name: "Browserless", href: "/providers/browserless" },
       { name: "Kernel", href: "/providers/kernel" },
+      { name: "Panerelay", href: "/providers/panerelay" },
       {
         name: "Remote Agent Browser",
         href: "/providers/remote-agent-browser",

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -34,6 +34,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "providers/browserbase": "Browserbase",
   "providers/browserless": "Browserless",
   "providers/kernel": "Kernel",
+  "providers/panerelay": "Panerelay",
   "providers/remote-agent-browser": "Remote Agent Browser",
   changelog: "Changelog",
 };


### PR DESCRIPTION
## Summary

- add a Panerelay provider guide for using agent-browser with explicitly authorized tabs in an existing Chrome or Microsoft Edge session
- document setup, authorization and control boundaries, the optional Agent Skill, limitations, and provider-specific diagnostics
- register the page in the docs navigation and metadata

## Testing

- `pnpm -C docs build`
- `pnpm -C docs exec eslint src/lib/docs-navigation.ts src/lib/page-titles.ts src/app/providers/panerelay/layout.tsx`
- `git diff --check`

The full `pnpm -C docs lint` command still reports the existing `react-hooks/set-state-in-effect` error in `docs/src/components/theme-toggle.tsx` and an unrelated unused-variable warning in `docs/src/app/api/search/route.ts`.