### PR TITLE
fix(cdp): don't hang when a CDP frame carries a lone UTF-16 surrogate

### DIFF
--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -10,7 +10,7 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::Message;
 
-use super::types::{CdpCommand, CdpEvent, CdpMessage};
+use super::types::{CdpCommand, CdpError, CdpEvent, CdpMessage};
 
 type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<CdpMessage>>>>;
 
@@ -24,6 +24,111 @@ const WS_KEEPALIVE_INTERVAL_SECS: u64 = 30;
 pub struct RawCdpMessage {
     pub text: String,
     pub session_id: Option<String>,
+}
+
+/// Rewrite unpaired UTF-16 surrogate escapes to the replacement character.
+///
+/// JSON does not require well-formed UTF-16 (RFC 8259 section 8.2), and Chrome
+/// does emit lone surrogates: a flag emoji (U+1F1FA U+1F1F8) is two code points
+/// (four UTF-16 units), and layout can split it across `InlineTextBox` nodes,
+/// leaving an accessibility node whose entire name is `"\ud83c"`. Rust strings
+/// are UTF-8 and cannot hold an unpaired surrogate, so `serde_json` rejects the
+/// whole message. Replacing the escape keeps the surrounding response usable —
+/// these split fragments are layout artifacts, never user-facing refs.
+///
+/// Returns `None` when the input has no lone surrogate, so the common path does
+/// not allocate.
+fn sanitize_lone_surrogates(msg: &str) -> Option<String> {
+    const ESCAPE_LEN: usize = 6; // \uXXXX
+    const HIGH_START: u32 = 0xD800;
+    const LOW_START: u32 = 0xDC00;
+    const SURROGATE_END: u32 = 0xE000;
+
+    let read_escape = |bytes: &[u8], at: usize| -> Option<u32> {
+        let end = at.checked_add(ESCAPE_LEN)?;
+        if end > bytes.len() || bytes[at] != b'\\' || bytes[at + 1] != b'u' {
+            return None;
+        }
+        let hex = &bytes[at + 2..end];
+        // from_str_radix would accept a leading sign, which is not a valid
+        // escape; require four literal hex digits.
+        if !hex.iter().all(u8::is_ascii_hexdigit) {
+            return None;
+        }
+        u32::from_str_radix(std::str::from_utf8(hex).ok()?, 16).ok()
+    };
+
+    let bytes = msg.as_bytes();
+    let mut out: Option<String> = None;
+    // Start of the run of untouched input not yet copied into `out`. Copying by
+    // slice rather than char-by-char keeps multi-byte UTF-8 sequences intact and
+    // means the escape scan never has to reason about character boundaries.
+    let mut copied = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        // Skip escaped characters so a literal `\\u` in the payload is not
+        // mistaken for the start of an escape sequence.
+        if bytes[i] == b'\\' && i + 1 < bytes.len() && bytes[i + 1] != b'u' {
+            i += 2;
+            continue;
+        }
+
+        let Some(unit) = read_escape(bytes, i) else {
+            // Advance one byte at a time: every escape starts with an ASCII
+            // backslash, so landing mid-sequence in a multi-byte character
+            // cannot produce a false match, and the bytes are copied verbatim
+            // as part of the surrounding run.
+            i += 1;
+            continue;
+        };
+
+        let is_high = (HIGH_START..LOW_START).contains(&unit);
+        let is_low = (LOW_START..SURROGATE_END).contains(&unit);
+
+        // A high surrogate immediately followed by a low one is a valid pair.
+        let paired = is_high
+            && read_escape(bytes, i + ESCAPE_LEN)
+                .is_some_and(|next| (LOW_START..SURROGATE_END).contains(&next));
+
+        if paired {
+            i += ESCAPE_LEN * 2;
+            continue;
+        }
+
+        if is_high || is_low {
+            let buf = out.get_or_insert_with(String::new);
+            // `copied` and `i` are both escape boundaries (ASCII), so this
+            // slice is always on a character boundary.
+            buf.push_str(&msg[copied..i]);
+            buf.push(char::REPLACEMENT_CHARACTER);
+            copied = i + ESCAPE_LEN;
+        }
+        i += ESCAPE_LEN;
+    }
+
+    if let Some(buf) = out.as_mut() {
+        buf.push_str(&msg[copied..]);
+    }
+
+    out
+}
+
+/// Best-effort extraction of a top-level command id from a frame that could not
+/// be deserialized into a [`CdpMessage`], so the caller can be failed fast
+/// instead of waiting forever for a response that will never be delivered.
+///
+/// This runs only on the cold path where deserialization already failed, so it
+/// can afford a full generic parse. That matters for correctness: a substring
+/// scan for `"id"` would happily match one nested inside `result`, and resolving
+/// the wrong pending request would report a spurious error on an unrelated
+/// command while the genuinely stuck one kept waiting.
+///
+/// Returns `None` when the frame is not valid JSON at all, has no top-level
+/// `id`, or carries an id outside `u64` (the inspect proxy uses negative ids).
+fn extract_command_id(msg: &str) -> Option<u64> {
+    let value: Value = serde_json::from_str(msg).ok()?;
+    value.get("id")?.as_u64()
 }
 
 pub struct CdpClient {
@@ -167,9 +272,48 @@ impl CdpClient {
 
                 let parsed: CdpMessage = match serde_json::from_str(&msg) {
                     Ok(m) => m,
-                    // Expected for inspect proxy messages with negative IDs
-                    // (CdpMessage.id is u64); handled via raw broadcast above.
-                    Err(_) => continue,
+                    Err(_) => {
+                        // Chrome can emit lone UTF-16 surrogates (a split flag
+                        // emoji in an InlineTextBox name), which serde_json
+                        // rejects. Retry with those escapes neutralized before
+                        // giving up on the frame.
+                        let repaired = sanitize_lone_surrogates(&msg);
+                        let candidate = repaired.as_deref().unwrap_or(&msg);
+
+                        match serde_json::from_str::<CdpMessage>(candidate) {
+                            Ok(m) => m,
+                            Err(_) => {
+                                // Never strand a caller: if the frame carries a
+                                // command id, fail that request so it returns an
+                                // error instead of hanging until the process is
+                                // killed. Frames without an id are expected for
+                                // inspect proxy messages with negative IDs
+                                // (CdpMessage.id is u64); those are handled via
+                                // the raw broadcast above.
+                                if let Some(id) = extract_command_id(candidate) {
+                                    let waiter = pending_clone.lock().await.remove(&id);
+                                    if let Some(tx) = waiter {
+                                        let _ = tx.send(CdpMessage {
+                                            id: Some(id),
+                                            result: None,
+                                            error: Some(CdpError {
+                                                code: None,
+                                                message: "Malformed CDP response could not be \
+                                                          parsed (unpaired UTF-16 surrogate or \
+                                                          invalid JSON)"
+                                                    .to_string(),
+                                                data: None,
+                                            }),
+                                            method: None,
+                                            params: None,
+                                            session_id: None,
+                                        });
+                                    }
+                                }
+                                continue;
+                            }
+                        }
+                    }
                 };
 
                 if let Some(id) = parsed.id {
@@ -433,4 +577,186 @@ fn enable_tcp_keepalive(stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::T
     let keepalive = keepalive.with_interval(std::time::Duration::from_secs(10));
 
     let _ = sock.set_tcp_keepalive(&keepalive);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact shape Chrome emits when layout splits a flag emoji: the
+    /// InlineTextBox name is the unpaired high surrogate of a flag emoji.
+    const LONE_SURROGATE_RESPONSE: &str = r#"{"id":7,"result":{"nodes":[{"nodeId":"-1000000831","role":{"value":"InlineTextBox"},"name":{"type":"computedString","value":"\ud83c"}}]}}"#;
+
+    #[test]
+    fn serde_json_rejects_lone_surrogates() {
+        // Guards the premise of the fix: without sanitizing, this frame is
+        // unparseable and the reader loop would drop the response.
+        assert!(serde_json::from_str::<CdpMessage>(LONE_SURROGATE_RESPONSE).is_err());
+    }
+
+    #[test]
+    fn sanitizes_lone_surrogate_into_parseable_message() {
+        let clean = sanitize_lone_surrogates(LONE_SURROGATE_RESPONSE)
+            .expect("lone surrogate should be rewritten");
+        let parsed: CdpMessage =
+            serde_json::from_str(&clean).expect("sanitized frame should parse");
+        assert_eq!(parsed.id, Some(7));
+
+        let name = parsed.result.unwrap()["nodes"][0]["name"]["value"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(name, "\u{FFFD}");
+    }
+
+    #[test]
+    fn preserves_multi_byte_characters_after_a_lone_surrogate() {
+        // Everything after the first rewrite must survive byte for byte. An
+        // earlier revision copied the tail one byte at a time, which silently
+        // mangled any multi-byte UTF-8 that followed the lone surrogate.
+        // The literal text is built with escapes so the source stays ASCII; what
+        // reaches the sanitizer is real multi-byte UTF-8.
+        let msg = format!(
+            "{{\"id\":9,\"result\":{{\"a\":\"\\ud83c\",\"b\":\"{}\",\"c\":\"{} ok\"}}}}",
+            "\u{4E2D}\u{6587}", "\u{1F1FA}\u{1F1F8}"
+        );
+        let clean = sanitize_lone_surrogates(&msg).expect("lone surrogate should be rewritten");
+        let parsed: CdpMessage = serde_json::from_str(&clean).expect("should parse");
+
+        let result = parsed.result.unwrap();
+        assert_eq!(result["a"].as_str().unwrap(), "\u{FFFD}");
+        assert_eq!(result["b"].as_str().unwrap(), "\u{4E2D}\u{6587}");
+        assert_eq!(result["c"].as_str().unwrap(), "\u{1F1FA}\u{1F1F8} ok");
+    }
+
+    #[test]
+    fn preserves_multi_byte_characters_between_lone_surrogates() {
+        // The tail after the final rewrite is copied separately from the runs
+        // between rewrites; both paths need to stay on character boundaries.
+        let msg = format!(
+            "{{\"id\":10,\"result\":{{\"a\":\"\\ud83c\",\"b\":\"{}\",\"c\":\"\\udc00\",\"d\":\"{}\"}}}}",
+            "\u{4E2D}", "\u{6587}"
+        );
+        let clean = sanitize_lone_surrogates(&msg).expect("lone surrogates should be rewritten");
+        let parsed: CdpMessage = serde_json::from_str(&clean).expect("should parse");
+
+        let result = parsed.result.unwrap();
+        assert_eq!(result["a"].as_str().unwrap(), "\u{FFFD}");
+        assert_eq!(result["b"].as_str().unwrap(), "\u{4E2D}");
+        assert_eq!(result["c"].as_str().unwrap(), "\u{FFFD}");
+        assert_eq!(result["d"].as_str().unwrap(), "\u{6587}");
+    }
+
+    #[test]
+    fn leaves_multi_byte_messages_without_surrogates_untouched() {
+        let msg = format!(
+            "{{\"id\":11,\"result\":{{\"value\":\"{} {} mixed\"}}}}",
+            "\u{4E2D}\u{6587}", "\u{1F1FA}\u{1F1F8}"
+        );
+        assert!(sanitize_lone_surrogates(&msg).is_none());
+    }
+
+    #[test]
+    fn leaves_valid_surrogate_pairs_untouched() {
+        // A well-formed pair is the whole flag emoji and must survive intact.
+        let msg = r#"{"id":1,"result":{"name":"\ud83c\uddfa\ud83c\uddf8"}}"#;
+        assert!(sanitize_lone_surrogates(msg).is_none());
+
+        let parsed: CdpMessage = serde_json::from_str(msg).unwrap();
+        assert_eq!(
+            parsed.result.unwrap()["name"].as_str().unwrap(),
+            "\u{1F1FA}\u{1F1F8}"
+        );
+    }
+
+    #[test]
+    fn leaves_ordinary_messages_untouched() {
+        let msg = r#"{"id":2,"result":{"value":"plain text, no escapes"}}"#;
+        assert!(sanitize_lone_surrogates(msg).is_none());
+    }
+
+    #[test]
+    fn ignores_escaped_backslash_before_u() {
+        // `\\u` is a literal backslash followed by 'u', not an escape sequence.
+        let msg = r#"{"id":3,"result":{"value":"C:\\users"}}"#;
+        assert!(sanitize_lone_surrogates(msg).is_none());
+    }
+
+    #[test]
+    fn rewrites_lone_low_surrogate() {
+        let msg = r#"{"id":4,"result":{"value":"\udc00"}}"#;
+        let clean = sanitize_lone_surrogates(msg).expect("lone low surrogate should be rewritten");
+        let parsed: CdpMessage = serde_json::from_str(&clean).unwrap();
+        assert_eq!(
+            parsed.result.unwrap()["value"].as_str().unwrap(),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn survives_backslash_escape_before_a_multi_byte_character() {
+        // `\<multi-byte>` is not valid JSON, but a broken relay can produce it.
+        // The scan skips two bytes past a backslash escape, which lands inside
+        // the character; nothing may slice or index on that offset.
+        let msg = "{\"x\":\"\\ud83c\",\"y\":\"\\\u{4E2D}\"}";
+        let clean = sanitize_lone_surrogates(msg).expect("lone surrogate should be rewritten");
+        assert!(clean.contains('\u{FFFD}'));
+        assert!(clean.contains('\u{4E2D}'));
+    }
+
+    #[test]
+    fn handles_three_consecutive_surrogate_escapes() {
+        // high + high + low: the first is unpaired, the second forms a pair.
+        let msg = r#"{"id":12,"result":{"value":"\ud83c\ud83c\udf00"}}"#;
+        let clean = sanitize_lone_surrogates(msg).expect("first surrogate should be rewritten");
+        let parsed: CdpMessage = serde_json::from_str(&clean).expect("should parse");
+        assert_eq!(
+            parsed.result.unwrap()["value"].as_str().unwrap(),
+            "\u{FFFD}\u{1F300}"
+        );
+    }
+
+    #[test]
+    fn handles_uppercase_hex_escapes() {
+        // Chrome emits lowercase, but the protocol does not require it.
+        let msg = r#"{"id":13,"result":{"value":"\uD83C"}}"#;
+        let clean = sanitize_lone_surrogates(msg).expect("uppercase escape should be rewritten");
+        let parsed: CdpMessage = serde_json::from_str(&clean).expect("should parse");
+        assert_eq!(
+            parsed.result.unwrap()["value"].as_str().unwrap(),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn extracts_command_id_from_parseable_frame() {
+        // The reader hands this the sanitized text, so the frame parses as
+        // generic JSON even when it does not fit CdpMessage.
+        assert_eq!(
+            extract_command_id(r#"{ "id" : 42 , "result":{}}"#),
+            Some(42)
+        );
+        let sanitized = sanitize_lone_surrogates(LONE_SURROGATE_RESPONSE).unwrap();
+        assert_eq!(extract_command_id(&sanitized), Some(7));
+    }
+
+    #[test]
+    fn ignores_ids_nested_inside_the_payload() {
+        // A substring scan would return 123 here and fail an unrelated command.
+        assert_eq!(
+            extract_command_id(r#"{"result":{"root":{"id":123}},"id":7}"#),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn extracts_no_id_from_event_frames() {
+        // Events carry no id; they must not resolve a pending command.
+        assert_eq!(
+            extract_command_id(r#"{"method":"Page.loadEventFired","params":{}}"#),
+            None
+        );
+        // Negative ids belong to the inspect proxy and do not fit u64.
+        assert_eq!(extract_command_id(r#"{"id":-3,"result":{}}"#), None);
+    }
 }


### PR DESCRIPTION
Fixes #1666.

## Problem

`snapshot` hangs forever on any page whose accessibility tree contains an unpaired UTF-16 surrogate. The most common real-world trigger is a flag emoji in a country picker — 🇺🇸 is two code points (four UTF-16 units), and Chrome's layout can split it across `InlineTextBox` nodes, producing an AX node whose entire name is one lone high surrogate:

```json
{"nodeId":"-1000000831","role":{"value":"InlineTextBox"},
 "name":{"type":"computedString","value":"\ud83c"}}
```

That is valid JSON (RFC 8259 does not require well-formed UTF-16) and Chrome emits it happily, but Rust strings are UTF-8 and cannot hold an unpaired surrogate, so `serde_json` rejects the whole frame with `unexpected end of hex escape`.

The reader loop treated any parse failure as an inspect proxy message and dropped it:

```rust
let parsed: CdpMessage = match serde_json::from_str(&msg) {
    Ok(m) => m,
    Err(_) => continue,   // the getFullAXTree response is dropped here
};
```

When the dropped frame is a command response, the pending oneshot is never resolved and the caller waits forever. Raw CDP against the same page returns in 43 ms; agent-browser never returns, and the process has to be SIGKILLed externally.

## Changes

**1. Retry the parse with lone surrogates neutralized.** `sanitize_lone_surrogates` rewrites unpaired surrogate escapes to `U+FFFD` and leaves valid pairs untouched. It returns `Option<String>` so the common path (no lone surrogate) does not allocate or copy. Split emoji fragments are layout artifacts that never become user-facing refs, so a replacement character is a safe stand-in and the rest of the response stays usable.

**2. Never silently strand a caller.** If a frame still fails to parse, `extract_command_id` pulls its `id` out with a cheap string scan and the pending request is resolved with a `CdpError` instead of being dropped. Callers now get an error immediately rather than hanging. Frames with no id (or negative inspect-proxy ids, which do not fit `u64`) still fall through to the existing `continue`, so the raw-broadcast path is unchanged.

The second change is the more important one: it turns this entire class of bug from an unrecoverable hang into a normal error, whatever the cause of the parse failure.

## Testing

8 new unit tests in `cli/src/native/cdp/client.rs`, including a guard test asserting that `serde_json` really does reject the lone-surrogate frame, so the premise of the fix cannot silently rot:

- `serde_json_rejects_lone_surrogates`
- `sanitizes_lone_surrogate_into_parseable_message`
- `leaves_valid_surrogate_pairs_untouched` (🇺🇸 round-trips intact)
- `leaves_ordinary_messages_untouched`
- `ignores_escaped_backslash_before_u` (a literal `\\u` is not an escape)
- `rewrites_lone_low_surrogate`
- `extracts_command_id_from_unparseable_frame`
- `extracts_no_id_from_event_frames`

Full suite: **1069 unit tests + 2 integration tests pass**, no regressions. `cargo clippy --all-targets` is clean and `cargo fmt --check` passes.

End-to-end on the real page that triggered this, same dialog and same DOM state for both binaries:

| binary | result |
|---|---|
| 0.33.2 as published | hangs indefinitely (killed after 20 s) |
| this branch | returns in **0.061 s**, full dialog tree |

The country combobox still snapshots correctly afterwards (`combobox "Phone number country"`), confirming the sanitizer does not damage the surrounding nodes.

Note that a static HTML file with the same markup does not reproduce the hang — whether Chrome splits the `InlineTextBox` mid-surrogate depends on real layout and line breaking. A live page is needed, which is why this bug looks intermittent and content-dependent.
