### PR TITLE
Reset element references for snapshot diffs

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6156,12 +6156,13 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         ..SnapshotOptions::default()
     };
     // Start from the same ref base as a normal baseline snapshot so unchanged lines align.
-    state.ref_map.clear();
+    // Build the replacement separately so a failed diff leaves the existing refs usable.
+    let mut current_ref_map = RefMap::new();
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &mut current_ref_map,
         state.active_frame_id.as_deref(),
         &state.iframe_sessions,
     )
@@ -6171,13 +6172,23 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
 
     let baseline_text = match baseline {
         Some(b) if std::path::Path::new(b).exists() => {
-            std::fs::read_to_string(b).map_err(|e| format!("Failed to read baseline: {}", e))?
+            let mut contents = std::fs::read_to_string(b)
+                .map_err(|e| format!("Failed to read baseline: {}", e))?;
+            // Plain CLI output ends with one newline when redirected to a baseline file.
+            if contents.ends_with('\n') {
+                contents.pop();
+                if contents.ends_with('\r') {
+                    contents.pop();
+                }
+            }
+            contents
         }
         Some(b) => b.to_string(),
         None => String::new(),
     };
 
     let result = diff::diff_snapshots(&baseline_text, &current);
+    state.ref_map = current_ref_map;
     Ok(json!({
         "diff": result.diff,
         "additions": result.additions,
@@ -6209,12 +6220,12 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     mgr.navigate(url1, wait_until).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let options = SnapshotOptions::default();
-    state.ref_map.clear();
+    let mut snap1_ref_map = RefMap::new();
     let snap1 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &mut snap1_ref_map,
         None,
         &state.iframe_sessions,
     )
@@ -6222,18 +6233,19 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
 
     // Navigate to URL2 and snapshot
     mgr.navigate(url2, wait_until).await?;
-    state.ref_map.clear();
+    let mut snap2_ref_map = RefMap::new();
     let snap2 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
         &options,
-        &mut state.ref_map,
+        &mut snap2_ref_map,
         None,
         &state.iframe_sessions,
     )
     .await?;
 
     let result = diff::diff_text(&snap1, &snap2);
+    state.ref_map = snap2_ref_map;
     Ok(json!({
         "diff": result,
         "url1": url1,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6155,6 +6155,8 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         selector,
         ..SnapshotOptions::default()
     };
+    // Start from the same ref base as a normal baseline snapshot so unchanged lines align.
+    state.ref_map.clear();
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -6207,6 +6209,7 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     mgr.navigate(url1, wait_until).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let options = SnapshotOptions::default();
+    state.ref_map.clear();
     let snap1 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6216,6 +6216,9 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .map(WaitUntil::from_str)
         .unwrap_or(WaitUntil::Load);
 
+    // Each navigation can replace the document, so invalidate refs before it starts.
+    state.ref_map.clear();
+
     // Navigate to URL1 and snapshot
     mgr.navigate(url1, wait_until).await?;
     let session_id = mgr.active_session_id()?.to_string();
@@ -6232,6 +6235,7 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     .await?;
 
     // Navigate to URL2 and snapshot
+    state.ref_map.clear();
     mgr.navigate(url2, wait_until).await?;
     let mut snap2_ref_map = RefMap::new();
     let snap2 = snapshot::take_snapshot(

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -37,6 +37,7 @@ fn native_test_fixture_html(name: &str) -> &'static str {
         "drag_probe" => include_str!("test_fixtures/drag_probe.html"),
         "html5_drag_probe" => include_str!("test_fixtures/html5_drag_probe.html"),
         "pointer_capture_probe" => include_str!("test_fixtures/pointer_capture_probe.html"),
+        "snapshot_diff_probe" => include_str!("test_fixtures/snapshot_diff_probe.html"),
         "upload_probe" => include_str!("test_fixtures/upload_probe.html"),
         _ => panic!("Unknown native test fixture: {}", name),
     }
@@ -3364,7 +3365,11 @@ async fn e2e_diff_snapshot() {
     assert_success(&resp);
 
     let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Hello</h1><p>World</p>" }),
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": native_test_fixture_url("snapshot_diff_probe")
+        }),
         &mut state,
     )
     .await;
@@ -3374,10 +3379,30 @@ async fn e2e_diff_snapshot() {
     let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
     assert_success(&resp);
     let baseline = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
+    assert!(baseline.starts_with("- button \"Primary action\" [ref=e1]"));
+
+    // Repeated diffs must each begin a fresh ref-numbering epoch.
+    for id in ["4", "5"] {
+        let resp = execute_command(
+            &json!({ "id": id, "action": "diff_snapshot", "baseline": baseline }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let data = get_data(&resp);
+        assert_eq!(data["changed"], false);
+        assert_eq!(data["additions"], 0);
+        assert_eq!(data["removals"], 0);
+        assert_eq!(data["diff"], "");
+    }
 
     // Modify the page
     let resp = execute_command(
-        &json!({ "id": "4", "action": "evaluate", "script": "document.querySelector('h1').textContent = 'Changed'" }),
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "document.querySelector('#primary-action').textContent = 'Updated action'"
+        }),
         &mut state,
     )
     .await;
@@ -3385,13 +3410,69 @@ async fn e2e_diff_snapshot() {
 
     // Diff against baseline
     let resp = execute_command(
-        &json!({ "id": "5", "action": "diff_snapshot", "baseline": baseline }),
+        &json!({ "id": "7", "action": "diff_snapshot", "baseline": baseline }),
         &mut state,
     )
     .await;
     assert_success(&resp);
     let data = get_data(&resp);
-    assert_eq!(data["changed"], true, "Diff should detect the h1 change");
+    assert_eq!(
+        data["changed"], true,
+        "Diff should detect the button change"
+    );
+    assert_eq!(data["additions"], 1);
+    assert_eq!(data["removals"], 1);
+    assert!(data["diff"].as_str().unwrap().contains("Updated action"));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_diff_url_aligns_refs_after_snapshot() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = native_test_fixture_url("snapshot_diff_probe");
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Populate the session ref map before comparing the same URL to itself.
+    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "diff_url",
+            "url1": url,
+            "url2": url
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["diff"]["identical"], true);
+    assert_eq!(data["diff"]["changed"], false);
+    assert_eq!(data["diff"]["additions"], 0);
+    assert_eq!(data["diff"]["removals"], 0);
+    assert_eq!(data["snapshot1"], data["snapshot2"]);
+    assert!(data["snapshot1"]
+        .as_str()
+        .unwrap()
+        .starts_with("- button \"Primary action\" [ref=e1]"));
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3380,11 +3380,38 @@ async fn e2e_diff_snapshot() {
     assert_success(&resp);
     let baseline = get_data(&resp)["snapshot"].as_str().unwrap().to_string();
     assert!(baseline.starts_with("- button \"Primary action\" [ref=e1]"));
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let baseline_path = baseline_dir.path().join("baseline.txt");
+    std::fs::write(&baseline_path, format!("{}\n", baseline)).unwrap();
+
+    // A failed diff must preserve the refs from the last successful snapshot.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "diff_snapshot",
+            "baseline": baseline_path,
+            "selector": "#missing"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    assert!(resp["error"]
+        .as_str()
+        .unwrap()
+        .contains("did not match any element"));
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "e1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
 
     // Repeated diffs must each begin a fresh ref-numbering epoch.
-    for id in ["4", "5"] {
+    for id in ["6", "7"] {
         let resp = execute_command(
-            &json!({ "id": id, "action": "diff_snapshot", "baseline": baseline }),
+            &json!({ "id": id, "action": "diff_snapshot", "baseline": baseline_path }),
             &mut state,
         )
         .await;
@@ -3399,7 +3426,7 @@ async fn e2e_diff_snapshot() {
     // Modify the page
     let resp = execute_command(
         &json!({
-            "id": "6",
+            "id": "8",
             "action": "evaluate",
             "script": "document.querySelector('#primary-action').textContent = 'Updated action'"
         }),
@@ -3410,7 +3437,7 @@ async fn e2e_diff_snapshot() {
 
     // Diff against baseline
     let resp = execute_command(
-        &json!({ "id": "7", "action": "diff_snapshot", "baseline": baseline }),
+        &json!({ "id": "9", "action": "diff_snapshot", "baseline": baseline_path }),
         &mut state,
     )
     .await;
@@ -3448,13 +3475,77 @@ async fn e2e_diff_url_aligns_refs_after_snapshot() {
     .await;
     assert_success(&resp);
 
-    // Populate the session ref map before comparing the same URL to itself.
-    let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
+    // A failed URL diff must preserve the refs from the last successful snapshot.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "snapshot",
+            "selector": "#primary-action"
+        }),
+        &mut state,
+    )
+    .await;
     assert_success(&resp);
+    let refs_before_failure = state
+        .ref_map
+        .entries_sorted()
+        .into_iter()
+        .map(|(ref_id, entry)| {
+            (
+                ref_id,
+                entry.backend_node_id,
+                entry.role,
+                entry.name,
+                entry.nth,
+                entry.selector,
+                entry.frame_id,
+            )
+        })
+        .collect::<Vec<_>>();
 
     let resp = execute_command(
         &json!({
             "id": "4",
+            "action": "diff_url",
+            "url1": url,
+            "url2": "http://[invalid"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    let refs_after_failure = state
+        .ref_map
+        .entries_sorted()
+        .into_iter()
+        .map(|(ref_id, entry)| {
+            (
+                ref_id,
+                entry.backend_node_id,
+                entry.role,
+                entry.name,
+                entry.nth,
+                entry.selector,
+                entry.frame_id,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(refs_after_failure, refs_before_failure);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "click", "selector": "e1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Populate the session ref map before comparing the same URL to itself.
+    let resp = execute_command(&json!({ "id": "6", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "7",
             "action": "diff_url",
             "url1": url,
             "url2": url

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3467,41 +3467,27 @@ async fn e2e_diff_url_aligns_refs_after_snapshot() {
     .await;
     assert_success(&resp);
 
+    let stale_url = "data:text/html,<button id='stale-action'>Stale action</button>";
     let url = native_test_fixture_url("snapshot_diff_probe");
     let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &json!({ "id": "2", "action": "navigate", "url": stale_url }),
         &mut state,
     )
     .await;
     assert_success(&resp);
 
-    // A failed URL diff must preserve the refs from the last successful snapshot.
+    // Populate refs that must be invalidated once the URL diff starts navigating.
     let resp = execute_command(
         &json!({
             "id": "3",
             "action": "snapshot",
-            "selector": "#primary-action"
+            "selector": "#stale-action"
         }),
         &mut state,
     )
     .await;
     assert_success(&resp);
-    let refs_before_failure = state
-        .ref_map
-        .entries_sorted()
-        .into_iter()
-        .map(|(ref_id, entry)| {
-            (
-                ref_id,
-                entry.backend_node_id,
-                entry.role,
-                entry.name,
-                entry.nth,
-                entry.selector,
-                entry.frame_id,
-            )
-        })
-        .collect::<Vec<_>>();
+    assert!(state.ref_map.get("e1").is_some());
 
     let resp = execute_command(
         &json!({
@@ -3514,38 +3500,35 @@ async fn e2e_diff_url_aligns_refs_after_snapshot() {
     )
     .await;
     assert_eq!(resp["success"], false);
-    let refs_after_failure = state
-        .ref_map
-        .entries_sorted()
-        .into_iter()
-        .map(|(ref_id, entry)| {
-            (
-                ref_id,
-                entry.backend_node_id,
-                entry.role,
-                entry.name,
-                entry.nth,
-                entry.selector,
-                entry.frame_id,
-            )
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(refs_after_failure, refs_before_failure);
+    assert!(state.ref_map.entries_sorted().is_empty());
 
     let resp = execute_command(
-        &json!({ "id": "5", "action": "click", "selector": "e1" }),
+        &json!({
+            "id": "5",
+            "action": "evaluate",
+            "script": "document.querySelector('#primary-action')?.textContent"
+        }),
         &mut state,
     )
     .await;
     assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "Primary action");
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "click", "selector": "e1" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    assert!(resp["error"].as_str().unwrap().contains("Unknown ref: e1"));
 
     // Populate the session ref map before comparing the same URL to itself.
-    let resp = execute_command(&json!({ "id": "6", "action": "snapshot" }), &mut state).await;
+    let resp = execute_command(&json!({ "id": "7", "action": "snapshot" }), &mut state).await;
     assert_success(&resp);
 
     let resp = execute_command(
         &json!({
-            "id": "7",
+            "id": "8",
             "action": "diff_url",
             "url1": url,
             "url2": url

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -1377,6 +1377,18 @@ mod tests {
     }
 
     #[test]
+    fn test_ref_map_clear_resets_ref_numbering() {
+        let mut map = RefMap::new();
+        map.add("e1".to_string(), Some(42), "button", "Submit", None);
+        map.set_next_ref_num(2);
+
+        map.clear();
+
+        assert!(map.get("e1").is_none());
+        assert_eq!(map.next_ref_num(), 1);
+    }
+
+    #[test]
     fn test_build_selector_js_css() {
         let js = build_selector_js("#submit-btn");
         assert!(js.contains("document.querySelector(\"#submit-btn\")"));

--- a/cli/src/native/test_fixtures/snapshot_diff_probe.html
+++ b/cli/src/native/test_fixtures/snapshot_diff_probe.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Snapshot diff probe</title>
+</head>
+<body>
+  <button id="primary-action" type="button">Primary action</button>
+  <label for="account-name">Account name</label>
+  <input id="account-name" type="text">
+  <a href="#target">Details</a>
+  <div id="target">Target</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Reset the shared element reference map before capturing the current page for snapshot diffs.
- Start URL comparisons from a fresh reference map so equivalent elements receive aligned references while the final page keeps actionable refs.
- Add deterministic coverage for reference-number resets, repeated unchanged diffs, a narrowly changed control, and same-URL comparisons after earlier snapshot activity.

## Why

Snapshot output includes generated element references. Reusing session reference state could assign different refs to otherwise identical content, producing false changes. Starting each comparison from a consistent reference epoch keeps unchanged snapshots aligned and ensures reported differences reflect page content.

## Verification

- `cd cli && cargo test test_ref_map_clear_resets_ref_numbering`
- `cd cli && cargo test e2e_diff_snapshot -- --ignored --test-threads=1`
- `cd cli && cargo test e2e_diff_url_aligns_refs_after_snapshot -- --ignored --test-threads=1`
- `cd cli && cargo fmt -- --check`
- `git diff --check 585e740fcef069d74e21f0e88e8bf4ea7df34385...HEAD`