### PR TITLE
fix(cdp): normalize root WebSocket request paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,6 +1413,8 @@ The `--cdp` flag accepts either:
 - A port number (e.g., `9222`) for local connections via `http://localhost:{port}`
 - A full WebSocket URL (e.g., `wss://...` or `ws://...`) for remote browser services
 
+Root WebSocket endpoints accept query strings with or without an explicit slash, so both `wss://browser-service.com?token=...` and `wss://browser-service.com/?token=...` work.
+
 This enables control of:
 
 - Electron apps

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2452,7 +2452,8 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 let _ = close_current_browser(state).await;
             }
             if let Err(e) = auto_launch(state, plugins_from_command_or_env(cmd)).await {
-                return error_response(&id, &format!("Auto-launch failed: {}", e));
+                let context = auto_launch_error_context(env::var("AGENT_BROWSER_CDP").is_ok());
+                return error_response(&id, &format!("{}: {}", context, e));
             }
             lifecycle_launched = true;
         } else {
@@ -2799,6 +2800,14 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     }
 
     resp
+}
+
+fn auto_launch_error_context(has_cdp: bool) -> &'static str {
+    if has_cdp {
+        "CDP connection failed"
+    } else {
+        "Auto-launch failed"
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -14722,6 +14731,28 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
             "Unexpected error: {}",
             error_msg
         );
+    }
+
+    #[test]
+    fn test_auto_launch_error_context_distinguishes_cdp_connections() {
+        assert_eq!(auto_launch_error_context(true), "CDP connection failed");
+        assert_eq!(auto_launch_error_context(false), "Auto-launch failed");
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_reports_cdp_connection_context() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_CDP"]);
+        guard.set("AGENT_BROWSER_CDP", "invalid-cdp-target");
+        let mut state = DaemonState::new();
+        let cmd = json!({ "action": "snapshot", "id": "cdp-error-context" });
+
+        let result = execute_command(&cmd, &mut state).await;
+
+        assert_eq!(result["success"], false);
+        assert!(result["error"]
+            .as_str()
+            .unwrap()
+            .starts_with("CDP connection failed: Invalid CDP target:"));
     }
 
     #[tokio::test]

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -18,6 +18,21 @@ type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<CdpMessage>>>>;
 /// through intermediate proxies (reverse proxies, load balancers, service meshes).
 const WS_KEEPALIVE_INTERVAL_SECS: u64 = 30;
 
+fn normalize_websocket_root_path(url: &str) -> String {
+    let Some(scheme_end) = url.find("://").map(|index| index + 3) else {
+        return url.to_string();
+    };
+    let authority = &url[scheme_end..];
+    let Some(query_offset) = authority.find('?') else {
+        return url.to_string();
+    };
+    if authority[..query_offset].contains('/') {
+        return url.to_string();
+    }
+    let query_index = scheme_end + query_offset;
+    format!("{}/{}", &url[..query_index], &url[query_index..])
+}
+
 /// Raw incoming CDP message (text) broadcast to all subscribers.
 /// Used by the inspect proxy to forward responses and events to DevTools.
 #[derive(Debug, Clone)]
@@ -79,7 +94,9 @@ impl CdpClient {
         url: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Result<Self, String> {
-        let mut request = url
+        let normalized_url = normalize_websocket_root_path(url);
+        let mut request = normalized_url
+            .as_str()
             .into_client_request()
             .map_err(|e| format!("Invalid WebSocket URL: {}", e))?;
 
@@ -433,4 +450,76 @@ fn enable_tcp_keepalive(stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::T
     let keepalive = keepalive.with_interval(std::time::Duration::from_secs(10));
 
     let _ = sock.set_tcp_keepalive(&keepalive);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    #[test]
+    fn normalizes_only_root_websocket_queries() {
+        assert_eq!(
+            normalize_websocket_root_path("wss://browser.example?token=a%2Fb"),
+            "wss://browser.example/?token=a%2Fb"
+        );
+        assert_eq!(
+            normalize_websocket_root_path("ws://[::1]:9222?token=test"),
+            "ws://[::1]:9222/?token=test"
+        );
+        assert_eq!(
+            normalize_websocket_root_path("wss://user:pass@browser.example?token=test"),
+            "wss://user:pass@browser.example/?token=test"
+        );
+        assert_eq!(
+            normalize_websocket_root_path("wss://browser.example?"),
+            "wss://browser.example/?"
+        );
+        assert_eq!(
+            normalize_websocket_root_path("wss://browser.example/?token=a%2Fb"),
+            "wss://browser.example/?token=a%2Fb"
+        );
+        assert_eq!(
+            normalize_websocket_root_path("wss://browser.example/cdp?token=a%2Fb"),
+            "wss://browser.example/cdp?token=a%2Fb"
+        );
+    }
+
+    #[tokio::test]
+    async fn root_websocket_url_with_query_sends_slash_request_target() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (path_tx, path_rx) = oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut path_tx = Some(path_tx);
+            let _ = tokio_tungstenite::accept_hdr_async(
+                stream,
+                move |
+                    request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                    response: tokio_tungstenite::tungstenite::handshake::server::Response,
+                | {
+                    if let Some(tx) = path_tx.take() {
+                        let path = request
+                            .uri()
+                            .path_and_query()
+                            .map(|value| value.as_str().to_string())
+                            .unwrap_or_default();
+                        let _ = tx.send(path);
+                    }
+                    Ok(response)
+                },
+            )
+            .await
+            .unwrap();
+        });
+
+        let url = format!("ws://127.0.0.1:{}?token=a%2Fb&scope=browser%20test", port);
+        let _client = CdpClient::connect(&url).await.unwrap();
+
+        assert_eq!(path_rx.await.unwrap(), "/?token=a%2Fb&scope=browser%20test");
+        server.await.unwrap();
+    }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3004,6 +3004,7 @@ Supported URL formats:
   - Port number: 9222 (connects to http://localhost:9222)
   - WebSocket URL: ws://localhost:9222/devtools/browser/...
   - Remote service: wss://remote-browser.example.com/cdp?token=...
+  - Root endpoint: wss://remote-browser.example.com?token=... (slash optional)
 
 Global Options:
   --json               Output as JSON
@@ -3737,7 +3738,7 @@ Options:
   --screenshot-format <fmt>  Screenshot format: png, jpeg (or AGENT_BROWSER_SCREENSHOT_FORMAT)
   --headed                   Show browser window (not headless) (or AGENT_BROWSER_HEADED env)
   --webgpu                   Enable WebGPU; uses SwiftShader software Vulkan on Linux, no GPU required (or AGENT_BROWSER_WEBGPU env)
-  --cdp <port>               Connect via CDP (Chrome DevTools Protocol)
+  --cdp <port|url>           Connect via CDP; root WebSocket query slash is optional
   --pin-tab                  Pin the session to its bound tab (or AGENT_BROWSER_PIN_TAB env)
                              Commands fail with a tab_gone error instead of falling back
                              to another tab when the bound tab is closed. JSON includes

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -32,6 +32,8 @@ The `--cdp` flag accepts either:
 - A port number (e.g., `9222`) for local connections via `http://localhost:{port}`
 - A full WebSocket URL (e.g., `wss://...` or `ws://...`) for remote browser services
 
+Root WebSocket endpoints accept query strings with or without an explicit slash, so both `wss://browser-service.com?token=...` and `wss://browser-service.com/?token=...` work.
+
 ## Auto-Connect
 
 Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -579,7 +579,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --screenshot-format <fmt> # Format: png (default), jpeg (or AGENT_BROWSER_SCREENSHOT_FORMAT)
 --headed                 # Show browser window (not headless)
 --webgpu                 # Enable WebGPU (software Vulkan on Linux, no GPU needed)
---cdp <port|url>         # Connect via Chrome DevTools Protocol (port or WebSocket URL)
+--cdp <port|url>         # Connect via CDP; root WebSocket query slash is optional
 --auto-connect           # Auto-discover and connect to running Chrome
 --color-scheme <scheme>  # Color scheme: dark, light, no-preference
 --download-path <path>   # Default download directory

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -440,7 +440,7 @@ EOF
 --headed                # show the window (default is headless)
 --webgpu                # enable WebGPU (software Vulkan on Linux, no GPU needed)
 --auto-connect          # connect to an already-running Chrome
---cdp <port>            # connect to a specific CDP port
+--cdp <port|url>        # connect to a CDP port or WebSocket URL; root query slash is optional
 --profile <name|path>   # use a Chrome profile (login state survives)
 --headers <json>        # HTTP headers scoped to the URL's origin
 --proxy <url>           # proxy server

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -388,7 +388,7 @@ agent-browser --session <name> ...    # Isolated browser session
 agent-browser --json ...              # JSON output for parsing
 agent-browser --headed ...            # Show browser window (not headless; on displayless Linux an Xvfb display starts automatically)
 agent-browser --webgpu ...            # Enable WebGPU (SwiftShader software Vulkan on Linux, no GPU needed)
-agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
+agent-browser --cdp <port|url> ...    # Connect via CDP; root query slash is optional
 agent-browser --pin-tab ...           # Pin the session to its bound tab (strict tab binding)
 agent-browser --no-pin-tab ...        # Disable a sticky pin previously enabled with --pin-tab
 agent-browser -p <provider> ...       # Browser provider or configured provider plugin


### PR DESCRIPTION
## Summary

- normalize slashless root WebSocket URLs so `ws://host?token=...` sends `/?token=...`
- preserve existing paths and encoded query bytes
- report daemon auto-connect failures as `CDP connection failed`
- update CLI help, README, docs, and the packaged core skill

## Verification

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `cargo test --manifest-path cli/Cargo.toml`
- regression test against a real local WebSocket server, including encoded query preservation
- force-red verification by bypassing normalization at the production call site

Refs #1734
