### PR TITLE
fix(cdp): close the WebSocket when disconnecting an external CDP connection

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1286,6 +1286,14 @@ impl BrowserManager {
                 .await;
         }
 
+        // Actually disconnect. This used to be implicit, and on an external
+        // connection it never happened: dropping the manager drops the `CdpClient`,
+        // whose reader task is detached and owns the read half of the socket, so the
+        // connection stayed open and subscribed for the life of the daemon. Every
+        // reconnect — including the one the 3s `is_connection_alive` probe triggers
+        // before a command — stranded one more still-subscribed socket on the remote.
+        self.client.close().await;
+
         if let Some(mut process) = self.browser_process.take() {
             let timeout = std::time::Duration::from_secs(5);
             let _ = tokio::task::spawn_blocking(move || {

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -41,8 +41,8 @@ pub struct CdpClient {
     pending: PendingMap,
     event_tx: broadcast::Sender<CdpEvent>,
     raw_tx: broadcast::Sender<RawCdpMessage>,
-    _reader_handle: tokio::task::JoinHandle<()>,
-    _keepalive_handle: tokio::task::JoinHandle<()>,
+    reader_handle: tokio::task::JoinHandle<()>,
+    keepalive_handle: tokio::task::JoinHandle<()>,
 }
 
 /// Removes a pending entry if `send_command` is cancelled mid-await (e.g. an
@@ -223,9 +223,38 @@ impl CdpClient {
             pending,
             event_tx,
             raw_tx,
-            _reader_handle: reader_handle,
-            _keepalive_handle: keepalive_handle,
+            reader_handle,
+            keepalive_handle,
         })
+    }
+
+    /// Disconnect: send a WebSocket Close frame, then stop the background tasks.
+    ///
+    /// Dropping a `CdpClient` does NOT close its socket. `reader_handle` and
+    /// `keepalive_handle` are detached `JoinHandle`s — dropping a handle leaves its
+    /// task running — and the reader task owns the read half of the split stream, so
+    /// the TCP connection stays open and subscribed for as long as the task lives.
+    /// Against a real Chrome that is invisible, because the only disconnect path is
+    /// `Browser.close`, and Chrome then closes the socket from its side. Against an
+    /// EXTERNAL endpoint (`--cdp` / `--auto-connect`) nothing closes it at all, so
+    /// every reconnect strands one still-subscribed client on the remote: it keeps
+    /// receiving the full event fan-out, and the keepalive task keeps pinging it.
+    /// A CDP multiplexer in front of one browser then re-broadcasts every event once
+    /// per stranded socket, which is a self-amplifying congestion spiral.
+    ///
+    /// Order matters. The keepalive stops first, so it cannot take the `ws_tx` lock or
+    /// ping a socket that is closing. The Close frame goes next, so the peer learns
+    /// this was deliberate. The reader stops last, which drops the read half and ends
+    /// the TCP connection even if the peer never answers the Close.
+    pub async fn close(&self) {
+        self.keepalive_handle.abort();
+        {
+            let mut ws_tx = self.ws_tx.lock().await;
+            // Best effort: a socket that is already dead has nothing to say goodbye to.
+            let _ = ws_tx.send(Message::Close(None)).await;
+            let _ = ws_tx.flush().await;
+        }
+        self.reader_handle.abort();
     }
 
     pub async fn send_command(
@@ -433,4 +462,57 @@ fn enable_tcp_keepalive(stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::T
     let keepalive = keepalive.with_interval(std::time::Duration::from_secs(10));
 
     let _ = sock.set_tcp_keepalive(&keepalive);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    /// `close` must end the socket, and dropping the client must not be mistaken for it.
+    ///
+    /// The regression this pins: `BrowserManager::close` disconnected nothing on an
+    /// external CDP connection, because a dropped `CdpClient` leaves its detached
+    /// reader task holding the read half of the stream. The remote then kept a live,
+    /// still-subscribed client for every reconnect the liveness probe triggered.
+    #[tokio::test]
+    async fn close_ends_the_socket_and_dropping_alone_does_not() {
+        // A server that reports, per connection, how its socket ended.
+        async fn serve(listener: TcpListener) -> String {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Close(_))) => return "close-frame".to_string(),
+                    Some(Ok(_)) => continue,
+                    Some(Err(_)) | None => return "stream-ended".to_string(),
+                }
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}/devtools/browser/t", listener.local_addr().unwrap());
+        let server = tokio::spawn(serve(listener));
+        let client = CdpClient::connect(&url).await.unwrap();
+        client.close().await;
+        let ended = tokio::time::timeout(std::time::Duration::from_secs(5), server)
+            .await
+            .expect("close() left the socket open")
+            .unwrap();
+        assert_eq!(ended, "close-frame", "close() must send a Close frame");
+
+        // The other half of the contract: a client that is merely DROPPED does not end
+        // the socket. That is exactly why `close` has to be called explicitly, and a
+        // future `Drop` impl that changes it should update this test deliberately.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}/devtools/browser/t", listener.local_addr().unwrap());
+        let server = tokio::spawn(serve(listener));
+        drop(CdpClient::connect(&url).await.unwrap());
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(750), server)
+                .await
+                .is_err(),
+            "a dropped client is expected to leave the socket open — see close()"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1726.

## The problem

`BrowserManager::close` disconnected nothing on an external CDP connection. It sends `Browser.close` only when the daemon launched the browser itself, which is right, but for `--cdp` / `--auto-connect` it then returned `Ok(())` without touching the socket.

Dropping the `CdpClient` does not close it either. `_reader_handle` and `_keepalive_handle` are detached `JoinHandle`s, so dropping the handles leaves both tasks running, and the reader task owns the read half of the split stream. The connection stays open, still subscribed to every event, and the keepalive keeps pinging it.

That matters because `close` is on the reconnect path, not only the shutdown path: `is_connection_alive` probes `Browser.getVersion` with a 3s timeout before every command, and a failed probe tears the manager down and dials a fresh socket. So each timed-out probe strands one live client on the remote. Issue #1726 has the production trace.

## The change

`CdpClient::close` sends a Close frame and stops both tasks. `BrowserManager::close` calls it on every path.

Order is deliberate and commented in the source: the keepalive aborts first so it cannot take the `ws_tx` lock or ping a socket that is closing; the Close frame goes next so the peer learns the disconnect was intentional; the reader aborts last, which drops the read half and ends the TCP connection even if the peer never answers the Close.

The two handle fields lose their leading underscore, since they are read now.

## Tests

A new `#[tokio::test]` in `cli/src/native/cdp/client.rs` pins both halves of the contract against a real WebSocket server: `close` produces a Close frame, and a client that is merely dropped leaves the socket open. The second assertion is the regression itself, so a future `Drop` impl has to change that test deliberately rather than by accident.

End to end, against a mock CDP endpoint that stalls `Browser.getVersion` past 3s, comparing `agent-browser 0.34.0` as shipped on npm with the same tree plus this patch, both `linux/amd64`:

| socket | 0.34.0 (npm) | patched |
| --- | --- | --- |
| #1 | still open | closed |
| #2 | still open | closed |
| #3 | still open | open (current) |

## Scope

Internal behaviour only: no new flag, command, environment variable, or output, so the `AGENTS.md` "update all of the following" list for user-facing features does not apply. No MCP surface changes.
