### PR TITLE
Fix Windows ARM64 launcher binary selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,24 @@ jobs:
       - name: Check version sync
         run: node scripts/check-version-sync.js
 
+  launcher:
+    name: Launcher
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Run launcher tests
+        run: pnpm run test:launcher
+
   rust:
     name: Rust
     runs-on: ubuntu-latest

--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -61,10 +61,14 @@ function getBinaryName() {
       return null;
   }
 
-  // Windows ARM64 uses the published x64 binary through built-in emulation.
-  // Keep this consistent with scripts/postinstall.js's effectiveArch.
+  // Prefer a source-built native ARM64 executable when present. Otherwise,
+  // use the published x64 binary through Windows' built-in emulation, keeping
+  // the fallback consistent with scripts/postinstall.js's effectiveArch.
   if (osKey === 'win32' && archKey === 'arm64') {
-    archKey = 'x64';
+    const nativeBinaryName = `agent-browser-${osKey}-${archKey}.exe`;
+    if (!existsSync(join(__dirname, nativeBinaryName))) {
+      archKey = 'x64';
+    }
   }
 
   const ext = os === 'win32' ? '.exe' : '';

--- a/bin/agent-browser.js
+++ b/bin/agent-browser.js
@@ -61,6 +61,12 @@ function getBinaryName() {
       return null;
   }
 
+  // Windows ARM64 uses the published x64 binary through built-in emulation.
+  // Keep this consistent with scripts/postinstall.js's effectiveArch.
+  if (osKey === 'win32' && archKey === 'arm64') {
+    archKey = 'x64';
+  }
+
   const ext = os === 'win32' ? '.exe' : '';
   return `agent-browser-${osKey}-${archKey}${ext}`;
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build:docker": "docker build --platform linux/amd64 -t agent-browser-builder -f docker/Dockerfile.build .",
     "release": "npm run version:sync && npm run build:all-platforms && npm publish",
     "postinstall": "node scripts/postinstall.js",
+    "test:launcher": "node --test test/launcher.test.mjs",
     "build:dashboard": "cd packages/dashboard && pnpm build"
   },
   "keywords": [

--- a/test/launcher.test.mjs
+++ b/test/launcher.test.mjs
@@ -9,12 +9,11 @@ import test from 'node:test';
 const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const launcherPath = join(repositoryRoot, 'bin', 'agent-browser.js');
 
-async function runLauncher(t, { platform, arch, binaryName, args }) {
+async function runLauncher(t, { platform, arch, binaries, args }) {
   const packageRoot = await mkdtemp(join(tmpdir(), 'agent-browser-launcher-'));
   const binDirectory = join(packageRoot, 'bin');
   const copiedLauncherPath = join(binDirectory, 'agent-browser.js');
   const bootstrapPath = join(packageRoot, 'bootstrap.mjs');
-  const fakeBinaryPath = join(binDirectory, binaryName);
 
   t.after(() => rm(packageRoot, { recursive: true, force: true }));
 
@@ -35,13 +34,16 @@ syncBuiltinESMExports();
 await import('./bin/agent-browser.js');
 `,
   );
-  await writeFile(
-    fakeBinaryPath,
-    `#!/bin/sh
-printf '%s\\n' 'fake-binary-ran' "$@"
+  for (const { name, marker } of binaries) {
+    const fakeBinaryPath = join(binDirectory, name);
+    await writeFile(
+      fakeBinaryPath,
+      `#!/bin/sh
+printf '%s\\n' ${JSON.stringify(marker)} "$@"
 `,
-  );
-  await chmod(fakeBinaryPath, 0o755);
+    );
+    await chmod(fakeBinaryPath, 0o755);
+  }
 
   return spawnSync(process.execPath, [bootstrapPath, ...args], {
     cwd: packageRoot,
@@ -54,12 +56,46 @@ test('Windows ARM64 launcher uses the published x64 executable', async (t) => {
   const result = await runLauncher(t, {
     platform: 'win32',
     arch: 'arm64',
-    binaryName: 'agent-browser-win32-x64.exe',
+    binaries: [
+      { name: 'agent-browser-win32-x64.exe', marker: 'x64-binary-ran' },
+    ],
     args,
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(result.stdout.trim().split('\n'), ['fake-binary-ran', ...args]);
+  assert.deepEqual(result.stdout.trim().split('\n'), ['x64-binary-ran', ...args]);
+  assert.doesNotMatch(result.stderr, /No binary found/);
+});
+
+test('Windows ARM64 launcher prefers an existing native executable', async (t) => {
+  const args = ['--version'];
+  const result = await runLauncher(t, {
+    platform: 'win32',
+    arch: 'arm64',
+    binaries: [
+      { name: 'agent-browser-win32-arm64.exe', marker: 'arm64-binary-ran' },
+      { name: 'agent-browser-win32-x64.exe', marker: 'x64-binary-ran' },
+    ],
+    args,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split('\n'), ['arm64-binary-ran', ...args]);
+});
+
+test('Windows ARM64 launcher runs when only a source-built native executable exists', async (t) => {
+  const args = ['snapshot'];
+  const result = await runLauncher(t, {
+    platform: 'win32',
+    arch: 'arm64',
+    binaries: [
+      { name: 'agent-browser-win32-arm64.exe', marker: 'arm64-binary-ran' },
+    ],
+    args,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split('\n'), ['arm64-binary-ran', ...args]);
   assert.doesNotMatch(result.stderr, /No binary found/);
 });
 
@@ -68,10 +104,12 @@ test('macOS ARM64 launcher keeps selecting the ARM64 executable', async (t) => {
   const result = await runLauncher(t, {
     platform: 'darwin',
     arch: 'arm64',
-    binaryName: 'agent-browser-darwin-arm64',
+    binaries: [
+      { name: 'agent-browser-darwin-arm64', marker: 'arm64-binary-ran' },
+    ],
     args,
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(result.stdout.trim().split('\n'), ['fake-binary-ran', ...args]);
+  assert.deepEqual(result.stdout.trim().split('\n'), ['arm64-binary-ran', ...args]);
 });

--- a/test/launcher.test.mjs
+++ b/test/launcher.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const launcherPath = join(repositoryRoot, 'bin', 'agent-browser.js');
+
+async function runLauncher(t, { platform, arch, binaryName, args }) {
+  const packageRoot = await mkdtemp(join(tmpdir(), 'agent-browser-launcher-'));
+  const binDirectory = join(packageRoot, 'bin');
+  const copiedLauncherPath = join(binDirectory, 'agent-browser.js');
+  const bootstrapPath = join(packageRoot, 'bootstrap.mjs');
+  const fakeBinaryPath = join(binDirectory, binaryName);
+
+  t.after(() => rm(packageRoot, { recursive: true, force: true }));
+
+  await mkdir(binDirectory, { recursive: true });
+  await writeFile(join(packageRoot, 'package.json'), '{"type":"module"}\n');
+  await copyFile(launcherPath, copiedLauncherPath);
+  await chmod(copiedLauncherPath, 0o755);
+  await writeFile(
+    bootstrapPath,
+    `import { createRequire, syncBuiltinESMExports } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const os = require('node:os');
+os.platform = () => ${JSON.stringify(platform)};
+os.arch = () => ${JSON.stringify(arch)};
+syncBuiltinESMExports();
+
+await import('./bin/agent-browser.js');
+`,
+  );
+  await writeFile(
+    fakeBinaryPath,
+    `#!/bin/sh
+printf '%s\\n' 'fake-binary-ran' "$@"
+`,
+  );
+  await chmod(fakeBinaryPath, 0o755);
+
+  return spawnSync(process.execPath, [bootstrapPath, ...args], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('Windows ARM64 launcher uses the published x64 executable', async (t) => {
+  const args = ['open', 'https://example.com'];
+  const result = await runLauncher(t, {
+    platform: 'win32',
+    arch: 'arm64',
+    binaryName: 'agent-browser-win32-x64.exe',
+    args,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split('\n'), ['fake-binary-ran', ...args]);
+  assert.doesNotMatch(result.stderr, /No binary found/);
+});
+
+test('macOS ARM64 launcher keeps selecting the ARM64 executable', async (t) => {
+  const args = ['--version'];
+  const result = await runLauncher(t, {
+    platform: 'darwin',
+    arch: 'arm64',
+    binaryName: 'agent-browser-darwin-arm64',
+    args,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split('\n'), ['fake-binary-ran', ...args]);
+});


### PR DESCRIPTION
On Windows ARM64, make the JavaScript launcher prefer an existing native ARM64 executable and fall back to the published x64 executable when the native binary is absent. This aligns launcher resolution with the postinstall artifact and Windows emulation support, preventing commands from failing with a false missing-binary error while preserving source-built native ARM64 binaries.

Add focused launcher regression coverage to CI for Windows ARM64 binary selection and unchanged macOS ARM64 behavior.