### PR TITLE
fix(stream): emit active main-frame URL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,6 +1501,18 @@ Connect to `ws://localhost:9223` to receive frames and send input:
 
 `seq` is a monotonic frame id, echoed back in an `ack` message under ack pacing. `metadata.timestamp` is the capture time in epoch milliseconds, so a client can tell how old a frame is by the time it draws it.
 
+**Receive URL updates:**
+
+```json
+{
+  "type": "url",
+  "url": "https://example.com/dashboard#activity",
+  "timestamp": 1785038682238
+}
+```
+
+On Chrome, URL messages follow full-document, History API, and fragment navigation in the active tab's main frame. Navigation inside child frames or background tabs does not emit a URL message or replace the active tab's cached URL.
+
 **Send mouse events:**
 
 ```json

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2791,17 +2791,10 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
 
         if let Some(ref mgr) = state.browser {
             let tabs = mgr.tab_list();
-            if matches!(
-                action,
-                "tab_new" | "tab_switch" | "tab_close" | "open" | "navigate"
-            ) {
-                let session_id = mgr.active_session_id().ok().map(|s| s.to_string());
-                server
-                    .bind_cdp_session_and_broadcast_tabs(session_id, &tabs)
-                    .await;
-            } else {
-                server.broadcast_tabs(&tabs).await;
-            }
+            let session_id = mgr.active_session_id().ok().map(|s| s.to_string());
+            server
+                .bind_cdp_session_and_broadcast_tabs(session_id, &tabs)
+                .await;
         }
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -857,22 +857,21 @@ impl DaemonState {
                 .browser
                 .as_ref()
                 .and_then(|m| m.active_session_id().ok().map(|s| s.to_string()));
-            server.set_cdp_session_id(session_id).await;
-
-            // Broadcast connection status change to WebSocket clients
             let connected = self.browser.is_some();
             let sc = server.is_screencasting().await;
             let (vw, vh) = server.viewport().await;
+            if let Some(ref mgr) = self.browser {
+                server
+                    .bind_cdp_session_and_broadcast_tabs(session_id, &mgr.tab_list())
+                    .await;
+            } else {
+                server
+                    .bind_cdp_session_and_broadcast_tabs(session_id, &[])
+                    .await;
+            }
             server
                 .broadcast_status(connected, sc, vw, vh, &self.engine)
                 .await;
-            if let Some(ref mgr) = self.browser {
-                server.broadcast_tabs(&mgr.tab_list()).await;
-            } else {
-                server.broadcast_tabs(&[]).await;
-            }
-            // Notify the background CDP event loop that the client changed
-            server.notify_client_changed();
         }
     }
 
@@ -2710,17 +2709,17 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         server.broadcast_result(&id, action, success, &data, duration_ms);
 
         if let Some(ref mgr) = state.browser {
-            server.broadcast_tabs(&mgr.tab_list()).await;
-
-            // Keep the stream server's CDP session in sync with the active tab
-            // so screencasting always targets the correct page.
+            let tabs = mgr.tab_list();
             if matches!(
                 action,
                 "tab_new" | "tab_switch" | "tab_close" | "open" | "navigate"
             ) {
                 let session_id = mgr.active_session_id().ok().map(|s| s.to_string());
-                server.set_cdp_session_id(session_id).await;
-                server.notify_client_changed();
+                server
+                    .bind_cdp_session_and_broadcast_tabs(session_id, &tabs)
+                    .await;
+            } else {
+                server.broadcast_tabs(&tabs).await;
             }
         }
     }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5936,6 +5936,50 @@ async fn e2e_stream_url_tracks_active_main_frame_navigation_categories() {
         .expect("background tab should navigate");
     expect_no_stream_url(&mut ws, tokio::time::Duration::from_millis(500)).await;
 
+    state
+        .browser
+        .as_ref()
+        .expect("browser should exist")
+        .client
+        .send_command(
+            "Target.createTarget",
+            Some(json!({ "url": format!("{base_url}/external") })),
+            None,
+        )
+        .await
+        .expect("external tab should open");
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+    let resp = execute_command(&json!({ "id": "10", "action": "url" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["url"], format!("{base_url}/external"));
+
+    let external_session = state
+        .browser
+        .as_ref()
+        .expect("browser should exist")
+        .active_session_id()
+        .expect("external tab should become active")
+        .to_string();
+    state
+        .browser
+        .as_ref()
+        .expect("browser should exist")
+        .client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({
+                "expression": "history.pushState({}, '', '/external-spa'); location.href"
+            })),
+            Some(&external_session),
+        )
+        .await
+        .expect("external tab should navigate within its document");
+    assert_eq!(
+        next_stream_url(&mut ws).await,
+        format!("{base_url}/external-spa")
+    );
+
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
     server.abort();

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -5414,6 +5414,769 @@ async fn e2e_relaunch_on_options_change() {
 }
 
 // ---------------------------------------------------------------------------
+// Stream: URL events follow active main-frame navigation
+// ---------------------------------------------------------------------------
+
+async fn start_stream_navigation_server() -> (String, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("stream navigation server should bind");
+    let port = listener
+        .local_addr()
+        .expect("stream navigation server should have an address")
+        .port();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buffer = vec![0u8; 4096];
+                let Ok(size) = stream.read(&mut buffer).await else {
+                    return;
+                };
+                let request = String::from_utf8_lossy(&buffer[..size]);
+                let request_target = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                let path = request_target.split('?').next().unwrap_or("/");
+                if let Some(destination) = path.strip_prefix("/redirect/") {
+                    let location = format!("/landed/{destination}");
+                    let response = format!(
+                        "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    return;
+                }
+                let body = match path {
+                    "/child" => {
+                        "<!doctype html><title>child</title><p id=\"child\">child</p>"
+                    }
+                    _ => {
+                        "<!doctype html><title>main</title><a id=\"anchor\" href=\"#section\">anchor</a><div id=\"section\">section</div><iframe id=\"child\" src=\"/child\"></iframe>"
+                    }
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    (format!("http://127.0.0.1:{port}"), handle)
+}
+
+async fn next_stream_url(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> String {
+    loop {
+        let message = tokio::time::timeout(tokio::time::Duration::from_secs(5), ws.next())
+            .await
+            .expect("stream should emit a URL message")
+            .expect("stream should stay open")
+            .expect("stream message should be valid");
+        if !message.is_text() {
+            continue;
+        }
+        let payload: Value =
+            serde_json::from_str(message.to_text().expect("message should be text"))
+                .expect("stream payload should be JSON");
+        if payload["type"] == "url" {
+            return payload["url"]
+                .as_str()
+                .expect("URL message should carry a URL")
+                .to_string();
+        }
+    }
+}
+
+async fn expect_no_stream_url(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    duration: tokio::time::Duration,
+) {
+    let deadline = tokio::time::Instant::now() + duration;
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let result = tokio::time::timeout(remaining, ws.next()).await;
+        let Ok(Some(Ok(message))) = result else {
+            return;
+        };
+        if !message.is_text() {
+            continue;
+        }
+        let payload: Value =
+            serde_json::from_str(message.to_text().expect("message should be text"))
+                .expect("stream payload should be JSON");
+        assert_ne!(
+            payload["type"], "url",
+            "unexpected background or child URL: {payload}"
+        );
+    }
+}
+
+async fn next_collected_stream_message(
+    messages: &mut tokio::sync::mpsc::UnboundedReceiver<Value>,
+    iteration: usize,
+    phase: &str,
+) -> Value {
+    tokio::time::timeout(tokio::time::Duration::from_secs(5), messages.recv())
+        .await
+        .unwrap_or_else(|_| panic!("stress iteration {iteration} timed out during {phase}"))
+        .unwrap_or_else(|| {
+            panic!("stress iteration {iteration} stream collector stopped during {phase}")
+        })
+}
+
+async fn wait_for_active_stream_tab(
+    messages: &mut tokio::sync::mpsc::UnboundedReceiver<Value>,
+    tab_id: &str,
+    iteration: usize,
+) {
+    loop {
+        let payload =
+            next_collected_stream_message(messages, iteration, "active-tab stream rebind").await;
+        if payload["type"] != "tabs" {
+            continue;
+        }
+        let is_active = payload["tabs"].as_array().is_some_and(|tabs| {
+            tabs.iter()
+                .any(|tab| tab["tabId"] == tab_id && tab["active"].as_bool() == Some(true))
+        });
+        if is_active {
+            return;
+        }
+    }
+}
+
+async fn wait_for_stress_stream_url(
+    messages: &mut tokio::sync::mpsc::UnboundedReceiver<Value>,
+    expected_url: &str,
+    forbidden_marker: &str,
+    iteration: usize,
+) {
+    loop {
+        let payload =
+            next_collected_stream_message(messages, iteration, "active URL convergence").await;
+        if payload["type"] != "url" {
+            continue;
+        }
+        let url = payload["url"]
+            .as_str()
+            .expect("stress URL payload should contain a URL");
+        assert!(
+            !url.contains(forbidden_marker),
+            "stress iteration {iteration} attributed the previous tab URL to the new active tab: {payload}"
+        );
+        if url == expected_url {
+            return;
+        }
+    }
+}
+
+async fn expect_no_forbidden_stream_url(
+    messages: &mut tokio::sync::mpsc::UnboundedReceiver<Value>,
+    forbidden_marker: &str,
+    iteration: usize,
+) {
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(100);
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let Ok(Some(payload)) = tokio::time::timeout(remaining, messages.recv()).await else {
+            return;
+        };
+        if payload["type"] != "url" {
+            continue;
+        }
+        let url = payload["url"]
+            .as_str()
+            .expect("stress URL payload should contain a URL");
+        assert!(
+            !url.contains(forbidden_marker),
+            "stress iteration {iteration} emitted a forbidden URL after convergence: {payload}"
+        );
+    }
+}
+
+async fn seeded_stream_tabs(port: u64, iteration: usize) -> Vec<Value> {
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("stress probe should connect to runtime stream");
+    loop {
+        let message = tokio::time::timeout(tokio::time::Duration::from_secs(5), ws.next())
+            .await
+            .unwrap_or_else(|_| {
+                panic!("stress iteration {iteration} probe timed out waiting for tabs")
+            })
+            .expect("stress probe stream should stay open")
+            .expect("stress probe message should be valid");
+        if !message.is_text() {
+            continue;
+        }
+        let payload: Value =
+            serde_json::from_str(message.to_text().expect("probe message should be text"))
+                .expect("probe stream payload should be JSON");
+        if payload["type"] == "tabs" {
+            return payload["tabs"]
+                .as_array()
+                .expect("probe tabs payload should be an array")
+                .clone();
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_stream_url_tracks_active_main_frame_navigation_categories() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+    let socket_dir = std::env::temp_dir().join(format!(
+        "agent-browser-e2e-stream-url-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&socket_dir).expect("socket dir should be created");
+    guard.set(
+        "AGENT_BROWSER_SOCKET_DIR",
+        socket_dir.to_str().expect("socket dir should be utf-8"),
+    );
+    guard.set("AGENT_BROWSER_SESSION", "e2e-stream-url");
+
+    let (base_url, server) = start_stream_navigation_server().await;
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "stream_enable", "port": 0 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let port = get_data(&resp)["port"]
+        .as_u64()
+        .expect("stream enable should report the bound port");
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("{base_url}/") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("websocket client should connect to runtime stream");
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(5), ws.next()).await;
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "history.pushState({}, '', '/spa'); location.href"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(next_stream_url(&mut ws).await, format!("{base_url}/spa"));
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "location.hash = 'section'; location.href"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        next_stream_url(&mut ws).await,
+        format!("{base_url}/spa#section")
+    );
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "evaluate",
+            "script": "document.querySelector('#child').contentWindow.history.pushState({}, '', '/child-spa'); 'done'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    expect_no_stream_url(&mut ws, tokio::time::Duration::from_millis(500)).await;
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "navigate", "url": format!("{base_url}/full") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(next_stream_url(&mut ws).await, format!("{base_url}/full"));
+
+    let resp = execute_command(
+        &json!({
+            "id": "7",
+            "action": "tab_new",
+            "url": format!("{base_url}/")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let background_session = state
+        .browser
+        .as_ref()
+        .expect("browser should exist")
+        .pages_list()
+        .into_iter()
+        .find(|page| page.tab_id == 2)
+        .expect("background tab should exist")
+        .session_id;
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    while tokio::time::timeout(tokio::time::Duration::from_millis(100), ws.next())
+        .await
+        .is_ok()
+    {}
+
+    let resp = execute_command(
+        &json!({
+            "id": "9",
+            "action": "evaluate",
+            "script": "history.pushState({}, '', '/after-switch'); location.href"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        next_stream_url(&mut ws).await,
+        format!("{base_url}/after-switch")
+    );
+
+    state
+        .browser
+        .as_ref()
+        .expect("browser should exist")
+        .client
+        .send_command(
+            "Page.navigate",
+            Some(json!({ "url": format!("{base_url}/background-full") })),
+            Some(&background_session),
+        )
+        .await
+        .expect("background tab should navigate");
+    expect_no_stream_url(&mut ws, tokio::time::Duration::from_millis(500)).await;
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
+    let _ = std::fs::remove_dir_all(&socket_dir);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_lightpanda_stream_url_tracks_active_full_navigation() {
+    let lightpanda_bin = match std::env::var("LIGHTPANDA_BIN") {
+        Ok(path) if !path.is_empty() => path,
+        _ => return,
+    };
+    let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+    let socket_dir = std::env::temp_dir().join(format!(
+        "agent-browser-e2e-lightpanda-stream-url-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&socket_dir).expect("socket dir should be created");
+    guard.set(
+        "AGENT_BROWSER_SOCKET_DIR",
+        socket_dir.to_str().expect("socket dir should be utf-8"),
+    );
+    guard.set("AGENT_BROWSER_SESSION", "e2e-lightpanda-stream-url");
+
+    let (base_url, server) = start_stream_navigation_server().await;
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "lp-stream", "action": "stream_enable", "port": 0 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let port = get_data(&resp)["port"]
+        .as_u64()
+        .expect("stream enable should report the bound port");
+
+    let resp = tokio::time::timeout(
+        tokio::time::Duration::from_secs(20),
+        execute_command(
+            &json!({
+                "id": "lp-launch",
+                "action": "launch",
+                "headless": true,
+                "engine": "lightpanda",
+                "executablePath": lightpanda_bin
+            }),
+            &mut state,
+        ),
+    )
+    .await
+    .expect("Lightpanda stream launch should not hang");
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "lp-initial",
+            "action": "navigate",
+            "url": format!("{base_url}/lp-initial")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("Lightpanda stream client should connect");
+    while tokio::time::timeout(tokio::time::Duration::from_millis(100), ws.next())
+        .await
+        .is_ok()
+    {}
+
+    let active_before_background = format!("{base_url}/lp-active-before-background");
+    let resp = execute_command(
+        &json!({
+            "id": "lp-active-before",
+            "action": "navigate",
+            "url": active_before_background
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(next_stream_url(&mut ws).await, active_before_background);
+
+    let resp = execute_command(
+        &json!({
+            "id": "lp-child-navigation",
+            "action": "evaluate",
+            "script": "document.querySelector('#child').src = '/lp-forbidden-child'; 'done'"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    expect_no_stream_url(&mut ws, tokio::time::Duration::from_millis(500)).await;
+
+    let tabs = seeded_stream_tabs(port, 0).await;
+    let active = tabs
+        .iter()
+        .find(|tab| tab["active"].as_bool() == Some(true))
+        .expect("Lightpanda reconnect should seed an active tab");
+    assert_eq!(active["tabId"], "t1");
+    assert_eq!(active["url"], active_before_background);
+
+    let final_url = format!("{base_url}/lp-active-final");
+    let resp = execute_command(
+        &json!({
+            "id": "lp-active-final",
+            "action": "navigate",
+            "url": final_url
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(next_stream_url(&mut ws).await, final_url);
+
+    let resp = execute_command(&json!({ "id": "lp-close", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+    server.abort();
+    let _ = std::fs::remove_dir_all(&socket_dir);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_stream_url_survives_real_world_navigation_stress() {
+    let guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+    let socket_dir = std::env::temp_dir().join(format!(
+        "agent-browser-e2e-stream-url-stress-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&socket_dir).expect("socket dir should be created");
+    guard.set(
+        "AGENT_BROWSER_SOCKET_DIR",
+        socket_dir.to_str().expect("socket dir should be utf-8"),
+    );
+    guard.set("AGENT_BROWSER_SESSION", "e2e-stream-url-stress");
+
+    let iterations = std::env::var("AGENT_BROWSER_STRESS_ITERATIONS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(40);
+    let mut seed = std::env::var("AGENT_BROWSER_STRESS_SEED")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(1677);
+
+    let (base_url, server) = start_stream_navigation_server().await;
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "stress-stream", "action": "stream_enable", "port": 0 }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let port = get_data(&resp)["port"]
+        .as_u64()
+        .expect("stream enable should report the bound port");
+
+    let resp = execute_command(
+        &json!({
+            "id": "stress-tab-a",
+            "action": "navigate",
+            "url": format!("{base_url}/app-a")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "stress-tab-b",
+            "action": "tab_new",
+            "url": format!("{base_url}/app-b")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let pages = state
+        .browser
+        .as_ref()
+        .expect("stress browser should exist")
+        .pages_list();
+    let session_a = pages
+        .iter()
+        .find(|page| page.tab_id == 1)
+        .expect("stress tab A should exist")
+        .session_id
+        .clone();
+    let session_b = pages
+        .iter()
+        .find(|page| page.tab_id == 2)
+        .expect("stress tab B should exist")
+        .session_id
+        .clone();
+    let client = Arc::clone(
+        &state
+            .browser
+            .as_ref()
+            .expect("stress browser should exist")
+            .client,
+    );
+
+    let (fast_ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("stress collector should connect to runtime stream");
+    let (message_tx, mut messages) = tokio::sync::mpsc::unbounded_channel::<Value>();
+    let collector = tokio::spawn(async move {
+        let mut ws = fast_ws;
+        while let Some(Ok(message)) = ws.next().await {
+            if !message.is_text() {
+                continue;
+            }
+            let Ok(payload) = serde_json::from_str::<Value>(
+                message.to_text().expect("collector message should be text"),
+            ) else {
+                continue;
+            };
+            if message_tx.send(payload).is_err() {
+                break;
+            }
+        }
+    });
+    wait_for_active_stream_tab(&mut messages, "t2", 0).await;
+
+    let (mut slow_ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("slow stress client should connect to runtime stream");
+
+    let mut active_tab = "t2";
+    for iteration in 0..iterations {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let delay_ms = 1 + (seed % 12);
+        let target_tab = if active_tab == "t1" { "t2" } else { "t1" };
+        let old_session = if active_tab == "t1" {
+            session_a.clone()
+        } else {
+            session_b.clone()
+        };
+        let forbidden_marker = format!("forbidden-{iteration}");
+        let same_document_path = format!("/{forbidden_marker}-old-spa");
+        let redirect_url = format!("{base_url}/redirect/{forbidden_marker}-old-full");
+
+        let late_client = Arc::clone(&client);
+        let late_session = old_session.clone();
+        let late_same_document_path = same_document_path.clone();
+        let late_child_marker = forbidden_marker.clone();
+        let late_same_document = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+            let expression = format!(
+                "history.pushState({{}}, '', {}); const child = document.querySelector('#child'); if (child?.contentWindow) child.contentWindow.history.pushState({{}}, '', '/{late_child_marker}-old-child'); location.href",
+                serde_json::to_string(&late_same_document_path)
+                    .expect("stress path should serialize")
+            );
+            late_client
+                .send_command(
+                    "Runtime.evaluate",
+                    Some(json!({ "expression": expression })),
+                    Some(&late_session),
+                )
+                .await
+        });
+
+        let redirect_client = Arc::clone(&client);
+        let redirect_session = old_session.clone();
+        let late_redirect = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms + 1)).await;
+            redirect_client
+                .send_command(
+                    "Page.navigate",
+                    Some(json!({ "url": redirect_url })),
+                    Some(&redirect_session),
+                )
+                .await
+        });
+
+        let resp = execute_command(
+            &json!({
+                "id": format!("stress-switch-{iteration}"),
+                "action": "tab_switch",
+                "tabId": target_tab
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        wait_for_active_stream_tab(&mut messages, target_tab, iteration).await;
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), late_same_document)
+            .await
+            .unwrap_or_else(|_| panic!("stress iteration {iteration} late SPA task timed out"))
+            .expect("late SPA task should join")
+            .expect("late SPA CDP command should succeed");
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), late_redirect)
+            .await
+            .unwrap_or_else(|_| panic!("stress iteration {iteration} late redirect task timed out"))
+            .expect("late redirect task should join")
+            .expect("late redirect CDP command should succeed");
+
+        let resp = execute_command(
+            &json!({
+                "id": format!("stress-child-{iteration}"),
+                "action": "evaluate",
+                "script": format!(
+                    "const child = document.querySelector('#child'); if (!child?.contentWindow) throw new Error('missing stress iframe'); child.contentWindow.history.pushState({{}}, '', '/{forbidden_marker}-active-child'); 'done'"
+                )
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+
+        let expected_url = format!("{base_url}/{target_tab}-active-{iteration}");
+        let resp = execute_command(
+            &json!({
+                "id": format!("stress-active-{iteration}"),
+                "action": "evaluate",
+                "script": format!(
+                    "history.replaceState({{}}, '', {}); location.href",
+                    serde_json::to_string(&expected_url).expect("stress URL should serialize")
+                )
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        wait_for_stress_stream_url(&mut messages, &expected_url, &forbidden_marker, iteration)
+            .await;
+
+        let resp = execute_command(
+            &json!({ "id": format!("stress-url-{iteration}"), "action": "url" }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        assert_eq!(
+            get_data(&resp)["url"],
+            expected_url,
+            "stress iteration {iteration} active browser URL diverged"
+        );
+        expect_no_forbidden_stream_url(&mut messages, &forbidden_marker, iteration).await;
+
+        if iteration % 5 == 0 {
+            let tabs = seeded_stream_tabs(port, iteration).await;
+            let active = tabs
+                .iter()
+                .find(|tab| tab["active"].as_bool() == Some(true))
+                .unwrap_or_else(|| {
+                    panic!("stress iteration {iteration} reconnect had no active tab")
+                });
+            assert_eq!(
+                active["tabId"], target_tab,
+                "stress iteration {iteration} reconnect seeded the wrong active tab"
+            );
+            assert_eq!(
+                active["url"], expected_url,
+                "stress iteration {iteration} reconnect seeded a stale URL"
+            );
+        }
+
+        if iteration % 7 == 6 {
+            drop(slow_ws);
+            let (replacement, _) =
+                tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+                    .await
+                    .expect("replacement slow stress client should connect");
+            slow_ws = replacement;
+        }
+
+        active_tab = target_tab;
+    }
+
+    drop(slow_ws);
+    collector.abort();
+    let resp = execute_command(
+        &json!({ "id": "stress-close", "action": "close" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    server.abort();
+    let _ = std::fs::remove_dir_all(&socket_dir);
+}
+
+// ---------------------------------------------------------------------------
 // Stream: custom viewport is reflected in screencast frame metadata
 // ---------------------------------------------------------------------------
 

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
+use std::collections::VecDeque;
 use std::sync::Arc;
 
+use futures_util::FutureExt;
 use tokio::sync::{broadcast, watch, Mutex, RwLock};
 
 use crate::native::cdp::client::CdpClient;
@@ -21,10 +23,77 @@ fn frame_timestamp_ms(meta: Option<&Value>) -> u64 {
         .unwrap_or(0)
 }
 
-/// Background task that subscribes to CDP events and broadcasts screencast frames in real-time.
-/// Also handles auto-start/stop of screencast based on WebSocket client count.
-/// Frames go through `frame_watch` (latest value wins) while every other
-/// message type stays on the ordered `frame_tx` broadcast channel.
+fn session_matches(active_session: Option<&str>, event_session: Option<&str>) -> bool {
+    match active_session {
+        Some("") => event_session.is_none_or(str::is_empty),
+        Some(active) => event_session == Some(active),
+        None => false,
+    }
+}
+
+fn main_frame_id(frame_tree: &Value) -> Option<String> {
+    frame_tree
+        .get("frameTree")
+        .and_then(|tree| tree.get("frame"))
+        .and_then(|frame| frame.get("id"))
+        .and_then(Value::as_str)
+        .map(String::from)
+}
+
+async fn seed_main_frame_id(
+    client: Arc<CdpClient>,
+    session_id: Option<String>,
+    delay: std::time::Duration,
+    enabled: bool,
+) -> Option<String> {
+    if !enabled {
+        std::future::pending::<()>().await;
+    }
+    tokio::time::sleep(delay).await;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        client.send_command_no_params("Page.getFrameTree", session_id.as_deref()),
+    )
+    .await
+    .ok()
+    .and_then(Result::ok)
+    .and_then(|tree| main_frame_id(&tree))
+}
+
+async fn publish_url(
+    frame_tx: &broadcast::Sender<String>,
+    last_tabs: &RwLock<Vec<Value>>,
+    cdp_session_id: &RwLock<Option<String>>,
+    event_session_id: Option<&str>,
+    url: &str,
+) {
+    let active_session = cdp_session_id.read().await;
+    if !session_matches(active_session.as_deref(), event_session_id) {
+        return;
+    }
+    {
+        let mut tabs = last_tabs.write().await;
+        for tab in tabs.iter_mut() {
+            if tab.get("active").and_then(Value::as_bool).unwrap_or(false) {
+                if let Some(tab) = tab.as_object_mut() {
+                    tab.insert("url".to_string(), json!(url));
+                }
+            }
+        }
+    }
+    let message = json!({
+        "type": "url",
+        "url": url,
+        "timestamp": timestamp_ms(),
+    });
+    let _ = frame_tx.send(message.to_string());
+}
+
+/// Subscribes to the active page's CDP events and broadcasts stream updates.
+///
+/// Frames use `frame_watch` so the latest value wins. Other messages stay on
+/// the ordered `frame_tx` channel. URL updates follow only the active main
+/// frame. Chrome also includes History API and fragment navigation.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn cdp_event_loop(
     frame_tx: broadcast::Sender<String>,
@@ -77,7 +146,9 @@ pub(super) async fn cdp_event_loop(
                 let vh = *viewport_height.lock().await;
 
                 let eng = last_engine.read().await.clone();
-                let supports_screencast = eng == "chrome";
+                let is_chrome = eng == "chrome";
+                let supports_screencast = is_chrome;
+                let supports_same_document_navigation = is_chrome;
 
                 if supports_screencast {
                     let _ = client_arc
@@ -112,8 +183,53 @@ pub(super) async fn cdp_event_loop(
                 });
                 let _ = frame_tx.send(status.to_string());
 
+                let frame_tree_seed = seed_main_frame_id(
+                    Arc::clone(&client_arc),
+                    session_id.clone(),
+                    std::time::Duration::ZERO,
+                    supports_same_document_navigation,
+                )
+                .fuse();
+                tokio::pin!(frame_tree_seed);
+                let mut seed_in_flight = supports_same_document_navigation;
+                let mut active_main_frame_id = None;
+                let mut pending_same_document = VecDeque::<(Option<String>, String, String)>::new();
+
                 loop {
                     tokio::select! {
+                        seeded_frame_id = &mut frame_tree_seed => {
+                            seed_in_flight = false;
+                            if active_main_frame_id.is_none() {
+                                active_main_frame_id = seeded_frame_id;
+                            }
+                            if let Some(main_frame_id) = active_main_frame_id.as_deref() {
+                                for (event_session_id, frame_id, url) in
+                                    pending_same_document.drain(..)
+                                {
+                                    if frame_id == main_frame_id {
+                                        publish_url(
+                                            &frame_tx,
+                                            &last_tabs,
+                                            &cdp_session_id,
+                                            event_session_id.as_deref(),
+                                            &url,
+                                        )
+                                        .await;
+                                    }
+                                }
+                            } else if !pending_same_document.is_empty() {
+                                frame_tree_seed.set(
+                                    seed_main_frame_id(
+                                        Arc::clone(&client_arc),
+                                        session_id.clone(),
+                                        std::time::Duration::from_millis(250),
+                                        true,
+                                    )
+                                    .fuse(),
+                                );
+                                seed_in_flight = true;
+                            }
+                        }
                         changed = shutdown_rx.changed() => {
                             if changed.is_err() || *shutdown_rx.borrow() {
                                 if supports_screencast {
@@ -136,22 +252,74 @@ pub(super) async fn cdp_event_loop(
                                                 .get("parentId")
                                                 .and_then(|v| v.as_str())
                                                 .is_none_or(|s| s.is_empty());
-                                            if is_main {
+                                            let is_active_session = session_matches(
+                                                session_id.as_deref(),
+                                                evt.session_id.as_deref(),
+                                            );
+                                            if is_main && is_active_session {
+                                                if supports_screencast {
+                                                    pending_same_document.clear();
+                                                    active_main_frame_id = frame
+                                                        .get("id")
+                                                        .and_then(Value::as_str)
+                                                        .map(String::from);
+                                                }
                                                 if let Some(url) = frame.get("url").and_then(|v| v.as_str()) {
-                                                    {
-                                                        let mut tabs = last_tabs.write().await;
-                                                        for tab in tabs.iter_mut() {
-                                                            if tab.get("active").and_then(|v| v.as_bool()).unwrap_or(false) {
-                                                                tab.as_object_mut().map(|o| o.insert("url".to_string(), json!(url)));
-                                                            }
-                                                        }
+                                                    publish_url(
+                                                        &frame_tx,
+                                                        &last_tabs,
+                                                        &cdp_session_id,
+                                                        evt.session_id.as_deref(),
+                                                        url,
+                                                    )
+                                                    .await;
+                                                }
+                                            }
+                                        }
+                                    } else if evt.method == "Page.navigatedWithinDocument" {
+                                        let is_active_session = supports_same_document_navigation
+                                            && session_matches(
+                                                session_id.as_deref(),
+                                                evt.session_id.as_deref(),
+                                            );
+                                        if is_active_session {
+                                            if let (Some(frame_id), Some(url)) = (
+                                                evt.params.get("frameId").and_then(Value::as_str),
+                                                evt.params.get("url").and_then(Value::as_str),
+                                            ) {
+                                                if active_main_frame_id.is_none() {
+                                                    if pending_same_document.len() == 64 {
+                                                        pending_same_document.pop_front();
                                                     }
-                                                    let msg = json!({
-                                                        "type": "url",
-                                                        "url": url,
-                                                        "timestamp": timestamp_ms(),
-                                                    });
-                                                    let _ = frame_tx.send(msg.to_string());
+                                                    pending_same_document
+                                                        .push_back((
+                                                            evt.session_id.clone(),
+                                                            frame_id.to_string(),
+                                                            url.to_string(),
+                                                        ));
+                                                    if !seed_in_flight {
+                                                        frame_tree_seed.set(
+                                                            seed_main_frame_id(
+                                                                Arc::clone(&client_arc),
+                                                                session_id.clone(),
+                                                                std::time::Duration::ZERO,
+                                                                true,
+                                                            )
+                                                            .fuse(),
+                                                        );
+                                                        seed_in_flight = true;
+                                                    }
+                                                } else if Some(frame_id)
+                                                    == active_main_frame_id.as_deref()
+                                                {
+                                                    publish_url(
+                                                        &frame_tx,
+                                                        &last_tabs,
+                                                        &cdp_session_id,
+                                                        evt.session_id.as_deref(),
+                                                        url,
+                                                    )
+                                                    .await;
                                                 }
                                             }
                                         }
@@ -345,6 +513,307 @@ pub async fn ack_screencast_frame(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use tokio::sync::mpsc;
+    use tokio_tungstenite::tungstenite::Message;
+
+    async fn mock_cdp_with_seed_delay(
+        main_frame_id: &str,
+        seed_delay: std::time::Duration,
+    ) -> (
+        Arc<CdpClient>,
+        mpsc::UnboundedSender<Value>,
+        Arc<Mutex<Vec<String>>>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!(
+            "ws://127.0.0.1:{}/devtools/browser/mock",
+            listener.local_addr().unwrap().port()
+        );
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Value>();
+        let methods = Arc::new(Mutex::new(Vec::new()));
+        let recorded = methods.clone();
+        let frame_id = main_frame_id.to_string();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut tx, mut rx) = ws.split();
+
+            loop {
+                tokio::select! {
+                    message = rx.next() => {
+                        let Some(Ok(Message::Text(text))) = message else {
+                            break;
+                        };
+                        let command: Value = serde_json::from_str(&text).unwrap();
+                        let id = command["id"].as_u64().unwrap();
+                        let method = command["method"].as_str().unwrap();
+                        recorded.lock().await.push(method.to_string());
+                        let result = if method == "Page.getFrameTree" {
+                            let delay = tokio::time::sleep(seed_delay);
+                            tokio::pin!(delay);
+                            loop {
+                                tokio::select! {
+                                    _ = &mut delay => break,
+                                    event = event_rx.recv() => {
+                                        let Some(event) = event else {
+                                            break;
+                                        };
+                                        tx.send(Message::Text(event.to_string())).await.unwrap();
+                                    }
+                                }
+                            }
+                            json!({ "frameTree": { "frame": { "id": frame_id } } })
+                        } else {
+                            json!({})
+                        };
+                        tx.send(Message::Text(json!({ "id": id, "result": result }).to_string()))
+                            .await
+                            .unwrap();
+                    }
+                    event = event_rx.recv() => {
+                        let Some(event) = event else {
+                            break;
+                        };
+                        tx.send(Message::Text(event.to_string())).await.unwrap();
+                    }
+                }
+            }
+        });
+
+        let client = Arc::new(CdpClient::connect(&url).await.unwrap());
+        (client, event_tx, methods)
+    }
+
+    async fn mock_cdp(
+        main_frame_id: &str,
+    ) -> (
+        Arc<CdpClient>,
+        mpsc::UnboundedSender<Value>,
+        Arc<Mutex<Vec<String>>>,
+    ) {
+        mock_cdp_with_seed_delay(main_frame_id, std::time::Duration::ZERO).await
+    }
+
+    async fn mock_cdp_with_first_seed_timeout(
+        main_frame_id: &str,
+    ) -> (
+        Arc<CdpClient>,
+        mpsc::UnboundedSender<Value>,
+        Arc<Mutex<Vec<String>>>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!(
+            "ws://127.0.0.1:{}/devtools/browser/retry",
+            listener.local_addr().unwrap().port()
+        );
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Value>();
+        let methods = Arc::new(Mutex::new(Vec::new()));
+        let recorded = methods.clone();
+        let frame_id = main_frame_id.to_string();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut tx, mut rx) = ws.split();
+            let mut frame_tree_requests = 0;
+
+            loop {
+                tokio::select! {
+                    message = rx.next() => {
+                        let Some(Ok(Message::Text(text))) = message else {
+                            break;
+                        };
+                        let command: Value = serde_json::from_str(&text).unwrap();
+                        let id = command["id"].as_u64().unwrap();
+                        let method = command["method"].as_str().unwrap();
+                        recorded.lock().await.push(method.to_string());
+                        if method == "Page.getFrameTree" {
+                            frame_tree_requests += 1;
+                            if frame_tree_requests == 1 {
+                                continue;
+                            }
+                            tx.send(Message::Text(json!({
+                                "id": id,
+                                "result": { "frameTree": { "frame": { "id": frame_id } } }
+                            }).to_string()))
+                            .await
+                            .unwrap();
+                        } else {
+                            tx.send(Message::Text(json!({ "id": id, "result": {} }).to_string()))
+                                .await
+                                .unwrap();
+                        }
+                    }
+                    event = event_rx.recv() => {
+                        let Some(event) = event else {
+                            break;
+                        };
+                        tx.send(Message::Text(event.to_string())).await.unwrap();
+                    }
+                }
+            }
+        });
+
+        let client = Arc::new(CdpClient::connect(&url).await.unwrap());
+        (client, event_tx, methods)
+    }
+
+    async fn silent_frame_tree_cdp() -> Arc<CdpClient> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!(
+            "ws://127.0.0.1:{}/devtools/browser/silent",
+            listener.local_addr().unwrap().port()
+        );
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut tx, mut rx) = ws.split();
+            while let Some(Ok(message)) = rx.next().await {
+                match message {
+                    Message::Text(text) => {
+                        let command: Value = serde_json::from_str(&text).unwrap();
+                        let method = command["method"].as_str().unwrap();
+                        if method != "Page.getFrameTree" {
+                            let id = command["id"].as_u64().unwrap();
+                            tx.send(Message::Text(json!({ "id": id, "result": {} }).to_string()))
+                                .await
+                                .unwrap();
+                        }
+                    }
+                    Message::Ping(payload) => {
+                        tx.send(Message::Pong(payload)).await.unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        });
+        Arc::new(CdpClient::connect(&url).await.unwrap())
+    }
+
+    struct LoopHarness {
+        events: mpsc::UnboundedSender<Value>,
+        messages: broadcast::Receiver<String>,
+        last_tabs: Arc<RwLock<Vec<Value>>>,
+        cdp_session_id: Arc<RwLock<Option<String>>>,
+        shutdown: watch::Sender<bool>,
+        task: tokio::task::JoinHandle<()>,
+        methods: Arc<Mutex<Vec<String>>>,
+    }
+
+    async fn start_loop_with_seed_delay(
+        active_session: Option<&str>,
+        main_frame_id: &str,
+        seed_delay: std::time::Duration,
+    ) -> LoopHarness {
+        let (client, events, methods) = mock_cdp_with_seed_delay(main_frame_id, seed_delay).await;
+        start_loop_with_client(active_session, client, events, methods).await
+    }
+
+    async fn start_loop_with_client(
+        active_session: Option<&str>,
+        client: Arc<CdpClient>,
+        events: mpsc::UnboundedSender<Value>,
+        methods: Arc<Mutex<Vec<String>>>,
+    ) -> LoopHarness {
+        start_loop_with_client_and_engine(active_session, client, events, methods, "chrome").await
+    }
+
+    async fn start_loop_with_client_and_engine(
+        active_session: Option<&str>,
+        client: Arc<CdpClient>,
+        events: mpsc::UnboundedSender<Value>,
+        methods: Arc<Mutex<Vec<String>>>,
+        engine: &str,
+    ) -> LoopHarness {
+        let (frame_tx, messages) = broadcast::channel(64);
+        let (frame_watch, _) = watch::channel(None);
+        let client_slot = Arc::new(RwLock::new(Some(client)));
+        let client_notify = Arc::new(tokio::sync::Notify::new());
+        let client_count = Arc::new(Mutex::new(1));
+        let cdp_session_id = Arc::new(RwLock::new(active_session.map(String::from)));
+        let last_tabs = Arc::new(RwLock::new(vec![
+            json!({ "tabId": "t1", "url": "https://active.test/", "active": true }),
+            json!({ "tabId": "t2", "url": "https://background.test/", "active": false }),
+        ]));
+        let (shutdown, shutdown_rx) = watch::channel(false);
+        let task = tokio::spawn(cdp_event_loop(
+            frame_tx,
+            frame_watch,
+            Arc::new(super::super::ScreencastConfig::default()),
+            client_slot,
+            client_notify.clone(),
+            Arc::new(Mutex::new(false)),
+            client_count,
+            cdp_session_id.clone(),
+            Arc::new(Mutex::new(1280)),
+            Arc::new(Mutex::new(720)),
+            last_tabs.clone(),
+            Arc::new(RwLock::new(engine.to_string())),
+            Arc::new(Mutex::new(false)),
+            shutdown_rx,
+        ));
+        client_notify.notify_one();
+
+        LoopHarness {
+            events,
+            messages,
+            last_tabs,
+            cdp_session_id,
+            shutdown,
+            task,
+            methods,
+        }
+    }
+
+    async fn start_loop(active_session: Option<&str>, main_frame_id: &str) -> LoopHarness {
+        start_loop_with_seed_delay(active_session, main_frame_id, std::time::Duration::ZERO).await
+    }
+
+    async fn next_message_of_type(messages: &mut broadcast::Receiver<String>, kind: &str) -> Value {
+        loop {
+            let text = tokio::time::timeout(std::time::Duration::from_secs(5), messages.recv())
+                .await
+                .expect("timed out waiting for stream message")
+                .expect("stream channel closed");
+            let message: Value = serde_json::from_str(&text).unwrap();
+            if message["type"] == kind {
+                return message;
+            }
+        }
+    }
+
+    async fn expect_no_url(messages: &mut broadcast::Receiver<String>) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(250);
+        while tokio::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let result = tokio::time::timeout(remaining, messages.recv()).await;
+            let Ok(Ok(text)) = result else {
+                return;
+            };
+            let message: Value = serde_json::from_str(&text).unwrap();
+            assert_ne!(message["type"], "url", "unexpected URL message: {message}");
+        }
+    }
+
+    async fn stop_loop(harness: LoopHarness) {
+        let _ = harness.shutdown.send(true);
+        harness.task.await.unwrap();
+    }
+
+    async fn wait_for_method(methods: &Mutex<Vec<String>>, expected: &str) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if methods.lock().await.iter().any(|method| method == expected) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("timed out waiting for CDP method");
+    }
 
     /// Reading the float as an integer stamps every frame 0, so no client can
     /// measure frame age.
@@ -360,5 +829,370 @@ mod tests {
         assert_eq!(frame_timestamp_ms(Some(&json!({}))), 0);
         assert_eq!(frame_timestamp_ms(Some(&json!({ "timestamp": 0 }))), 0);
         assert_eq!(frame_timestamp_ms(Some(&json!({ "timestamp": "nope" }))), 0);
+    }
+
+    #[tokio::test]
+    async fn test_same_document_navigation_tracks_active_main_frame_and_ignores_child() {
+        let mut harness = start_loop(Some("S-ACTIVE"), "F-MAIN").await;
+        next_message_of_type(&mut harness.messages, "status").await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frameId": "F-MAIN",
+                    "url": "https://active.test/spa",
+                    "navigationType": "historyApi"
+                }
+            }))
+            .unwrap();
+        let history = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(history["url"], "https://active.test/spa");
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frameId": "F-MAIN",
+                    "url": "https://active.test/spa#section",
+                    "navigationType": "fragment"
+                }
+            }))
+            .unwrap();
+        let fragment = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(fragment["url"], "https://active.test/spa#section");
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frameId": "F-CHILD",
+                    "url": "https://active.test/child",
+                    "navigationType": "historyApi"
+                }
+            }))
+            .unwrap();
+        expect_no_url(&mut harness.messages).await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "sessionId": "S-BACKGROUND",
+                "params": {
+                    "frameId": "F-BACKGROUND",
+                    "url": "https://background.test/spa",
+                    "navigationType": "historyApi"
+                }
+            }))
+            .unwrap();
+        expect_no_url(&mut harness.messages).await;
+        assert_eq!(
+            harness.last_tabs.read().await[0]["url"],
+            "https://active.test/spa#section"
+        );
+        assert!(harness
+            .methods
+            .lock()
+            .await
+            .iter()
+            .any(|method| method == "Page.getFrameTree"));
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_lightpanda_background_full_navigation_does_not_replace_active_url() {
+        let (client, events, methods) = mock_cdp("F-MAIN").await;
+        let mut harness = start_loop_with_client_and_engine(
+            Some("S-ACTIVE"),
+            client,
+            events,
+            methods,
+            "lightpanda",
+        )
+        .await;
+        next_message_of_type(&mut harness.messages, "status").await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.frameNavigated",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frame": {
+                        "id": "F-MAIN",
+                        "url": "https://active.test/full"
+                    }
+                }
+            }))
+            .unwrap();
+        let active = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(active["url"], "https://active.test/full");
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.frameNavigated",
+                "sessionId": "S-BACKGROUND",
+                "params": {
+                    "frame": {
+                        "id": "F-BACKGROUND",
+                        "url": "https://background.test/changed"
+                    }
+                }
+            }))
+            .unwrap();
+        expect_no_url(&mut harness.messages).await;
+        assert_eq!(
+            harness.last_tabs.read().await[0]["url"],
+            "https://active.test/full"
+        );
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_old_session_event_cannot_replace_new_active_tab_url() {
+        let mut harness = start_loop(Some("S-OLD"), "F-OLD").await;
+        next_message_of_type(&mut harness.messages, "status").await;
+
+        {
+            let mut session = harness.cdp_session_id.write().await;
+            let mut tabs = harness.last_tabs.write().await;
+            *session = Some("S-NEW".to_string());
+            *tabs = vec![
+                json!({ "tabId": "t1", "url": "https://old.test/", "active": false }),
+                json!({ "tabId": "t2", "url": "https://new.test/", "active": true }),
+            ];
+        }
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.frameNavigated",
+                "sessionId": "S-OLD",
+                "params": {
+                    "frame": {
+                        "id": "F-OLD",
+                        "url": "https://old.test/late"
+                    }
+                }
+            }))
+            .unwrap();
+        expect_no_url(&mut harness.messages).await;
+        assert_eq!(
+            harness.last_tabs.read().await[1]["url"],
+            "https://new.test/"
+        );
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_same_document_navigation_retries_after_seed_timeout() {
+        let (client, events, methods) = mock_cdp_with_first_seed_timeout("F-MAIN").await;
+        let mut harness = start_loop_with_client(Some("S-ACTIVE"), client, events, methods).await;
+        next_message_of_type(&mut harness.messages, "status").await;
+        wait_for_method(&harness.methods, "Page.getFrameTree").await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frameId": "F-MAIN",
+                    "url": "https://active.test/recovered",
+                    "navigationType": "historyApi"
+                }
+            }))
+            .unwrap();
+
+        let message = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(message["url"], "https://active.test/recovered");
+        assert_eq!(
+            harness
+                .methods
+                .lock()
+                .await
+                .iter()
+                .filter(|method| method.as_str() == "Page.getFrameTree")
+                .count(),
+            2
+        );
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_same_document_navigation_waits_for_main_frame_seed() {
+        let mut harness = start_loop_with_seed_delay(
+            Some("S-ACTIVE"),
+            "F-MAIN",
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+        next_message_of_type(&mut harness.messages, "status").await;
+        wait_for_method(&harness.methods, "Page.getFrameTree").await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frameId": "F-MAIN",
+                    "url": "https://active.test/immediate",
+                    "navigationType": "historyApi"
+                }
+            }))
+            .unwrap();
+        let message = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(message["url"], "https://active.test/immediate");
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_same_document_seed_buffer_discards_oldest_event_at_capacity() {
+        let mut harness = start_loop_with_seed_delay(
+            Some("S-ACTIVE"),
+            "F-MAIN",
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+        next_message_of_type(&mut harness.messages, "status").await;
+        wait_for_method(&harness.methods, "Page.getFrameTree").await;
+
+        for index in 0..65 {
+            harness
+                .events
+                .send(json!({
+                    "method": "Page.navigatedWithinDocument",
+                    "sessionId": "S-ACTIVE",
+                    "params": {
+                        "frameId": "F-MAIN",
+                        "url": format!("https://active.test/{index}"),
+                        "navigationType": "historyApi"
+                    }
+                }))
+                .unwrap();
+        }
+
+        let first = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(first["url"], "https://active.test/1");
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_background_full_navigation_does_not_replace_active_url() {
+        let mut harness = start_loop(Some("S-ACTIVE"), "F-MAIN").await;
+        next_message_of_type(&mut harness.messages, "status").await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.frameNavigated",
+                "sessionId": "S-ACTIVE",
+                "params": {
+                    "frame": {
+                        "id": "F-MAIN",
+                        "url": "https://active.test/full"
+                    }
+                }
+            }))
+            .unwrap();
+        let active = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(active["url"], "https://active.test/full");
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.frameNavigated",
+                "sessionId": "S-BACKGROUND",
+                "params": {
+                    "frame": {
+                        "id": "F-BACKGROUND",
+                        "url": "https://background.test/changed"
+                    }
+                }
+            }))
+            .unwrap();
+        expect_no_url(&mut harness.messages).await;
+        assert_eq!(
+            harness.last_tabs.read().await[0]["url"],
+            "https://active.test/full"
+        );
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_direct_page_navigation_matches_empty_active_session() {
+        let mut harness = start_loop(Some(""), "F-DIRECT").await;
+        next_message_of_type(&mut harness.messages, "status").await;
+
+        harness
+            .events
+            .send(json!({
+                "method": "Page.navigatedWithinDocument",
+                "params": {
+                    "frameId": "F-DIRECT",
+                    "url": "https://provider.test/spa",
+                    "navigationType": "historyApi"
+                }
+            }))
+            .unwrap();
+        let message = next_message_of_type(&mut harness.messages, "url").await;
+        assert_eq!(message["url"], "https://provider.test/spa");
+
+        stop_loop(harness).await;
+    }
+
+    #[tokio::test]
+    async fn test_unanswered_frame_tree_seed_does_not_block_shutdown() {
+        let client = silent_frame_tree_cdp().await;
+        let (frame_tx, mut messages) = broadcast::channel(64);
+        let (frame_watch, _) = watch::channel(None);
+        let client_notify = Arc::new(tokio::sync::Notify::new());
+        let (shutdown, shutdown_rx) = watch::channel(false);
+        let task = tokio::spawn(cdp_event_loop(
+            frame_tx,
+            frame_watch,
+            Arc::new(super::super::ScreencastConfig::default()),
+            Arc::new(RwLock::new(Some(client.clone()))),
+            client_notify.clone(),
+            Arc::new(Mutex::new(false)),
+            Arc::new(Mutex::new(1)),
+            Arc::new(RwLock::new(Some("S-ACTIVE".to_string()))),
+            Arc::new(Mutex::new(1280)),
+            Arc::new(Mutex::new(720)),
+            Arc::new(RwLock::new(Vec::new())),
+            Arc::new(RwLock::new("chrome".to_string())),
+            Arc::new(Mutex::new(false)),
+            shutdown_rx,
+        ));
+        client_notify.notify_one();
+
+        next_message_of_type(&mut messages, "status").await;
+        let started = tokio::time::Instant::now();
+        let _ = shutdown.send(true);
+        tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .expect("frame tree seed should not hold shutdown for the CDP timeout")
+            .unwrap();
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "shutdown waited for the default CDP command timeout"
+        );
+        assert_eq!(client.pending_len().await, 0);
     }
 }

--- a/cli/src/native/stream/mod.rs
+++ b/cli/src/native/stream/mod.rs
@@ -245,12 +245,6 @@ impl StreamServer {
         self.client_notify.notify_one();
     }
 
-    /// Update the active CDP page session ID used for screencast commands.
-    pub async fn set_cdp_session_id(&self, session_id: Option<String>) {
-        let mut guard = self.cdp_session_id.write().await;
-        *guard = session_id;
-    }
-
     /// Check whether the server currently has active screencast running.
     pub async fn is_screencasting(&self) -> bool {
         *self.screencasting.lock().await
@@ -585,6 +579,26 @@ impl StreamServer {
             "timestamp": timestamp_ms(),
         });
         let _ = self.frame_tx.send(msg.to_string());
+    }
+
+    pub async fn bind_cdp_session_and_broadcast_tabs(
+        &self,
+        session_id: Option<String>,
+        tabs: &[Value],
+    ) {
+        let mut session_guard = self.cdp_session_id.write().await;
+        let mut tabs_guard = self.last_tabs.write().await;
+        *session_guard = session_id;
+        *tabs_guard = tabs.to_vec();
+        let msg = json!({
+            "type": "tabs",
+            "tabs": tabs,
+            "timestamp": timestamp_ms(),
+        });
+        let _ = self.frame_tx.send(msg.to_string());
+        drop(tabs_guard);
+        drop(session_guard);
+        self.client_notify.notify_one();
     }
 }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3043,6 +3043,9 @@ available localhost port automatically and reports it back.
 Notes:
   - 'stream enable' creates the WebSocket server.
   - WebSocket clients trigger frame streaming automatically.
+  - On Chrome, URL messages follow full-document, History API, and fragment
+    navigation in the active tab's main frame. Child-frame and background-tab
+    navigation does not emit URL messages.
   - Frames are delivered latest-first: the newest frame is picked at send
     time, so frames produced during an in-flight write are skipped, never
     queued. Input events dispatch immediately, independent of frame

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -78,6 +78,20 @@ The server sends frame messages with base64-encoded images:
 
 `metadata.timestamp` is the capture time in epoch milliseconds. Comparing it against the clock when the frame is drawn gives the age of what is on screen, which is the number worth watching on a constrained link.
 
+### URL messages
+
+On Chrome, the server sends URL updates for full-document, History API, and fragment navigation in the active tab's main frame:
+
+```json
+{
+  "type": "url",
+  "url": "https://example.com/dashboard#activity",
+  "timestamp": 1785038682238
+}
+```
+
+Navigation inside child frames or background tabs does not emit a URL message or replace the active tab's cached URL.
+
 ### Status messages
 
 Connection and screencast status:

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -510,7 +510,7 @@ That pulls in:
 - `references/session-management.md` — persistence, multi-session workflows
 - `references/profiling.md` — Chrome DevTools tracing and profiling
 - `references/video-recording.md` — video capture options
-- `references/streaming.md` covers live viewport streaming, remote input, per-client frame rate, and the encoding vars that set bandwidth cost
+- `references/streaming.md` covers live viewport streaming, Chrome active main-frame URL updates, remote input, per-client frame rate, and the encoding vars that set bandwidth cost
 - `references/proxy-support.md` — proxy configuration
 - `references/webgpu.md` — screenshots/video of WebGPU pages (three.js, Babylon.js), Linux/CI setup
 - `templates/*` — starter shell scripts for auth, capture, form automation

--- a/skill-data/core/references/streaming.md
+++ b/skill-data/core/references/streaming.md
@@ -64,7 +64,8 @@ Every message is JSON text with a `type` field.
 
 - `status`: connection state, screencasting flag, viewport size, engine, recording flag. Sent once on connect and again on change.
 - `tabs`: the current tab list, sent on connect when tabs are known and on change.
-- `url`, `console`: navigation and console events.
+- `url`: on Chrome, full-document, History API, and fragment navigation in the active tab's main frame. Child-frame and background-tab navigation is ignored.
+- `console`: console events.
 
 Status, tabs, url, and console travel on an ordered channel: they are delivered in order and are never replaced by a newer message the way frames are. They are not unconditionally durable. A client that falls far enough behind can lag out of that channel and lose messages it never saw, so treat console output as a live feed, not an audit log.
 


### PR DESCRIPTION
## Summary

- emit URL updates for active main-frame navigations in the stream
- cover full navigations, History API changes, and fragment updates in Chrome
- ignore child-frame and background-session events while rebinding the active session and cached tab atomically
- support Lightpanda full-navigation URL updates with bounded seeding, retry, and shutdown cleanup
- document stream URL behavior and add real-browser regression coverage

Fixes #1677

## Verification

- cargo fmt -- --check
- git diff --check
- cargo test -- --test-threads=1: 1,122 passed, 106 ignored
- Chrome navigation stress: 100 iterations with seed 1677
- Chrome navigation stress: 20 iterations each with seeds 1677, 42, and 9001
- Lightpanda 0.3.6 stream E2E: 10 consecutive passes
- all three Lightpanda E2Es together
- cargo clippy --all-targets -- -D warnings
- force-red checks confirmed for Chrome and Lightpanda regressions

## Lightpanda note

Lightpanda currently rejects opening a second page with TargetAlreadyLoaded, consistent with lightpanda-io/browser#1962. Its full-navigation path is covered by a real Lightpanda E2E; background-session filtering is covered by the deterministic CDP harness.