### PR TITLE
fix(errors): clear page error log

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4639,6 +4639,13 @@ mod tests {
     }
 
     #[test]
+    fn test_errors_clear() {
+        let cmd = parse_command(&args("errors --clear"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "errors");
+        assert_eq!(cmd["clear"], true);
+    }
+
+    #[test]
     fn test_record_restart() {
         let cmd = parse_command(&args("record restart output.webm"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "recording_restart");

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2406,7 +2406,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "headers" => handle_headers(cmd, state).await,
         "offline" => handle_offline(cmd, state).await,
         "console" => handle_console(cmd, state).await,
-        "errors" => handle_errors(state).await,
+        "errors" => handle_errors(cmd, state).await,
         "session_info" => handle_session_info(state).await,
         "state_save" => handle_state_save(cmd, state).await,
         "state_load" => handle_state_load(cmd, state).await,
@@ -5653,8 +5653,14 @@ async fn handle_console(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
     }
 }
 
-async fn handle_errors(state: &DaemonState) -> Result<Value, String> {
-    Ok(state.event_tracker.get_errors_json())
+async fn handle_errors(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let clear = cmd.get("clear").and_then(|v| v.as_bool()).unwrap_or(false);
+    if clear {
+        state.event_tracker.clear_errors();
+        Ok(json!({ "cleared": true }))
+    } else {
+        Ok(state.event_tracker.get_errors_json())
+    }
 }
 
 async fn handle_session_info(state: &DaemonState) -> Result<Value, String> {
@@ -11186,6 +11192,26 @@ mod tests {
     #[test]
     fn find_actions_help_text_matches_the_accepted_set() {
         assert_eq!(FIND_ACTIONS.join(", "), "click, fill, check, hover, text");
+    }
+
+    #[tokio::test]
+    async fn errors_clear_empties_page_error_log() {
+        let mut state = DaemonState::new();
+        state
+            .event_tracker
+            .add_error("boom", Some("app.js"), Some(7), Some(3));
+
+        let resp = execute_command(
+            &json!({ "id": "1", "action": "errors", "clear": true }),
+            &mut state,
+        )
+        .await;
+        assert_eq!(resp["success"], true);
+        assert_eq!(resp["data"]["cleared"], true);
+
+        let resp = execute_command(&json!({ "id": "2", "action": "errors" }), &mut state).await;
+        assert_eq!(resp["success"], true);
+        assert_eq!(resp["data"]["errors"], json!([]));
     }
 
     /// `type`, `focus`, and `uncheck` are real standalone commands but were

--- a/cli/src/native/network.rs
+++ b/cli/src/native/network.rs
@@ -625,6 +625,10 @@ impl EventTracker {
         self.console_entries.clear();
     }
 
+    pub fn clear_errors(&mut self) {
+        self.error_entries.clear();
+    }
+
     pub fn get_console_json(&self) -> Value {
         let messages: Vec<Value> = self
             .console_entries


### PR DESCRIPTION
## Summary

- honor the existing `clear` flag in the native `errors` action
- add `EventTracker::clear_errors()` to clear the page error buffer
- add parser and native action regressions for `errors --clear`

## Root cause

The CLI and MCP paths already forwarded `clear: true`, but the daemon-side `errors` handler ignored the command payload and always returned the current error buffer.

Fixes #1645.

## Verification

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml test_errors_clear`
- `cargo test --manifest-path cli/Cargo.toml errors_clear_empties_page_error_log`
- real CLI session: trigger a page `ReferenceError`, confirm `errors --json` reports it, run `errors --clear --json`, then confirm `errors --json` returns `errors: []`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets`
- `cargo test --manifest-path cli/Cargo.toml` has 1041 passing tests and one unrelated Windows-localized `download_bytes_connection_refused_includes_details` assertion failure