### PR TITLE
fix(native): normalize Windows download paths for Chrome

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "base64",
  "chrono",
  "dirs",
+ "dunce",
  "futures-util",
  "getrandom 0.2.17",
  "hex",
@@ -473,6 +474,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,6 +40,7 @@ rust-embed = "8"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
+dunce = "1"
 windows-sys = { version = "0.52", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -6161,6 +6161,23 @@ async fn handle_set_media(cmd: &Value, state: &DaemonState) -> Result<Value, Str
     Ok(json!({ "set": true }))
 }
 
+/// Canonicalize an existing path for use as a Chrome CDP download directory.
+///
+/// `std::fs::canonicalize` is correct on Unix, but on Windows it returns a
+/// verbatim `\\?\`-prefixed path that `Browser.setDownloadBehavior` rejects,
+/// canceling the download. `dunce` uses the legacy form only when it can do
+/// so without changing the path's meaning.
+fn canonicalize_for_cdp(path: &Path) -> std::io::Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        dunce::canonicalize(path)
+    }
+    #[cfg(not(windows))]
+    {
+        path.canonicalize()
+    }
+}
+
 async fn handle_download(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let selector = cmd
         .get("selector")
@@ -6191,8 +6208,7 @@ async fn handle_download(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .map_err(|e| format!("Failed to create download directory: {}", e))?;
 
     // Canonicalize after mkdir so the path actually exists for resolution
-    let download_dir = download_dir
-        .canonicalize()
+    let download_dir = canonicalize_for_cdp(&download_dir)
         .map_err(|e| format!("Failed to resolve download directory: {}", e))?;
     let dest = download_dir.join(
         raw_dest
@@ -14507,5 +14523,42 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
             let auto_handled = auto_dialog && matches!(*dialog_type, "beforeunload" | "alert");
             assert!(!auto_handled, "{dialog_type} should NOT be auto-handled");
         }
+    }
+
+    #[test]
+    fn canonicalize_for_cdp_preserves_target() {
+        let dir = tempfile::tempdir().expect("tempdir must be created");
+        let standard = dir
+            .path()
+            .canonicalize()
+            .expect("the temporary directory must be canonicalizable");
+
+        let resolved = canonicalize_for_cdp(dir.path())
+            .expect("canonicalize_for_cdp must resolve an existing directory");
+        assert!(
+            resolved.is_absolute(),
+            "resolved path must be absolute, got {:?}",
+            resolved,
+        );
+
+        #[cfg(windows)]
+        {
+            let simplified = dunce::simplified(&standard);
+            assert_eq!(resolved.as_path(), simplified);
+            if simplified != standard.as_path() {
+                assert!(!resolved.to_string_lossy().starts_with(r"\\?\"));
+            }
+        }
+
+        #[cfg(not(windows))]
+        assert_eq!(resolved, standard);
+
+        assert_eq!(
+            resolved
+                .canonicalize()
+                .expect("the simplified path must remain canonicalizable"),
+            standard,
+            "simplifying the path must not change its target",
+        );
     }
 }


### PR DESCRIPTION
Fixes #1659

## Summary

- canonicalize download directories with `dunce` on Windows before passing them to Chrome CDP
- preserve the existing `std::fs::canonicalize` behavior on non-Windows platforms
- cover safe Windows path simplification while verifying that the resolved path still targets the same directory

## Root cause

`handle_download` canonicalized the destination directory with `std::fs::canonicalize`. On Windows, that normally produces a verbatim path such as `\\?\C:\downloads`. Chrome rejects that representation in `Browser.setDownloadBehavior.downloadPath` and reports the download as canceled.

The fix uses the Windows-target-only `dunce` dependency to return a legacy path when that conversion is safe. Verbatim UNC, device, reserved-name, and long paths retain their canonical representation rather than being stripped manually. The shared native download handler continues to serve both CLI and MCP callers.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml canonicalize_for_cdp_preserves_target -- --nocapture`
- `cargo clippy --manifest-path cli/Cargo.toml`
- real Windows Chrome 151 workflow: three consecutive downloads to absolute `C:\...` destinations completed successfully and each downloaded file matched the expected contents
- `cargo test --profile ci --manifest-path cli/Cargo.toml`: 1041 passed, 1 failed, 96 ignored; the unrelated existing failure is `install::tests::download_bytes_connection_refused_includes_details`, which expects the English text `connection refused` while this zh-CN Windows host returns the localized OS error for WSAECONNREFUSED

`cargo clippy --manifest-path cli/Cargo.toml -- -D warnings` also reaches existing warnings in unchanged files; ordinary Clippy completes successfully and the changed code introduces no new warning.
