### PR TITLE
fix(select): tolerate non-breaking spaces and match accessible name

### DIFF
--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -8407,3 +8407,126 @@ async fn e2e_find_role_document_matches_root() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+// ---------------------------------------------------------------------------
+// Select with &nbsp; option labels and opaque values
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn e2e_select_option_nbsp_and_accessible_name() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<html><body></body></html>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A province <select> whose option labels contain non-breaking spaces and
+    // whose values are opaque codes. This is the shape that broke `select`: the
+    // accessibility snapshot renders "Capital<nbsp>Federal" as "CapitalFederal"
+    // (nbsp stripped), a string that equals neither the value ("C") nor the raw
+    // textContent. The nbsp is inserted via char code so the source stays ASCII
+    // and does not depend on data-URL entity decoding.
+    let build = r#"(() => {
+        const sel = document.createElement('select');
+        sel.id = 'prov';
+        const nbsp = String.fromCharCode(0xA0);
+        const mk = (v, t) => { const o = document.createElement('option'); o.value = v; o.textContent = t; sel.appendChild(o); };
+        mk('', 'Provincia');
+        mk('B', 'Buenos' + nbsp + 'Aires');
+        mk('C', 'Capital' + nbsp + 'Federal');
+        document.body.appendChild(sel);
+        return sel.options.length;
+    })()"#;
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "evaluate", "script": build }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], 3);
+
+    // 1. Select by the exact accessible name the snapshot shows (nbsp stripped,
+    //    so the two words are joined). This is what an agent copies from the
+    //    tree and previously matched nothing.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "select", "selector": "#prov", "values": ["CapitalFederal"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "document.getElementById('prov').value" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "C");
+
+    // 2. The human-normal label (single ASCII space) also resolves, even though
+    //    the DOM label uses a non-breaking space.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "select", "selector": "#prov", "values": ["Buenos Aires"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "evaluate", "script": "document.getElementById('prov').value" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "B");
+
+    // 3. Selecting by the opaque value still works.
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "select", "selector": "#prov", "values": ["C"] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "evaluate", "script": "document.getElementById('prov').value" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "C");
+
+    // 4. A value that matches no option fails loudly and lists what was
+    //    available, instead of silently succeeding.
+    let resp = execute_command(
+        &json!({ "id": "10", "action": "select", "selector": "#prov", "values": ["Montevideo"] }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    let error = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("No option matched") && error.contains("Capital Federal"),
+        "expected available-options error, got: {error}"
+    );
+
+    // The failed select must not have changed the current selection.
+    let resp = execute_command(
+        &json!({ "id": "11", "action": "evaluate", "script": "document.getElementById('prov').value" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "C");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -441,15 +441,53 @@ pub async fn select_option(
     // Matching nothing must be an error, not a silent success: an agent that
     // selects a misspelled option otherwise sees "Done", and only discovers
     // the page state is wrong after more commands. List what was available.
+    //
+    // Matching is also whitespace-insensitive. The accessibility snapshot an
+    // agent reads names an option with invisible characters (zero-width spaces
+    // and U+00A0 / &nbsp;) stripped, so `Capital&nbsp;Federal` is shown as
+    // `CapitalFederal` -- a string equal to neither the raw `value` nor
+    // `textContent`. Each option is matched against its value, label and
+    // textContent in three forms: verbatim, whitespace-collapsed (any run of
+    // whitespace incl. nbsp -> a single space) and invisible-stripped (mirrors
+    // the snapshot). A case-insensitive pass runs only when nothing matched, so
+    // the exact string shown in `snapshot -i` is selectable without over-eager
+    // matching.
     let js = r#"function(vals) {
+            const INVISIBLE = /[\u00A0\u200B\u200C\u200D\u2060\uFEFF]/g;
+            const WS = /[\s\u200B\u200C\u200D\u2060]+/g;
+            const collapse = (s) => (s == null ? "" : String(s)).replace(WS, " ").trim();
+            const strip = (s) => (s == null ? "" : String(s)).replace(INVISIBLE, "").replace(/\s+/g, " ").trim();
+            const forms = (s) => { const r = s == null ? "" : String(s); return [r, r.trim(), collapse(r), strip(r)]; };
+            const candidates = (opt) => {
+                const set = new Set();
+                for (const src of [opt.value, opt.label, opt.textContent]) {
+                    for (const f of forms(src)) set.add(f);
+                }
+                return set;
+            };
             const options = Array.from(this.options);
-            let matched = 0;
-            for (const opt of options) {
-                opt.selected = vals.includes(opt.value) || vals.includes(opt.textContent.trim());
-                if (opt.selected) matched += 1;
-            }
+            const pass = (ci) => {
+                let n = 0;
+                for (const opt of options) {
+                    let cands = candidates(opt);
+                    if (ci) cands = new Set([...cands].map((c) => c.toLowerCase()));
+                    let hit = false;
+                    for (const v of vals) {
+                        for (let f of forms(v)) {
+                            if (ci) f = f.toLowerCase();
+                            if (cands.has(f)) { hit = true; break; }
+                        }
+                        if (hit) break;
+                    }
+                    opt.selected = hit;
+                    if (hit) n += 1;
+                }
+                return n;
+            };
+            let matched = pass(false);
+            if (matched === 0) matched = pass(true);
             if (matched === 0) {
-                const available = options.map(o => o.value + ' ("' + o.textContent.trim() + '")').join(', ');
+                const available = options.map(o => JSON.stringify(o.value) + ' ("' + collapse(o.textContent) + '")').join(', ');
                 return { error: 'No option matched ' + JSON.stringify(vals) + '. Available options: ' + available };
             }
             this.dispatchEvent(new Event('change', { bubbles: true }));

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -441,6 +441,9 @@ pub async fn select_option(
     // Matching nothing must be an error, not a silent success: an agent that
     // selects a misspelled option otherwise sees "Done", and only discovers
     // the page state is wrong after more commands. List what was available.
+    // A failed match is also non-destructive: the matching options are computed
+    // before anything is mutated, so a select that matches nothing leaves the
+    // element's current value untouched instead of clearing it.
     //
     // Matching is also whitespace-insensitive. The accessibility snapshot an
     // agent reads names an option with invisible characters (zero-width spaces
@@ -466,32 +469,34 @@ pub async fn select_option(
                 return set;
             };
             const options = Array.from(this.options);
-            const pass = (ci) => {
-                let n = 0;
+            // Decide which options match WITHOUT mutating: a failed select must
+            // leave the <select>'s current value untouched, so nothing is
+            // deselected until at least one match is known.
+            const wantedFor = (ci) => {
+                const wanted = new Set();
                 for (const opt of options) {
                     let cands = candidates(opt);
                     if (ci) cands = new Set([...cands].map((c) => c.toLowerCase()));
-                    let hit = false;
                     for (const v of vals) {
+                        let hit = false;
                         for (let f of forms(v)) {
                             if (ci) f = f.toLowerCase();
                             if (cands.has(f)) { hit = true; break; }
                         }
-                        if (hit) break;
+                        if (hit) { wanted.add(opt); break; }
                     }
-                    opt.selected = hit;
-                    if (hit) n += 1;
                 }
-                return n;
+                return wanted;
             };
-            let matched = pass(false);
-            if (matched === 0) matched = pass(true);
-            if (matched === 0) {
+            let wanted = wantedFor(false);
+            if (wanted.size === 0) wanted = wantedFor(true);
+            if (wanted.size === 0) {
                 const available = options.map(o => JSON.stringify(o.value) + ' ("' + collapse(o.textContent) + '")').join(', ');
                 return { error: 'No option matched ' + JSON.stringify(vals) + '. Available options: ' + available };
             }
+            for (const opt of options) opt.selected = wanted.has(opt);
             this.dispatchEvent(new Event('change', { bubbles: true }));
-            return { matched };
+            return { matched: wanted.size };
         }"#
     .to_string();
 


### PR DESCRIPTION
Fixes #1700.

## What

Make `select` option-matching whitespace-insensitive and accessible-name aware,
so a native `<select>` option whose label contains a non-breaking space
(U+00A0) — or other invisible characters — is selectable by the exact name the
accessibility snapshot displays.

## Why

`select_option` matched an option only by an exact `value` or an exact trimmed
`textContent`. But `snapshot -i` renders an option's accessible name with
invisible characters (zero-width spaces and U+00A0) **stripped**
(`snapshot.rs` `INVISIBLE_CHARS` + `display_name.replace(INVISIBLE_CHARS, "")`),
so `Capital&nbsp;Federal` is shown as `CapitalFederal`. That string equals
neither the opaque `value` (`"C"`) nor the raw `textContent` (which still
contains the U+00A0), so `select "CapitalFederal"` — and even a human-normal
`select "Capital Federal"` — matched nothing. The command then errored on the
very name it had just displayed, and any dependent flow (e.g. an AJAX-populated
second dropdown gated on the province `change`) never fired.

## Change

- **`cli/src/native/interaction.rs`** — rewrote the matching predicate in
  `select_option`. Each option is compared against its `value`, `label` and
  `textContent` in three forms: verbatim, whitespace-collapsed (any run of
  whitespace, including U+00A0 and zero-width characters, → a single space) and
  invisible-stripped (mirrors the snapshot's name rendering). A case-insensitive
  pass runs only when nothing matched. The verbatim pass is tried first, so
  existing matches are unchanged; the fall-through only widens what resolves.
  The loud `No option matched ...; available: [...]` error is preserved for a
  genuine miss.
- **`cli/src/native/e2e_tests.rs`** — new `e2e_select_option_nbsp_and_accessible_name`.

## Generality

- Not tied to any site: it normalizes whitespace/invisible characters that any
  `<select>` may carry, and matches the name the snapshot actually shows.
- Behavior-preserving: exact matches still win first; the widening is additive,
  with case-insensitivity as a last resort to avoid over-eager matches.
- Both the CLI and MCP `select` surfaces route through `select_option`
  (`mcp.rs` `call_select` forwards `["select", …]` through the CLI parser), so
  no `mcp.rs` change is needed and both surfaces get the fix.

## Testing

New e2e test asserts, against an inline `<select>` with `&nbsp;` labels and
opaque values:

- select by the displayed name `CapitalFederal` → sets value `C`
- select by the normal-space label `Buenos Aires` → sets value `B`
- select by the opaque value `C` → sets value `C`
- select `Montevideo` (no match) → fails loudly with the available-options list
  and leaves the selection unchanged

It runs in the existing `native-e2e` CI job
(`cargo test e2e -- --ignored --test-threads=1`).
