### PR TITLE
fix(release): restore ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         if: matrix.use_zigbuild
         run: |
           pip3 install ziglang
-          cargo install cargo-zigbuild --version 0.22.3 --locked
+          cargo install cargo-zigbuild --version 0.23.2 --locked
 
       - name: Configure Rust linkers
         if: runner.os == 'Linux'

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -858,18 +858,21 @@ mod tests {
             .spawn()
             .expect("failed to spawn child");
 
-        std::thread::sleep(std::time::Duration::from_millis(200));
-
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                assert!(
-                    !status.success(),
-                    "child exited with code 42, should not be success"
-                );
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) if std::time::Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("child did not exit before the deadline");
+                }
+                Ok(None) => std::thread::sleep(std::time::Duration::from_millis(10)),
+                Err(e) => panic!("try_wait() should succeed without waitpid(-1): {}", e),
             }
-            Ok(None) => panic!("try_wait() returned None but child should have exited"),
-            Err(e) => panic!("try_wait() should succeed without waitpid(-1): {}", e),
-        }
+        };
+
+        assert_eq!(status.code(), Some(42));
     }
 
     /// Regression test for #1101: idle timeout must fire even while the


### PR DESCRIPTION
## Summary

- upgrade cargo-zigbuild to 0.23.2 so Rust 1.98 ARM64 builds do not pass the unsupported Cortex-A53 linker argument to Zig 0.16
- replace the macOS-sensitive fixed 200 ms child-exit sleep with bounded polling, timeout cleanup, and exact exit-code verification

## Root cause

The v0.35.0 release run failed both Linux ARM64 targets after stable Rust advanced to 1.98.0 and added `-Wl,--fix-cortex-a53-843419`. cargo-zigbuild 0.22.3 forwarded it to Zig 0.16.0, which rejected it. cargo-zigbuild 0.23.2 filters that exact argument.

The macOS x64 CI failure was a timing race in the test: under full-suite load, `/bin/sh -c "exit 42"` had not exited by the hardcoded 200 ms check.

## Validation

- built all four Zig release targets with Rust 1.98.0 and Zig 0.16.0: ARM64 GNU 2.28, ARM64 musl, x64 GNU 2.28, and x64 musl
- verified GNU artifacts require no GLIBC newer than 2.28 and musl artifacts are static
- forced the old test red with a one-second delayed child; it failed for the intended `try_wait() returned None` reason
- passed the delayed-child variant 100/100 times with deadline polling
- passed the final narrow test and the full macOS x64 suite: 1,145 passed, 101 ignored, plus 2 doctor integration tests
- passed cargo fmt, cargo clippy with warnings denied, diff checks, and the exact-head Review Gate