### PR TITLE
Create tabs in the background; drop implicit bringToFront on switch and auto-connect

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2878,11 +2878,6 @@ async fn open_fresh_tab_for_auto_connect(state: &mut DaemonState) -> Result<(), 
         return Ok(());
     };
     mgr.tab_new(None, None).await?;
-    let session_id = mgr.active_session_id()?.to_string();
-    let _ = mgr
-        .client
-        .send_command("Page.bringToFront", None, Some(&session_id))
-        .await;
     // Best effort: a failed write is retried after the next command.
     let _ = maybe_persist_tab_binding(state);
     Ok(())
@@ -6686,7 +6681,7 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
             .client
             .send_command_typed(
                 "Target.createTarget",
-                &json!({ "url": "about:blank", "browserContextId": context_id }),
+                &json!({ "url": "about:blank", "browserContextId": context_id, "background": true }),
                 None,
             )
             .await?;
@@ -9416,7 +9411,7 @@ async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value
             .client
             .send_command_typed(
                 "Target.createTarget",
-                &json!({ "url": "about:blank", "browserContextId": context_id }),
+                &json!({ "url": "about:blank", "browserContextId": context_id, "background": true }),
                 None,
             )
             .await?;

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -663,6 +663,7 @@ impl BrowserManager {
                     "Target.createTarget",
                     &CreateTargetParams {
                         url: "about:blank".to_string(),
+                        background: true,
                     },
                     None,
                 )
@@ -1361,6 +1362,7 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: "about:blank".to_string(),
+                    background: true,
                 },
                 None,
             )
@@ -1526,6 +1528,7 @@ impl BrowserManager {
                 "Target.createTarget",
                 &CreateTargetParams {
                     url: target_url.to_string(),
+                    background: true,
                 },
                 None,
             )
@@ -1603,11 +1606,9 @@ impl BrowserManager {
         // An explicit switch re-binds the session and clears any tab_gone.
         self.bind_active_target();
 
-        // Bring tab to front
-        let _ = self
-            .client
-            .send_command("Page.bringToFront", None, Some(&session_id))
-            .await;
+        // No Page.bringToFront here: raising the tab raises the whole browser
+        // over the user's current app. CDP drives background tabs fine, and an
+        // explicit raise is available as the `bringtofront` command.
 
         // A dialog-blocked tab cannot answer script evaluation until the dialog
         // is resolved, so fall back to the last known url/title instead of

--- a/cli/src/native/cdp/types.rs
+++ b/cli/src/native/cdp/types.rs
@@ -141,6 +141,9 @@ pub struct SetDiscoverTargetsParams {
 #[serde(rename_all = "camelCase")]
 pub struct CreateTargetParams {
     pub url: String,
+    /// Create without foregrounding: a foreground create raises the whole
+    /// browser over the user's current app when Chrome is headed.
+    pub background: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/src/native/state.rs
+++ b/cli/src/native/state.rs
@@ -120,6 +120,7 @@ async fn collect_storage_via_temp_target(
             "Target.createTarget",
             &CreateTargetParams {
                 url: "about:blank".to_string(),
+                background: true,
             },
             None,
         )


### PR DESCRIPTION
## Summary

Create every tab in the background (`Target.createTarget` with `background: true`) and remove the two implicit `Page.bringToFront` calls (tab switch, auto-connect fresh tab). The explicit `bringtofront` command is unchanged, so raising the window stays available as an opt-in.

## Why

A `Target.createTarget` without `background: true` is a foreground create. On a headed Chrome on macOS that raises the whole browser over whatever app the user is in. The daemon does this every time it pins a fresh tab at attach, and it follows with `Page.bringToFront` on every tab switch and on auto-connect.

We attach many daemon sessions to one shared headed Chrome (`--cdp`, `--pin-tab`, one session per coding agent). Measured on macOS (Darwin 25): sampling the frontmost app at 150ms while agents work, Chrome took OS focus every few seconds with no user action. Isolated, both calls steal focus 3 out of 3 times each; the same `createTarget` with `background: true` steals it 0 out of 3 times.

Related: #1247 (background mode request), #1688 (`state save` foregrounds Chrome — its temp target is one of the sites fixed here), #1427 (adds `tab new --background`; this PR instead changes the default, because the daemon's own internal creates are the ones users cannot reach with a flag).

## What

- `CreateTargetParams` gains `background: bool`, set to `true` at all four typed call sites (connect-time create, pin-tab attach, `tab_new`, the `state save` temp target) and the two `json!` sites (browser-context creates).
- `switch_tab` no longer sends `Page.bringToFront`. CDP drives background tabs fine; the switch still re-binds the session and enables domains.
- `open_fresh_tab_for_auto_connect` no longer sends `Page.bringToFront`.

No new flags, no new env vars. `bringtofront` still raises deliberately.

## Test plan

- `cargo test --release --bin agent-browser`: 1099 passed. One failure in our environment, `same_origin_command_post_relays_without_wildcard_cors`, is unrelated: it builds its socket path from `CARGO_MANIFEST_DIR`, and our checkout sits deep enough that the path exceeds the macOS `SUN_LEN` limit. It fails the same way on unpatched source at that path.
- Against a real headed Chrome over `--cdp` on macOS: attach with no binding, `tab new`, and `tab <id>` all complete without Chrome taking OS focus (frontmost app sampled at 150ms throughout); pages load, snapshots and screenshots work from the backgrounded tabs.
