### PR TITLE
Upgrade rustls-webpki to 0.103.13

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Update the sole locked `rustls-webpki` resolution from 0.103.9 to the patched stable 0.103.13 release.

This keeps the CLI on its existing 0.103 compatibility line while hardening certificate validation against malformed certificate revocation list data that could otherwise trigger a panic and denial of service in deployments that exercise CRL parsing.