### PR TITLE
fix(windows): hide detached daemon child processes

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ rust-embed = "8"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.52", features = ["Win32_System_Threading", "Win32_System_Console", "Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4723,9 +4723,11 @@ fn open_url_in_browser(url: &str) {
     #[cfg(target_os = "linux")]
     let result = std::process::Command::new("xdg-open").arg(url).spawn();
     #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("cmd")
-        .args(["/c", "start", "", url])
-        .spawn();
+    let result = {
+        let mut command = crate::native::process::background_std_command("cmd");
+        command.args(["/c", "start", "", url]);
+        command.spawn()
+    };
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     let result: Result<std::process::Child, std::io::Error> = Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,

--- a/cli/src/native/mod.rs
+++ b/cli/src/native/mod.rs
@@ -25,6 +25,8 @@ pub mod network;
 #[allow(dead_code)]
 pub mod policy;
 #[allow(dead_code)]
+pub mod process;
+#[allow(dead_code)]
 pub mod providers;
 #[allow(dead_code)]
 pub mod react;

--- a/cli/src/native/process.rs
+++ b/cli/src/native/process.rs
@@ -1,0 +1,116 @@
+use std::ffi::OsStr;
+use std::process::Command;
+
+/// Build a child command that stays invisible when launched by the detached daemon.
+pub(crate) fn background_std_command<S: AsRef<OsStr>>(program: S) -> Command {
+    let command = Command::new(program);
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let mut command = command;
+        command.creation_flags(windows_sys::Win32::System::Threading::CREATE_NO_WINDOW);
+        command
+    }
+
+    #[cfg(not(windows))]
+    {
+        command
+    }
+}
+
+pub(crate) fn background_tokio_command<S: AsRef<OsStr>>(program: S) -> tokio::process::Command {
+    let command = background_std_command(program);
+    tokio::process::Command::from(command)
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    const DETACHED_PARENT_ENV: &str = "AGENT_BROWSER_TEST_DETACHED_PARENT";
+    const DETACHED_PARENT_TEST: &str =
+        "native::process::tests::detached_parent_spawns_background_child";
+    const CONSOLE_PROBE_ENV: &str = "AGENT_BROWSER_TEST_CONSOLE_PROBE";
+    const CONSOLE_PROBE_TEST: &str = "native::process::tests::console_probe_has_no_console";
+    const CHILD_KIND_ENV: &str = "AGENT_BROWSER_TEST_CHILD_KIND";
+
+    #[test]
+    fn configured_background_children_have_no_console() {
+        for child_kind in ["std", "tokio"] {
+            let output = detached_parent(child_kind).output().unwrap();
+            assert!(
+                output.status.success(),
+                "{child_kind} console probe failed:\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    fn detached_parent(child_kind: &str) -> Command {
+        use std::os::windows::process::CommandExt;
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut command = Command::new(current_exe);
+        command
+            .args(["--exact", DETACHED_PARENT_TEST, "--ignored"])
+            .env(DETACHED_PARENT_ENV, "1")
+            .env(CHILD_KIND_ENV, child_kind)
+            .creation_flags(windows_sys::Win32::System::Threading::DETACHED_PROCESS);
+        command
+    }
+
+    #[test]
+    #[ignore]
+    fn detached_parent_spawns_background_child() {
+        if std::env::var_os(DETACHED_PARENT_ENV).is_none() {
+            return;
+        }
+
+        // SAFETY: GetConsoleCP has no parameters and only inspects this process's console.
+        assert_eq!(
+            unsafe { windows_sys::Win32::System::Console::GetConsoleWindow() },
+            0,
+            "intermediate process was not detached"
+        );
+
+        let current_exe = std::env::current_exe().unwrap();
+        let output = match std::env::var(CHILD_KIND_ENV).unwrap().as_str() {
+            "std" => background_std_command(current_exe)
+                .args(["--exact", CONSOLE_PROBE_TEST, "--ignored"])
+                .env(CONSOLE_PROBE_ENV, "1")
+                .output()
+                .unwrap(),
+            "tokio" => {
+                let mut command = background_tokio_command(current_exe);
+                command
+                    .args(["--exact", CONSOLE_PROBE_TEST, "--ignored"])
+                    .env(CONSOLE_PROBE_ENV, "1");
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(command.output())
+                    .unwrap()
+            }
+            child_kind => panic!("unknown child kind: {child_kind}"),
+        };
+        assert!(
+            output.status.success(),
+            "background child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn console_probe_has_no_console() {
+        if std::env::var_os(CONSOLE_PROBE_ENV).is_none() {
+            return;
+        }
+
+        // SAFETY: GetConsoleWindow has no parameters and only inspects this process's console.
+        let console = unsafe { windows_sys::Win32::System::Console::GetConsoleWindow() };
+        assert_eq!(console, 0, "background child created a console window");
+    }
+}

--- a/cli/src/native/stream/chat.rs
+++ b/cli/src/native/stream/chat.rs
@@ -503,7 +503,7 @@ pub(crate) async fn execute_chat_tool(session: &str, command: &str) -> String {
     args.extend(global_flags);
     args.extend(cmd_words);
 
-    let mut cmd = tokio::process::Command::new(&exe);
+    let mut cmd = crate::native::process::background_tokio_command(&exe);
     cmd.args(&args)
         .env_remove("AGENT_BROWSER_DASHBOARD")
         .env_remove("AGENT_BROWSER_DASHBOARD_PORT")

--- a/cli/src/native/stream/dashboard.rs
+++ b/cli/src/native/stream/dashboard.rs
@@ -697,7 +697,7 @@ async fn exec_cli(body: &str) -> Result<String, String> {
 
     let exe = std::env::current_exe().map_err(|e| format!("Cannot resolve executable: {}", e))?;
 
-    let mut cmd = tokio::process::Command::new(&exe);
+    let mut cmd = crate::native::process::background_tokio_command(&exe);
     cmd.args(&args)
         .arg("--json")
         .env_remove("AGENT_BROWSER_DASHBOARD")
@@ -779,7 +779,7 @@ pub(super) async fn spawn_session(body: &str) -> Result<String, String> {
 
     let exe = std::env::current_exe().map_err(|e| format!("Cannot resolve executable: {}", e))?;
 
-    let mut cmd = tokio::process::Command::new(&exe);
+    let mut cmd = crate::native::process::background_tokio_command(&exe);
     cmd.arg("open")
         .arg("about:blank")
         .arg("--session")


### PR DESCRIPTION
## Summary

- centralize detached-daemon child command construction
- apply `CREATE_NO_WINDOW` on Windows to the inspect URL launcher and the dashboard/chat CLI subprocesses
- keep non-Windows process behavior unchanged
- add real Windows regression coverage for both `std::process::Command` and `tokio::process::Command`

## Root cause

The Windows daemon is launched with `DETACHED_PROCESS`, so it has no console. Console-subsystem children spawned without creation flags therefore receive a newly allocated visible console window.

This change constructs the affected background children through one shared helper. On Windows the helper applies `CREATE_NO_WINDOW`; elsewhere it returns an ordinary command.

This intentionally does not modify the FFmpeg recording path because open PR #1513 already owns that part of the report.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml native::process::tests -- --test-threads=1` (1 passed, 2 ignored internal probes)
- `cargo test --quiet --profile ci --manifest-path cli/Cargo.toml -- --skip install::tests::download_bytes_connection_refused_includes_details` (1092 passed, 0 failed, 104 ignored)
- `cargo clippy --manifest-path cli/Cargo.toml --no-deps` completed without warnings in changed production files; current main has existing warnings in unrelated files
- the Windows regression launches an intermediate test process with `DETACHED_PROCESS`, then verifies that children created through both the standard and Tokio helpers have no console window
- mutation check: removing `CREATE_NO_WINDOW` makes the detached-parent regression fail for the standard child before it reaches the Tokio case

The filtered install test asserts the English text `connection refused`, while this Windows environment returns the localized socket error text.

Addresses #1644