### PR TITLE
fix(diff): support interactive snapshot filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ When a JavaScript dialog is pending, all command responses include a `warning` f
 agent-browser diff snapshot                              # Compare current vs last snapshot
 agent-browser diff snapshot --baseline before.txt        # Compare current vs saved snapshot file
 agent-browser diff snapshot --selector "#main" --compact # Scoped snapshot diff
+agent-browser diff snapshot --interactive                # Interactive elements only
 agent-browser diff screenshot --baseline before.png      # Visual pixel diff against baseline
 agent-browser diff screenshot --baseline b.png -o d.png  # Save diff image to custom path
 agent-browser diff screenshot --baseline b.png -t 0.2    # Adjust color threshold (0-1)

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2249,6 +2249,9 @@ fn parse_diff(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     "-c" | "--compact" => {
                         obj.insert("compact".to_string(), json!(true));
                     }
+                    "-i" | "--interactive" => {
+                        obj.insert("interactive".to_string(), json!(true));
+                    }
                     "-d" | "--depth" => {
                         if let Some(d) = rest.get(i + 1) {
                             match d.parse::<u32>() {
@@ -2276,13 +2279,13 @@ fn parse_diff(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     other if other.starts_with('-') => {
                         return Err(ParseError::InvalidValue {
                             message: format!("Unknown flag: {}", other),
-                            usage: "diff snapshot [--baseline <file>] [--selector <sel>] [--compact] [--depth <n>]",
+                            usage: "diff snapshot [--baseline <file>] [--selector <sel>] [--compact] [--interactive] [--depth <n>]",
                         });
                     }
                     other => {
                         return Err(ParseError::InvalidValue {
                             message: format!("Unexpected argument: {}", other),
-                            usage: "diff snapshot [--baseline <file>] [--selector <sel>] [--compact] [--depth <n>]",
+                            usage: "diff snapshot [--baseline <file>] [--selector <sel>] [--compact] [--interactive] [--depth <n>]",
                         });
                     }
                 }
@@ -5303,6 +5306,16 @@ mod tests {
         assert_eq!(cmd["selector"], "#main");
         assert_eq!(cmd["compact"], true);
         assert_eq!(cmd["maxDepth"], 3);
+    }
+
+    #[test]
+    fn test_diff_snapshot_interactive() {
+        let cmd = parse_command(&args("diff snapshot --interactive"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "diff_snapshot");
+        assert_eq!(cmd["interactive"], true);
+
+        let short = parse_command(&args("diff snapshot -i"), &default_flags()).unwrap();
+        assert_eq!(short["interactive"], true);
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1501,7 +1501,7 @@ fn parity_tools() -> Vec<Value> {
             TOOL_DIFF_SNAPSHOT,
             "Diff snapshot",
             "Diff current snapshot against last or baseline.",
-            json!({ "baseline": { "type": "string" }, "selector": { "type": "string" }, "compact": { "type": "boolean" }, "depth": { "type": "integer" } }),
+            json!({ "baseline": { "type": "string" }, "selector": { "type": "string" }, "compact": { "type": "boolean" }, "interactive": { "type": "boolean" }, "depth": { "type": "integer" } }),
             &[],
         ),
         tool(
@@ -3038,6 +3038,10 @@ fn call_device(arguments: &Value) -> Result<Value, ProtocolError> {
 }
 
 fn call_diff_snapshot(arguments: &Value) -> Result<Value, ProtocolError> {
+    call_cli_tool(arguments, diff_snapshot_args(arguments)?, None)
+}
+
+fn diff_snapshot_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
     let mut args = vec!["diff".to_string(), "snapshot".to_string()];
     if let Some(baseline) = optional_string(arguments, "baseline")? {
         args.push("--baseline".to_string());
@@ -3050,11 +3054,14 @@ fn call_diff_snapshot(arguments: &Value) -> Result<Value, ProtocolError> {
     if optional_bool(arguments, "compact")?.unwrap_or(false) {
         args.push("--compact".to_string());
     }
+    if optional_bool(arguments, "interactive")?.unwrap_or(false) {
+        args.push("--interactive".to_string());
+    }
     if let Some(depth) = optional_u64(arguments, "depth")? {
         args.push("--depth".to_string());
         args.push(depth.to_string());
     }
-    call_cli_tool(arguments, args, None)
+    Ok(args)
 }
 
 fn call_diff_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
@@ -4249,6 +4256,23 @@ mod tests {
         assert_eq!(
             open["inputSchema"]["properties"]["idleTimeout"]["type"],
             "string"
+        );
+    }
+
+    #[test]
+    fn diff_snapshot_tool_forwards_interactive_filter() {
+        let diff_snapshot = tools()
+            .into_iter()
+            .find(|tool| tool["name"].as_str() == Some(TOOL_DIFF_SNAPSHOT))
+            .unwrap();
+        assert_eq!(
+            diff_snapshot["inputSchema"]["properties"]["interactive"]["type"],
+            "boolean"
+        );
+
+        assert_eq!(
+            diff_snapshot_args(&json!({ "interactive": true })).unwrap(),
+            vec!["diff", "snapshot", "--interactive"]
         );
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6001,25 +6001,7 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
-    let compact = cmd
-        .get("compact")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let max_depth = cmd
-        .get("maxDepth")
-        .and_then(|v| v.as_u64())
-        .map(|d| d as usize);
-    let selector = cmd
-        .get("selector")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    let options = SnapshotOptions {
-        compact,
-        depth: max_depth,
-        selector,
-        ..SnapshotOptions::default()
-    };
+    let options = diff_snapshot_options(cmd);
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -6048,6 +6030,41 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         "unchanged": result.unchanged,
         "changed": result.changed,
     }))
+}
+
+fn diff_snapshot_options(cmd: &Value) -> SnapshotOptions {
+    SnapshotOptions {
+        compact: cmd
+            .get("compact")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        interactive: cmd
+            .get("interactive")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        depth: cmd
+            .get("maxDepth")
+            .and_then(|value| value.as_u64())
+            .map(|depth| depth as usize),
+        selector: cmd
+            .get("selector")
+            .and_then(|value| value.as_str())
+            .map(String::from),
+        ..SnapshotOptions::default()
+    }
+}
+
+#[cfg(test)]
+mod diff_snapshot_options_tests {
+    use super::*;
+
+    #[test]
+    fn interactive_option_is_forwarded_to_snapshot() {
+        let cmd = json!({ "interactive": true });
+        let options = diff_snapshot_options(&cmd);
+
+        assert!(options.interactive);
+    }
 }
 
 async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3152,6 +3152,7 @@ Snapshot Diff:
     -b, --baseline <file>    Compare against a saved snapshot file
     -s, --selector <sel>     Scope snapshot to a CSS selector or @ref
     -c, --compact            Use compact snapshot format
+    -i, --interactive        Only include interactive elements
     -d, --depth <n>          Limit snapshot tree depth
 
   Without --baseline, compares against the last snapshot taken in this session.

--- a/docs/src/app/diffing/page.mdx
+++ b/docs/src/app/diffing/page.mdx
@@ -33,6 +33,9 @@ agent-browser diff snapshot --baseline before.txt
 
 # Scope to a specific part of the page
 agent-browser diff snapshot --selector "#main" --compact
+
+# Compare only interactive elements
+agent-browser diff snapshot --interactive
 ```
 
 Without `--baseline`, the command automatically compares against the most recent snapshot taken in the current session. This is the primary use case for agents verifying that an action had the intended effect.
@@ -47,6 +50,7 @@ Without `--baseline`, the command automatically compares against the most recent
     <tr><td><code>-b, --baseline &lt;file&gt;</code></td><td>Path to a saved snapshot file to compare against</td></tr>
     <tr><td><code>-s, --selector &lt;sel&gt;</code></td><td>Scope the current snapshot to a CSS selector or @ref</td></tr>
     <tr><td><code>-c, --compact</code></td><td>Use compact snapshot format</td></tr>
+    <tr><td><code>-i, --interactive</code></td><td>Only include interactive elements</td></tr>
     <tr><td><code>-d, --depth &lt;n&gt;</code></td><td>Limit snapshot tree depth</td></tr>
   </tbody>
 </table>

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -323,6 +323,16 @@ Other capabilities use the same protocol:
 
 `plugin run` is for `command.run` and custom capabilities. Core capabilities and protocol request types use their dedicated command paths.
 
+## Compare page state
+
+```bash
+agent-browser diff snapshot                  # Compare against the last snapshot
+agent-browser diff snapshot --interactive    # Compare interactive elements only
+agent-browser diff snapshot --baseline before.txt
+```
+
+Snapshot diff accepts the same `-i` / `--interactive` filter as `snapshot`, plus `--selector`, `--compact`, and `--depth`.
+
 ## State Management
 
 ```bash


### PR DESCRIPTION
Fixes #1647

## Summary

- add `-i` / `--interactive` support to `diff snapshot`
- forward the filter through the native snapshot options and the MCP tool schema
- document the flag across CLI help, README, agent skill reference, and the docs site

## Root cause

`diff snapshot` built a fresh `SnapshotOptions` value but never copied the interactive filter supported by the regular `snapshot` command. As a result, comparing against an interactive snapshot produced a noisy full-tree diff instead of applying the same filter to the current snapshot.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --profile ci --manifest-path cli/Cargo.toml test_diff_snapshot_interactive -- --nocapture`
- `cargo test --profile ci --manifest-path cli/Cargo.toml diff_snapshot_tool_forwards_interactive_filter -- --nocapture`
- `cargo test --profile ci --manifest-path cli/Cargo.toml interactive_option_is_forwarded_to_snapshot -- --nocapture`
- `cargo clippy --manifest-path cli/Cargo.toml`
- full `cargo test --profile ci --manifest-path cli/Cargo.toml`: 1092 passed, 100 ignored, and 1 unrelated existing Windows-localization assertion failed because the host reports WSAECONNREFUSED in Chinese while the test expects the English phrase `connection refused`

`cargo clippy --manifest-path cli/Cargo.toml -- -D warnings` also reaches existing warnings in unchanged files; the changed code introduces no new warning.
