### PR TITLE
fix: pass CDP connect headers for generic --cdp URLs

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -327,6 +327,24 @@ fn parse_cookie_header(header: &str) -> Result<Vec<Value>, String> {
     Ok(out)
 }
 
+
+fn parse_cdp_headers_flag(flags: &Flags) -> Result<Option<Value>, ParseError> {
+    let Some(ref headers_json) = flags.cdp_headers else {
+        return Ok(None);
+    };
+    let headers = serde_json::from_str::<Value>(headers_json).map_err(|_| ParseError::InvalidValue {
+        message: format!("Invalid JSON for --cdp-headers: {}", headers_json),
+        usage: r#"connect <url> --cdp-headers '{"Authorization":"Bearer …"}'"#,
+    })?;
+    if !headers.is_object() {
+        return Err(ParseError::InvalidValue {
+            message: format!("Invalid JSON object for --cdp-headers: {}", headers_json),
+            usage: r#"connect <url> --cdp-headers '{"Authorization":"Bearer …"}'"#,
+        });
+    }
+    Ok(Some(headers))
+}
+
 pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError> {
     let mut result = parse_command_inner(args, flags)?;
 
@@ -1204,13 +1222,18 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 context: "connect".to_string(),
                 usage: "connect <port|url>",
             })?;
+            let cdp_headers = parse_cdp_headers_flag(flags)?;
             // Check if it's a URL (ws://, wss://, http://, https://)
             if endpoint.starts_with("ws://")
                 || endpoint.starts_with("wss://")
                 || endpoint.starts_with("http://")
                 || endpoint.starts_with("https://")
             {
-                Ok(json!({ "id": id, "action": "launch", "cdpUrl": endpoint }))
+                let mut cmd = json!({ "id": id, "action": "launch", "cdpUrl": endpoint });
+                if let Some(headers) = cdp_headers {
+                    cmd["cdpHeaders"] = headers;
+                }
+                Ok(cmd)
             } else {
                 // It's a port number - validate and use cdpPort field
                 let port: u16 = match endpoint.parse::<u32>() {
@@ -1240,7 +1263,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                         });
                     }
                 };
-                Ok(json!({ "id": id, "action": "launch", "cdpPort": port }))
+                let mut cmd = json!({ "id": id, "action": "launch", "cdpPort": port });
+                if let Some(headers) = cdp_headers {
+                    cmd["cdpHeaders"] = headers;
+                }
+                Ok(cmd)
             }
         }
 
@@ -3174,6 +3201,7 @@ mod tests {
             init_scripts: Vec::new(),
             enable: Vec::new(),
             cdp: None,
+            cdp_headers: None,
             profile: None,
             state: None,
             proxy: None,
@@ -5119,6 +5147,20 @@ mod tests {
         assert_eq!(cmd["action"], "launch");
         assert_eq!(cmd["cdpPort"], 9222);
         assert!(cmd.get("cdpUrl").is_none());
+    }
+
+    #[test]
+    fn test_connect_with_cdp_headers() {
+        let mut flags = default_flags();
+        flags.cdp_headers = Some(r#"{"Authorization":"Bearer t"}"#.to_string());
+        let cmd = parse_command(
+            &args("connect wss://example.com/cdp"),
+            &flags,
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "launch");
+        assert_eq!(cmd["cdpUrl"], "wss://example.com/cdp");
+        assert_eq!(cmd["cdpHeaders"]["Authorization"], "Bearer t");
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -82,6 +82,7 @@ pub struct Config {
     pub ignore_https_errors: Option<bool>,
     pub allow_file_access: Option<bool>,
     pub cdp: Option<String>,
+    pub cdp_headers: Option<String>,
     pub auto_connect: Option<bool>,
     pub headers: Option<String>,
     pub annotate: Option<bool>,
@@ -152,6 +153,7 @@ impl Config {
             ignore_https_errors: other.ignore_https_errors.or(self.ignore_https_errors),
             allow_file_access: other.allow_file_access.or(self.allow_file_access),
             cdp: other.cdp.or(self.cdp),
+            cdp_headers: other.cdp_headers.or(self.cdp_headers),
             auto_connect: other.auto_connect.or(self.auto_connect),
             headers: other.headers.or(self.headers),
             annotate: other.annotate.or(self.annotate),
@@ -251,6 +253,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--headers",
         "--executable-path",
         "--cdp",
+        "--cdp-headers",
         "--extension",
         "--init-script",
         "--enable",
@@ -337,6 +340,9 @@ pub struct Flags {
     pub headers: Option<String>,
     pub executable_path: Option<String>,
     pub cdp: Option<String>,
+    /// JSON object of WebSocket headers for `--cdp` connect (e.g. Authorization).
+    /// Distinct from page/origin `--headers`.
+    pub cdp_headers: Option<String>,
     pub extensions: Vec<String>,
     pub init_scripts: Vec<String>,
     pub enable: Vec<String>,
@@ -500,6 +506,9 @@ pub fn parse_flags(args: &[String]) -> Flags {
             .ok()
             .or(config.executable_path),
         cdp: env::var("AGENT_BROWSER_CDP").ok().or(config.cdp),
+        cdp_headers: env::var("AGENT_BROWSER_CDP_HEADERS")
+            .ok()
+            .or(config.cdp_headers),
         extensions,
         init_scripts,
         enable,
@@ -775,6 +784,12 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--cdp-headers" => {
+                if let Some(h) = args.get(i + 1) {
+                    flags.cdp_headers = Some(h.clone());
+                    i += 1;
+                }
+            }
             "--profile" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.profile = Some(s.clone());
@@ -1045,6 +1060,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--headers",
         "--executable-path",
         "--cdp",
+        "--cdp-headers",
         "--extension",
         "--init-script",
         "--enable",
@@ -1133,6 +1149,22 @@ mod tests {
     fn test_parse_headers_flag() {
         let flags = parse_flags(&args(r#"open example.com --headers {"Auth":"token"}"#));
         assert_eq!(flags.headers, Some(r#"{"Auth":"token"}"#.to_string()));
+    }
+
+    #[test]
+    fn test_parse_cdp_headers_flag() {
+        let flags = parse_flags(&[
+            "snapshot".to_string(),
+            "--cdp".to_string(),
+            "wss://example.com/cdp".to_string(),
+            "--cdp-headers".to_string(),
+            r#"{"Authorization":"Bearer t"}"#.to_string(),
+        ]);
+        assert_eq!(flags.cdp.as_deref(), Some("wss://example.com/cdp"));
+        assert_eq!(
+            flags.cdp_headers.as_deref(),
+            Some(r#"{"Authorization":"Bearer t"}"#)
+        );
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1420,6 +1420,36 @@ fn main() {
             launch_cmd["downloadPath"] = json!(dp);
         }
 
+        
+        if let Some(ref headers_json) = flags.cdp_headers {
+            match serde_json::from_str::<serde_json::Value>(headers_json) {
+                Ok(headers) if headers.is_object() => {
+                    launch_cmd["cdpHeaders"] = headers;
+                }
+                Ok(_) => {
+                    let msg = format!(
+                        "Invalid JSON object for --cdp-headers: {}",
+                        headers_json
+                    );
+                    if flags.json {
+                        print_json_error(&msg);
+                    } else {
+                        eprintln!("{} {}", color::error_indicator(), msg);
+                    }
+                    exit(1);
+                }
+                Err(_) => {
+                    let msg = format!("Invalid JSON for --cdp-headers: {}", headers_json);
+                    if flags.json {
+                        print_json_error(&msg);
+                    } else {
+                        eprintln!("{} {}", color::error_indicator(), msg);
+                    }
+                    exit(1);
+                }
+            }
+        }
+
         let err = match send_command(launch_cmd, &flags.session) {
             Ok(resp) if resp.success => None,
             Ok(resp) => Some(

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3787,6 +3787,25 @@ async fn try_load_storage_state(state: &mut DaemonState, path: &Option<String>) 
 // Phase 1 handlers
 // ---------------------------------------------------------------------------
 
+
+/// Optional WebSocket connect headers for generic CDP URLs (`cdpUrl` / `--cdp`).
+/// Distinct from page/origin `--headers` (Fetch interception).
+fn cdp_headers_from_command(cmd: &Value) -> Option<Vec<(String, String)>> {
+    let map = cmd.get("cdpHeaders")?.as_object()?;
+    if map.is_empty() {
+        return None;
+    }
+    let headers: Vec<(String, String)> = map
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+        .collect();
+    if headers.is_empty() {
+        None
+    } else {
+        Some(headers)
+    }
+}
+
 async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     // Absent field falls back to the daemon's spawn-time env (mirrors
     // hideScrollbars/webgpu), keeping the launch hash stable when follow-up
@@ -4018,7 +4037,12 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(url) = cdp_url {
         state.reset_input_state();
-        state.browser = Some(BrowserManager::connect_cdp(url).await?);
+        let browser = if let Some(headers) = cdp_headers_from_command(cmd) {
+            BrowserManager::connect_cdp_with_headers(url, Some(headers)).await?
+        } else {
+            BrowserManager::connect_cdp(url).await?
+        };
+        state.browser = Some(browser);
         state.launch_hash = Some(new_hash);
         state.subscribe_to_browser_events();
         state.start_fetch_handler();

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -25,6 +25,10 @@ agent-browser --cdp "wss://browser-service.com/cdp?token=..." snapshot
 
 # Works with any CDP-compatible service
 agent-browser --cdp "ws://localhost:9222/devtools/browser/abc123" open example.com
+
+# Authenticated CDP WebSocket (e.g. Cloudflare Browser Rendering)
+agent-browser --cdp "wss://api.cloudflare.com/.../devtools/browser" \
+  --cdp-headers '{"Authorization":"Bearer YOUR_API_TOKEN"}' snapshot
 ```
 
 The `--cdp` flag accepts either:


### PR DESCRIPTION
Fixes #1642.

## Problem

Generic CDP connect (`--cdp wss://…` / launch `cdpUrl`) calls `BrowserManager::connect_cdp` with **no WebSocket headers**.

Authenticated remote browsers (e.g. [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-run/cdp/playwright/)) require connect headers such as `Authorization: Bearer …`.

`--headers` is **page/origin** Fetch headers — a different concern.

Provider paths already use `connect_cdp_with_headers` (agentcore). Generic CDP did not.

## Solution

- Parse optional `cdpHeaders` on the launch command
- Use `connect_cdp_with_headers` when present
- CLI: `--cdp-headers '<json>'` and `AGENT_BROWSER_CDP_HEADERS`
- Docs: short note on CDP mode page

```bash
agent-browser --cdp "wss://api.cloudflare.com/.../devtools/browser" \
  --cdp-headers '{"Authorization":"Bearer YOUR_API_TOKEN"}' snapshot
```

## Notes

- Additive, non-breaking
- Against **main** (0.33.x native CLI)
- Related: #1663 targets the historical 0.19 JS `BrowserManager` API still used by `@mastra/agent-browser` (pinned to `agent-browser@0.19.0` because 0.20+ removed the JS package exports)

## Verification

- `cargo test cdp_headers` — pass
- `cargo check` — pass