### PR TITLE
fix(frames): scope eval to the selected frame, capture cross-origin iframe console, resolve cross-origin frames by selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,9 +351,11 @@ Switching to a tab discarded by Chrome's Memory Saver reactivates it, since a di
 ### Frames
 
 ```bash
-agent-browser frame <sel>             # Switch to iframe
+agent-browser frame <sel>             # Switch to iframe (ref, CSS selector, name or URL)
 agent-browser frame main              # Back to main frame
 ```
+
+Snapshot refs already reach into iframes without switching. Switching additionally scopes `eval`, so a script can read or seed state inside an embedded app, cross-origin ones included. `console` reports cross-origin iframe messages on the active page alongside the main frame's.
 
 ### Dialogs
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -257,8 +257,10 @@ pub(super) fn is_active_iframe_console_event(
     session_id: Option<&str>,
     active_iframe_sessions: &HashSet<String>,
 ) -> bool {
-    matches!(method, "Runtime.consoleAPICalled" | "Runtime.exceptionThrown")
-        && session_id.is_some_and(|sid| active_iframe_sessions.contains(sid))
+    matches!(
+        method,
+        "Runtime.consoleAPICalled" | "Runtime.exceptionThrown"
+    ) && session_id.is_some_and(|sid| active_iframe_sessions.contains(sid))
 }
 
 fn active_frame_scope_may_have_changed(drained: &DrainedEvents) -> bool {
@@ -8349,7 +8351,11 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
 
         let doc = mgr
             .client
-            .send_command("DOM.getDocument", Some(json!({ "depth": 0 })), Some(&session_id))
+            .send_command(
+                "DOM.getDocument",
+                Some(json!({ "depth": 0 })),
+                Some(&session_id),
+            )
             .await?;
         let root_node_id = doc
             .get("root")

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -246,6 +246,21 @@ fn is_active_iframe_network_event(
         && session_id.is_some_and(|sid| active_iframe_sessions.contains(sid))
 }
 
+/// Console output and page errors raised inside a cross-origin iframe arrive on
+/// that iframe's own CDP session, so the top-session filter drops them. An
+/// embedded app (a Forge macro, a payment widget, an OAuth frame) then looks
+/// silent even when it is logging. Admit those two event kinds from iframe
+/// sessions attached to the ACTIVE page — the same subset network tracking
+/// uses, so a background tab's frames stay out.
+pub(super) fn is_active_iframe_console_event(
+    method: &str,
+    session_id: Option<&str>,
+    active_iframe_sessions: &HashSet<String>,
+) -> bool {
+    matches!(method, "Runtime.consoleAPICalled" | "Runtime.exceptionThrown")
+        && session_id.is_some_and(|sid| active_iframe_sessions.contains(sid))
+}
+
 fn active_frame_scope_may_have_changed(drained: &DrainedEvents) -> bool {
     !drained.attached_iframe_sessions.is_empty()
         || !drained.detached_iframe_sessions.is_empty()
@@ -1418,7 +1433,14 @@ impl DaemonState {
                             &self.active_iframe_sessions,
                         );
 
-                    if !session_matches && !iframe_network_event {
+                    let iframe_console_event = !session_matches
+                        && is_active_iframe_console_event(
+                            &event.method,
+                            event.session_id.as_deref(),
+                            &self.active_iframe_sessions,
+                        );
+
+                    if !session_matches && !iframe_network_event && !iframe_console_event {
                         continue;
                     }
 
@@ -4780,7 +4802,22 @@ async fn handle_evaluate(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
         .and_then(|v| v.as_str())
         .ok_or("Missing 'script' parameter")?;
 
-    let result = mgr.evaluate(script, None).await?;
+    // Honor an active `frame <sel>` selection, like element resolution and
+    // `wait` already do. Without this, `frame` reported success and `eval`
+    // still ran in the top document.
+    let result = match state.active_frame_id.as_deref() {
+        Some(frame_id) => match state.iframe_sessions.get(frame_id) {
+            // Cross-origin frame: it owns a dedicated CDP session.
+            Some(frame_session) => mgr.evaluate_in_session(frame_session, script, None).await?,
+            // Same-process frame: no session of its own, reach its realm
+            // through the owning element's contentWindow.
+            None => {
+                let session_id = mgr.active_session_id()?.to_string();
+                mgr.evaluate_in_frame(&session_id, frame_id, script).await?
+            }
+        },
+        None => mgr.evaluate(script, None).await?,
+    };
     let url = mgr.get_url().await.unwrap_or_default();
     Ok(json!({ "result": result, "origin": url }))
 }
@@ -8287,7 +8324,12 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
             return Ok(json!({ "frame": label }));
         }
 
-        // CSS selector path
+        // CSS selector path. Resolve the element itself and read the frame id
+        // off the node, the way the ref path does. Matching the frame TREE by
+        // name/id/src only works for same-process frames: a cross-origin child
+        // is a separate target and is absent from the top session's tree, so
+        // `frame "#some-iframe"` used to fail with "Frame not found" for
+        // exactly the embedded apps that most need addressing.
         let js = format!(
             r#"(() => {{
                 const el = document.querySelector({});
@@ -8299,11 +8341,65 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
             }})()"#,
             serde_json::to_string(sel).unwrap_or_default()
         );
-        let result = mgr.evaluate(&js, None).await?;
-        let frame_name = result.as_str().ok_or("Could not find frame for selector")?;
-        if let Some(frame_id) = find_frame(frame_tree, Some(frame_name), None) {
+        let label = mgr.evaluate(&js, None).await?;
+        let label = label
+            .as_str()
+            .ok_or("Could not find frame for selector")?
+            .to_string();
+
+        let doc = mgr
+            .client
+            .send_command("DOM.getDocument", Some(json!({ "depth": 0 })), Some(&session_id))
+            .await?;
+        let root_node_id = doc
+            .get("root")
+            .and_then(|r| r.get("nodeId"))
+            .and_then(|v| v.as_i64())
+            .ok_or("Could not read the document root")?;
+        let node = mgr
+            .client
+            .send_command(
+                "DOM.querySelector",
+                Some(json!({ "nodeId": root_node_id, "selector": sel })),
+                Some(&session_id),
+            )
+            .await?;
+        let node_id = node
+            .get("nodeId")
+            .and_then(|v| v.as_i64())
+            .filter(|id| *id != 0)
+            .ok_or("Could not find frame for selector")?;
+        let describe = mgr
+            .client
+            .send_command(
+                "DOM.describeNode",
+                Some(json!({ "nodeId": node_id, "depth": 1 })),
+                Some(&session_id),
+            )
+            .await?;
+        let frame_id = describe
+            .get("node")
+            .and_then(|n| n.get("contentDocument"))
+            .and_then(|cd| cd.get("frameId"))
+            .and_then(|v| v.as_str())
+            .or_else(|| {
+                describe
+                    .get("node")
+                    .and_then(|n| n.get("frameId"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(|v| v.to_string());
+
+        if let Some(frame_id) = frame_id {
             state.active_frame_id = Some(frame_id);
-            return Ok(json!({ "frame": frame_name }));
+            return Ok(json!({ "frame": label }));
+        }
+
+        // Same-process frames still resolve through the tree when the node
+        // carries no frame id.
+        if let Some(frame_id) = find_frame(frame_tree, Some(&label), None) {
+            state.active_frame_id = Some(frame_id);
+            return Ok(json!({ "frame": label }));
         }
     }
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1173,9 +1173,21 @@ impl BrowserManager {
         Ok(result.as_str().unwrap_or("").to_string())
     }
 
-    pub async fn evaluate(&self, script: &str, _args: Option<Value>) -> Result<Value, String> {
+    pub async fn evaluate(&self, script: &str, args: Option<Value>) -> Result<Value, String> {
         let session_id = self.active_session_id()?.to_string();
+        self.evaluate_in_session(&session_id, script, args).await
+    }
 
+    /// Evaluate in an explicit CDP session. A cross-origin iframe owns a
+    /// dedicated session (Target.setAutoAttach), so passing that session id is
+    /// what makes `frame <sel>` followed by `eval` run inside the iframe
+    /// instead of the top document.
+    pub async fn evaluate_in_session(
+        &self,
+        session_id: &str,
+        script: &str,
+        _args: Option<Value>,
+    ) -> Result<Value, String> {
         let result: EvaluateResult = self
             .client
             .send_command_typed(
@@ -1185,7 +1197,7 @@ impl BrowserManager {
                     return_by_value: Some(true),
                     await_promise: Some(true),
                 },
-                Some(&session_id),
+                Some(session_id),
             )
             .await?;
 
@@ -1199,6 +1211,64 @@ impl BrowserManager {
         }
 
         Ok(result.result.value.unwrap_or(Value::Null))
+    }
+
+    /// Evaluate in a SAME-PROCESS child frame, in its main world.
+    ///
+    /// Such a frame has no dedicated CDP session, so the session id alone
+    /// cannot address it. The chain below reaches its realm without
+    /// subscribing to execution-context events: resolve the owning <iframe>
+    /// element, take its `contentWindow` (legal because the frame is
+    /// same-origin here), and call a function on that window object —
+    /// Runtime.callFunctionOn compiles the function in the realm of the object
+    /// it is called on, so the script runs inside the frame.
+    pub async fn evaluate_in_frame(
+        &self,
+        session_id: &str,
+        frame_id: &str,
+        script: &str,
+    ) -> Result<Value, String> {
+        let owner_object_id =
+            super::element::frame_owner_object_id(&self.client, session_id, frame_id).await?;
+
+        // `contentWindow.eval(...)` and not a function compiled here: an
+        // indirect eval called as a method of the child window runs in THAT
+        // window's realm. Calling a locally-compiled function on the child
+        // window object instead keeps running in the parent's realm, which is
+        // the trap this avoids (measured: it returned the parent's location).
+        let declaration = format!(
+            "function() {{ const w = this.contentWindow; if (!w) throw new Error('frame window unavailable'); return w.eval({}); }}",
+            serde_json::to_string(script).unwrap_or_else(|_| "''".to_string())
+        );
+        let result = self
+            .client
+            .send_command(
+                "Runtime.callFunctionOn",
+                Some(json!({
+                    "objectId": owner_object_id,
+                    "functionDeclaration": declaration,
+                    "returnByValue": true,
+                    "awaitPromise": true,
+                })),
+                Some(session_id),
+            )
+            .await?;
+
+        if let Some(details) = result.get("exceptionDetails") {
+            let msg = details
+                .get("exception")
+                .and_then(|e| e.get("description"))
+                .and_then(|v| v.as_str())
+                .or_else(|| details.get("text").and_then(|v| v.as_str()))
+                .unwrap_or("evaluation failed");
+            return Err(format!("Evaluation error: {}", msg));
+        }
+
+        Ok(result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .cloned()
+            .unwrap_or(Value::Null))
     }
 
     async fn evaluate_simple(&self, expression: &str) -> Result<Value, String> {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -8407,3 +8407,164 @@ async fn e2e_find_role_document_matches_root() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+/// Serves a top page with two children on one port: a same-origin frame and a
+/// cross-origin one (`localhost` vs `127.0.0.1` differ as origins). Each child
+/// sets a main-world global and logs, so a test can tell which realm ran.
+async fn start_frame_eval_server() -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let handle = tokio::spawn(async move {
+        for _ in 0..100 {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 8192];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+
+                let body = match path {
+                    "/top" => format!(
+                        r#"<!doctype html><html lang="en"><head><title>Top</title></head>
+<body><main><h1>Top</h1>
+<iframe id="same" title="Same" src="/same"></iframe>
+<iframe id="cross" title="Cross" src="http://127.0.0.1:{port}/cross"></iframe>
+</main><script>window.REALM = 'top';</script></body></html>"#
+                    ),
+                    "/same" => r#"<!doctype html><html lang="en"><head><title>Same</title></head>
+<body><main><h1>Same</h1></main><script>window.REALM = 'same';
+console.log('same-frame-log');</script></body></html>"#
+                        .to_string(),
+                    "/cross" => r#"<!doctype html><html lang="en"><head><title>Cross</title></head>
+<body><main><h1>Cross</h1></main><script>window.REALM = 'cross';
+console.log('cross-frame-log');</script></body></html>"#
+                        .to_string(),
+                    _ => "<!doctype html><html lang=\"en\"><body></body></html>".to_string(),
+                };
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    (port, handle)
+}
+
+/// `frame <sel>` used to set the active frame while `eval` kept running in the
+/// top document, so a script aimed at an embedded app silently read the host
+/// page instead. Both frame kinds are covered because they take different code
+/// paths: the cross-origin child owns a CDP session, the same-origin one does
+/// not and is reached through its owner element.
+#[tokio::test]
+#[ignore]
+async fn e2e_eval_runs_inside_the_active_frame() {
+    let (port, server) = start_frame_eval_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://localhost:{port}/top") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let read_realm = |id: &str| json!({ "id": id, "action": "evaluate", "script": "window.REALM" });
+
+    let resp = execute_command(&read_realm("3"), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], json!("top"));
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "frame", "selector": "#same" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&read_realm("5"), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!("same"),
+        "eval should run in the same-origin frame after `frame #same`"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "frame", "selector": "#cross" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&read_realm("7"), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!("cross"),
+        "eval should run in the cross-origin frame after `frame #cross`"
+    );
+
+    let resp = execute_command(&json!({ "id": "8", "action": "mainframe" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(&read_realm("9"), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], json!("top"));
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// A cross-origin frame logs on its own CDP session, which the top-session
+/// filter dropped. An embedded app then read as silent while it was logging.
+#[tokio::test]
+#[ignore]
+async fn e2e_console_includes_cross_origin_frame_logs() {
+    let (port, server) = start_frame_eval_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://localhost:{port}/top") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "console" }), &mut state).await;
+    assert_success(&resp);
+    let logged = serde_json::to_string(&get_data(&resp)).unwrap_or_default();
+    assert!(
+        logged.contains("same-frame-log"),
+        "same-origin frame logs share the top session and were already captured: {logged}"
+    );
+    assert!(
+        logged.contains("cross-frame-log"),
+        "cross-origin frame logs arrive on the frame's own session and must be admitted: {logged}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -690,6 +690,42 @@ async fn test_frame_context_management() {
     assert!(state.active_frame_id.is_none());
 }
 
+#[test]
+fn test_iframe_console_events_admitted_only_for_active_frame_sessions() {
+    use super::actions::is_active_iframe_console_event;
+
+    let mut active = std::collections::HashSet::new();
+    active.insert("frame-session".to_string());
+
+    assert!(is_active_iframe_console_event(
+        "Runtime.consoleAPICalled",
+        Some("frame-session"),
+        &active
+    ));
+    assert!(is_active_iframe_console_event(
+        "Runtime.exceptionThrown",
+        Some("frame-session"),
+        &active
+    ));
+    // A frame in a background tab is not in the active set.
+    assert!(!is_active_iframe_console_event(
+        "Runtime.consoleAPICalled",
+        Some("other-session"),
+        &active
+    ));
+    // Unrelated events keep flowing through the normal session filter.
+    assert!(!is_active_iframe_console_event(
+        "Network.requestWillBeSent",
+        Some("frame-session"),
+        &active
+    ));
+    assert!(!is_active_iframe_console_event(
+        "Runtime.consoleAPICalled",
+        None,
+        &active
+    ));
+}
+
 #[tokio::test]
 async fn test_addstyle_supports_content_and_url() {
     let mut state = DaemonState::new();

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2043,6 +2043,7 @@ agent-browser eval - Execute JavaScript
 Usage: agent-browser eval [options] <script>
 
 Executes JavaScript code in the browser context and returns the result.
+Runs in the frame selected by `frame <sel>`, or the main frame otherwise.
 
 Options:
   -b, --base64         Decode script from base64 (avoids shell escaping issues)
@@ -2491,10 +2492,11 @@ agent-browser frame - Switch frame context
 
 Usage: agent-browser frame <selector|main>
 
-Switch to an iframe or back to the main frame.
+Switch to an iframe or back to the main frame. The selection also scopes eval,
+including for cross-origin iframes.
 
 Arguments:
-  <selector>           CSS selector for iframe
+  <selector>           CSS selector, element ref, frame name or URL
   main                 Switch back to main frame
 
 Global Options:
@@ -2504,6 +2506,8 @@ Global Options:
 Examples:
   agent-browser frame "#embed-iframe"
   agent-browser frame "iframe[name='content']"
+  agent-browser frame @e3
+  agent-browser frame "#embed-iframe" && agent-browser eval "location.origin"
   agent-browser frame main
 "##
         }

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -285,6 +285,17 @@ agent-browser frame main              # Return to main frame
 
 The `frame` command accepts element refs (`@e3`), CSS selectors (`"#my-iframe"`), or frame name/URL.
 
+A selected frame also scopes `eval`, which is how a script reads or seeds state inside an embedded app:
+
+```bash
+agent-browser frame "#payment-iframe"
+agent-browser eval "localStorage.setItem('mode','test')"   # runs inside the iframe
+agent-browser eval "location.origin"                       # the iframe's origin
+agent-browser frame main
+```
+
+`console` reports messages and uncaught errors from cross-origin iframes on the active page alongside the main frame's, so an embedded app is never silent.
+
 ## Dialogs
 
 ```bash

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -266,6 +266,17 @@ The `frame` command accepts:
 - **CSS selectors** — `frame "#payment-iframe"` finds the iframe by selector
 - **Frame name/URL** — matches against the browser's frame tree
 
+A selected frame also scopes `eval`, so a script can read or set state inside an embedded app:
+
+```bash
+agent-browser frame "#payment-iframe"
+agent-browser eval "localStorage.setItem('mode','test')"   # runs inside the iframe
+agent-browser eval "location.origin"                       # the iframe's origin
+agent-browser frame main
+```
+
+`console` reports messages from cross-origin iframes on the active page alongside the main frame's, so an embedded app's logging and uncaught errors are visible without switching frames.
+
 ## Dialogs
 
 By default, `alert` and `beforeunload` dialogs are automatically accepted so they never block the agent. `confirm` and `prompt` dialogs still require explicit handling. Use `--no-auto-dialog` to disable this behavior.


### PR DESCRIPTION
Fixes #318. Fixes #1696.

Snapshot and click already reach into cross-origin iframes (#925), so an embedded app can be driven — but it cannot be evaluated in, cannot be addressed by CSS selector, and its console is invisible. Three code paths still assume the top target's session.

## What changes

**1. `eval` runs in the selected frame (#318).** `handle_evaluate` ignored `state.active_frame_id`, so `frame <sel>` reported success and the script still ran in the top document. It now resolves the frame the way `wait` and element resolution already do:

- cross-origin child: evaluate on its dedicated CDP session (`evaluate_in_session`)
- same-process child: no session of its own, so reach its realm through the owner element (`evaluate_in_frame`)

The same-process path uses `contentWindow.eval(...)` rather than a locally compiled function called on the child window. That distinction is load-bearing: `Runtime.callFunctionOn` compiles the declaration in the caller's realm, so the function-on-window form kept returning the parent's `location`. An indirect eval invoked as a method of the child window is what actually crosses.

**2. `console` reports cross-origin iframe output (#1696).** The event loop dropped every event whose session id was not the top session, with a carve-out limited to `Network.*`. `Runtime.consoleAPICalled` and `Runtime.exceptionThrown` from an iframe session now pass the same filter, scoped to `active_iframe_sessions` so background-tab frames stay out.

**3. `frame "<selector>"` resolves cross-origin frames (#1696).** The CSS path read `el.name || el.id || el.src` and matched that against `Page.getFrameTree` of the top session. A cross-origin child is a separate target and is absent from that tree, so the command failed with `Frame not found` for exactly the frames that most need addressing. It now resolves the element and reads the frame id off the node (`DOM.getDocument` → `DOM.querySelector` → `DOM.describeNode`, `contentDocument.frameId` with the node's own `frameId` as fallback), the way the `@ref` path already did. The frame-tree match is kept as a fallback.

## Verification

Measured against a purpose-built local pair, parent on `127.0.0.1` and child on `localhost` so the origins differ, with a same-origin child as the control:

| | same-origin child | cross-origin child |
|---|---|---|
| `frame <sel>` then `eval` lands in that realm | before: no — after: yes | before: `Frame not found` — after: yes |
| `console` carries its messages | before and after: yes | before: no — after: yes |

Main-frame `eval` is unchanged, which the first test asserts explicitly.

Tests added:
- `test_iframe_console_events_admitted_only_for_active_frame_sessions` — unit, covers the allowlist including the background-tab and non-console cases
- `e2e_eval_runs_inside_the_active_frame` — asserts the realm for main, same-origin and cross-origin
- `e2e_console_includes_cross_origin_frame_logs`

Suite on this branch: `cargo test --profile ci` green (1112 unit), `cargo test -- --ignored` green (103 e2e), `cargo fmt --check` clean, `cargo clippy -- -D warnings` clean, version-sync clean.

## Docs

Updated per AGENTS.md: `cli/src/output.rs` help for `frame` and `eval`, `README.md`, `skill-data/core/references/commands.md`, `docs/src/app/commands/page.mdx`, plus inline comments at each changed site. No CLI command, flag, or output shape changed — only the execution target of existing commands — so `cli/src/mcp.rs` needs no matching change. CHANGELOG left alone, per the release process in AGENTS.md.

## Open question

Console output now merges messages from several realms into one list with no frame marker. Adding a frame label to `console` output would be a user-facing change, so it is left out of this PR — happy to follow up if you want it.
