### PR TITLE
feat(tabs): tab/window reliability — tabs-on-change, popup discipline, ref↔tab binding, window verbs

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -165,6 +165,7 @@ pub fn is_top_level_command(value: &str) -> bool {
             | "pushstate"
             | "removeinitscript"
             | "session"
+            | "restart"
             | "mcp"
             | "doctor"
             | "install"
@@ -1536,16 +1537,66 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Window ===
         "window" => {
-            const VALID: &[&str] = &["new"];
+            const VALID: &[&str] = &[
+                "new",
+                "list",
+                "close",
+                "bounds",
+                "minimize",
+                "maximize",
+                "fullscreen",
+                "normal",
+                "focus",
+            ];
             match rest.first().copied() {
                 Some("new") => Ok(json!({ "id": id, "action": "window_new" })),
+                Some("list") | None => Ok(json!({ "id": id, "action": "window_list" })),
+                Some("close") => match rest.get(1) {
+                    Some(tab) => Ok(json!({ "id": id, "action": "window_close", "tab": tab })),
+                    None => Ok(json!({ "id": id, "action": "window_close" })),
+                },
+                Some("bounds") => {
+                    let width: i64 = rest.get(1).and_then(|s| s.parse().ok()).ok_or_else(|| {
+                        ParseError::MissingArguments {
+                            context: "window bounds".to_string(),
+                            usage: "window bounds <width> <height> [x y]",
+                        }
+                    })?;
+                    let height: i64 =
+                        rest.get(2).and_then(|s| s.parse().ok()).ok_or_else(|| {
+                            ParseError::MissingArguments {
+                                context: "window bounds".to_string(),
+                                usage: "window bounds <width> <height> [x y]",
+                            }
+                        })?;
+                    let mut cmd = json!({
+                        "id": id,
+                        "action": "window_bounds",
+                        "width": width,
+                        "height": height,
+                    });
+                    if let (Some(x), Some(y)) = (
+                        rest.get(3).and_then(|s| s.parse::<i64>().ok()),
+                        rest.get(4).and_then(|s| s.parse::<i64>().ok()),
+                    ) {
+                        let obj = cmd.as_object_mut().expect("literal object");
+                        obj.insert("left".to_string(), json!(x));
+                        obj.insert("top".to_string(), json!(y));
+                    }
+                    Ok(cmd)
+                }
+                Some(state @ ("minimize" | "maximize" | "fullscreen" | "normal")) => Ok(json!({
+                    "id": id,
+                    "action": "window_bounds",
+                    "windowState": state,
+                })),
+                Some("focus") => match rest.get(1) {
+                    Some(tab) => Ok(json!({ "id": id, "action": "window_focus", "tab": tab })),
+                    None => Ok(json!({ "id": id, "action": "window_focus" })),
+                },
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
                     valid_options: VALID,
-                }),
-                None => Err(ParseError::MissingArguments {
-                    context: "window".to_string(),
-                    usage: "window <new>",
                 }),
             }
         }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1603,10 +1603,16 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     }
                     Ok(cmd)
                 }
-                Some(state @ ("minimize" | "maximize" | "fullscreen" | "normal")) => Ok(json!({
+                Some(verb @ ("minimize" | "maximize" | "fullscreen" | "normal")) => Ok(json!({
                     "id": id,
                     "action": "window_bounds",
-                    "windowState": state,
+                    // CDP's Browser.Bounds windowState enum uses the
+                    // past-participle forms.
+                    "windowState": match verb {
+                        "minimize" => "minimized",
+                        "maximize" => "maximized",
+                        other => other,
+                    },
                 })),
                 Some("focus") => match rest.get(1) {
                     Some(tab) => Ok(json!({ "id": id, "action": "window_focus", "tab": tab })),

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1488,10 +1488,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         "tab" => {
             match rest.first().copied() {
                 Some("new") => {
-                    // Accepted forms:
+                    // Accepted forms (flags may precede or follow the url):
                     //   tab new [url]
                     //   tab new --label <name> [url]
-                    //   tab new [url] --label <name>
+                    //   tab new --background [url]
+                    //   tab new --context <name> [url]
                     let mut cmd = json!({ "id": id, "action": "tab_new" });
                     let mut i = 1;
                     while i < rest.len() {
@@ -1504,6 +1505,18 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                                 cmd["label"] = json!(name);
                                 i += 2;
                             }
+                            "--background" | "-b" => {
+                                cmd["background"] = json!(true);
+                                i += 1;
+                            }
+                            "--context" => {
+                                let name = rest.get(i + 1).ok_or(ParseError::MissingArguments {
+                                    context: "tab new --context".to_string(),
+                                    usage: "tab new --context <name> [url]",
+                                })?;
+                                cmd["context"] = json!(name);
+                                i += 2;
+                            }
                             other if !other.starts_with("--") && cmd.get("url").is_none() => {
                                 cmd["url"] = json!(other);
                                 i += 1;
@@ -1511,7 +1524,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                             other => {
                                 return Err(ParseError::UnknownSubcommand {
                                     subcommand: other.to_string(),
-                                    valid_options: &["--label", "<url>"],
+                                    valid_options: &[
+                                        "--label",
+                                        "--background",
+                                        "--context",
+                                        "<url>",
+                                    ],
                                 });
                             }
                         }

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -37,6 +37,14 @@ pub struct Response {
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
+    /// Tab list, present only when it changed since the previous response
+    /// and more than one tab is (or was) involved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tabs: Option<Value>,
+    /// One-shot notices about events the agent did not initiate (popup
+    /// opened, tab crashed or closed underneath, browser relaunched).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notices: Option<Vec<String>>,
 }
 
 #[allow(dead_code)]

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -712,7 +712,7 @@ fn daemon_version_matches(session: &str) -> bool {
 }
 
 /// Kill a running daemon by reading its PID file and sending a kill signal.
-fn kill_stale_daemon(session: &str) {
+pub fn kill_stale_daemon(session: &str) {
     // Remove the socket first so no new connections reach the old daemon
     #[cfg(unix)]
     {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1210,14 +1210,13 @@ fn main() {
             Ok(data) => connection::Response {
                 success: true,
                 data: Some(data),
-                error: None,
-                warning: None,
+                ..Default::default()
             },
             Err(e) => connection::Response {
                 success: false,
                 data: None,
                 error: Some(e),
-                warning: None,
+                ..Default::default()
             },
         };
         let output_opts = OutputOptions::from_flags(&flags);
@@ -2193,6 +2192,8 @@ mod tests {
             })),
             error: None,
             warning: None,
+            tabs: None,
+            notices: None,
         };
 
         let prompt = confirmation_prompt_from_response(&resp).unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1094,6 +1094,27 @@ fn main() {
         return;
     }
 
+    // Handle restart client-side: recovery for a wedged daemon ("CDP
+    // response channel closed") that cannot answer a graceful shutdown over
+    // its own socket. Kills the daemon process and cleans up its files; the
+    // next command starts a fresh daemon.
+    if clean.first().map(|s| s.as_str()) == Some("restart") {
+        connection::kill_stale_daemon(&flags.session);
+        if flags.json {
+            print_json_value(json!({
+                "success": true,
+                "data": { "restarted": true, "session": flags.session },
+            }));
+        } else {
+            println!(
+                "{} Daemon for session `{}` killed and cleaned up; the next command starts a fresh one",
+                color::green("✓"),
+                flags.session
+            );
+        }
+        return;
+    }
+
     // Handle close --all: close all active sessions
     if matches!(
         clean.first().map(|s| s.as_str()),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2699,6 +2699,10 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "responsebody" => handle_responsebody(cmd, state).await,
         "waitfordownload" => handle_waitfordownload(cmd, state).await,
         "window_new" => handle_window_new(cmd, state).await,
+        "window_list" => handle_window_list(state).await,
+        "window_close" => handle_window_close(cmd, state).await,
+        "window_bounds" => handle_window_bounds(cmd, state).await,
+        "window_focus" => handle_window_focus(cmd, state).await,
         "diff_screenshot" => handle_diff_screenshot(cmd, state).await,
         "video_start" => handle_video_start(cmd, state).await,
         "video_stop" => handle_video_stop(state).await,
@@ -9446,6 +9450,228 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
     Ok(json!({
         "tabId": super::browser::format_tab_id(tab_id),
         "total": total,
+    }))
+}
+
+/// Browser-level `Browser.getWindowForTarget`: (windowId, bounds).
+/// `bounds` carries left/top/width/height/windowState per CDP.
+async fn window_for_target(
+    client: &super::cdp::client::CdpClient,
+    target_id: &str,
+) -> Result<(i64, Value), String> {
+    let result = client
+        .send_command(
+            "Browser.getWindowForTarget",
+            Some(json!({ "targetId": target_id })),
+            None,
+        )
+        .await?;
+    let window_id = result
+        .get("windowId")
+        .and_then(|v| v.as_i64())
+        .ok_or("Browser.getWindowForTarget returned no windowId")?;
+    let bounds = result.get("bounds").cloned().unwrap_or(Value::Null);
+    Ok((window_id, bounds))
+}
+
+/// Resolve an optional `tab` param (`t<N>` or label) to a tracked page,
+/// defaulting to the active page.
+fn resolve_tab_param(
+    cmd: &Value,
+    mgr: &super::browser::BrowserManager,
+) -> Result<super::browser::PageInfo, String> {
+    match cmd.get("tab").and_then(|v| v.as_str()) {
+        Some(tab_ref_str) => {
+            let tab_ref = super::browser::TabRef::parse(tab_ref_str)?;
+            let tab_id = mgr.resolve_tab_ref(&tab_ref)?;
+            mgr.pages_list()
+                .into_iter()
+                .find(|p| p.tab_id == tab_id)
+                .ok_or_else(|| format!("Tab ID {} not found", tab_id))
+        }
+        None => mgr
+            .active_page()
+            .cloned()
+            .ok_or_else(|| "No active page".to_string()),
+    }
+}
+
+async fn handle_window_list(state: &mut DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let active_tab = mgr.active_tab_id();
+    // Group the flat tab list by OS window. Insertion order = first tab seen.
+    let mut window_order: Vec<i64> = Vec::new();
+    let mut window_bounds: HashMap<i64, Value> = HashMap::new();
+    let mut window_tabs: HashMap<i64, Vec<Value>> = HashMap::new();
+    for page in mgr.pages_list() {
+        // Direct-page providers and webviews may not support window lookup;
+        // group those under windowId -1 rather than failing the listing.
+        let (window_id, bounds) = window_for_target(&mgr.client, &page.target_id)
+            .await
+            .unwrap_or((-1, Value::Null));
+        if !window_order.contains(&window_id) {
+            window_order.push(window_id);
+            window_bounds.insert(window_id, bounds);
+        }
+        window_tabs.entry(window_id).or_default().push(json!({
+            "tabId": super::browser::format_tab_id(page.tab_id),
+            "label": page.label,
+            "url": page.url,
+            "active": Some(page.tab_id) == active_tab,
+        }));
+    }
+    let windows: Vec<Value> = window_order
+        .into_iter()
+        .map(|wid| {
+            let bounds = window_bounds.remove(&wid).unwrap_or(Value::Null);
+            let tabs = window_tabs.remove(&wid).unwrap_or_default();
+            let has_active = tabs
+                .iter()
+                .any(|t| t.get("active").and_then(|v| v.as_bool()).unwrap_or(false));
+            json!({
+                "windowId": wid,
+                "bounds": bounds,
+                "active": has_active,
+                "tabs": tabs,
+            })
+        })
+        .collect();
+    Ok(json!({ "windows": windows }))
+}
+
+async fn handle_window_bounds(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let page = mgr.active_page().ok_or("No active page")?;
+    let (window_id, current) = window_for_target(&mgr.client, &page.target_id).await?;
+
+    let bounds = if let Some(window_state) = cmd.get("windowState").and_then(|v| v.as_str()) {
+        json!({ "windowState": window_state })
+    } else {
+        // Chrome rejects size changes while minimized/maximized/fullscreen;
+        // drop back to normal first when needed.
+        let current_state = current
+            .get("windowState")
+            .and_then(|v| v.as_str())
+            .unwrap_or("normal");
+        if current_state != "normal" {
+            mgr.client
+                .send_command(
+                    "Browser.setWindowBounds",
+                    Some(json!({
+                        "windowId": window_id,
+                        "bounds": { "windowState": "normal" },
+                    })),
+                    None,
+                )
+                .await?;
+        }
+        let mut bounds = json!({
+            "windowState": "normal",
+            "width": cmd.get("width").and_then(|v| v.as_i64()).unwrap_or(1280),
+            "height": cmd.get("height").and_then(|v| v.as_i64()).unwrap_or(720),
+        });
+        let obj = bounds.as_object_mut().expect("literal object");
+        if let Some(left) = cmd.get("left").and_then(|v| v.as_i64()) {
+            obj.insert("left".to_string(), json!(left));
+        }
+        if let Some(top) = cmd.get("top").and_then(|v| v.as_i64()) {
+            obj.insert("top".to_string(), json!(top));
+        }
+        bounds
+    };
+
+    mgr.client
+        .send_command(
+            "Browser.setWindowBounds",
+            Some(json!({ "windowId": window_id, "bounds": bounds })),
+            None,
+        )
+        .await?;
+
+    Ok(json!({ "windowId": window_id, "bounds": bounds }))
+}
+
+async fn handle_window_focus(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let page = resolve_tab_param(cmd, mgr)?;
+    mgr.client
+        .send_command("Page.bringToFront", None, Some(&page.session_id))
+        .await?;
+    let window_id = window_for_target(&mgr.client, &page.target_id)
+        .await
+        .map(|(wid, _)| wid)
+        .ok();
+    Ok(json!({
+        "tabId": super::browser::format_tab_id(page.tab_id),
+        "windowId": window_id,
+        // Raising a window shows that tab to a human watching the display;
+        // the agent's own active tab is deliberately unchanged.
+        "activeTabUnchanged": true,
+    }))
+}
+
+async fn handle_window_close(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let (window_id, doomed, active_was_closed) = {
+        let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+        let anchor = resolve_tab_param(cmd, mgr)?;
+        let (window_id, _) = window_for_target(&mgr.client, &anchor.target_id).await?;
+        let mut doomed: Vec<super::browser::PageInfo> = Vec::new();
+        for page in mgr.pages_list() {
+            let (wid, _) = window_for_target(&mgr.client, &page.target_id)
+                .await
+                .unwrap_or((-1, Value::Null));
+            if wid == window_id {
+                doomed.push(page);
+            }
+        }
+        if doomed.len() >= mgr.page_count() {
+            return Err("Cannot close the last window".to_string());
+        }
+        let active_tab = mgr.active_tab_id();
+        let active_was_closed = doomed.iter().any(|p| Some(p.tab_id) == active_tab);
+        (window_id, doomed, active_was_closed)
+    };
+
+    let mut closed_tabs: Vec<String> = Vec::new();
+    for page in &doomed {
+        let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+        let _ = mgr
+            .client
+            .send_command(
+                "Target.closeTarget",
+                Some(json!({ "targetId": page.target_id })),
+                None,
+            )
+            .await;
+        // Remove synchronously so the drain path doesn't announce our own
+        // window close as an external tab death.
+        mgr.remove_page_by_target_id(&page.target_id);
+        closed_tabs.push(super::browser::format_tab_id(page.tab_id));
+    }
+
+    if active_was_closed {
+        state.ref_map.clear();
+        state.iframe_sessions.clear();
+        state.active_frame_id = None;
+    }
+
+    let (new_active, remaining) = {
+        let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+        mgr.update_active_page_if_needed();
+        if let Ok(session_id) = mgr.active_session_id().map(String::from) {
+            mgr.enable_domains_pub(&session_id).await?;
+        }
+        (
+            mgr.active_tab_id().map(super::browser::format_tab_id),
+            mgr.page_count(),
+        )
+    };
+
+    Ok(json!({
+        "windowId": window_id,
+        "closedTabs": closed_tabs,
+        "activeTab": new_active,
+        "total": remaining,
     }))
 }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -228,6 +228,8 @@ struct DrainedEvents {
     attached_other_sessions: Vec<String>,
     /// Session IDs from Target.detachedFromTarget.
     detached_iframe_sessions: Vec<String>,
+    /// Target IDs from Target.targetCrashed.
+    crashed_targets: Vec<String>,
     /// (request_id, event session_id) pairs from `Network.loadingFinished`
     /// while HAR recording; bodies are fetched for these in
     /// `apply_drained_events` before Chrome evicts them (e.g. on navigation).
@@ -441,6 +443,13 @@ pub struct DaemonState {
     active_provider_connection: bool,
     /// Actions already approved while replaying a confirmed command.
     confirmed_policy_actions: HashSet<String>,
+    /// One-shot notices about tab-level events the agent did not initiate
+    /// (popup opened, active tab crashed/closed, browser relaunched).
+    /// Drained into the `notices` field of the next response.
+    pub pending_notices: Vec<String>,
+    /// (signature, page_count) of the tab list as of the last response, used
+    /// to render the tab list into responses only when it changed.
+    last_tabs_state: Option<(u64, usize)>,
 }
 
 fn default_idle_shutdown_is_blocked(
@@ -531,6 +540,8 @@ impl DaemonState {
             active_provider_session: None,
             active_provider_connection: false,
             confirmed_policy_actions: HashSet::new(),
+            pending_notices: Vec::new(),
+            last_tabs_state: None,
         }
     }
 
@@ -932,6 +943,20 @@ impl DaemonState {
             }
         }
 
+        // Mark crashed targets so `tab list` can render them
+        for target_id in &drained.crashed_targets {
+            if let Some(ref mut mgr) = self.browser {
+                if let Some((tab_id, was_active)) = mgr.mark_crashed(target_id) {
+                    if was_active {
+                        self.pending_notices.push(format!(
+                            "Active tab {} crashed; `reload` to revive it or switch with `tab <ref>`",
+                            super::browser::format_tab_id(tab_id)
+                        ));
+                    }
+                }
+            }
+        }
+
         // Track cross-origin iframe sessions
         for (frame_id, iframe_sid) in &drained.attached_iframe_sessions {
             self.iframe_sessions
@@ -1022,6 +1047,11 @@ impl DaemonState {
                             url: page_url,
                             title: target_info.title.clone(),
                             target_type: target_info.target_type.clone(),
+                            parent_tab_id: target_info
+                                .opener_id
+                                .as_deref()
+                                .and_then(|o| mgr.tab_id_for_target(o)),
+                            crashed: false,
                         });
                     }
 
@@ -1149,6 +1179,12 @@ impl DaemonState {
                         url: page_url,
                         title: te.target_info.title.clone(),
                         target_type: te.target_info.target_type.clone(),
+                        parent_tab_id: te
+                            .target_info
+                            .opener_id
+                            .as_deref()
+                            .and_then(|o| mgr.tab_id_for_target(o)),
+                        crashed: false,
                     });
                     mgr.resume_if_waiting_pub(&attach.session_id).await
                 }
@@ -1270,6 +1306,7 @@ impl DaemonState {
         let mut attached_worker_sessions: Vec<(TargetInfo, String)> = Vec::new();
         let mut attached_other_sessions: Vec<String> = Vec::new();
         let mut detached_iframe_sessions: Vec<String> = Vec::new();
+        let mut crashed_targets: Vec<String> = Vec::new();
         let mut har_finished_requests: Vec<(String, Option<String>)> = Vec::new();
 
         loop {
@@ -1364,6 +1401,13 @@ impl DaemonState {
                                 event.params.get("sessionId").and_then(|v| v.as_str())
                             {
                                 detached_iframe_sessions.push(sid.to_string());
+                            }
+                            continue;
+                        }
+                        "Target.targetCrashed" => {
+                            if let Some(tid) = event.params.get("targetId").and_then(|v| v.as_str())
+                            {
+                                crashed_targets.push(tid.to_string());
                             }
                             continue;
                         }
@@ -1724,6 +1768,7 @@ impl DaemonState {
             attached_worker_sessions,
             attached_other_sessions,
             detached_iframe_sessions,
+            crashed_targets,
             har_finished_requests,
         }
     }
@@ -2581,6 +2626,34 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                     )),
                 );
             }
+        }
+    }
+
+    // Tab-list-on-change: render the tab list into any response whenever it
+    // changed since the last response and more than one tab is (or was)
+    // involved — the agent should never have to poll `tab list` to notice a
+    // popup, a closed tab, or a crash.
+    if let Some(ref mgr) = state.browser {
+        let signature = mgr.tabs_signature();
+        let count = mgr.page_count();
+        if state.last_tabs_state != Some((signature, count)) {
+            let prev_count = state.last_tabs_state.map(|(_, c)| c).unwrap_or(count);
+            if (count > 1 || prev_count > 1)
+                && !matches!(action, "tab_list" | "tab_new" | "tab_switch" | "tab_close")
+            {
+                if let Some(obj) = resp.as_object_mut() {
+                    obj.insert("tabs".to_string(), json!(mgr.tab_list()));
+                }
+            }
+            state.last_tabs_state = Some((signature, count));
+        }
+    }
+
+    // Deliver one-shot notices (popup opened, tab crashed/closed, relaunch).
+    if !state.pending_notices.is_empty() {
+        let notices: Vec<String> = state.pending_notices.drain(..).collect();
+        if let Some(obj) = resp.as_object_mut() {
+            obj.insert("notices".to_string(), json!(notices));
         }
     }
 
@@ -6490,6 +6563,8 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
             url: "about:blank".to_string(),
             title: String::new(),
             target_type: "page".to_string(),
+            parent_tab_id: None,
+            crashed: false,
         });
 
         (mgr.client.clone(), new_session_id, nav_url)
@@ -9170,6 +9245,8 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
             url: "about:blank".to_string(),
             title: String::new(),
             target_type: "page".to_string(),
+            parent_tab_id: None,
+            crashed: false,
         });
         (tab_id, attach.session_id)
     };
@@ -13072,6 +13149,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
                 url: "about:blank".to_string(),
                 title: String::new(),
                 target_type: "page".to_string(),
+                parent_tab_id: None,
+                crashed: false,
             },
             super::super::browser::PageInfo {
                 tab_id: 2,
@@ -13081,6 +13160,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
                 url: "about:blank".to_string(),
                 title: String::new(),
                 target_type: "page".to_string(),
+                parent_tab_id: None,
+                crashed: false,
             },
             super::super::browser::PageInfo {
                 tab_id: 3,
@@ -13090,6 +13171,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
                 url: "about:blank".to_string(),
                 title: String::new(),
                 target_type: "page".to_string(),
+                parent_tab_id: None,
+                crashed: false,
             },
         ];
 
@@ -13109,6 +13192,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             url: String::new(),
             title: String::new(),
             target_type: "page".to_string(),
+            parent_tab_id: None,
+            crashed: false,
         }];
 
         assert_eq!(

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -9588,6 +9588,15 @@ async fn handle_window_bounds(cmd: &Value, state: &mut DaemonState) -> Result<Va
     let (window_id, current) = window_for_target(&mgr.client, &page.target_id).await?;
 
     let bounds = if let Some(window_state) = cmd.get("windowState").and_then(|v| v.as_str()) {
+        // Browser.setWindowBounds{minimized|maximized} aborts headless Chrome
+        // outright (reproduced on 0.32.3-tako.4 smoke: "CDP response channel
+        // closed" + relaunch). Refuse with the alternative instead.
+        if mgr.is_headless() && (window_state == "minimized" || window_state == "maximized") {
+            return Err(format!(
+                "window {} needs a headed browser (AGENT_BROWSER_HEADED=1); in headless Chrome use `window bounds <w> <h>` or `set viewport` instead",
+                if window_state == "minimized" { "minimize" } else { "maximize" }
+            ));
+        }
         json!({ "windowState": window_state })
     } else {
         // Chrome rejects size changes while minimized/maximized/fullscreen;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -255,6 +255,16 @@ fn active_frame_scope_may_have_changed(drained: &DrainedEvents) -> bool {
         || !drained.destroyed_targets.is_empty()
 }
 
+/// Returns the first `@eN` element-ref argument of a command, if any.
+/// Selector-bearing params across the verb set: `selector` (click/fill/…),
+/// and `source`/`target` (drag).
+fn command_ref_argument(cmd: &Value) -> Option<&str> {
+    ["selector", "source", "target"]
+        .iter()
+        .filter_map(|key| cmd.get(*key).and_then(|v| v.as_str()))
+        .find(|s| s.starts_with('@'))
+}
+
 /// Register a page the agent did not create (popup, `target=_blank`, tab
 /// opened by a human in the same browser). Unless follow-popups is enabled
 /// the page is added WITHOUT stealing the active tab. Returns the notice for
@@ -2497,6 +2507,32 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         }
     }
 
+    // Element refs belong to the tab whose snapshot minted them. If the
+    // active tab changed since (relaunch, retarget after a tab died, any
+    // path that did not clear the ref map), using a stale `@ref` is a hard
+    // error — never the role/name fallback, which could silently resolve a
+    // same-role element in a different page.
+    if let Some(stale_ref) = command_ref_argument(cmd) {
+        if let (Some(minted), Some(active)) = (
+            state.ref_map.minted_tab(),
+            state.browser.as_ref().and_then(|m| m.active_tab_id()),
+        ) {
+            if minted != active {
+                let minted_tab = super::browser::format_tab_id(minted);
+                return error_response(
+                    &id,
+                    &format!(
+                        "{} was minted on tab {}, but the active tab is now {} — switch back with `tab {}`, or run `snapshot` here for fresh refs",
+                        stale_ref,
+                        minted_tab,
+                        super::browser::format_tab_id(active),
+                        minted_tab
+                    ),
+                );
+            }
+        }
+    }
+
     let result = match action {
         "launch" => handle_launch(cmd, state).await,
         "navigate" => handle_navigate(cmd, state).await,
@@ -2715,6 +2751,15 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 );
             }
         }
+    }
+
+    // Stamp freshly minted refs with the tab they belong to. Every path that
+    // changes the active tab either clears the ref map or is caught by the
+    // minted-tab check above, so a non-empty unstamped map can only mean the
+    // refs were minted during this command, on the current active tab.
+    if !state.ref_map.is_empty() && state.ref_map.minted_tab().is_none() {
+        let active = state.browser.as_ref().and_then(|m| m.active_tab_id());
+        state.ref_map.set_minted_tab(active);
     }
 
     // Tab-list-on-change: render the tab list into any response whenever it

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -255,6 +255,44 @@ fn active_frame_scope_may_have_changed(drained: &DrainedEvents) -> bool {
         || !drained.destroyed_targets.is_empty()
 }
 
+/// Register a page the agent did not create (popup, `target=_blank`, tab
+/// opened by a human in the same browser). Unless follow-popups is enabled
+/// the page is added WITHOUT stealing the active tab. Returns the notice for
+/// the next response and whether the new page became active.
+fn register_uninvited_page(
+    mgr: &mut super::browser::BrowserManager,
+    page: super::browser::PageInfo,
+    tab_id: u32,
+    parent_tab_id: Option<u32>,
+    url: &str,
+    follow_popups: bool,
+) -> (String, bool) {
+    let tab = super::browser::format_tab_id(tab_id);
+    let opener = parent_tab_id
+        .map(|p| format!(" (opened by {})", super::browser::format_tab_id(p)))
+        .unwrap_or_default();
+    let shown_url = if url.is_empty() { "about:blank" } else { url };
+    if follow_popups {
+        mgr.add_page(page);
+        (
+            format!(
+                "New tab {}{} opened and is now active (AGENT_BROWSER_FOLLOW_POPUPS): {} — element refs were cleared, re-snapshot before using @e refs",
+                tab, opener, shown_url
+            ),
+            true,
+        )
+    } else {
+        mgr.add_page_background(page);
+        (
+            format!(
+                "New tab {}{} opened in background: {} — switch with `tab {}`",
+                tab, opener, shown_url, tab
+            ),
+            false,
+        )
+    }
+}
+
 /// Compute a hash of the [`LaunchOptions`] fields that require a browser
 /// relaunch when changed (baked into the Chrome process at startup).
 ///
@@ -447,6 +485,10 @@ pub struct DaemonState {
     /// (popup opened, active tab crashed/closed, browser relaunched).
     /// Drained into the `notices` field of the next response.
     pub pending_notices: Vec<String>,
+    /// When true (AGENT_BROWSER_FOLLOW_POPUPS), a popup/`target=_blank` tab
+    /// becomes the active tab on open — the pre-0.32.3-tako.4 behavior —
+    /// with an announcement. Default: popups open in the background.
+    pub follow_popups: bool,
     /// (signature, page_count) of the tab list as of the last response, used
     /// to render the tab list into responses only when it changed.
     last_tabs_state: Option<(u64, usize)>,
@@ -541,6 +583,10 @@ impl DaemonState {
             active_provider_connection: false,
             confirmed_policy_actions: HashSet::new(),
             pending_notices: Vec::new(),
+            follow_popups: matches!(
+                env::var("AGENT_BROWSER_FOLLOW_POPUPS").as_deref(),
+                Ok("1" | "true" | "yes")
+            ),
             last_tabs_state: None,
         }
     }
@@ -1007,6 +1053,9 @@ impl DaemonState {
             let filter = self.domain_filter.read().await.clone();
             let has_proxy_creds = self.proxy_credentials.read().await.is_some();
             let controls_active = filter.is_some() || has_proxy_creds;
+            let follow_popups = self.follow_popups;
+            let mut popup_notice: Option<String> = None;
+            let mut popup_activated = false;
             let setup_result = if let Some(ref mut mgr) = self.browser {
                 async {
                     mgr.prepare_domains_pub(page_sid).await?;
@@ -1039,20 +1088,31 @@ impl DaemonState {
                         mgr.update_page_target_info(target_info);
                     } else {
                         let tab_id = mgr.assign_tab_id();
-                        mgr.add_page(super::browser::PageInfo {
+                        let parent_tab_id = target_info
+                            .opener_id
+                            .as_deref()
+                            .and_then(|o| mgr.tab_id_for_target(o));
+                        let page = super::browser::PageInfo {
                             tab_id,
                             label: None,
                             target_id: target_info.target_id.clone(),
                             session_id: page_sid.clone(),
-                            url: page_url,
+                            url: page_url.clone(),
                             title: target_info.title.clone(),
                             target_type: target_info.target_type.clone(),
-                            parent_tab_id: target_info
-                                .opener_id
-                                .as_deref()
-                                .and_then(|o| mgr.tab_id_for_target(o)),
+                            parent_tab_id,
                             crashed: false,
-                        });
+                        };
+                        let (notice, activated) = register_uninvited_page(
+                            mgr,
+                            page,
+                            tab_id,
+                            parent_tab_id,
+                            &page_url,
+                            follow_popups,
+                        );
+                        popup_notice = Some(notice);
+                        popup_activated = activated;
                     }
 
                     mgr.resume_if_waiting_pub(page_sid).await
@@ -1061,6 +1121,13 @@ impl DaemonState {
             } else {
                 Ok(())
             };
+            if let Some(notice) = popup_notice {
+                self.pending_notices.push(notice);
+            }
+            if popup_activated {
+                // The active tab changed underneath any existing snapshot.
+                self.ref_map.clear();
+            }
             if let Err(error) = setup_result {
                 if controls_active {
                     return close_after_network_control_failure(self, error).await;
@@ -1131,6 +1198,9 @@ impl DaemonState {
             let filter = self.domain_filter.read().await.clone();
             let has_proxy_creds = self.proxy_credentials.read().await.is_some();
             let controls_active = filter.is_some() || has_proxy_creds;
+            let follow_popups = self.follow_popups;
+            let mut popup_notice: Option<String> = None;
+            let mut popup_activated = false;
             let setup_result = if let Some(ref mut mgr) = self.browser {
                 async {
                     let attach: AttachToTargetResult = mgr
@@ -1171,27 +1241,45 @@ impl DaemonState {
                     }
 
                     let tab_id = mgr.assign_tab_id();
-                    mgr.add_page(super::browser::PageInfo {
+                    let parent_tab_id = te
+                        .target_info
+                        .opener_id
+                        .as_deref()
+                        .and_then(|o| mgr.tab_id_for_target(o));
+                    let page = super::browser::PageInfo {
                         tab_id,
                         label: None,
                         target_id: te.target_info.target_id.clone(),
                         session_id: attach.session_id.clone(),
-                        url: page_url,
+                        url: page_url.clone(),
                         title: te.target_info.title.clone(),
                         target_type: te.target_info.target_type.clone(),
-                        parent_tab_id: te
-                            .target_info
-                            .opener_id
-                            .as_deref()
-                            .and_then(|o| mgr.tab_id_for_target(o)),
+                        parent_tab_id,
                         crashed: false,
-                    });
+                    };
+                    let (notice, activated) = register_uninvited_page(
+                        mgr,
+                        page,
+                        tab_id,
+                        parent_tab_id,
+                        &page_url,
+                        follow_popups,
+                    );
+                    popup_notice = Some(notice);
+                    popup_activated = activated;
                     mgr.resume_if_waiting_pub(&attach.session_id).await
                 }
                 .await
             } else {
                 Ok(())
             };
+            if let Some(notice) = popup_notice {
+                self.pending_notices.push(notice);
+            }
+            if popup_activated {
+                // The active tab changed underneath any existing snapshot.
+                self.ref_map.clear();
+            }
             if let Err(error) = setup_result {
                 if controls_active {
                     return close_after_network_control_failure(self, error).await;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2859,7 +2859,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 /// subsequent navigations don't hijack the user's existing tabs.
 async fn connect_auto_with_fresh_tab() -> Result<BrowserManager, String> {
     let mut mgr = BrowserManager::connect_auto().await?;
-    mgr.tab_new(None, None).await?;
+    mgr.tab_new(None, None, false, None).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let _ = mgr
         .client
@@ -5024,6 +5024,8 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
                     Some(&href)
                 },
                 None,
+                false,
+                None,
             )
             .await?;
         }
@@ -6215,18 +6217,40 @@ async fn handle_tab_list(state: &DaemonState) -> Result<Value, String> {
 async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let url = cmd.get("url").and_then(|v| v.as_str());
     let label = cmd.get("label").and_then(|v| v.as_str());
+    let background = cmd
+        .get("background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let context_name = cmd.get("context").and_then(|v| v.as_str());
     let domain_filter = state.domain_filter.read().await.clone();
     let has_proxy_creds = state.proxy_credentials.read().await.is_some();
     let defer_url_until_controls =
         should_defer_url_until_network_controls(domain_filter.as_ref(), has_proxy_creds, url)?;
 
-    state.ref_map.clear();
-    state.active_iframe_sessions.clear();
-    state.active_frame_id = None;
+    if !background {
+        // A background tab leaves the active tab (and its refs/frames) alone.
+        state.ref_map.clear();
+        state.active_iframe_sessions.clear();
+        state.active_frame_id = None;
+    }
     let mut result = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-        mgr.tab_new(if defer_url_until_controls { None } else { url }, label)
-            .await?
+        let context_id = match context_name {
+            Some(name) => Some(mgr.ensure_named_context(name).await?),
+            None => None,
+        };
+        let mut result = mgr
+            .tab_new(
+                if defer_url_until_controls { None } else { url },
+                label,
+                background,
+                context_id.as_deref(),
+            )
+            .await?;
+        if let (Some(name), Some(obj)) = (context_name, result.as_object_mut()) {
+            obj.insert("context".to_string(), json!(name));
+        }
+        result
     };
 
     install_network_controls_or_close(state, has_proxy_creds).await?;
@@ -6234,16 +6258,35 @@ async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
 
     if defer_url_until_controls {
         if let Some(url) = url {
-            let nav = {
-                let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-                mgr.navigate(url, WaitUntil::Load).await?
-            };
-            if let Some(obj) = result.as_object_mut() {
-                if let Some(value) = nav.get("url") {
-                    obj.insert("url".to_string(), value.clone());
+            if background {
+                // mgr.navigate targets the ACTIVE tab; navigate the new
+                // background tab through its own session instead.
+                let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+                let new_tab_id = result.get("tabId").and_then(|v| v.as_str()).unwrap_or("");
+                let session = mgr
+                    .pages_list()
+                    .into_iter()
+                    .find(|p| super::browser::format_tab_id(p.tab_id) == new_tab_id)
+                    .map(|p| p.session_id)
+                    .ok_or("New background tab vanished before navigation")?;
+                mgr.client
+                    .send_command("Page.navigate", Some(json!({ "url": url })), Some(&session))
+                    .await?;
+                if let Some(obj) = result.as_object_mut() {
+                    obj.insert("url".to_string(), json!(url));
                 }
-                if let Some(value) = nav.get("title") {
-                    obj.insert("title".to_string(), value.clone());
+            } else {
+                let nav = {
+                    let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+                    mgr.navigate(url, WaitUntil::Load).await?
+                };
+                if let Some(obj) = result.as_object_mut() {
+                    if let Some(value) = nav.get("url") {
+                        obj.insert("url".to_string(), value.clone());
+                    }
+                    if let Some(value) = nav.get("title") {
+                        obj.insert("title".to_string(), value.clone());
+                    }
                 }
             }
         }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -992,10 +992,31 @@ impl DaemonState {
             }
         }
 
-        // Remove destroyed targets
+        // Remove destroyed targets. If the ACTIVE tab died, announce the
+        // retarget — the old behavior silently re-pointed the next command
+        // at a neighboring tab — and drop refs minted on the dead tab.
         for target_id in &drained.destroyed_targets {
             if let Some(ref mut mgr) = self.browser {
-                mgr.remove_page_by_target_id(target_id);
+                if let Some((removed, was_active)) = mgr.remove_page_by_target_id(target_id) {
+                    if was_active {
+                        let removed_id = super::browser::format_tab_id(removed.tab_id);
+                        let notice = match mgr.active_page() {
+                            Some(next) => format!(
+                                "Active tab {} ({}) was closed externally — now on {} ({})",
+                                removed_id,
+                                removed.url,
+                                super::browser::format_tab_id(next.tab_id),
+                                next.url
+                            ),
+                            None => format!(
+                                "Active tab {} ({}) was closed externally — no tabs remain; the next page command opens a fresh about:blank tab",
+                                removed_id, removed.url
+                            ),
+                        };
+                        self.pending_notices.push(notice);
+                        self.ref_map.clear();
+                    }
+                }
             }
         }
 
@@ -2435,6 +2456,14 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 return error_response(&id, &format!("Auto-launch failed: {}", e));
             }
             lifecycle_launched = true;
+            if lifecycle_relaunched_browser {
+                // The old process's tabs are gone and ids restart at t1; a
+                // model still holding t3 would only see "Tab t3 not found".
+                state.ref_map.clear();
+                state.pending_notices.push(
+                    "Browser was relaunched — previous tab ids and element refs are invalid; tab ids restart at t1".to_string(),
+                );
+            }
         } else {
             lifecycle_reused = true;
         }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1857,11 +1857,16 @@ impl BrowserManager {
         update_page_target_info_in_pages(&mut self.pages, target)
     }
 
-    pub fn remove_page_by_target_id(&mut self, target_id: &str) {
-        if let Some(pos) = self.pages.iter().position(|p| p.target_id == target_id) {
-            self.pages.remove(pos);
-            self.update_active_page_after_removal(pos);
-        }
+    /// Remove a page whose target was destroyed externally (tab closed by
+    /// the page itself, a human, or a crash-reap). Returns the removed page
+    /// and whether it was the active tab, so callers can announce the
+    /// retarget instead of the next command silently running elsewhere.
+    pub fn remove_page_by_target_id(&mut self, target_id: &str) -> Option<(PageInfo, bool)> {
+        let pos = self.pages.iter().position(|p| p.target_id == target_id)?;
+        let was_active = pos == self.active_page_index;
+        let removed = self.pages.remove(pos);
+        self.update_active_page_after_removal(pos);
+        Some((removed, was_active))
     }
 
     pub fn has_target(&self, target_id: &str) -> bool {
@@ -1875,6 +1880,11 @@ impl BrowserManager {
     /// Returns the stable `tab_id` of the currently active page, if any.
     pub fn active_tab_id(&self) -> Option<u32> {
         self.pages.get(self.active_page_index).map(|p| p.tab_id)
+    }
+
+    /// Returns the currently active page, if any.
+    pub fn active_page(&self) -> Option<&PageInfo> {
+        self.pages.get(self.active_page_index)
     }
 
     /// Returns true if a tab with the given stable `tab_id` is still open.

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -365,6 +365,8 @@ pub struct BrowserManager {
     /// Origins visited during this session, used by save_state to collect cross-origin localStorage.
     visited_origins: HashSet<String>,
     next_tab_id: u32,
+    /// User-named browser contexts (`tab new --context <name>`), name → id.
+    named_contexts: HashMap<String, String>,
     /// True when the CDP WebSocket is already scoped to a page target and
     /// browser-level Target.* commands are not available.
     direct_page: bool,
@@ -456,6 +458,7 @@ impl BrowserManager {
                 ignore_https_errors,
                 visited_origins: HashSet::new(),
                 next_tab_id: 1,
+                named_contexts: HashMap::new(),
                 direct_page: false,
                 headless,
             };
@@ -547,6 +550,7 @@ impl BrowserManager {
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
+            named_contexts: HashMap::new(),
             direct_page,
             headless: true,
         };
@@ -605,6 +609,8 @@ impl BrowserManager {
                     "Target.createTarget",
                     &CreateTargetParams {
                         url: "about:blank".to_string(),
+                        background: None,
+                        browser_context_id: None,
                     },
                     None,
                 )
@@ -1189,6 +1195,8 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: "about:blank".to_string(),
+                    background: None,
+                    browser_context_id: None,
                 },
                 None,
             )
@@ -1347,10 +1355,40 @@ impl BrowserManager {
         self.pages.iter().any(|p| p.label.as_deref() == Some(label))
     }
 
+    /// Resolve a named browser context to its id, creating the context on
+    /// first use. Named contexts give storage/cookie isolation inside one
+    /// browser ("logged in as two users") without a second session.
+    pub async fn ensure_named_context(&mut self, name: &str) -> Result<String, String> {
+        if !is_valid_label(name) {
+            return Err(format!(
+                "Invalid context name `{}`; names must start with a letter and contain only \
+                 letters, digits, `-`, and `_`",
+                name
+            ));
+        }
+        if let Some(id) = self.named_contexts.get(name) {
+            return Ok(id.clone());
+        }
+        let result = self
+            .client
+            .send_command_no_params("Target.createBrowserContext", None)
+            .await?;
+        let context_id = result
+            .get("browserContextId")
+            .and_then(|v| v.as_str())
+            .ok_or("Failed to create browser context")?
+            .to_string();
+        self.named_contexts
+            .insert(name.to_string(), context_id.clone());
+        Ok(context_id)
+    }
+
     pub async fn tab_new(
         &mut self,
         url: Option<&str>,
         label: Option<&str>,
+        background: bool,
+        browser_context_id: Option<&str>,
     ) -> Result<Value, String> {
         if let Some(label) = label {
             if !is_valid_label(label) {
@@ -1377,6 +1415,8 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: target_url.to_string(),
+                    background: if background { Some(true) } else { None },
+                    browser_context_id: browser_context_id.map(|s| s.to_string()),
                 },
                 None,
             )
@@ -1411,12 +1451,15 @@ impl BrowserManager {
             parent_tab_id: None,
             crashed: false,
         });
-        self.active_page_index = index;
+        if !background {
+            self.active_page_index = index;
+        }
 
         Ok(json!({
             "tabId": format_tab_id(tab_id),
             "label": label,
             "url": target_url,
+            "background": background,
             "total": self.pages.len(),
         }))
     }
@@ -2048,6 +2091,7 @@ async fn initialize_lightpanda_manager(
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
+            named_contexts: HashMap::new(),
             direct_page: false,
             headless: true,
         };

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1845,6 +1845,14 @@ impl BrowserManager {
         self.active_page_index = index;
     }
 
+    /// Register a page WITHOUT making it the active tab. Used for targets the
+    /// agent did not create (popups, `target=_blank`, tabs opened by a human
+    /// in the same browser window) so they never silently steal focus. If no
+    /// pages existed before, index 0 is the new page and it is active anyway.
+    pub fn add_page_background(&mut self, page: PageInfo) {
+        self.pages.push(page);
+    }
+
     pub fn update_page_target_info(&mut self, target: &TargetInfo) -> bool {
         update_page_target_info_in_pages(&mut self.pages, target)
     }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -127,6 +127,10 @@ pub(crate) fn should_track_target(target: &TargetInfo) -> bool {
 
 fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo) -> bool {
     if let Some(page) = pages.iter_mut().find(|p| p.target_id == target.target_id) {
+        if page.crashed && page.url != target.url {
+            // The renderer navigated again — Chrome revived it.
+            page.crashed = false;
+        }
         page.url = target.url.clone();
         page.title = target.title.clone();
         page.target_type = target.target_type.clone();
@@ -220,6 +224,12 @@ pub struct PageInfo {
     pub url: String,
     pub title: String,
     pub target_type: String, // "page" or "webview"
+    /// Stable id of the tab that opened this one (from CDP `openerId`), for
+    /// popups and `target=_blank` tabs. None for agent-created tabs.
+    pub parent_tab_id: Option<u32>,
+    /// True once Target.targetCrashed fired for this tab. Cleared on
+    /// navigation (Chrome revives the renderer).
+    pub crashed: bool,
 }
 
 /// Canonical string form of a stable tab id: `t1`, `t2`, ... The `t` prefix
@@ -551,6 +561,8 @@ impl BrowserManager {
                 url: String::new(),
                 title: String::new(),
                 target_type: "page".to_string(),
+                parent_tab_id: None,
+                crashed: false,
             });
             manager.active_page_index = 0;
             manager.enable_domains_direct().await?;
@@ -620,6 +632,8 @@ impl BrowserManager {
                 url: "about:blank".to_string(),
                 title: String::new(),
                 target_type: "page".to_string(),
+                parent_tab_id: None,
+                crashed: false,
             });
             self.active_page_index = 0;
             self.enable_domains(&attach_result.session_id).await?;
@@ -647,6 +661,8 @@ impl BrowserManager {
                     url: target.url.clone(),
                     title: target.title.clone(),
                     target_type: target.target_type.clone(),
+                    parent_tab_id: None,
+                    crashed: false,
                 });
             }
 
@@ -1200,6 +1216,8 @@ impl BrowserManager {
             url: "about:blank".to_string(),
             title: String::new(),
             target_type: "page".to_string(),
+            parent_tab_id: None,
+            crashed: false,
         });
         self.active_page_index = 0;
         self.enable_domains(&attach_result.session_id).await?;
@@ -1236,16 +1254,64 @@ impl BrowserManager {
             .iter()
             .enumerate()
             .map(|(i, p)| {
-                json!({
+                let mut tab = json!({
                     "tabId": format_tab_id(p.tab_id),
                     "label": p.label,
                     "title": p.title,
                     "url": p.url,
                     "type": p.target_type,
                     "active": i == self.active_page_index,
-                })
+                });
+                let obj = tab.as_object_mut().expect("literal object");
+                if let Some(parent) = p.parent_tab_id {
+                    obj.insert("parentTabId".to_string(), json!(format_tab_id(parent)));
+                }
+                if p.crashed {
+                    obj.insert("crashed".to_string(), json!(true));
+                }
+                tab
             })
             .collect()
+    }
+
+    /// Stable tab id for a CDP target id, if the target is tracked as a tab.
+    pub fn tab_id_for_target(&self, target_id: &str) -> Option<u32> {
+        self.pages
+            .iter()
+            .find(|p| p.target_id == target_id)
+            .map(|p| p.tab_id)
+    }
+
+    /// Mark a tab crashed (Target.targetCrashed). Returns the stable tab id
+    /// and whether it is the active tab, if the target is tracked.
+    pub fn mark_crashed(&mut self, target_id: &str) -> Option<(u32, bool)> {
+        let active_index = self.active_page_index;
+        self.pages
+            .iter_mut()
+            .enumerate()
+            .find(|(_, p)| p.target_id == target_id)
+            .map(|(i, p)| {
+                p.crashed = true;
+                (p.tab_id, i == active_index)
+            })
+    }
+
+    /// Order-sensitive fingerprint of everything `tab_list` renders. Used to
+    /// decide whether the tab list changed since the last response.
+    pub fn tabs_signature(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        self.active_page_index.hash(&mut h);
+        for p in &self.pages {
+            p.tab_id.hash(&mut h);
+            p.label.hash(&mut h);
+            p.url.hash(&mut h);
+            p.title.hash(&mut h);
+            p.crashed.hash(&mut h);
+            p.parent_tab_id.hash(&mut h);
+        }
+        h.finish()
     }
 
     /// Resolve a user-supplied `TabRef` (either `t<N>` or a label) to the
@@ -1342,6 +1408,8 @@ impl BrowserManager {
             url: target_url.to_string(),
             title: String::new(),
             target_type: "page".to_string(),
+            parent_tab_id: None,
+            crashed: false,
         });
         self.active_page_index = index;
 
@@ -2147,6 +2215,7 @@ mod tests {
             url: String::new(),
             attached: None,
             browser_context_id: None,
+            opener_id: None,
         };
 
         assert!(should_track_target(&target));
@@ -2161,6 +2230,7 @@ mod tests {
             url: "chrome://newtab/".to_string(),
             attached: None,
             browser_context_id: None,
+            opener_id: None,
         };
 
         assert!(!should_track_target(&target));
@@ -2176,6 +2246,8 @@ mod tests {
             url: String::new(),
             title: String::new(),
             target_type: "page".to_string(),
+            parent_tab_id: None,
+            crashed: false,
         }];
         let target = TargetInfo {
             target_id: "popup-1".to_string(),
@@ -2184,6 +2256,7 @@ mod tests {
             url: "https://example.com/popup".to_string(),
             attached: None,
             browser_context_id: None,
+            opener_id: None,
         };
 
         assert!(update_page_target_info_in_pages(&mut pages, &target));

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -372,7 +372,9 @@ pub struct BrowserManager {
     direct_page: bool,
     /// Whether the daemon-spawned browser actually runs headless after
     /// launch rules such as extension-forced headed mode. Meaningless for
-    /// attached browsers (browser_process is None).
+    /// attached browsers (browser_process is None). Window-state changes
+    /// (minimize/maximize) abort headless Chrome, so those verbs are refused
+    /// up front (see is_headless / handle_window_bounds).
     headless: bool,
 }
 
@@ -390,6 +392,12 @@ impl BrowserManager {
     /// lifecycle. An explicit AGENT_BROWSER_IDLE_TIMEOUT_MS applies regardless.
     pub fn blocks_default_idle_shutdown(&self) -> bool {
         self.browser_process.is_none() || !self.headless
+    }
+
+    /// Whether window-state changes (minimize/maximize) are unsafe: they
+    /// abort headless Chrome outright.
+    pub fn is_headless(&self) -> bool {
+        self.headless
     }
 
     pub async fn launch(options: LaunchOptions, engine: Option<&str>) -> Result<Self, String> {

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -144,6 +144,13 @@ pub struct SetDiscoverTargetsParams {
 #[serde(rename_all = "camelCase")]
 pub struct CreateTargetParams {
     pub url: String,
+    /// Open without focusing the target (tab new --background).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+    /// Create the target inside a specific browser context (tab new
+    /// --context <name> maps names to context ids daemon-side).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_context_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -110,6 +110,9 @@ pub struct TargetInfo {
     pub url: String,
     pub attached: Option<bool>,
     pub browser_context_id: Option<String>,
+    /// Target id of the opener, present when this target was opened by
+    /// another page (window.open, target=_blank).
+    pub opener_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -18,6 +18,11 @@ pub struct RefEntry {
 pub struct RefMap {
     map: HashMap<String, RefEntry>,
     next_ref: usize,
+    /// Stable tab id of the tab whose snapshot minted the current refs.
+    /// `@eN` refs are only valid on that tab; using one while another tab is
+    /// active is a hard error (never the role/name fallback, which could
+    /// silently resolve a same-role element in the wrong page).
+    minted_tab: Option<u32>,
 }
 
 impl RefMap {
@@ -25,7 +30,20 @@ impl RefMap {
         Self {
             map: HashMap::new(),
             next_ref: 1,
+            minted_tab: None,
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn minted_tab(&self) -> Option<u32> {
+        self.minted_tab
+    }
+
+    pub fn set_minted_tab(&mut self, tab: Option<u32>) {
+        self.minted_tab = tab;
     }
 
     pub fn add(
@@ -110,6 +128,7 @@ impl RefMap {
     pub fn clear(&mut self) {
         self.map.clear();
         self.next_ref = 1;
+        self.minted_tab = None;
     }
 
     pub fn next_ref_num(&self) -> usize {

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -120,6 +120,8 @@ async fn collect_storage_via_temp_target(
             "Target.createTarget",
             &CreateTargetParams {
                 url: "about:blank".to_string(),
+                background: None,
+                browser_context_id: None,
             },
             None,
         )

--- a/cli/src/native/webdriver/backend.rs
+++ b/cli/src/native/webdriver/backend.rs
@@ -129,6 +129,10 @@ pub const WEBDRIVER_UNSUPPORTED_ACTIONS: &[&str] = &[
     "network",
     "har_start",
     "har_stop",
+    "window_list",
+    "window_close",
+    "window_bounds",
+    "window_focus",
 ];
 
 #[cfg(test)]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -801,10 +801,24 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
                 } else {
                     " ".to_string()
                 };
+                let mut suffix = String::new();
+                if let Some(parent) = tab.get("parentTabId").and_then(|v| v.as_str()) {
+                    suffix.push_str(&color::dim(&format!(" (opened by {})", parent)));
+                }
+                if tab
+                    .get("crashed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    suffix.push_str(&format!(" {}", color::red("[crashed]")));
+                }
                 if let Some(label) = tab_label {
-                    println!("{} [{}] {} {} - {}", marker, tab_id, label, title, url);
+                    println!(
+                        "{} [{}] {} {} - {}{}",
+                        marker, tab_id, label, title, url, suffix
+                    );
                 } else {
-                    println!("{} [{}] {} - {}", marker, tab_id, title, url);
+                    println!("{} [{}] {} - {}{}", marker, tab_id, title, url, suffix);
                 }
             }
             return;

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2534,8 +2534,18 @@ Operations:
   list                       List open tabs with their ids and labels (default)
   new [url]                  Open a new tab
   new --label <name> [url]   Open a new tab with a label like `docs` or `app`
+  new --background [url]     Open a tab WITHOUT switching to it (active tab
+                             and element refs stay untouched)
+  new --context <name> [url] Open in a named isolated browser context — own
+                             cookies/storage (e.g. logged in as a second
+                             user); the context is created on first use
   close [t<N>|label]         Close a tab (current if no ref given)
   <t<N>|label>               Switch to a tab by id or label
+
+Tab list annotations: `(opened by tN)` marks popup provenance, `[crashed]`
+a dead renderer. Any command's response gains a `tabs (...)` section when
+the tab list changed since the previous response; popups open in the
+background and are announced instead of stealing focus.
 
 Global Options:
   --json               Output as JSON

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -385,6 +385,66 @@ fn format_a11y_target(target: &serde_json::Value) -> Option<String> {
 }
 
 pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &OutputOptions) {
+    print_response_body(resp, action, opts);
+    // Notices and the tab-list-on-change section print for every rendering
+    // branch, including errors. JSON mode already carries both fields in the
+    // envelope.
+    if !opts.json {
+        print_notices(resp);
+        print_tabs_section(resp);
+    }
+}
+
+fn print_notices(resp: &Response) {
+    if let Some(ref notices) = resp.notices {
+        for notice in notices {
+            eprintln!("{} {}", color::warning_indicator(), notice);
+        }
+    }
+}
+
+fn print_tabs_section(resp: &Response) {
+    let Some(tabs) = resp.tabs.as_ref().and_then(|v| v.as_array()) else {
+        return;
+    };
+    println!("{}", color::dim(&format!("tabs ({}):", tabs.len())));
+    for tab in tabs {
+        let tab_id = tab.get("tabId").and_then(|v| v.as_str()).unwrap_or("?");
+        let label = tab.get("label").and_then(|v| v.as_str());
+        let title = tab.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let url = tab.get("url").and_then(|v| v.as_str()).unwrap_or("");
+        let active = tab.get("active").and_then(|v| v.as_bool()).unwrap_or(false);
+        let crashed = tab
+            .get("crashed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let parent = tab.get("parentTabId").and_then(|v| v.as_str());
+        let marker = if active {
+            color::cyan("→")
+        } else {
+            " ".to_string()
+        };
+        let mut line = format!("{} [{}]", marker, tab_id);
+        if let Some(label) = label {
+            line.push_str(&format!(" {}", label));
+        }
+        if !title.is_empty() {
+            line.push_str(&format!(" {}", title));
+        }
+        if !url.is_empty() {
+            line.push_str(&format!(" - {}", url));
+        }
+        if let Some(parent) = parent {
+            line.push_str(&color::dim(&format!(" (opened by {})", parent)));
+        }
+        if crashed {
+            line.push_str(&format!(" {}", color::red("[crashed]")));
+        }
+        println!("{}", line);
+    }
+}
+
+fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptions) {
     if opts.json {
         if opts.content_boundaries {
             let mut json_val = serde_json::to_value(resp).unwrap_or_default();

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -742,6 +742,49 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
             }
             return;
         }
+        // Window list
+        if let Some(windows) = data.get("windows").and_then(|v| v.as_array()) {
+            for win in windows {
+                let wid = win.get("windowId").and_then(|v| v.as_i64()).unwrap_or(-1);
+                let bounds = win.get("bounds");
+                let state = bounds
+                    .and_then(|b| b.get("windowState"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let size = bounds
+                    .and_then(|b| {
+                        Some(format!(
+                            "{}x{}",
+                            b.get("width")?.as_i64()?,
+                            b.get("height")?.as_i64()?
+                        ))
+                    })
+                    .unwrap_or_else(|| "?".to_string());
+                let active = win.get("active").and_then(|v| v.as_bool()).unwrap_or(false);
+                let marker = if active {
+                    color::cyan("→")
+                } else {
+                    " ".to_string()
+                };
+                println!("{} window {} ({}, {})", marker, wid, state, size);
+                if let Some(tabs) = win.get("tabs").and_then(|v| v.as_array()) {
+                    for tab in tabs {
+                        let tab_id = tab.get("tabId").and_then(|v| v.as_str()).unwrap_or("?");
+                        let label = tab.get("label").and_then(|v| v.as_str());
+                        let url = tab.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                        let tab_active =
+                            tab.get("active").and_then(|v| v.as_bool()).unwrap_or(false);
+                        let tab_marker = if tab_active { "→" } else { " " };
+                        if let Some(label) = label {
+                            println!("  {} [{}] {} - {}", tab_marker, tab_id, label, url);
+                        } else {
+                            println!("  {} [{}] {}", tab_marker, tab_id, url);
+                        }
+                    }
+                }
+            }
+            return;
+        }
         // Tabs
         if let Some(tabs) = data.get("tabs").and_then(|v| v.as_array()) {
             for tab in tabs {
@@ -2517,19 +2560,34 @@ Examples:
             r##"
 agent-browser window - Manage browser windows
 
-Usage: agent-browser window <operation>
+Usage: agent-browser window <operation> [args]
 
-Manage browser windows.
+Manage OS-level browser windows. A window groups tabs; `window new` creates
+a fresh window backed by its own browser context (isolated cookies/storage).
 
 Operations:
-  new                  Open new browser window
+  list                        List windows with their tabs (default)
+  new                         Open new browser window (isolated context)
+  close [t<N>|label]          Close the window containing a tab (default: active tab's window)
+  bounds <w> <h> [x y]        Resize (and optionally move) the active tab's window
+  minimize|maximize|fullscreen|normal
+                              Set the active tab's window state
+  focus [t<N>|label]          Raise the window containing a tab and show that
+                              tab on the display; the agent's active tab is
+                              NOT changed (use `tab <ref>` for that)
 
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
 
 Examples:
+  agent-browser window
   agent-browser window new
+  agent-browser window bounds 1280 800
+  agent-browser window bounds 1280 800 0 0
+  agent-browser window maximize
+  agent-browser window focus docs
+  agent-browser window close t3
 "##
         }
 
@@ -3621,8 +3679,14 @@ Storage:
                              Or:  cookies set --curl <file> [--domain <host>] (auto-detects JSON/cURL/Cookie-header files)
   storage <local|session>    Manage web storage
 
-Tabs:
-  tab [new|list|close|<n>]   Manage tabs
+Tabs & Windows:
+  tab [list]                 List tabs (stable ids t1, t2, ... + labels)
+  tab new [--label <name>] [url]
+                             Open a tab (never bare integers; `tab --help`)
+  tab <t<N>|label>           Switch tabs
+  tab close [t<N>|label]     Close a tab (default: active)
+  window [list|new|close|focus|bounds <w> <h>|minimize|maximize|fullscreen|normal]
+                             Manage OS windows (`window --help`)
 
 Diff:
   diff snapshot              Compare current vs last snapshot
@@ -3701,6 +3765,9 @@ Confirmation:
 Sessions:
   session                    Show current session name
   session list               List active sessions
+  restart                    Kill this session's daemon (recovery for a wedged
+                             daemon, e.g. "CDP response channel closed"); the
+                             next command starts a fresh one
 
 MCP:
   mcp                        Start an MCP stdio server exposing agent-browser tools


### PR DESCRIPTION
Seven commits (rebased onto current main, all 1065 tests + clippy green) that close the silent wrong-tab failure classes we kept hitting driving agent-browser in production, plus real window management:

1. **Tabs-on-change**: any response whose tab list changed since the previous response (and >1 tab involved) carries a `tabs` field, rendered as a compact section — an agent notices popups/closed tabs/crashes without polling `tab list`. Adds `parentTabId` (CDP openerId) and `crashed` (Target.targetCrashed, cleared on re-navigation) to tab info.
2. **Popup discipline**: pages the agent did not create (window.open, target=_blank, human-opened) register in the *background* with a notice ("New tab t4 (opened by t2) opened in background: <url> — switch with `tab t4`") instead of silently stealing the active tab out from under the next command. `AGENT_BROWSER_FOLLOW_POPUPS=1` restores auto-follow, announced, with ref invalidation.
3. **Ref↔tab binding**: `@eN` refs are stamped with their minting tab; using one while another tab is active is a hard error naming the fix — previously the role/name fallback could silently resolve a same-role element in a different page.
4. **Announced retarget**: when the active tab is destroyed externally the next response says where the agent landed; automatic browser relaunches explain that tab ids reset to t1.
5. **Window verbs**: `window list` (tabs grouped by OS window with bounds/state), `window close`, `window bounds <w> <h> [x y]`, `minimize|maximize|fullscreen|normal`, `window focus [ref]` (raise a window/show a tab to a watching human WITHOUT changing the agent's active tab), plus a client-side `restart` verb that recovers a wedged daemon ("CDP response channel closed") that can't answer a socket shutdown. Fixes `--help` documenting the rejected positional `tab <n>` form and omitting `window`.
6. **`tab new --background`** (open without focus, active tab/refs untouched) and **`tab new --context <name>`** (named isolated browser contexts — own cookies/storage inside one browser).
7. **Headless windowState guard**: `Browser.setWindowBounds{minimized|maximized}` aborts headless Chrome outright (reproduced); those verbs now fail fast in headless with the working alternative, and the CLI maps the verb spellings to CDP's past-participle enum values.

Follow-ups to our earlier upstreams (#1591 NO_STREAM); we run this in production across a fleet of dev boxes. Happy to split into smaller PRs if you prefer — the commits are individually scoped and each passes the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQrk8zHX7GqjT251paC28T