### PR TITLE
fix(output): show page error text

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -117,6 +117,10 @@ fn format_storage_text(data: &serde_json::Value) -> Option<String> {
     Some(format!("{}: {}", key, format_storage_value(value)))
 }
 
+fn page_error_text(error: &serde_json::Value) -> &str {
+    error.get("text").and_then(|v| v.as_str()).unwrap_or("")
+}
+
 fn format_stream_status_text(action: Option<&str>, data: &serde_json::Value) -> Option<String> {
     match action {
         Some("stream_disable") => data
@@ -793,7 +797,7 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         // Errors
         if let Some(errors) = data.get("errors").and_then(|v| v.as_array()) {
             for err in errors {
-                let msg = err.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                let msg = page_error_text(err);
                 println!("{} {}", color::error_indicator(), msg);
             }
             return;
@@ -3973,7 +3977,7 @@ pub fn print_version() {
 mod tests {
     use super::{
         boundary_origin, format_a11y_text, format_storage_text, format_vitals_text,
-        format_with_boundaries, OutputOptions,
+        format_with_boundaries, page_error_text, OutputOptions,
     };
     use serde_json::json;
 
@@ -4039,6 +4043,13 @@ mod tests {
         let rendered = format_storage_text(&data).unwrap();
 
         assert_eq!(rendered, "No storage entries");
+    }
+
+    #[test]
+    fn test_page_error_text_uses_event_tracker_field() {
+        let error = json!({ "text": "Error: detached rejection" });
+
+        assert_eq!(page_error_text(&error), "Error: detached rejection");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- read page errors from the `text` field emitted by `EventTracker`
- add a regression test for plain-text error rendering

Fixes #1692.

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml test_page_error_text_uses_event_tracker_field`
- `cargo test --manifest-path cli/Cargo.toml` (1114 passed, 103 ignored)
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -A clippy::nonminimal-bool -D warnings`
- live macOS arm64 run against Chrome: detached Promise and timer errors both render with their full text and stack; `--json` output is unchanged

Current main triggers `clippy::nonminimal_bool` in `cli/src/native/cdp/chrome.rs:337` without the exemption.
