### PR TITLE
fix: reset refs before diff snapshots

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5746,6 +5746,8 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         selector,
         ..SnapshotOptions::default()
     };
+
+    state.ref_map.clear();
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3375,6 +3375,29 @@ async fn e2e_diff_snapshot() {
     assert_success(&resp);
     let baseline = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
 
+    // Regression: diffing an unchanged page against its own baseline must
+    // report no changes. diff_snapshot must reset ref IDs like snapshot does,
+    // otherwise every ref'd line shows up as an addition.
+    let resp = execute_command(
+        &json!({ "id": "3b", "action": "diff_snapshot", "baseline": baseline }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(
+        data["additions"], 0,
+        "Unchanged page diff should have no additions"
+    );
+    assert_eq!(
+        data["removals"], 0,
+        "Unchanged page diff should have no removals"
+    );
+    assert_eq!(
+        data["changed"], false,
+        "Unchanged page diff should not be marked changed"
+    );
+
     // Modify the page
     let resp = execute_command(
         &json!({ "id": "4", "action": "evaluate", "script": "document.querySelector('h1').textContent = 'Changed'" }),


### PR DESCRIPTION
## Summary

- Reset snapshot reference mappings before taking a diff snapshot.
- Add an end-to-end regression assertion that an unchanged page produces an empty diff.

Fixes #1394

## Verification

local verification not run; relying on upstream CI

The fresh worktree has no installed Node/Rust dependencies, so the local e2e suite could not be run.
