### PR TITLE
docs(skills): add protected Vercel deployment access

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ agent-browser skills                  # List available skills
 agent-browser skills list             # Same as above
 agent-browser skills get <name>       # Output a skill's full content
 agent-browser skills get <name> --full  # Include references and templates
+agent-browser skills get protected-vercel-deployments  # Access protected Vercel deployments
 agent-browser skills get --all        # Output every skill
 agent-browser skills path [name]      # Print skill directory path
 ```

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3411,6 +3411,7 @@ Examples:
   agent-browser skills list
   agent-browser skills get core
   agent-browser skills get core --full
+  agent-browser skills get protected-vercel-deployments
   agent-browser skills get electron --full
   agent-browser skills get --all
   agent-browser skills path core
@@ -3503,7 +3504,8 @@ Start here (for AI agents):
   Skills ship with the CLI (always version-matched) and include workflow
   patterns, ref/selector usage, and copy-paste examples. Prefer this over
   guessing commands from flag docs alone. Specialized skills cover Electron
-  apps, Slack, exploratory testing, and cloud browser providers.
+  apps, Slack, exploratory testing, protected Vercel deployments, and cloud
+  browser providers.
 
   skills [list]                List available skills
   skills get core              Core usage guide (overview + common patterns)

--- a/docs/src/app/skills/page.mdx
+++ b/docs/src/app/skills/page.mdx
@@ -67,6 +67,7 @@ This design solves the version drift problem: the installed SKILL.md rarely chan
 - **electron** — Automate any Electron app (VS Code, Slack, Discord, Figma, etc.) by connecting to its built-in Chrome DevTools Protocol port.
 - **slack** — Browser-based Slack automation. Check unreads, navigate channels, search conversations, send messages, and extract data.
 - **vercel-sandbox** — Run agent-browser + headless Chrome inside ephemeral Vercel Sandbox microVMs.
+- **protected-vercel-deployments** — Access and test Vercel deployments behind Vercel Authentication, SSO, or Deployment Protection with short-lived Trusted Sources OIDC tokens.
 - **agentcore** — Run agent-browser on AWS Bedrock AgentCore cloud browsers.
 
 Use `agent-browser skills list` to see all available skills, then `agent-browser skills get <name>` to load one. `agent-browser skills get core --full` is the recommended starting point for most browser tasks.

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -458,6 +458,7 @@ EOF
 - **Slack workspace automation**: `agent-browser skills get slack`
 - **Exploratory testing / QA / bug hunts**: `agent-browser skills get dogfood`
 - **Vercel Sandbox microVMs**: `agent-browser skills get vercel-sandbox`
+- **Vercel deployment behind Authentication, SSO, or Deployment Protection**: `agent-browser skills get protected-vercel-deployments`
 - **AWS Bedrock AgentCore cloud browser**: `agent-browser skills get agentcore`
 
 ## Accessibility audits

--- a/skill-data/protected-vercel-deployments/SKILL.md
+++ b/skill-data/protected-vercel-deployments/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: protected-vercel-deployments
+description: Access and test Vercel deployments protected by Vercel Authentication, SSO, or Deployment Protection with agent-browser. Use when a preview or production URL redirects to a Vercel login page, returns a protection 401 or 403, or needs short-lived Trusted Sources OIDC authentication instead of a static bypass secret or public exception.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*), Bash(vc:*), Bash(vercel:*)
+---
+
+# Protected Vercel deployments
+
+Use the caller's existing Vercel identity and a short-lived OIDC token. Do not disable Deployment Protection, make the deployment public, or ask for a static bypass secret first.
+
+## Same-project preview
+
+A local development token for a linked project can access that project's protected Preview deployments through the default Trusted Sources self-access rule. No Trusted Sources configuration is normally required.
+
+Confirm the local identity and project link:
+
+```bash
+vc whoami
+test -f .vercel/project.json || vc link --yes --team <team> --project <project>
+```
+
+If the target project or team cannot be inferred safely, ask the user which project to link. Linking does not change Deployment Protection.
+
+Create a named browser session, mint a development OIDC token with the Vercel CLI, then inject it without printing or persisting it:
+
+```bash
+export AGENT_BROWSER_SESSION="$(agent-browser session id --scope worktree --prefix vercel-preview)"
+export VERCEL_PREVIEW_URL="https://my-app.vercel.app"
+
+(
+  TOKEN="$(vc project token)"
+  test -n "$TOKEN"
+  agent-browser open "$VERCEL_PREVIEW_URL" --headers \
+    "{\"x-vercel-trusted-oidc-idp-token\":\"$TOKEN\"}"
+)
+
+agent-browser snapshot -i
+```
+
+Continue the normal workflow in that same session. The header is scoped to the target origin and applies to the document, scripts, styles, fonts, and in-page requests. If the browser session is closed or restarted, repeat the authenticated `open` command.
+
+On older Vercel CLI versions without `vc project token`, inject the linked project's development environment without printing the token:
+
+```bash
+vc env run -- sh -c \
+  'test -n "$VERCEL_OIDC_TOKEN" && agent-browser open "$1" --headers "{\"x-vercel-trusted-oidc-idp-token\":\"$VERCEL_OIDC_TOKEN\"}"' \
+  sh "$VERCEL_PREVIEW_URL"
+```
+
+Never print the token, paste it into source, or save it in an environment file.
+
+## Other environments and callers
+
+Trusted Sources configuration is needed when:
+
+- a local development token must reach a protected Production deployment;
+- the caller belongs to another Vercel project or team;
+- the target project's self-access rules were customized; or
+- Vercel returns `TRUSTED_SOURCES_ENVIRONMENT_MISMATCH`.
+
+There is no supported Vercel CLI or public REST API for editing Trusted Sources rules. An authorized human must open the target project's **Settings → Deployment Protection → Trusted Sources** and add only the required caller and environment mapping. A local token has the `development` environment, so protected Production access requires `development` to `production`.
+
+Stop and hand off the exact rule to the human. Do not use browser automation to change access control, and do not broaden unrelated environment mappings. Retry the authenticated `open` after the human confirms the rule is saved.
+
+## Human intervention boundaries
+
+The same-project development to Preview path should run without human intervention when the Vercel CLI is already authenticated and the directory is linked correctly. A human is needed only when:
+
+- the Vercel CLI has no authenticated identity and no existing `VERCEL_TOKEN`; interactive `vc login` requires the user;
+- the correct project or team cannot be inferred safely for `vc link`;
+- a Trusted Sources rule must be added or changed; the dashboard is the only supported management surface, and this changes access control;
+- Secure Backend Access with OIDC Federation was disabled on the calling project and must be re-enabled in **Settings → Security**; or
+- the static-secret fallback must be enabled or rotated and the agent needs explicit authorization for that access-control change. After approval, the agent can use `vc project protection` instead of requiring dashboard interaction.
+
+The agent can diagnose each case and state the exact action required, then continue after the user confirms completion.
+
+## Use the correct header
+
+Send the Vercel-issued token as:
+
+```text
+x-vercel-trusted-oidc-idp-token: <VERCEL_OIDC_TOKEN>
+```
+
+Do not substitute `x-vercel-oidc-token`. That header carries workload identity into a Vercel Function; it does not authenticate an inbound request through Deployment Protection.
+
+## Diagnose failures
+
+- Redirect to `vercel.com/login`: Deployment Protection did not accept the request.
+- `TRUSTED_SOURCES_ENVIRONMENT_MISMATCH`: the token is valid, but its caller environment cannot reach the target environment.
+- Application `401` or `403` after protection passes: debug the application's own authentication separately.
+- Application `404` on a deliberately missing route: the request passed Deployment Protection and reached the application.
+
+## Static-secret fallback
+
+Use Protection Bypass for Automation only when OIDC is not viable or the tool cannot send the Trusted Sources header. Enabling or rotating it changes access control, so obtain explicit authorization first. Create a dedicated secret so it can be rotated independently, keep it in an environment variable, and pass it as a header:
+
+```bash
+vc project protection enable <project> --protection-bypass \
+  --protection-bypass-secret "$VERCEL_AUTOMATION_BYPASS_SECRET"
+
+agent-browser open "$VERCEL_PREVIEW_URL" --headers \
+  "{\"x-vercel-protection-bypass\":\"$VERCEL_AUTOMATION_BYPASS_SECRET\",\"x-vercel-set-bypass-cookie\":\"true\"}"
+```
+
+The cookie directive creates a reusable `_vercel_jwt` cookie. Treat saved browser state containing that cookie as a credential.
+
+## Avoid dead ends
+
+- There is no `vercel share` CLI command. Shareable Links are intended for people and are not the automation path.
+- `vercel curl` is useful for HTTP requests, but it cannot render and interact with a page.
+- Deployment Protection Exceptions make the domain public. Do not use them merely to unblock an agent.
+- Do not expose OIDC tokens, bypass secrets, authenticated URLs, or saved state in logs, screenshots, source files, or user-facing output.

--- a/skill-data/protected-vercel-deployments/SKILL.md
+++ b/skill-data/protected-vercel-deployments/SKILL.md
@@ -12,11 +12,14 @@ Use the caller's existing Vercel identity and a short-lived OIDC token. Do not d
 
 A local development token for the target project can access that project's protected Preview deployments through the default Trusted Sources self-access rule. No Trusted Sources configuration is normally required.
 
-Confirm the local identity:
+Confirm the local identity and Vercel CLI version:
 
 ```bash
 vc whoami
+vc --version
 ```
+
+Require Vercel CLI `53.3.0` or newer before running `vc project token`. Versions `50.25.0` through `53.2.x` write the token to stderr, so command substitution captures nothing and the credential can appear in logs. If the installed version is older, stop and ask the user to upgrade it. Do not attempt to capture or recover the token from stderr.
 
 Set the target project and scope explicitly. If they cannot be inferred safely, ask the user. In a directory whose existing `.vercel/project.json` link has been verified against the target, `vc project token` without a project name is also valid. Do not run `vc link` merely to get an OIDC token: current Vercel CLI versions also pull development variables into `.env.local` when linking.
 
@@ -40,14 +43,6 @@ agent-browser snapshot -i
 
 Continue the normal workflow in that same session. The header is scoped to the target origin and applies to the document, scripts, styles, fonts, and in-page requests. If the browser session is closed or restarted, repeat the authenticated `open` command.
 
-On older Vercel CLI versions without `vc project token`, inject the target project's development environment without printing the token:
-
-```bash
-vc env run --project "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE" -- sh -c \
-  'test -n "$VERCEL_OIDC_TOKEN" && agent-browser open "$1" --headers "{\"x-vercel-trusted-oidc-idp-token\":\"$VERCEL_OIDC_TOKEN\"}"' \
-  sh "$VERCEL_PREVIEW_URL"
-```
-
 Never print the token, paste it into source, or save it in an environment file.
 
 ## Other environments and callers
@@ -68,6 +63,7 @@ Stop and hand off the exact rule to the human. Do not use browser automation to 
 The same-project development to Preview path should run without human intervention when the Vercel CLI is already authenticated and the target project and scope are known. A human is needed only when:
 
 - the Vercel CLI has no authenticated identity and no existing `VERCEL_TOKEN`; interactive `vc login` requires the user;
+- the installed Vercel CLI is older than `53.3.0` and must be upgraded before token minting;
 - the correct target project or scope cannot be inferred safely for token minting;
 - a Trusted Sources rule must be added or changed; the dashboard is the only supported management surface, and this changes access control;
 - Secure Backend Access with OIDC Federation was disabled on the calling project and must be re-enabled in **Settings → Security**; or

--- a/skill-data/protected-vercel-deployments/SKILL.md
+++ b/skill-data/protected-vercel-deployments/SKILL.md
@@ -10,25 +10,26 @@ Use the caller's existing Vercel identity and a short-lived OIDC token. Do not d
 
 ## Same-project preview
 
-A local development token for a linked project can access that project's protected Preview deployments through the default Trusted Sources self-access rule. No Trusted Sources configuration is normally required.
+A local development token for the target project can access that project's protected Preview deployments through the default Trusted Sources self-access rule. No Trusted Sources configuration is normally required.
 
-Confirm the local identity and project link:
+Confirm the local identity:
 
 ```bash
 vc whoami
-test -f .vercel/project.json || vc link --yes --team <team> --project <project>
 ```
 
-If the target project or team cannot be inferred safely, ask the user which project to link. Linking does not change Deployment Protection.
+Set the target project and scope explicitly. If they cannot be inferred safely, ask the user. In a directory whose existing `.vercel/project.json` link has been verified against the target, `vc project token` without a project name is also valid. Do not run `vc link` merely to get an OIDC token: current Vercel CLI versions also pull development variables into `.env.local` when linking.
 
 Create a named browser session, mint a development OIDC token with the Vercel CLI, then inject it without printing or persisting it:
 
 ```bash
 export AGENT_BROWSER_SESSION="$(agent-browser session id --scope worktree --prefix vercel-preview)"
 export VERCEL_PREVIEW_URL="https://my-app.vercel.app"
+export VERCEL_PROJECT="my-app"
+export VERCEL_SCOPE="my-team"
 
 (
-  TOKEN="$(vc project token)"
+  TOKEN="$(vc project token "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE")"
   test -n "$TOKEN"
   agent-browser open "$VERCEL_PREVIEW_URL" --headers \
     "{\"x-vercel-trusted-oidc-idp-token\":\"$TOKEN\"}"
@@ -39,10 +40,10 @@ agent-browser snapshot -i
 
 Continue the normal workflow in that same session. The header is scoped to the target origin and applies to the document, scripts, styles, fonts, and in-page requests. If the browser session is closed or restarted, repeat the authenticated `open` command.
 
-On older Vercel CLI versions without `vc project token`, inject the linked project's development environment without printing the token:
+On older Vercel CLI versions without `vc project token`, inject the target project's development environment without printing the token:
 
 ```bash
-vc env run -- sh -c \
+vc env run --project "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE" -- sh -c \
   'test -n "$VERCEL_OIDC_TOKEN" && agent-browser open "$1" --headers "{\"x-vercel-trusted-oidc-idp-token\":\"$VERCEL_OIDC_TOKEN\"}"' \
   sh "$VERCEL_PREVIEW_URL"
 ```
@@ -64,10 +65,10 @@ Stop and hand off the exact rule to the human. Do not use browser automation to 
 
 ## Human intervention boundaries
 
-The same-project development to Preview path should run without human intervention when the Vercel CLI is already authenticated and the directory is linked correctly. A human is needed only when:
+The same-project development to Preview path should run without human intervention when the Vercel CLI is already authenticated and the target project and scope are known. A human is needed only when:
 
 - the Vercel CLI has no authenticated identity and no existing `VERCEL_TOKEN`; interactive `vc login` requires the user;
-- the correct project or team cannot be inferred safely for `vc link`;
+- the correct target project or scope cannot be inferred safely for token minting;
 - a Trusted Sources rule must be added or changed; the dashboard is the only supported management surface, and this changes access control;
 - Secure Backend Access with OIDC Federation was disabled on the calling project and must be re-enabled in **Settings → Security**; or
 - the static-secret fallback must be enabled or rotated and the agent needs explicit authorization for that access-control change. After approval, the agent can use `vc project protection` instead of requiring dashboard interaction.

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -32,6 +32,7 @@ agent-browser skills get slack             # Slack workspace automation
 agent-browser skills get dogfood           # Exploratory testing / QA / bug hunts
 agent-browser skills get derive-client     # Record a HAR, derive a standalone API client for a site
 agent-browser skills get vercel-sandbox    # agent-browser inside Vercel Sandbox microVMs
+agent-browser skills get protected-vercel-deployments  # Access protected Vercel deployments
 agent-browser skills get agentcore         # AWS Bedrock AgentCore cloud browsers
 ```
 


### PR DESCRIPTION
## Summary

- add a bundled `protected-vercel-deployments` skill for browser automation behind Vercel Deployment Protection
- prefer short-lived Trusted Sources OIDC via `vc project token` and `x-vercel-trusted-oidc-idp-token`
- document explicit human handoffs for dashboard-only Trusted Sources and OIDC Federation changes
- retain Protection Bypass for Automation as an authorized fallback
- expose the skill through CLI, core skill, discovery stub, README, and docs

## Context

Customers already had the necessary Vercel CLI identity and agent-browser header support, but agents did not connect the two. The same guidance exists in the Vercel plugin and v0 in separate pieces. This packages the workflow where agent-browser users discover it.

## Validation

- skill validator: passed
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- focused Rust skill tests: 11 passed
- runtime `skills list` and `skills get protected-vercel-deployments`
- shell smoke: exact OIDC header received as valid JSON, no token output, token scope ended
- Review Gate exact-HEAD report: passed
