### PR TITLE
Prepare v0.35.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,25 @@
 # agent-browser
 
-## 0.35.1
+## 0.35.2
 
 <!-- release:start -->
+### Security
+
+- Hardened **dashboard origin validation and reverse-proxy access** with same-origin provenance enforcement that defends against DNS rebinding, form/header smuggling, and cross-origin requests. Reverse-proxied origins now require exact HTTPS allowlisting and generated token authentication, while tokenless IPv4 and IPv6 loopback access remains supported. Dashboard options are validated strictly, and CLI and MCP lifecycle behavior is aligned (#1738)
+
+### Bug Fixes
+
+- Fixed **root remote CDP WebSocket URLs with query strings** to insert the required slash before the query while preserving the encoded query (#1735)
+
+### Contributors
+
+- @ctate
+- @Railly
+
+<!-- release:end -->
+
+## 0.35.1
+
 ### Bug Fixes
 
 - Fixed **Windows ARM64 launcher selection** to prefer a native ARM64 executable when present and fall back to the published x64 executable through Windows emulation when it is not (#1725)
@@ -20,7 +37,6 @@
 - @Angelmmiguel
 - @anupamme
 - @nexxusbruno-ship-it
-<!-- release:end -->
 
 ## 0.35.0
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.35.1"
+version = "0.35.2"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.35.1"
+version = "0.35.2"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.35.2
+
+<p className="text-[#888] text-sm">August 31, 2026</p>
+
+### Security
+
+- Hardened **dashboard origin validation and reverse-proxy access** with same-origin provenance enforcement that defends against DNS rebinding, form/header smuggling, and cross-origin requests. Reverse-proxied origins now require exact HTTPS allowlisting and generated token authentication, while tokenless IPv4 and IPv6 loopback access remains supported. Dashboard options are validated strictly, and CLI and MCP lifecycle behavior is aligned (#1738)
+
+### Bug Fixes
+
+- Fixed **root remote CDP WebSocket URLs with query strings** to insert the required slash before the query while preserving the encoded query (#1735)
+
+---
+
 ## v0.35.1
 
 <p className="text-[#888] text-sm">August 26, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.35.1";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.35.2";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v0.35.2

Synchronize the agent-browser, CLI, dashboard, Eve, and sandbox version metadata at 0.35.2, with matching changelog and documentation entries.

This patch release delivers dashboard access hardening: dashboard API requests now require trusted same-origin provenance, reverse-proxied deployments require explicit HTTPS origin allowlisting and generated-token authentication, and dashboard options are validated strictly. These changes protect exposed dashboard deployments from cross-origin, DNS-rebinding, and request-smuggling attacks while preserving tokenless loopback access.

It also fixes remote CDP WebSocket URLs that use the root path with query parameters by inserting the required slash before the query without altering the encoded query, restoring compatibility with services that require that URL form.