### PR TITLE
feat: discover Helium during auto-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,19 +593,19 @@ agent-browser provides multiple ways to persist login sessions so you don't re-a
 | **Chrome profile reuse** | Reuse your existing Chrome login state (cookies, sessions) with zero setup | `--profile <name>` / `AGENT_BROWSER_PROFILE` |
 | **Persistent profile** | Full browser state (cookies, IndexedDB, service workers, cache) across restarts | `--profile <path>` / `AGENT_BROWSER_PROFILE` |
 | **Session persistence** | Auto-save/restore cookies + localStorage from a stable session key | `--session <id> --restore` / `AGENT_BROWSER_RESTORE` |
-| **Import from your browser** | Grab auth from a Chrome session you already logged into | `--auto-connect` + `state save` |
+| **Import from your browser** | Grab auth from a supported Chromium browser session you already logged into | `--auto-connect` + `state save` |
 | **State file** | Load a previously saved state JSON on launch | `--state <path>` / `AGENT_BROWSER_STATE` |
 | **Auth vault** | Store credentials locally (encrypted), login by name | `auth save` / `auth login` |
 
 ### Import auth from your browser
 
-If you are already logged in to a site in Chrome, you can grab that auth state and reuse it:
+If you are already logged in to a site in Chrome, Chromium, Brave, or Helium on macOS, you can grab that auth state and reuse it:
 
 ```bash
 # 1. Launch Chrome with remote debugging enabled
 #    macOS:
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222
-#    Or use --auto-connect to discover an already-running Chrome
+#    Or use --auto-connect to discover an already-running supported browser
 
 # 2. Connect and save the authenticated state
 agent-browser --auto-connect state save ./my-auth.json
@@ -940,7 +940,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--headed` | Show browser window (not headless) (or `AGENT_BROWSER_HEADED` env) |
 | `--webgpu` | Enable WebGPU; SwiftShader software Vulkan on Linux, no GPU required (or `AGENT_BROWSER_WEBGPU` env) |
 | `--cdp <port\|url>` | Connect via Chrome DevTools Protocol (port or WebSocket URL) |
-| `--auto-connect` | Auto-discover and connect to running Chrome (or `AGENT_BROWSER_AUTO_CONNECT` env) |
+| `--auto-connect` | Auto-discover and connect to a supported Chromium browser, including Helium on macOS (or `AGENT_BROWSER_AUTO_CONNECT` env) |
 | `--color-scheme <scheme>` | Color scheme: `dark`, `light`, `no-preference` (or `AGENT_BROWSER_COLOR_SCHEME` env) |
 | `--download-path <path>` | Default download directory (or `AGENT_BROWSER_DOWNLOAD_PATH` env) |
 | `--content-boundaries` | Wrap page output in boundary markers for LLM safety (or `AGENT_BROWSER_CONTENT_BOUNDARIES` env) |
@@ -1379,10 +1379,10 @@ This enables control of:
 
 ### Auto-Connect
 
-Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
+Use `--auto-connect` to automatically discover and connect to a running supported Chromium browser without specifying a port:
 
 ```bash
-# Auto-discover running Chrome with remote debugging
+# Auto-discover a supported Chromium browser with remote debugging
 agent-browser --auto-connect open example.com
 agent-browser --auto-connect snapshot
 
@@ -1390,9 +1390,9 @@ agent-browser --auto-connect snapshot
 AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
 ```
 
-Auto-connect discovers Chrome by:
+Auto-connect discovers browsers by:
 
-1. Reading Chrome's `DevToolsActivePort` file from the default user data directory
+1. Reading `DevToolsActivePort` from the default user data directories for Chrome, Chrome Canary, Chromium, Brave, and Helium on macOS
 2. Falling back to probing common debugging ports (9222, 9229)
 3. If HTTP-based discovery (`/json/version`, `/json/list`) fails, falling back to a direct WebSocket connection
 
@@ -1400,7 +1400,7 @@ This is useful when:
 
 - Chrome 144+ has remote debugging enabled via `chrome://inspect/#remote-debugging` (which uses a dynamic port)
 - You want a zero-configuration connection to your existing browser
-- You don't want to track which port Chrome is using
+- You don't want to track which port the browser is using
 
 ## Streaming (Browser Preview)
 

--- a/agent-browser.schema.json
+++ b/agent-browser.schema.json
@@ -130,7 +130,7 @@
     },
     "autoConnect": {
       "type": "boolean",
-      "description": "Auto-discover and connect to a running Chrome instance."
+      "description": "Auto-discover and connect to a supported Chromium browser, including Helium on macOS."
     },
     "annotate": {
       "type": "boolean",

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -974,7 +974,7 @@ pub async fn auto_connect_cdp() -> Result<String, String> {
         }
     }
 
-    Err("No running Chrome instance found. Launch Chrome with --remote-debugging-port or use --cdp.".to_string())
+    Err("No running supported Chromium browser found. Launch Chrome, Chromium, Brave, or Helium with --remote-debugging-port or use --cdp.".to_string())
 }
 
 /// Resolve a CDP WebSocket URL from a DevToolsActivePort entry.
@@ -1027,8 +1027,8 @@ async fn verify_ws_endpoint(ws_url: &str) -> bool {
     matches!(result, Ok(Some(())))
 }
 
-/// Returns the default Chrome user-data directory paths for the current platform.
-/// Includes Chrome, Chrome Canary, Chromium, and Brave.
+/// Returns the default Chromium browser user-data directory paths for the current platform.
+/// Includes Chrome, Chrome Canary, Chromium, Brave, and Helium on macOS.
 pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
@@ -1041,6 +1041,7 @@ pub fn get_chrome_user_data_dirs() -> Vec<PathBuf> {
                 "Google/Chrome Canary",
                 "Chromium",
                 "BraveSoftware/Brave-Browser",
+                "net.imput.helium",
             ] {
                 dirs.push(base.join(name));
             }
@@ -2403,6 +2404,16 @@ mod tests {
             result.args.iter().any(|a| a == "--password-store=basic"),
             "profile path should keep keychain flags"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_get_chrome_user_data_dirs_includes_helium() {
+        let dirs = get_chrome_user_data_dirs();
+
+        assert!(dirs
+            .iter()
+            .any(|path| { path.ends_with("Library/Application Support/net.imput.helium") }));
     }
 
     // -------------------------------------------------------------------

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3684,7 +3684,7 @@ Authentication:
                              (or AGENT_BROWSER_SESSION_NAME env)
   --state <path>             Load saved auth state (cookies + storage) from JSON file
                              (or AGENT_BROWSER_STATE env)
-  --auto-connect             Connect to a running Chrome to reuse its auth state
+  --auto-connect             Connect to a supported Chromium browser to reuse auth state
                              Tip: agent-browser --auto-connect state save ./auth.json
   --headers <json>           HTTP headers scoped to URL's origin (e.g., Authorization bearer token)
 
@@ -3786,7 +3786,7 @@ Environment:
   AGENT_BROWSER_DEBUG            Debug output
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS Ignore HTTPS certificate errors
   AGENT_BROWSER_PROVIDER         Browser provider (ios, browserbase, kernel, browseruse, browserless, agentcore, or plugin name)
-  AGENT_BROWSER_AUTO_CONNECT     Auto-discover and connect to running Chrome
+  AGENT_BROWSER_AUTO_CONNECT     Auto-discover Chrome, Chromium, Brave, or Helium on macOS
   AGENT_BROWSER_ALLOW_FILE_ACCESS Allow file:// URLs to access local files
   AGENT_BROWSER_HIDE_SCROLLBARS  Hide scrollbars in headless Chromium screenshots (default: true)
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)
@@ -3840,7 +3840,7 @@ Examples:
   agent-browser screenshot --annotate    # Labeled screenshot for vision models
   agent-browser wait 2000               # Wait for slow pages to settle
   agent-browser --cdp 9222 snapshot      # Connect via CDP port
-  agent-browser --auto-connect snapshot  # Auto-discover running Chrome
+  agent-browser --auto-connect snapshot  # Auto-discover a supported Chromium browser
   agent-browser stream enable            # Start runtime streaming on an auto-selected port
   agent-browser stream status            # Inspect runtime streaming state
   agent-browser --color-scheme dark open example.com  # Dark mode

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -34,10 +34,10 @@ The `--cdp` flag accepts either:
 
 ## Auto-Connect
 
-Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
+Use `--auto-connect` to automatically discover and connect to a running supported Chromium browser without specifying a port:
 
 ```bash
-# Auto-discover running Chrome with remote debugging
+# Auto-discover a supported Chromium browser with remote debugging
 agent-browser --auto-connect open example.com
 agent-browser --auto-connect snapshot
 
@@ -45,9 +45,9 @@ agent-browser --auto-connect snapshot
 AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
 ```
 
-Auto-connect discovers Chrome by:
+Auto-connect discovers browsers by:
 
-1. Reading Chrome's `DevToolsActivePort` file from the default user data directory
+1. Reading `DevToolsActivePort` from the default user data directories for Chrome, Chrome Canary, Chromium, Brave, and Helium on macOS
 2. Falling back to probing common debugging ports (9222, 9229)
 3. If HTTP-based discovery (`/json/version`, `/json/list`) fails, falling back to a direct WebSocket connection
 
@@ -55,7 +55,7 @@ This is useful when:
 
 - Chrome 144+ has remote debugging enabled via `chrome://inspect/#remote-debugging` (which uses a dynamic port)
 - You want a zero-configuration connection to your existing browser
-- You don't want to track which port Chrome is using
+- You don't want to track which port the browser is using
 
 ## Color scheme
 
@@ -103,7 +103,7 @@ This enables control of:
     <tr><td><code>--exact</code></td><td>Exact, case-sensitive match (accessible name for role)</td></tr>
     <tr><td><code>--headed</code></td><td>Show browser window</td></tr>
     <tr><td><code>{"--cdp <port|url>"}</code></td><td>CDP connection (port or WebSocket URL)</td></tr>
-    <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to running Chrome</td></tr>
+    <tr><td><code>--auto-connect</code></td><td>Auto-discover and connect to a supported Chromium browser, including Helium on macOS</td></tr>
     <tr><td><code>--color-scheme &lt;scheme&gt;</code></td><td>Persistent color scheme (<code>dark</code>, <code>light</code>, <code>no-preference</code>)</td></tr>
     <tr><td><code>--debug</code></td><td>Debug output</td></tr>
   </tbody>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -576,7 +576,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --headed                 # Show browser window (not headless)
 --webgpu                 # Enable WebGPU (software Vulkan on Linux, no GPU needed)
 --cdp <port|url>         # Connect via Chrome DevTools Protocol (port or WebSocket URL)
---auto-connect           # Auto-discover and connect to running Chrome
+--auto-connect           # Auto-discover Chrome, Chromium, Brave, or Helium on macOS
 --color-scheme <scheme>  # Color scheme: dark, light, no-preference
 --download-path <path>   # Default download directory
 --content-boundaries     # Wrap page output in boundary markers for LLM safety

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -239,7 +239,7 @@ These environment variables configure additional daemon and runtime behavior:
   <tbody>
     <tr><td><code>AGENT_BROWSER_CONFIG</code></td><td>Path to an explicit config file.</td><td>(default discovery)</td></tr>
     <tr><td><code>AGENT_BROWSER_SESSION</code></td><td>Isolated browser session name.</td><td><code>default</code></td></tr>
-    <tr><td><code>AGENT_BROWSER_AUTO_CONNECT</code></td><td>Auto-discover and connect to a running Chrome instance.</td><td>(disabled)</td></tr>
+    <tr><td><code>AGENT_BROWSER_AUTO_CONNECT</code></td><td>Auto-discover and connect to a supported Chromium browser, including Helium on macOS.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_ALLOW_FILE_ACCESS</code></td><td>Allow <code>file://</code> URLs to access local files.</td><td>(disabled)</td></tr>
     <tr><td><code>AGENT_BROWSER_EXECUTABLE_PATH</code></td><td>Custom browser executable path.</td><td>(auto-discover)</td></tr>
     <tr><td><code>AGENT_BROWSER_PROFILE</code></td><td>Chrome profile name or persistent profile directory.</td><td>(none)</td></tr>

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -92,7 +92,7 @@ The profile directory stores:
 
 ## Import auth from your browser
 
-If you are already logged in to a site in Chrome, you can grab that auth state and reuse it in agent-browser. This is the fastest way to bypass login flows, OAuth, SSO, or 2FA.
+If you are already logged in to a site in Chrome, Chromium, Brave, or Helium on macOS, you can grab that auth state and reuse it in agent-browser. This is the fastest way to bypass login flows, OAuth, SSO, or 2FA.
 
 **Step 1:** Start Chrome with remote debugging:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -427,7 +427,7 @@ EOF
 --json                  # JSON output (for machine parsing)
 --headed                # show the window (default is headless)
 --webgpu                # enable WebGPU (software Vulkan on Linux, no GPU needed)
---auto-connect          # connect to an already-running Chrome
+--auto-connect          # connect to Chrome, Chromium, Brave, or Helium on macOS
 --cdp <port>            # connect to a specific CDP port
 --profile <name|path>   # use a Chrome profile (login state survives)
 --headers <json>        # HTTP headers scoped to the URL's origin

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -22,7 +22,7 @@ Login flows, session persistence, OAuth, 2FA, and authenticated browsing.
 
 ## Import Auth from Your Browser
 
-The fastest way to authenticate is to reuse cookies from a Chrome session you are already logged into.
+The fastest way to authenticate is to reuse cookies from a supported Chromium browser session you are already logged into. Auto-connect discovers Chrome, Chromium, Brave, and Helium on macOS.
 
 **Step 1: Start Chrome with remote debugging**
 
@@ -44,7 +44,7 @@ Log in to your target site(s) in this Chrome window as you normally would.
 **Step 2: Grab the auth state**
 
 ```bash
-# Auto-discover the running Chrome and save its cookies + localStorage
+# Auto-discover the running supported browser and save its cookies + localStorage
 agent-browser --auto-connect state save ./my-auth.json
 ```
 


### PR DESCRIPTION
## Summary

- discover Helium on macOS by checking its default user-data directory for DevToolsActivePort
- update CLI, schema, README, docs, and the bundled core skill to describe supported Chromium browsers
- add a macOS regression test for the Helium path

This is a current-main successor to #1063 and credits that PR for identifying the Helium user-data path. Unlike #1063, this change includes only the verified current Helium bundle path, net.imput.helium.

No MCP change is needed because this extends the existing auto-connect behavior without adding a new flag or command.

## Checks

- cargo test --manifest-path cli/Cargo.toml (1062 passed, 97 ignored)
- targeted Helium and CDP resolution tests
- cargo fmt --manifest-path cli/Cargo.toml -- --check
- pnpm -C docs build
- git diff --check

Strict Clippy currently stops on a pre-existing nonminimal_bool warning at cli/src/native/cdp/chrome.rs:337, outside this diff.