### PR TITLE
fix(launcher): fall back to x64 binary on Windows ARM64 in bin/agent-browser.js

### DIFF
--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -61,6 +61,13 @@ function getBinaryName() {
       return null;
   }
 
+  // Windows ARM64 falls back to the x64 binary (runs via Windows' built-in
+  // x64 emulation); no native ARM64 build is published.
+  // Keep in sync with scripts/postinstall.js (effectiveArch).
+  if (osKey === 'win32' && archKey === 'arm64') {
+    archKey = 'x64';
+  }
+
   const ext = os === 'win32' ? '.exe' : '';
   return `agent-browser-${osKey}-${archKey}${ext}`;
 }


### PR DESCRIPTION
**Describe the bug**

On Windows 11 ARM64, `postinstall.js` correctly falls back to the x64 binary (added in #1269): it downloads `agent-browser-win32-x64.exe`, which runs fine under Windows' built-in x64 emulation.

However, the Node launcher `bin/agent-browser.js` was not updated with the same fallback. Its `getBinaryName()` maps `arch() === 'arm64'` to `agent-browser-win32-arm64.exe`, a file that never exists (no native ARM64 build is published). Any invocation that goes through the JS wrapper fails:

```
Error: No binary found for win32-arm64
Expected: ...\node_modules\agent-browser\bin\agent-browser-win32-arm64.exe
```

This affects `npx agent-browser`, and global installs whenever the shim rewrite in `fixWindowsShims()` didn't take effect (npm creates the shims *after* lifecycle scripts run — the postinstall itself documents that the JS wrapper is the fallback path in that case; package managers that skip lifecycle scripts, e.g. bun by default, hit it too).

**To reproduce**

1. On Windows 11 ARM64: `npx agent-browser@0.34.0 --version` (or any install where `bin/agent-browser.js` ends up being the entry point).
2. Observe `Error: No binary found for win32-arm64` even though `bin/agent-browser-win32-x64.exe` was downloaded by postinstall.

**Expected behavior**

The launcher resolves the same binary name that postinstall downloads: on `win32` + `arm64`, fall back to `agent-browser-win32-x64.exe`, mirroring `scripts/postinstall.js` (`effectiveArch`) and `fixWindowsShims()`.

**Fix**

Mirror the postinstall fallback in `getBinaryName()` in `bin/agent-browser.js`. Verified on a Windows 11 ARM64 machine: with this change the global install resolves and runs the x64 binary correctly (`agent-browser 0.34.0`).

A follow-up worth considering: extract the name-resolution into a shared helper used by both `bin/agent-browser.js` and `scripts/postinstall.js` so the two cannot drift again.

Generated with [Claude Code](https://claude.com/claude-code)
