### PR TITLE
fix(cdp): harden transport parsing and shutdown

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1286,6 +1286,8 @@ impl BrowserManager {
                 .await;
         }
 
+        self.client.close().await;
+
         if let Some(mut process) = self.browser_process.take() {
             let timeout = std::time::Duration::from_secs(5);
             let _ = tokio::task::spawn_blocking(move || {
@@ -3012,6 +3014,64 @@ mod tests {
             bound_target_gone: None,
             headless: true,
         }
+    }
+
+    #[tokio::test]
+    async fn test_close_external_manager_disconnects_without_closing_browser() {
+        use futures_util::StreamExt;
+        use tokio::io::AsyncReadExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let mut browser_close_seen = false;
+
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Text(text))) => {
+                        let command: Value = serde_json::from_str(&text).unwrap();
+                        browser_close_seen |= command["method"] == "Browser.close";
+                    }
+                    Some(Ok(Message::Close(_))) => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) | None => break,
+                }
+            }
+
+            let mut byte = [0u8; 1];
+            let count = tokio::time::timeout(Duration::from_secs(1), ws.get_mut().read(&mut byte))
+                .await
+                .expect("external manager close should shut down TCP")
+                .expect("external manager TCP read should succeed");
+            (browser_close_seen, count)
+        });
+
+        let client = CdpClient::connect(&format!("ws://{}", addr)).await.unwrap();
+        let mut manager = BrowserManager {
+            client: Arc::new(client),
+            browser_process: None,
+            ws_url: format!("ws://{}", addr),
+            pages: Vec::new(),
+            active_page_index: 0,
+            default_timeout_ms: 25_000,
+            download_path: None,
+            ignore_https_errors: false,
+            visited_origins: HashSet::new(),
+            next_tab_id: 1,
+            direct_page: false,
+            pin_tab: false,
+            bound_target_id: None,
+            bound_target_gone: None,
+            headless: true,
+        };
+        manager.close().await.unwrap();
+
+        let (browser_close_seen, count) = server.await.unwrap();
+        assert!(!browser_close_seen);
+        assert_eq!(count, 0);
     }
 
     const TARGET_A: &str = "AAAA0000BBBB1111CCCC2222DDDD3333";

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -447,6 +447,7 @@ fn tab_gone_error(target_id: &str, last_url: &str) -> String {
 const LIGHTPANDA_CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const LIGHTPANDA_CDP_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_TARGET_INIT_TIMEOUT: Duration = Duration::from_secs(10);
+const FAILED_INITIALIZATION_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
 
 impl BrowserManager {
     /// True when a *default* idle timeout must not close this browser:
@@ -517,7 +518,7 @@ impl BrowserManager {
             }
         };
 
-        let manager = if engine == "lightpanda" {
+        let mut manager = if engine == "lightpanda" {
             initialize_lightpanda_manager(ws_url, process).await?
         } else {
             let client = Arc::new(CdpClient::connect(&ws_url).await?);
@@ -538,11 +539,24 @@ impl BrowserManager {
                 bound_target_gone: None,
                 headless,
             };
-            manager.discover_and_attach_targets().await?;
+            if let Err(error) = manager.discover_and_attach_targets().await {
+                let _ = manager
+                    .close_with_timeout(Some(FAILED_INITIALIZATION_CLOSE_TIMEOUT))
+                    .await;
+                return Err(error);
+            }
             manager
         };
 
-        let session_id = manager.active_session_id()?.to_string();
+        let session_id = match manager.active_session_id() {
+            Ok(session_id) => session_id.to_string(),
+            Err(error) => {
+                let _ = manager
+                    .close_with_timeout(Some(FAILED_INITIALIZATION_CLOSE_TIMEOUT))
+                    .await;
+                return Err(error);
+            }
+        };
 
         if ignore_https_errors {
             let _ = manager
@@ -633,7 +647,7 @@ impl BrowserManager {
             headless: true,
         };
 
-        if direct_page {
+        let initialization = if direct_page {
             let tab_id = manager.assign_tab_id();
             manager.pages.push(PageInfo {
                 tab_id,
@@ -645,9 +659,15 @@ impl BrowserManager {
                 target_type: "page".to_string(),
             });
             manager.active_page_index = 0;
-            manager.enable_domains_direct().await?;
+            manager.enable_domains_direct().await
         } else {
-            manager.discover_and_attach_targets().await?;
+            manager.discover_and_attach_targets().await
+        };
+        if let Err(error) = initialization {
+            let _ = manager
+                .close_with_timeout(Some(FAILED_INITIALIZATION_CLOSE_TIMEOUT))
+                .await;
+            return Err(error);
         }
         Ok(manager)
     }
@@ -1284,14 +1304,23 @@ impl BrowserManager {
     }
 
     pub async fn close(&mut self) -> Result<(), String> {
+        self.close_with_timeout(None).await
+    }
+
+    async fn close_with_timeout(
+        &mut self,
+        browser_close_timeout: Option<Duration>,
+    ) -> Result<(), String> {
         if self.browser_process.is_some() {
             // Only send Browser.close when we launched the browser ourselves.
             // For external connections (--auto-connect, --cdp) we just disconnect
             // without shutting down the user's browser.
-            let _ = self
-                .client
-                .send_command_no_params("Browser.close", None)
-                .await;
+            let close = self.client.send_command_no_params("Browser.close", None);
+            if let Some(timeout) = browser_close_timeout {
+                let _ = tokio::time::timeout(timeout, close).await;
+            } else {
+                let _ = close.await;
+            }
         }
 
         self.client.close().await;
@@ -2336,6 +2365,9 @@ async fn initialize_lightpanda_manager(
                 return Ok(manager);
             }
             Err(err) => {
+                let _ = manager
+                    .close_with_timeout(Some(FAILED_INITIALIZATION_CLOSE_TIMEOUT))
+                    .await;
                 if Instant::now() >= deadline {
                     return Err(lightpanda_target_init_timeout(Some(&err)));
                 }
@@ -3091,6 +3123,283 @@ mod tests {
         let (browser_close_seen, count) = server.await.unwrap();
         assert!(!browser_close_seen);
         assert_eq!(count, 0);
+    }
+
+    async fn initialization_server(
+        fail_method: &'static str,
+        existing_target: bool,
+        attempts: usize,
+        ignore_browser_close: bool,
+    ) -> (String, tokio::task::JoinHandle<Vec<Vec<String>>>) {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio::io::AsyncReadExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let mut observed = Vec::new();
+            for attempt in 0..attempts {
+                let (stream, _) = listener.accept().await.unwrap();
+                let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                let mut methods = Vec::new();
+                loop {
+                    let message = tokio::time::timeout(Duration::from_secs(2), ws.next())
+                        .await
+                        .expect("failed initialization must disconnect before retry or return");
+                    match message {
+                        Some(Ok(Message::Text(text))) => {
+                            let command: Value = serde_json::from_str(&text).unwrap();
+                            let method = command["method"].as_str().unwrap();
+                            methods.push(method.to_string());
+                            if ignore_browser_close && method == "Browser.close" {
+                                continue;
+                            }
+                            let response = if attempt == 0 && method == fail_method {
+                                json!({"id": command["id"], "error": {
+                                    "code": -32000, "message": "injected initialization failure"
+                                }})
+                            } else {
+                                let result = match method {
+                                    "Target.getTargets" if existing_target => {
+                                        json!({"targetInfos": [{
+                                            "targetId": "page-1", "type": "page", "url": "about:blank",
+                                            "title": "", "attached": false
+                                        }]})
+                                    }
+                                    "Target.getTargets" => json!({"targetInfos": []}),
+                                    "Target.createTarget" => json!({"targetId": "page-1"}),
+                                    "Target.attachToTarget" => json!({"sessionId": "session-1"}),
+                                    "Runtime.evaluate" => {
+                                        json!({"result": {"type": "number", "value": 1}})
+                                    }
+                                    _ => json!({}),
+                                };
+                                json!({"id": command["id"], "result": result})
+                            };
+                            ws.send(Message::Text(response.to_string())).await.unwrap();
+                        }
+                        Some(Ok(Message::Close(_))) => break,
+                        Some(Ok(_)) => {}
+                        other => panic!("expected client close, got {other:?}"),
+                    }
+                }
+                let mut byte = [0u8; 1];
+                let count =
+                    tokio::time::timeout(Duration::from_secs(1), ws.get_mut().read(&mut byte))
+                        .await
+                        .expect("initialization cleanup must shut down TCP");
+                assert!(
+                    matches!(count, Ok(0))
+                        || matches!(count, Err(ref error) if error.kind() == std::io::ErrorKind::ConnectionReset),
+                    "connection remained readable: {count:?}"
+                );
+                observed.push(methods);
+            }
+            observed
+        });
+        (url, server)
+    }
+
+    async fn assert_failed_external_initialization(
+        fail_method: &'static str,
+        direct: bool,
+        existing: bool,
+    ) {
+        let (url, server) = initialization_server(fail_method, existing, 2, false).await;
+        let error = BrowserManager::connect_cdp_inner(&url, direct, None)
+            .await
+            .err()
+            .expect("initialization should fail");
+        assert!(error.contains("injected initialization failure"), "{error}");
+        let mut manager = tokio::time::timeout(
+            Duration::from_secs(4),
+            BrowserManager::connect_cdp_inner(&url, direct, None),
+        )
+        .await
+        .expect("retry should succeed after cleanup")
+        .unwrap();
+        manager.close().await.unwrap();
+        for methods in server.await.unwrap() {
+            assert!(!methods.iter().any(|method| method == "Browser.close"));
+        }
+    }
+
+    macro_rules! failed_initialization_test {
+        ($name:ident, $method:literal, $direct:literal, $existing:literal) => {
+            #[tokio::test]
+            async fn $name() {
+                assert_failed_external_initialization($method, $direct, $existing).await;
+            }
+        };
+    }
+
+    failed_initialization_test!(
+        test_failed_discover_disconnects,
+        "Target.setDiscoverTargets",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_get_targets_disconnects,
+        "Target.getTargets",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_create_target_disconnects,
+        "Target.createTarget",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_attach_disconnects,
+        "Target.attachToTarget",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_direct_page_disconnects,
+        "Page.enable",
+        true,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_new_page_page_disconnects,
+        "Page.enable",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_existing_page_page_disconnects,
+        "Page.enable",
+        false,
+        true
+    );
+    failed_initialization_test!(
+        test_failed_direct_runtime_disconnects,
+        "Runtime.enable",
+        true,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_new_page_runtime_disconnects,
+        "Runtime.enable",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_existing_page_runtime_disconnects,
+        "Runtime.enable",
+        false,
+        true
+    );
+    failed_initialization_test!(
+        test_failed_direct_network_disconnects,
+        "Network.enable",
+        true,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_new_page_network_disconnects,
+        "Network.enable",
+        false,
+        false
+    );
+    failed_initialization_test!(
+        test_failed_existing_page_network_disconnects,
+        "Network.enable",
+        false,
+        true
+    );
+
+    #[cfg(unix)]
+    fn initialization_process(url: &str) -> (tempfile::TempDir, LaunchOptions) {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let executable = dir.path().join("chrome");
+        let port = url::Url::parse(url).unwrap().port().unwrap();
+        std::fs::write(&executable, format!(
+            "#!/bin/sh\nfor arg in \"$@\"; do\ncase \"$arg\" in\n--user-data-dir=*) profile=${{arg#*=}} ;;\nesac\ndone\nprintf '%s\\n' {port} /devtools/browser/test > \"$profile/DevToolsActivePort\"\nprintf '%s\\n' \"$$\" > '{}/pid'\nexec sleep 60\n",
+            dir.path().display()
+        )).unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let options = LaunchOptions {
+            executable_path: Some(executable.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        (dir, options)
+    }
+
+    #[cfg(unix)]
+    fn assert_initialization_process_reaped(dir: &std::path::Path) {
+        let pid: i32 = std::fs::read_to_string(dir.join("pid"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert_eq!(
+            unsafe { libc::kill(pid, 0) },
+            -1,
+            "browser process is still alive"
+        );
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+        assert_eq!(
+            unsafe { libc::waitpid(pid, std::ptr::null_mut(), libc::WNOHANG) },
+            -1
+        );
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ECHILD)
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_failed_local_initialization_disconnects_and_reaps() {
+        for (method, ignore_close) in [
+            ("Target.getTargets", false),
+            ("Network.enable", false),
+            ("Network.enable", true),
+        ] {
+            let (url, server) = initialization_server(method, false, 1, ignore_close).await;
+            let (dir, options) = initialization_process(&url);
+            let error = BrowserManager::launch(options, None)
+                .await
+                .err()
+                .expect("launch should fail");
+            assert!(error.contains("injected initialization failure"), "{error}");
+            let observed = server.await.unwrap();
+            assert!(observed[0].iter().any(|method| method == "Browser.close"));
+            assert_initialization_process_reaped(dir.path());
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_failed_lightpanda_initialization_disconnects_before_retry() {
+        let (url, server) = initialization_server("Network.enable", false, 2, false).await;
+        let (dir, options) = initialization_process(&url);
+        let process = tokio::task::spawn_blocking(move || launch_chrome(&options))
+            .await
+            .unwrap()
+            .unwrap();
+        let mut manager = tokio::time::timeout(
+            Duration::from_secs(4),
+            initialize_lightpanda_manager(url, BrowserProcess::Chrome(process)),
+        )
+        .await
+        .expect("Lightpanda should release the failed connection and retry")
+        .unwrap();
+        assert!(!manager.browser_process.as_mut().unwrap().has_exited());
+        manager.close().await.unwrap();
+        let observed = server.await.unwrap();
+        assert!(!observed[0].iter().any(|method| method == "Browser.close"));
+        assert!(observed[1].iter().any(|method| method == "Browser.close"));
+        assert_initialization_process_reaped(dir.path());
     }
 
     const TARGET_A: &str = "AAAA0000BBBB1111CCCC2222DDDD3333";

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -1,22 +1,41 @@
 use std::collections::HashMap;
 use std::io::Write;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::net::Shutdown;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use serde::de::IgnoredAny;
+use serde::Deserialize;
 use serde_json::Value;
-use tokio::sync::{broadcast, oneshot, Mutex};
+use tokio::sync::{broadcast, oneshot, watch, Mutex};
+use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::Connector;
 
-use super::types::{CdpCommand, CdpEvent, CdpMessage};
+use super::types::{CdpCommand, CdpError, CdpEvent, CdpMessage};
 
 type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<CdpMessage>>>>;
+type WsTx = Arc<
+    Mutex<
+        futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            Message,
+        >,
+    >,
+>;
 
 /// Interval between WebSocket ping frames sent to keep the connection alive
 /// through intermediate proxies (reverse proxies, load balancers, service meshes).
 const WS_KEEPALIVE_INTERVAL_SECS: u64 = 30;
+const TRANSPORT_CLOSE_TIMEOUT: Duration = Duration::from_millis(500);
+const CONNECTION_CLOSED_ERROR: &str = "CDP connection closed";
 
 /// Raw incoming CDP message (text) broadcast to all subscribers.
 /// Used by the inspect proxy to forward responses and events to DevTools.
@@ -26,23 +45,100 @@ pub struct RawCdpMessage {
     pub session_id: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct CdpIdEnvelope {
+    id: Option<u64>,
+    #[serde(rename = "result")]
+    _result: Option<IgnoredAny>,
+    #[serde(rename = "error")]
+    _error: Option<IgnoredAny>,
+    #[serde(rename = "method")]
+    _method: Option<IgnoredAny>,
+    #[serde(rename = "params")]
+    _params: Option<IgnoredAny>,
+    #[serde(rename = "sessionId")]
+    _session_id: Option<IgnoredAny>,
+}
+
+fn sanitize_lone_surrogates(msg: &str) -> Option<String> {
+    const ESCAPE_LEN: usize = 6;
+    const HIGH_START: u32 = 0xD800;
+    const LOW_START: u32 = 0xDC00;
+    const SURROGATE_END: u32 = 0xE000;
+
+    let read_escape = |bytes: &[u8], at: usize| -> Option<u32> {
+        let end = at.checked_add(ESCAPE_LEN)?;
+        if end > bytes.len() || bytes[at] != b'\\' || bytes[at + 1] != b'u' {
+            return None;
+        }
+        let hex = &bytes[at + 2..end];
+        if !hex.iter().all(u8::is_ascii_hexdigit) {
+            return None;
+        }
+        u32::from_str_radix(std::str::from_utf8(hex).ok()?, 16).ok()
+    };
+
+    let bytes = msg.as_bytes();
+    let mut out: Option<String> = None;
+    let mut copied = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() && bytes[i + 1] != b'u' {
+            i += 2;
+            continue;
+        }
+
+        let Some(unit) = read_escape(bytes, i) else {
+            i += 1;
+            continue;
+        };
+
+        let is_high = (HIGH_START..LOW_START).contains(&unit);
+        let is_low = (LOW_START..SURROGATE_END).contains(&unit);
+        let paired = is_high
+            && read_escape(bytes, i + ESCAPE_LEN)
+                .is_some_and(|next| (LOW_START..SURROGATE_END).contains(&next));
+
+        if paired {
+            i += ESCAPE_LEN * 2;
+            continue;
+        }
+
+        if is_high || is_low {
+            let buf = out.get_or_insert_with(String::new);
+            buf.push_str(&msg[copied..i]);
+            buf.push(char::REPLACEMENT_CHARACTER);
+            copied = i + ESCAPE_LEN;
+        }
+        i += ESCAPE_LEN;
+    }
+
+    if let Some(buf) = out.as_mut() {
+        buf.push_str(&msg[copied..]);
+    }
+
+    out
+}
+
+fn extract_command_id(msg: &str) -> Option<u64> {
+    let envelope: CdpIdEnvelope = serde_json::from_str(msg).ok()?;
+    envelope.id.filter(|id| *id > 0)
+}
+
 pub struct CdpClient {
-    ws_tx: Arc<
-        Mutex<
-            futures_util::stream::SplitSink<
-                tokio_tungstenite::WebSocketStream<
-                    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-                >,
-                Message,
-            >,
-        >,
-    >,
+    ws_tx: WsTx,
+    socket: socket2::Socket,
+    closed: Arc<AtomicBool>,
+    close_complete: AtomicBool,
+    close_lock: Mutex<()>,
+    cancel_tx: watch::Sender<bool>,
     next_id: AtomicU64,
     pending: PendingMap,
     event_tx: broadcast::Sender<CdpEvent>,
     raw_tx: broadcast::Sender<RawCdpMessage>,
-    _reader_handle: tokio::task::JoinHandle<()>,
-    _keepalive_handle: tokio::task::JoinHandle<()>,
+    reader_handle: Mutex<Option<JoinHandle<()>>>,
+    keepalive_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 /// Removes a pending entry if `send_command` is cancelled mid-await (e.g. an
@@ -101,12 +197,29 @@ impl CdpClient {
             ..Default::default()
         };
 
-        let (ws_stream, _) =
-            tokio_tungstenite::connect_async_with_config(request, Some(ws_config), false)
-                .await
-                .map_err(|e| format!("CDP WebSocket connect failed: {}", e))?;
+        Self::connect_request(request, ws_config, None).await
+    }
+
+    async fn connect_request(
+        request: Request<()>,
+        ws_config: WebSocketConfig,
+        connector: Option<Connector>,
+    ) -> Result<Self, String> {
+        let (ws_stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            request,
+            Some(ws_config),
+            false,
+            connector,
+        )
+        .await
+        .map_err(|e| format!("CDP WebSocket connect failed: {}", e))?;
 
         enable_tcp_keepalive(ws_stream.get_ref());
+        let tcp_stream = underlying_tcp_stream(ws_stream.get_ref())
+            .ok_or_else(|| "Unsupported CDP stream type".to_string())?;
+        let socket = socket2::SockRef::from(tcp_stream)
+            .try_clone()
+            .map_err(|error| format!("Failed to duplicate CDP socket: {}", error))?;
 
         let (ws_tx, mut ws_rx) = ws_stream.split();
         let ws_tx = Arc::new(Mutex::new(ws_tx));
@@ -114,13 +227,16 @@ impl CdpClient {
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
         let (event_tx, _) = broadcast::channel(4096);
         let (raw_tx, _) = broadcast::channel(4096);
+        let closed = Arc::new(AtomicBool::new(false));
 
         let pending_clone = pending.clone();
         let event_tx_clone = event_tx.clone();
         let raw_tx_clone = raw_tx.clone();
+        let closed_reader = closed.clone();
 
         // Notify used to stop the keepalive task when the reader loop exits.
         let (cancel_tx, mut cancel_rx) = tokio::sync::watch::channel(false);
+        let reader_cancel_tx = cancel_tx.clone();
 
         let reader_handle = tokio::spawn(async move {
             while let Some(msg) = ws_rx.next().await {
@@ -166,10 +282,37 @@ impl CdpClient {
                 }
 
                 let parsed: CdpMessage = match serde_json::from_str(&msg) {
-                    Ok(m) => m,
-                    // Expected for inspect proxy messages with negative IDs
-                    // (CdpMessage.id is u64); handled via raw broadcast above.
-                    Err(_) => continue,
+                    Ok(parsed) => parsed,
+                    Err(_) => {
+                        let repaired = sanitize_lone_surrogates(&msg);
+                        let candidate = repaired.as_deref().unwrap_or(&msg);
+                        match serde_json::from_str(candidate) {
+                            Ok(parsed) => parsed,
+                            Err(error) => {
+                                if let Some(id) = extract_command_id(candidate) {
+                                    let waiter = pending_clone.lock().await.remove(&id);
+                                    if let Some(tx) = waiter {
+                                        let _ = tx.send(CdpMessage {
+                                            id: Some(id),
+                                            result: None,
+                                            error: Some(CdpError {
+                                                code: None,
+                                                message: format!(
+                                                    "Malformed CDP response: {}",
+                                                    error
+                                                ),
+                                                data: None,
+                                            }),
+                                            method: None,
+                                            params: None,
+                                            session_id: None,
+                                        });
+                                    }
+                                }
+                                continue;
+                            }
+                        }
+                    }
                 };
 
                 if let Some(id) = parsed.id {
@@ -192,10 +335,11 @@ impl CdpClient {
             // Reader loop exited (connection closed or error). Drop all pending
             // command senders so callers get an immediate channel-closed error
             // instead of waiting for the 30-second timeout.
+            closed_reader.store(true, Ordering::SeqCst);
             pending_clone.lock().await.clear();
 
-            // Stop the keepalive task — the connection is gone.
-            let _ = cancel_tx.send(true);
+            // Stop the keepalive task because the connection is gone.
+            let _ = reader_cancel_tx.send(true);
         });
 
         // Spawn a keepalive task that sends WebSocket Ping frames at a regular
@@ -203,6 +347,7 @@ impl CdpClient {
         // cloud load balancers) from closing idle WebSocket connections. If the
         // send fails, the connection is dead and we stop pinging.
         let keepalive_tx = ws_tx.clone();
+        let closed_keepalive = closed.clone();
         let keepalive_handle = tokio::spawn(async move {
             let interval = std::time::Duration::from_secs(WS_KEEPALIVE_INTERVAL_SECS);
             loop {
@@ -211,6 +356,9 @@ impl CdpClient {
                     _ = cancel_rx.changed() => break,
                 }
                 let mut tx = keepalive_tx.lock().await;
+                if closed_keepalive.load(Ordering::SeqCst) {
+                    break;
+                }
                 if tx.send(Message::Ping(Vec::new())).await.is_err() {
                     break;
                 }
@@ -219,13 +367,56 @@ impl CdpClient {
 
         Ok(Self {
             ws_tx,
+            socket,
+            closed,
+            close_complete: AtomicBool::new(false),
+            close_lock: Mutex::new(()),
+            cancel_tx,
             next_id: AtomicU64::new(1),
             pending,
             event_tx,
             raw_tx,
-            _reader_handle: reader_handle,
-            _keepalive_handle: keepalive_handle,
+            reader_handle: Mutex::new(Some(reader_handle)),
+            keepalive_handle: Mutex::new(Some(keepalive_handle)),
         })
+    }
+
+    fn ensure_open(&self) -> Result<(), String> {
+        if self.closed.load(Ordering::SeqCst) {
+            Err(CONNECTION_CLOSED_ERROR.to_string())
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn abort_task(handle: &Mutex<Option<JoinHandle<()>>>) {
+        let Some(task) = handle.lock().await.take() else {
+            return;
+        };
+        task.abort();
+        let _ = tokio::time::timeout(TRANSPORT_CLOSE_TIMEOUT, task).await;
+    }
+
+    pub async fn close(&self) {
+        let _close_guard = self.close_lock.lock().await;
+        if self.close_complete.load(Ordering::SeqCst) {
+            return;
+        }
+        self.closed.store(true, Ordering::SeqCst);
+
+        let _ = self.cancel_tx.send(true);
+        Self::abort_task(&self.keepalive_handle).await;
+
+        let _ = tokio::time::timeout(TRANSPORT_CLOSE_TIMEOUT, async {
+            let mut ws_tx = self.ws_tx.lock().await;
+            let _ = ws_tx.close().await;
+        })
+        .await;
+
+        let _ = self.socket.shutdown(Shutdown::Both);
+        Self::abort_task(&self.reader_handle).await;
+        self.pending.lock().await.clear();
+        self.close_complete.store(true, Ordering::SeqCst);
     }
 
     pub async fn send_command(
@@ -248,11 +439,6 @@ impl CdpClient {
 
         let (tx, rx) = oneshot::channel();
 
-        {
-            let mut pending = self.pending.lock().await;
-            pending.insert(id, tx);
-        }
-
         // Cleans up the pending entry if this future is cancelled mid-await (#1528).
         let mut guard = PendingGuard {
             pending: self.pending.clone(),
@@ -262,10 +448,15 @@ impl CdpClient {
 
         {
             let mut ws_tx = self.ws_tx.lock().await;
-            ws_tx
-                .send(Message::Text(json))
-                .await
-                .map_err(|e| format!("Failed to send CDP command: {}", e))?;
+            self.ensure_open()?;
+            let mut pending = self.pending.lock().await;
+            pending.insert(id, tx);
+            drop(pending);
+            if let Err(error) = ws_tx.send(Message::Text(json)).await {
+                self.pending.lock().await.remove(&id);
+                guard.done = true;
+                return Err(format!("Failed to send CDP command: {}", error));
+            }
         }
 
         let response = match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
@@ -307,6 +498,7 @@ impl CdpClient {
         InspectProxyHandle {
             ws_tx: self.ws_tx.clone(),
             raw_tx: self.raw_tx.clone(),
+            closed: self.closed.clone(),
         }
     }
 
@@ -356,6 +548,7 @@ impl CdpClient {
             .map_err(|e| format!("Failed to serialize CDP command: {}", e))?;
 
         let mut ws_tx = self.ws_tx.lock().await;
+        self.ensure_open()?;
         ws_tx
             .send(Message::Text(json))
             .await
@@ -366,6 +559,7 @@ impl CdpClient {
     /// Used by the inspect proxy to forward DevTools frontend messages.
     pub async fn send_raw(&self, json: String) -> Result<(), String> {
         let mut ws_tx = self.ws_tx.lock().await;
+        self.ensure_open()?;
         ws_tx
             .send(Message::Text(json))
             .await
@@ -380,27 +574,20 @@ impl CdpClient {
     }
 }
 
-type WsTx = Arc<
-    Mutex<
-        futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
-    >,
->;
-
 /// Lightweight handle for the inspect WebSocket proxy, holding only
 /// the cloneable parts of CdpClient needed for bidirectional message forwarding.
 pub struct InspectProxyHandle {
     ws_tx: WsTx,
     raw_tx: broadcast::Sender<RawCdpMessage>,
+    closed: Arc<AtomicBool>,
 }
 
 impl InspectProxyHandle {
     pub async fn send_raw(&self, json: String) -> Result<(), String> {
         let mut ws_tx = self.ws_tx.lock().await;
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(CONNECTION_CLOSED_ERROR.to_string());
+        }
         ws_tx
             .send(Message::Text(json))
             .await
@@ -416,10 +603,8 @@ impl InspectProxyHandle {
 /// This is best-effort: failures are silently ignored since the WebSocket-level
 /// Ping keepalive provides the primary connection liveness mechanism.
 fn enable_tcp_keepalive(stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>) {
-    let tcp_stream = match stream {
-        tokio_tungstenite::MaybeTlsStream::Plain(s) => s,
-        tokio_tungstenite::MaybeTlsStream::Rustls(s) => s.get_ref().0,
-        _ => return,
+    let Some(tcp_stream) = underlying_tcp_stream(stream) else {
+        return;
     };
 
     // SockRef borrows the fd without taking ownership.
@@ -433,4 +618,384 @@ fn enable_tcp_keepalive(stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::T
     let keepalive = keepalive.with_interval(std::time::Duration::from_secs(10));
 
     let _ = sock.set_tcp_keepalive(&keepalive);
+}
+
+fn underlying_tcp_stream(
+    stream: &tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+) -> Option<&tokio::net::TcpStream> {
+    match stream {
+        tokio_tungstenite::MaybeTlsStream::Plain(stream) => Some(stream),
+        tokio_tungstenite::MaybeTlsStream::Rustls(stream) => Some(stream.get_ref().0),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use serde_json::json;
+    use std::io::Read;
+    use std::net::TcpListener as StdTcpListener;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    const TEST_CERT_DER: &str = "MIIBPDCB46ADAgECAgkA9xwXmIhbzQIwCgYIKoZIzj0EAwIwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDgzMDA1NTU0NFoXDTM2MDgyNzA1NTU0NFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQdmPO0sXXFRmVn7+8MViXGom2rYy8aV3Oc0pNZhUmFGaPl4MRFzc1G0yaV/WRBPF/BUh2LGsXCvUsn7NqaYkFaMeMBwwGgYDVR0RBBMwEYIJbG9jYWxob3N0hwR/AAABMAoGCCqGSM49BAMCA0gAMEUCIQC32oureGNAupABEmonQPAQBD7OdJjXmUxoVQNr0UB+6AIgb23GMwxTjwHyLG4tZcJST7r3cCW8K/Y+1h618j2f+Uw=";
+    const TEST_KEY_DER: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgIVZST8Vhc5f3OW+4kF78f8o1nQCRwjW/Yo8CXQ35Y9uhRANCAARB2Y87SxdcVGZWfv7wxWJcaibatjLxpXc5zSk1mFSYUZo+XgxEXNzUbTJpX9ZEE8X8FSHYsaxcK9Syfs2ppiQV";
+
+    #[test]
+    fn repairs_only_unpaired_surrogate_escapes() {
+        let msg = r#"{"id":1,"result":{"high":"\ud800","low":"\udfff","pair":"\ud83d\ude00","escaped":"\\ud800","text":"café 中文"}}"#;
+        let repaired = sanitize_lone_surrogates(msg).expect("lone surrogates should be repaired");
+        let parsed: CdpMessage = serde_json::from_str(&repaired).expect("repaired message");
+        let result = parsed.result.expect("result");
+
+        assert_eq!(result["high"], "\u{fffd}");
+        assert_eq!(result["low"], "\u{fffd}");
+        assert_eq!(result["pair"], "😀");
+        assert_eq!(result["escaped"], r"\ud800");
+        assert_eq!(result["text"], "café 中文");
+    }
+
+    #[test]
+    fn extracts_only_positive_top_level_command_ids() {
+        assert_eq!(
+            extract_command_id(r#"{"id":7,"result":{"value":"\ud800"}}"#),
+            Some(7)
+        );
+        assert_eq!(
+            extract_command_id(r#"{"result":{"id":42,"value":"\ud800"}}"#),
+            None
+        );
+        assert_eq!(
+            extract_command_id(r#"{"id":-1,"result":{"value":"\ud800"}}"#),
+            None
+        );
+        assert_eq!(
+            extract_command_id(r#"{"method":"Fetch.requestPaused","params":{"value":"\ud800"}}"#),
+            None
+        );
+        assert_eq!(extract_command_id(r#"{"id":0,"result":{}}"#), None);
+    }
+
+    #[tokio::test]
+    async fn repairs_response_and_event_then_processes_next_command() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            let first = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            let first_id = serde_json::from_str::<Value>(&first).unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            ws.send(Message::Text(format!(
+                r#"{{"id":{first_id},"result":{{"value":"\ud800"}}}}"#
+            )))
+            .await
+            .unwrap();
+            ws.send(Message::Text(
+                r#"{"method":"Fetch.requestPaused","params":{"requestId":"r1","request":{"url":"https://example.test/\udfff"}},"sessionId":"s1"}"#.to_string(),
+            ))
+            .await
+            .unwrap();
+
+            let second = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            let second_id = serde_json::from_str::<Value>(&second).unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            ws.send(Message::Text(
+                json!({"id": second_id, "result": {"value": "ok"}}).to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let client = CdpClient::connect(&url).await.unwrap();
+        let mut events = client.subscribe();
+
+        let first = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.send_command_no_params("Accessibility.getFullAXTree", None),
+        )
+        .await
+        .expect("surrogate response should complete")
+        .unwrap();
+        assert_eq!(first["value"], "\u{fffd}");
+
+        let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("surrogate event should arrive")
+            .unwrap();
+        assert_eq!(event.method, "Fetch.requestPaused");
+        assert_eq!(
+            event.params["request"]["url"],
+            "https://example.test/\u{fffd}"
+        );
+
+        let second = client
+            .send_command_no_params("Browser.getVersion", None)
+            .await
+            .unwrap();
+        assert_eq!(second["value"], "ok");
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn malformed_response_fails_only_its_top_level_pending_command() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            let first = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            let first_id = serde_json::from_str::<Value>(&first).unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            ws.send(Message::Text(format!(
+                r#"{{"id":{first_id},"result":{{"value":"\ud800"}},"method":42}}"#
+            )))
+            .await
+            .unwrap();
+
+            let second = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            let second_id = serde_json::from_str::<Value>(&second).unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            ws.send(Message::Text(format!(
+                r#"{{"result":{{"id":{second_id},"value":"\ud800"}},"method":42}}"#
+            )))
+            .await
+            .unwrap();
+            ws.send(Message::Text(
+                json!({"id": second_id, "result": {"value": "still-open"}}).to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let client = CdpClient::connect(&url).await.unwrap();
+        let error = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.send_command_no_params("Broken.response", None),
+        )
+        .await
+        .expect("malformed response should not time out")
+        .unwrap_err();
+        assert!(error.contains("Malformed CDP response"), "{error}");
+
+        let result = client
+            .send_command_no_params("Browser.getVersion", None)
+            .await
+            .unwrap();
+        assert_eq!(result["value"], "still-open");
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn close_releases_pending_and_rejects_all_write_paths() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let (command_seen_tx, command_seen_rx) = oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let _ = ws.next().await;
+            let _ = command_seen_tx.send(());
+            while ws.next().await.is_some() {}
+        });
+
+        let client = Arc::new(CdpClient::connect(&url).await.unwrap());
+        let inspect = client.inspect_handle();
+        let command_client = client.clone();
+        let command = tokio::spawn(async move {
+            command_client
+                .send_command_no_params("Never.responds", None)
+                .await
+        });
+
+        command_seen_rx.await.unwrap();
+        assert_eq!(client.pending_len().await, 1);
+        client.close().await;
+
+        let command_error = tokio::time::timeout(Duration::from_secs(1), command)
+            .await
+            .expect("pending command should be released")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(command_error, "CDP response channel closed");
+        assert_eq!(client.pending_len().await, 0);
+
+        assert_eq!(
+            client
+                .send_command_no_params("Browser.getVersion", None)
+                .await
+                .unwrap_err(),
+            CONNECTION_CLOSED_ERROR
+        );
+        assert_eq!(
+            client
+                .send_command_no_wait("Browser.getVersion", None, None)
+                .await
+                .unwrap_err(),
+            CONNECTION_CLOSED_ERROR
+        );
+        assert_eq!(
+            client.send_raw("{}".to_string()).await.unwrap_err(),
+            CONNECTION_CLOSED_ERROR
+        );
+        assert_eq!(
+            inspect.send_raw("{}".to_string()).await.unwrap_err(),
+            CONNECTION_CLOSED_ERROR
+        );
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_close_sends_close_and_forces_tcp_eof_with_inspect_alive() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let close = tokio::time::timeout(Duration::from_secs(1), ws.next())
+                .await
+                .expect("server should receive close")
+                .expect("stream should yield close")
+                .expect("close frame should parse");
+            assert!(matches!(close, Message::Close(_)));
+
+            let mut byte = [0u8; 1];
+            let count = tokio::time::timeout(Duration::from_secs(1), ws.get_mut().read(&mut byte))
+                .await
+                .expect("server should observe TCP shutdown")
+                .expect("server TCP read should succeed");
+            assert_eq!(count, 0);
+        });
+
+        let client = Arc::new(CdpClient::connect(&url).await.unwrap());
+        let inspect = client.inspect_handle();
+        let close_a = {
+            let client = client.clone();
+            tokio::spawn(async move { client.close().await })
+        };
+        let close_b = {
+            let client = client.clone();
+            tokio::spawn(async move { client.close().await })
+        };
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            close_a.await.unwrap();
+            close_b.await.unwrap();
+            client.close().await;
+        })
+        .await
+        .expect("concurrent close should be bounded");
+
+        server.await.unwrap();
+        drop(inspect);
+    }
+
+    #[tokio::test]
+    async fn close_is_bounded_when_the_sink_is_busy() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let _ = accepted_tx.send(());
+            while ws.next().await.is_some() {}
+        });
+
+        let client = Arc::new(CdpClient::connect(&url).await.unwrap());
+        accepted_rx.await.unwrap();
+        let sink_guard = client.ws_tx.lock().await;
+        let close_client = client.clone();
+        tokio::time::timeout(Duration::from_secs(1), async move {
+            close_client.close().await;
+        })
+        .await
+        .expect("close should not wait indefinitely for the sink");
+        drop(sink_guard);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rustls_close_forces_underlying_tcp_eof() {
+        let certificate = CertificateDer::from(
+            base64::engine::general_purpose::STANDARD
+                .decode(TEST_CERT_DER)
+                .unwrap(),
+        );
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+            base64::engine::general_purpose::STANDARD
+                .decode(TEST_KEY_DER)
+                .unwrap(),
+        ));
+        let server_config = Arc::new(
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![certificate.clone()], key)
+                .unwrap(),
+        );
+
+        let listener = StdTcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let connection = rustls::ServerConnection::new(server_config).unwrap();
+            let tls = rustls::StreamOwned::new(connection, stream);
+            let mut ws = tokio_tungstenite::tungstenite::accept(tls).unwrap();
+            assert!(matches!(ws.read().unwrap(), Message::Close(_)));
+
+            let mut byte = [0u8; 1];
+            let count = ws
+                .get_mut()
+                .get_mut()
+                .read(&mut byte)
+                .expect("server TCP read should succeed");
+            assert_eq!(count, 0);
+        });
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(certificate).unwrap();
+        let client_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth(),
+        );
+        let request = format!("wss://127.0.0.1:{port}")
+            .into_client_request()
+            .unwrap();
+        let config = WebSocketConfig {
+            max_message_size: None,
+            max_frame_size: None,
+            ..Default::default()
+        };
+        let client =
+            CdpClient::connect_request(request, config, Some(Connector::Rustls(client_config)))
+                .await
+                .unwrap();
+
+        client.close().await;
+        server.join().unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

- repair lone UTF-16 surrogate escapes before typed CDP parsing while preserving valid pairs and ordinary Unicode
- fail only the matching positive top-level pending command when a malformed response still cannot be parsed
- make CDP shutdown bounded and idempotent, release pending callers, reject post-close writes, and force TCP EOF through shared plain or Rustls transports
- disconnect external CDP transports without sending `Browser.close` to browsers agent-browser does not own

Closes #1666.
Closes #1726.

## Testing

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- `cargo test --locked --manifest-path cli/Cargo.toml`: 1,164 unit tests and 2 integration tests passed
- 8 focused CDP tests passed five consecutive runs
- `e2e_launch_navigate_evaluate_close` passed against real Chrome
- fix-absent mutations proved lone-surrogate repair and `shutdown(Both)` are load-bearing
- Microsoft Windows Server 2025 with Rust 1.98.0: all 8 CDP tests and `test_close_external_manager_disconnects_without_closing_browser` passed through a cuse scenario
