### PR TITLE
fix(cdp): adopt Chrome New Tab Page as fallback target

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -121,9 +121,40 @@ fn is_internal_chrome_target(url: &str) -> bool {
         || url.starts_with("devtools://")
 }
 
+fn is_chrome_new_tab_target(target: &TargetInfo) -> bool {
+    (target.target_type == "page" || target.target_type == "webview")
+        && matches!(
+            target.url.as_str(),
+            "chrome://newtab/" | "chrome://new-tab-page/"
+        )
+}
+
 pub(crate) fn should_track_target(target: &TargetInfo) -> bool {
     (target.target_type == "page" || target.target_type == "webview")
         && (target.url.is_empty() || !is_internal_chrome_target(&target.url))
+}
+
+/// Prefer normal user-facing pages. If Chrome only exposes its user-facing New
+/// Tab Page, adopt that existing target instead of creating a fresh about:blank
+/// tab while keeping the broad internal-target filter intact when a regular
+/// page is available.
+fn select_initial_page_targets(targets: Vec<TargetInfo>) -> Vec<TargetInfo> {
+    let mut page_targets = Vec::new();
+    let mut new_tab_fallbacks = Vec::new();
+
+    for target in targets {
+        if should_track_target(&target) {
+            page_targets.push(target);
+        } else if is_chrome_new_tab_target(&target) {
+            new_tab_fallbacks.push(target);
+        }
+    }
+
+    if page_targets.is_empty() {
+        new_tab_fallbacks
+    } else {
+        page_targets
+    }
 }
 
 fn update_page_target_info_in_pages(pages: &mut [PageInfo], target: &TargetInfo) -> bool {
@@ -649,11 +680,7 @@ impl BrowserManager {
             .send_command_typed("Target.getTargets", &json!({}), None)
             .await?;
 
-        let page_targets: Vec<TargetInfo> = result
-            .target_infos
-            .into_iter()
-            .filter(should_track_target)
-            .collect();
+        let page_targets = select_initial_page_targets(result.target_infos);
 
         if page_targets.is_empty() {
             // Create a new tab
@@ -2485,6 +2512,75 @@ mod tests {
         };
 
         assert!(!should_track_target(&target));
+    }
+
+    #[test]
+    fn test_initial_target_selection_prefers_regular_page_over_new_tab() {
+        let targets = vec![
+            TargetInfo {
+                target_id: "new-tab".to_string(),
+                target_type: "page".to_string(),
+                title: "New Tab".to_string(),
+                url: "chrome://new-tab-page/".to_string(),
+                attached: None,
+                browser_context_id: None,
+            },
+            TargetInfo {
+                target_id: "app".to_string(),
+                target_type: "page".to_string(),
+                title: "App".to_string(),
+                url: "https://example.com".to_string(),
+                attached: None,
+                browser_context_id: None,
+            },
+        ];
+
+        let selected = select_initial_page_targets(targets);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].target_id, "app");
+    }
+
+    #[test]
+    fn test_initial_target_selection_uses_new_tab_as_fallback() {
+        for url in ["chrome://newtab/", "chrome://new-tab-page/"] {
+            let targets = vec![
+                TargetInfo {
+                    target_id: "new-tab".to_string(),
+                    target_type: "page".to_string(),
+                    title: "New Tab".to_string(),
+                    url: url.to_string(),
+                    attached: None,
+                    browser_context_id: None,
+                },
+                TargetInfo {
+                    target_id: "omnibox".to_string(),
+                    target_type: "page".to_string(),
+                    title: String::new(),
+                    url: "chrome://omnibox-popup.top-chrome/".to_string(),
+                    attached: None,
+                    browser_context_id: None,
+                },
+            ];
+
+            let selected = select_initial_page_targets(targets);
+            assert_eq!(selected.len(), 1);
+            assert_eq!(selected[0].target_id, "new-tab");
+            assert_eq!(selected[0].url, url);
+        }
+    }
+
+    #[test]
+    fn test_initial_target_selection_keeps_other_internal_targets_filtered() {
+        let targets = vec![TargetInfo {
+            target_id: "omnibox".to_string(),
+            target_type: "page".to_string(),
+            title: String::new(),
+            url: "chrome://omnibox-popup.top-chrome/".to_string(),
+            attached: None,
+            browser_context_id: None,
+        }];
+
+        assert!(select_initial_page_targets(targets).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When connecting to an already-running Chrome over CDP, `discover_and_attach_targets()` filters all `chrome://` targets. If the browser only has its user-facing New Tab Page open, discovery sees no usable page and creates a fresh `about:blank` target instead.

This keeps the existing internal-target filter unchanged for normal cases. `chrome://newtab/` and `chrome://new-tab-page/` are used only as a fallback when no regular user-facing page exists, before the current `Target.createTarget("about:blank")` fallback runs.

A regular web page still always wins over the New Tab Page, and other Chrome-internal targets such as `chrome://omnibox-popup.top-chrome/`, extensions, and DevTools remain filtered.

Related to #1544 / #1559, but this covers a different path: those address a real Chrome binary launched by agent-browser by suppressing Chrome's startup NTP. With an already-running browser connected over CDP, the user's NTP already exists and needs to be adopted rather than suppressed.

## Validation

- Added regression tests covering:
  - regular pages taking precedence over NTP
  - both `chrome://newtab/` and `chrome://new-tab-page/` as fallback targets
  - other internal Chrome targets remaining filtered
- `git diff --check` passes.
- Manually verified against Chrome 151 on macOS that the existing NTP target can be attached and driven directly over CDP without navigation or replacement. `Page.enable`, `Runtime.enable`, `Network.enable`, `Runtime.evaluate`, `Accessibility.getFullAXTree`, `DOM.getDocument`, and `Page.bringToFront` all succeed on the original NTP target.
