### PR TITLE
fix: pass cdpHeaders through connectOverCDP for authenticated CDP URLs

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -111,6 +111,7 @@ export type BrowserLaunchOptions = Pick<
   | 'executablePath'
   | 'cdpPort'
   | 'cdpUrl'
+  | 'cdpHeaders'
   | 'autoConnect'
   | 'extensions'
   | 'profile'
@@ -1497,7 +1498,10 @@ export class BrowserManager {
     }
 
     if (cdpEndpoint) {
-      await this.connectViaCDP(cdpEndpoint);
+      await this.connectViaCDP(cdpEndpoint, {
+        timeout: options?.timeout,
+        headers: options?.cdpHeaders,
+      });
       return;
     }
 
@@ -1739,7 +1743,7 @@ export class BrowserManager {
    */
   private async connectViaCDP(
     cdpEndpoint: string | undefined,
-    options?: { timeout?: number }
+    options?: { timeout?: number; headers?: Record<string, string> }
   ): Promise<void> {
     if (!cdpEndpoint) {
       throw new Error('CDP endpoint is required for CDP connection');
@@ -1766,7 +1770,10 @@ export class BrowserManager {
     }
 
     const browser = await chromium
-      .connectOverCDP(cdpUrl, { timeout: options?.timeout })
+      .connectOverCDP(cdpUrl, {
+        timeout: options?.timeout,
+        ...(options?.headers ? { headers: options.headers } : {}),
+      })
       .catch(() => {
         throw new Error(
           `Failed to connect via CDP to ${cdpUrl}. ` +

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface LaunchCommand extends BaseCommand {
   executablePath?: string;
   cdpPort?: number;
   cdpUrl?: string;
+  /** Headers for chromium.connectOverCDP (e.g. Authorization for Cloudflare Browser Rendering). */
+  cdpHeaders?: Record<string, string>;
   autoConnect?: boolean; // Auto-discover and connect to running Chrome via DevToolsActivePort
   extensions?: string[];
   profile?: string; // Path to persistent browser profile directory


### PR DESCRIPTION
Fixes #1642.

Replaces closed #1643 (fork was deleted by mistake). Same fix, cleaner diff: **only** `src/types.ts` + `src/browser.ts`.

## Problem

`BrowserManager.launch({ cdpUrl })` connects via Playwright with timeout only:

```ts
chromium.connectOverCDP(cdpUrl, { timeout: options?.timeout })
```

Providers such as [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-run/cdp/playwright/) require **WebSocket connect headers** (e.g. `Authorization: Bearer …`). There is no API to supply those on the generic CDP path.

`BrowserLaunchOptions.headers` is already used for page `extraHTTPHeaders`, which is a different concern.

## Solution

- Add optional `cdpHeaders?: Record<string, string>` to `LaunchCommand` / `BrowserLaunchOptions`
- Forward them from `launch()` → `connectViaCDP()` → `chromium.connectOverCDP(url, { headers })`

```ts
await manager.launch({
  cdpUrl: 'wss://api.cloudflare.com/.../devtools/browser?keep_alive=600000',
  cdpHeaders: {
    Authorization: `Bearer ${token}`,
  },
});
```

## Notes

- Additive, non-breaking.
- Targeted at the **0.19.x** `BrowserManager` JS API still consumed by `@mastra/agent-browser`.
- Base branch: `ctate/prepare-v0.19` (current `main` is the Rust CLI path; native main already has `connect_cdp_with_headers`).
- Companion Mastra PR: https://github.com/mastra-ai/mastra/pull/20606

## Checklist

- [x] Linked related issue(s)
- [x] Description covers problem and solution
- [x] Minimal diff (2 files)