### PR TITLE
feat(batch): add --omit-command to JSON results

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,15 @@ echo '[
   ["click", "@e1"],
   ["screenshot", "result.png"]
 ]' | agent-browser batch --json
+
+# Avoid echoing raw command arrays that contain confidential stdin values.
+# Rows use a zero-based index instead.
+echo '[["fill", "#password", "secret"]]' | \
+  agent-browser batch --json --omit-command
 ```
+
+`--omit-command` applies to successful and failed rows, including `--bail`
+output. Without it, JSON output keeps the existing `command` field.
 
 ### Clipboard
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1925,8 +1925,18 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         // === Batch ===
         "batch" => {
             let bail = rest.contains(&"--bail");
-            let commands: Vec<&str> = rest.iter().filter(|a| **a != "--bail").copied().collect();
-            let mut cmd = json!({ "id": id, "action": "batch", "bail": bail });
+            let omit_command = rest.contains(&"--omit-command");
+            let commands: Vec<&str> = rest
+                .iter()
+                .filter(|a| **a != "--bail" && **a != "--omit-command")
+                .copied()
+                .collect();
+            let mut cmd = json!({
+                "id": id,
+                "action": "batch",
+                "bail": bail,
+                "omitCommand": omit_command,
+            });
             if !commands.is_empty() {
                 cmd["commands"] = json!(commands);
             }
@@ -5821,6 +5831,18 @@ mod tests {
         let cmd = parse_command(&args("batch --bail"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "batch");
         assert_eq!(cmd["bail"], true);
+    }
+
+    #[test]
+    fn test_batch_with_omit_command() {
+        let cmd = parse_command(
+            &args("batch --omit-command --bail screenshot"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["omitCommand"], true);
+        assert_eq!(cmd["bail"], true);
+        assert_eq!(cmd["commands"], json!(["screenshot"]));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1719,13 +1719,17 @@ fn main() {
     // Handle batch command: from args or stdin
     if cmd.get("action").and_then(|v| v.as_str()) == Some("batch") {
         let bail = cmd.get("bail").and_then(|v| v.as_bool()).unwrap_or(false);
+        let omit_command = cmd
+            .get("omitCommand")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let arg_commands = cmd.get("commands").and_then(|v| v.as_array()).map(|arr| {
             arr.iter()
                 .filter_map(|v| v.as_str())
                 .map(commands::shell_words_split)
                 .collect::<Vec<Vec<String>>>()
         });
-        run_batch(&flags, &daemon_opts, bail, arg_commands);
+        run_batch(&flags, &daemon_opts, bail, omit_command, arg_commands);
         return;
     }
 
@@ -1788,6 +1792,7 @@ fn run_batch(
     flags: &Flags,
     daemon_opts: &DaemonOptions,
     bail: bool,
+    omit_command: bool,
     arg_commands: Option<Vec<Vec<String>>>,
 ) {
     let commands: Vec<Vec<String>> = if let Some(cmds) = arg_commands {
@@ -1847,11 +1852,10 @@ fn run_batch(
             Err(e) => {
                 had_error = true;
                 if flags.json {
-                    results.push(json!({
-                        "command": cmd_args,
-                        "success": false,
-                        "error": e.format(),
-                    }));
+                    let mut result = batch_result_identity(i, cmd_args, omit_command);
+                    result["success"] = json!(false);
+                    result["error"] = json!(e.format());
+                    results.push(result);
                     if bail {
                         break;
                     }
@@ -1882,12 +1886,10 @@ fn run_batch(
         match send_command_with_respawn(parsed, &flags.session, daemon_opts) {
             Ok(resp) => {
                 if flags.json {
-                    let mut result = json!({
-                        "command": cmd_args,
-                        "success": resp.success,
-                        "result": resp.data,
-                        "error": resp.error,
-                    });
+                    let mut result = batch_result_identity(i, cmd_args, omit_command);
+                    result["success"] = json!(resp.success);
+                    result["result"] = json!(resp.data);
+                    result["error"] = json!(resp.error);
                     // Match the single-command `Response` serialization,
                     // which only emits `code` when set (e.g. `tab_gone`).
                     // Without this, machine-readable error codes are
@@ -1920,11 +1922,10 @@ fn run_batch(
             Err(e) => {
                 had_error = true;
                 if flags.json {
-                    results.push(json!({
-                        "command": cmd_args,
-                        "success": false,
-                        "error": e.to_string(),
-                    }));
+                    let mut result = batch_result_identity(i, cmd_args, omit_command);
+                    result["success"] = json!(false);
+                    result["error"] = json!(e.to_string());
+                    results.push(result);
                     if bail {
                         break;
                     }
@@ -1947,6 +1948,18 @@ fn run_batch(
 
     if had_error {
         exit(1);
+    }
+}
+
+fn batch_result_identity(
+    index: usize,
+    command: &[String],
+    omit_command: bool,
+) -> serde_json::Value {
+    if omit_command {
+        json!({ "index": index })
+    } else {
+        json!({ "command": command })
     }
 }
 
@@ -2517,5 +2530,24 @@ mod tests {
         assert_eq!(prompt.action, "plugin:stealth:launch.mutate");
         assert_eq!(prompt.description, "plugin:stealth:launch.mutate");
         assert_eq!(prompt.confirmation_id, "original-command");
+    }
+
+    #[test]
+    fn test_batch_result_identity_omits_sensitive_command() {
+        let command = vec![
+            "fill".to_string(),
+            "#password".to_string(),
+            "PUBLIC_SENTINEL".to_string(),
+        ];
+
+        let omitted = batch_result_identity(3, &command, true);
+        assert_eq!(omitted, json!({ "index": 3 }));
+        assert!(!serde_json::to_string(&omitted)
+            .unwrap()
+            .contains("PUBLIC_SENTINEL"));
+
+        let default = batch_result_identity(3, &command, false);
+        assert_eq!(default["command"], json!(command));
+        assert!(default.get("index").is_none());
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3210,6 +3210,7 @@ separated by blank lines (or as a JSON array with --json).
 Options:
   --bail               Stop on first error (default: continue all commands)
   --json               Output results as a JSON array
+  --omit-command       With --json, replace each raw command with its zero-based index
 
 Argument Mode:
   Each quoted argument is a full command string:
@@ -3229,6 +3230,7 @@ Examples:
   agent-browser batch "open https://example.com" "screenshot"
   agent-browser batch --bail "open https://example.com" "click @e1" "screenshot"
   echo '[["open", "https://example.com"], ["snapshot"]]' | agent-browser batch
+  echo '[["fill", "#password", "secret"]]' | agent-browser batch --json --omit-command
   agent-browser batch --bail < commands.json
 "##
         }
@@ -3630,8 +3632,9 @@ Init scripts:
   removeinitscript <id>      Remove a script registered via --init-script or addinitscript
 
 Batch:
-  batch [--bail] ["cmd" ...]  Execute multiple commands sequentially (args or stdin)
+  batch [options] ["cmd" ...] Execute multiple commands sequentially (args or stdin)
                               --bail stops on first error (default: continue all)
+                              --omit-command hides raw commands in JSON results
 
 Auth Vault:
   auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)

--- a/cli/tests/batch_cli.rs
+++ b/cli/tests/batch_cli.rs
@@ -1,0 +1,113 @@
+//! Integration tests for omitting raw commands from batch JSON output.
+
+use serde_json::Value;
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_agent-browser");
+const SESSION: &str = "batch-omit-command-test";
+
+struct BatchCli {
+    socket_dir: TempDir,
+    home: TempDir,
+}
+
+impl BatchCli {
+    fn new() -> Self {
+        Self {
+            socket_dir: TempDir::new().unwrap(),
+            home: TempDir::new().unwrap(),
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(BIN);
+        command
+            .args(["--session", SESSION])
+            .env("AGENT_BROWSER_SOCKET_DIR", self.socket_dir.path())
+            .env("HOME", self.home.path())
+            .env("USERPROFILE", self.home.path())
+            .env_remove("XDG_RUNTIME_DIR")
+            .env_remove("AGENT_BROWSER_NAMESPACE")
+            .env("NO_COLOR", "1");
+        command
+    }
+
+    fn run(&self, input: &str, args: &[&str]) -> Output {
+        let mut child = self
+            .command()
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to start agent-browser batch");
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(input.as_bytes())
+            .expect("failed to write batch input");
+        child
+            .wait_with_output()
+            .expect("batch command failed to wait")
+    }
+}
+
+impl Drop for BatchCli {
+    fn drop(&mut self) {
+        let _ = self.command().arg("close").output();
+    }
+}
+
+#[test]
+fn batch_omit_command_hides_input_and_preserves_row_identity() {
+    let cli = BatchCli::new();
+    let input = r#"[["stream","status"],["definitely-unknown","PUBLIC_SENTINEL"]]"#;
+    let output = cli.run(input, &["batch", "--json", "--omit-command"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(!stdout.contains("PUBLIC_SENTINEL"));
+    assert!(!stderr.contains("PUBLIC_SENTINEL"));
+
+    let rows: Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+    let rows = rows.as_array().expect("batch output should be an array");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["index"], 0);
+    assert_eq!(rows[0]["success"], true);
+    assert!(rows[0].get("command").is_none());
+    assert_eq!(rows[1]["index"], 1);
+    assert_eq!(rows[1]["success"], false);
+    assert!(rows[1].get("command").is_none());
+}
+
+#[test]
+fn batch_omit_command_preserves_default_and_bail_behavior() {
+    let cli = BatchCli::new();
+    let input =
+        r##"[["definitely-unknown","PUBLIC_SENTINEL"],["fill","#password","SECOND_SENTINEL"]]"##;
+
+    let default = cli.run(input, &["batch", "--json"]);
+    assert_eq!(default.status.code(), Some(1));
+    let default_stdout = String::from_utf8(default.stdout).expect("stdout should be utf8");
+    let rows: Value = serde_json::from_str(&default_stdout).expect("stdout should be JSON");
+    assert_eq!(rows[0]["command"][1], "PUBLIC_SENTINEL");
+    assert!(rows[0].get("index").is_none());
+
+    let omitted = cli.run(input, &["batch", "--json", "--omit-command", "--bail"]);
+    assert_eq!(omitted.status.code(), Some(1));
+    let stdout = String::from_utf8(omitted.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(omitted.stderr).expect("stderr should be utf8");
+    assert!(!stdout.contains("PUBLIC_SENTINEL"));
+    assert!(!stdout.contains("SECOND_SENTINEL"));
+    assert!(!stderr.contains("PUBLIC_SENTINEL"));
+    assert!(!stderr.contains("SECOND_SENTINEL"));
+    let rows: Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+    let rows = rows.as_array().expect("batch output should be an array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["index"], 0);
+    assert!(rows[0].get("command").is_none());
+}

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -619,6 +619,11 @@ echo '[
   ["click", "@e1"],
   ["screenshot", "result.png"]
 ]' | agent-browser batch --json
+
+# Avoid echoing raw command arrays that contain confidential stdin values.
+# Rows use a zero-based index instead.
+echo '[["fill", "#password", "secret"]]' | \
+  agent-browser batch --json --omit-command
 ```
 
 <table>
@@ -628,8 +633,12 @@ echo '[
   <tbody>
     <tr><td><code>--bail</code></td><td>Stop on first error (default: continue all commands)</td></tr>
     <tr><td><code>--json</code></td><td>Output results as a JSON array</td></tr>
+    <tr><td><code>--omit-command</code></td><td>With <code>--json</code>, replace each raw command with its zero-based index</td></tr>
   </tbody>
 </table>
+
+`--omit-command` applies to successful and failed rows, including `--bail`
+output. Without it, JSON output keeps the existing `command` field.
 
 ## MCP server
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -40,6 +40,11 @@ agent-browser batch \
 
 `open` with no URL gives you a clean launch so any interception, cookies, or init scripts you register take effect on the *first* real navigation. Use for SSR-only debug (`--resource-type script`), protected-origin auth, or capturing fresh `react suspense`/`vitals` state without noise from a prior page.
 
+For batches that carry confidential values on stdin, combine `--json` with
+`--omit-command`. Every success or error row then uses a stable zero-based
+`index` instead of echoing the raw command array. Default JSON output keeps the
+existing `command` field, and `--bail` remains supported.
+
 ## Snapshot (page analysis)
 
 ```bash


### PR DESCRIPTION

### Summary

- add an opt-in `batch --json --omit-command` flag
- replace the raw `command` array with a stable zero-based `index`
- use the same identity path for parse errors, successful daemon responses, daemon send failures, and `--bail` output
- preserve the existing JSON shape when the flag is not supplied
- document the option in CLI help, the README, canonical skill data, and the documentation site

### Why

Batch stdin can contain confidential values such as passwords. JSON mode currently echoes the complete parsed command into each result row, which makes otherwise-confidential stdin pipelines unsuitable for structured output.

The new behavior is opt-in, so existing consumers keep receiving `command` by default. Callers that opt in can correlate rows through `index` without recovering the original command contents.

### Validation

- `rustfmt --edition 2021 --check cli/src/main.rs cli/src/commands.rs cli/src/output.rs cli/tests/batch_cli.rs`
- `cargo --offline --config 'profile.test.debug=0' --config 'build.incremental=false' test --test batch_cli` (2 passed)
- `cargo --offline --config 'profile.test.debug=0' --config 'build.incremental=false' check --tests`
- `cargo --offline --config 'profile.dev.debug=0' --config 'build.incremental=false' clippy -- -D warnings`
- real CLI integration coverage verifies a successful row and a parse-error row use stable indexes while the input sentinel is absent from stdout and stderr
- default JSON mode still returns the original `command` array
- `--omit-command --bail` returns only the first failed row and does not expose either input sentinel

Closes #1718.

