### PR TITLE
fix(install): skip sudo when running as root during --with-deps

### DIFF
--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -600,8 +600,10 @@ fn install_linux_deps() {
         // Run apt-get update before resolving t64 package variants. Fresh
         // sandbox images may have no local package index yet, which would
         // make apt-cache miss packages that are actually available.
-        println!("Running: sudo apt-get update");
-        let update_status = Command::new("sudo").args(["apt-get", "update"]).status();
+        println!("Running: {}apt-get update", privilege_prefix());
+        let update_status = privileged_command("apt-get")
+            .map(|mut cmd| cmd.arg("update").status())
+            .unwrap_or_else(|e| Err(io::Error::other(e)));
 
         match update_status {
             Ok(s) if !s.success() => {
@@ -694,10 +696,9 @@ fn install_linux_deps() {
         // due to dependency conflicts (e.g. on Ubuntu 24.04 with the
         // t64 transition).
         println!("Checking for conflicts...");
-        let sim_output = Command::new("sudo")
-            .args(["apt-get", "install", "--simulate"])
-            .args(&deps)
-            .output();
+        let sim_output = privileged_command("apt-get")
+            .map(|mut cmd| cmd.args(["install", "--simulate"]).args(&deps).output())
+            .unwrap_or_else(|e| Err(io::Error::other(e)));
 
         match sim_output {
             Ok(output) => {
@@ -718,7 +719,11 @@ fn install_linux_deps() {
                     }
                     eprintln!();
                     eprintln!("  To install dependencies manually, run:");
-                    eprintln!("    sudo apt-get install {}", deps.join(" "));
+                    eprintln!(
+                        "    {}apt-get install {}",
+                        privilege_prefix(),
+                        deps.join(" ")
+                    );
                     exit(1);
                 }
 
@@ -748,7 +753,11 @@ fn install_linux_deps() {
                     }
                     eprintln!();
                     eprintln!("  To install dependencies manually, run:");
-                    eprintln!("    sudo apt-get install {}", deps.join(" "));
+                    eprintln!(
+                        "    {}apt-get install {}",
+                        privilege_prefix(),
+                        deps.join(" ")
+                    );
                     eprintln!();
                     eprintln!("  Review the apt output carefully before confirming.");
                     exit(1);
@@ -764,22 +773,84 @@ fn install_linux_deps() {
         }
 
         // Safe to proceed: no removals detected
-        let install_cmd = format!("sudo apt-get install -y {}", deps.join(" "));
+        let install_cmd = format!(
+            "{}apt-get install -y {}",
+            privilege_prefix(),
+            deps.join(" ")
+        );
         println!("Running: {}", install_cmd);
-        let status = Command::new("sudo")
-            .args(["apt-get", "install", "-y"])
-            .args(&deps)
-            .status();
+        let status = privileged_command("apt-get")
+            .map(|mut cmd| cmd.args(["install", "-y"]).args(&deps).status())
+            .unwrap_or_else(|e| Err(io::Error::other(e)));
 
         report_install_status(status);
     } else {
         // dnf / yum path — these package managers do not remove packages
         // during install, so the simulate-first guard is not needed.
-        let install_cmd = format!("sudo {} install -y {}", pkg_mgr, deps.join(" "));
+        let install_cmd = format!(
+            "{} {} install -y {}",
+            privilege_prefix(),
+            pkg_mgr,
+            deps.join(" ")
+        );
         println!("Running: {}", install_cmd);
-        let status = Command::new("sh").arg("-c").arg(&install_cmd).status();
+        let status = privileged_command(pkg_mgr)
+            .map(|mut cmd| cmd.args(["install", "-y"]).args(&deps).status())
+            .unwrap_or_else(|e| Err(io::Error::other(e)));
 
         report_install_status(status);
+    }
+}
+
+/// Whether this process is running as root (effective UID 0).
+fn is_root() -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: geteuid() takes no arguments and always succeeds.
+        unsafe { libc::geteuid() == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+/// Build a command that runs a package-manager invocation with root
+/// privileges: the package manager directly when the process is already
+/// root (e.g. a minimal container without sudo), otherwise prefixed with
+/// `sudo`. Errors when neither root privileges nor sudo are available.
+fn privileged_command(pkg_mgr: &str) -> Result<Command, String> {
+    privileged_command_with(is_root(), which_exists("sudo"), pkg_mgr)
+}
+
+/// Testable core of `privileged_command`: decide how to invoke a package
+/// manager given whether the process is root and whether sudo exists.
+fn privileged_command_with(
+    is_root: bool,
+    has_sudo: bool,
+    pkg_mgr: &str,
+) -> Result<Command, String> {
+    if is_root {
+        return Ok(Command::new(pkg_mgr));
+    }
+    if has_sudo {
+        let mut cmd = Command::new("sudo");
+        cmd.arg(pkg_mgr);
+        return Ok(cmd);
+    }
+    Err(format!(
+        "{} needs root privileges to install system dependencies: run as root or install sudo",
+        pkg_mgr
+    ))
+}
+
+/// Display prefix for privileged invocations: empty when already root,
+/// `"sudo "` otherwise. Mirrors what `privileged_command` will actually run.
+fn privilege_prefix() -> &'static str {
+    if is_root() {
+        ""
+    } else {
+        "sudo "
     }
 }
 
@@ -898,6 +969,36 @@ mod tests {
             install_status_result(Err(io::Error::new(io::ErrorKind::NotFound, "missing sudo")))
                 .unwrap_err();
         assert!(err.contains("could not run install command"));
+    }
+
+    #[test]
+    fn privileged_command_runs_package_manager_directly_when_root() {
+        let cmd = privileged_command_with(true, false, "apt-get").unwrap();
+        assert_eq!(cmd.get_program(), "apt-get");
+        assert_eq!(cmd.get_args().count(), 0);
+    }
+
+    #[test]
+    fn privileged_command_prefers_sudo_when_not_root() {
+        let cmd = privileged_command_with(false, true, "apt-get").unwrap();
+        assert_eq!(cmd.get_program(), "sudo");
+        assert_eq!(
+            cmd.get_args().collect::<Vec<_>>(),
+            vec![std::ffi::OsStr::new("apt-get")]
+        );
+    }
+
+    #[test]
+    fn privileged_command_does_not_need_sudo_when_root() {
+        let cmd = privileged_command_with(true, false, "dnf").unwrap();
+        assert_eq!(cmd.get_program(), "dnf");
+    }
+
+    #[test]
+    fn privileged_command_errors_without_root_or_sudo() {
+        let err = privileged_command_with(false, false, "apt-get").unwrap_err();
+        assert!(err.contains("root privileges"));
+        assert!(err.contains("install sudo"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`agent-browser install --with-deps` always ran the detected package manager
through `sudo`, so it failed with a confusing "No such file or directory"
in minimal root containers (e.g. Docker) that have apt-get but no sudo
package, even though the process already had root privileges.

`install_linux_deps` in `cli/src/install.rs` now invokes the package
manager directly when the effective UID is 0, falls back to `sudo` for
non-root processes, and emits a specific error when neither root
privileges nor sudo are available.

Closes #1650

## Verification

- new helper `privileged_command(pkg_mgr)` chooses direct invocation (root)
  vs `sudo <pkg_mgr>` (non-root) vs a specific error (neither); the
  testable core `privileged_command_with(is_root, has_sudo, pkg_mgr)` is
  covered by four unit tests across all four branches
- `install_linux_deps` update, simulate, and install steps all route through
  the helper; display strings ("Running: ...") and the manual-install hints
  reflect the actual invocation (no more hardcoded "sudo" when root)
- MCP path is untouched: `call_install` delegates to the CLI via
  `call_cli_tool(["install", "--with-deps"])`, so the fix applies
  transparently
- `cargo test install` -> 15/15 pass (4 new); `cargo check` clean;
  `cargo fmt` clean. `cargo clippy -- -D warnings` surfaces one pre-existing
  `nonminimal_bool` warning in `src/native/cdp/chrome.rs:337`, unrelated to
  this change.

Only `cli/src/install.rs` is changed.
