### PR TITLE
fix(lightpanda): drop the removed `serve --timeout` flag

### DIFF
--- a/cli/src/native/cdp/lightpanda.rs
+++ b/cli/src/native/cdp/lightpanda.rs
@@ -11,7 +11,6 @@ use super::discovery::discover_cdp_url_with_timeout;
 const LIGHTPANDA_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const LIGHTPANDA_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_DISCOVERY_TIMEOUT: Duration = Duration::from_millis(500);
-const LIGHTPANDA_SESSION_TIMEOUT_SECS: u64 = 604800; // 1 week, the documented maximum
 const MAX_LOG_LINES: usize = 40;
 
 pub struct LightpandaProcess {
@@ -47,8 +46,6 @@ fn build_lightpanda_serve_args(port: u16, proxy: Option<&str>) -> Vec<String> {
         "127.0.0.1".to_string(),
         "--port".to_string(),
         port.to_string(),
-        "--timeout".to_string(),
-        LIGHTPANDA_SESSION_TIMEOUT_SECS.to_string(),
     ];
 
     if let Some(proxy) = proxy {
@@ -456,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_lightpanda_serve_args_sets_explicit_session_timeout() {
+    fn test_build_lightpanda_serve_args_without_proxy() {
         let args = build_lightpanda_serve_args(9222, None);
 
         assert_eq!(
@@ -467,8 +464,6 @@ mod tests {
                 "127.0.0.1".to_string(),
                 "--port".to_string(),
                 "9222".to_string(),
-                "--timeout".to_string(),
-                "604800".to_string(),
             ]
         );
     }
@@ -485,8 +480,6 @@ mod tests {
                 "127.0.0.1".to_string(),
                 "--port".to_string(),
                 "9333".to_string(),
-                "--timeout".to_string(),
-                "604800".to_string(),
                 "--http_proxy".to_string(),
                 "http://127.0.0.1:8080".to_string(),
             ]


### PR DESCRIPTION
## Summary

`build_lightpanda_serve_args` still passes `--timeout 604800` to `lightpanda serve`. That flag has been a no-op in Lightpanda since April 2026 (lightpanda-io/browser `999f57b72`, kept only as a deprecation warning) and was removed on 2026-08-27 in lightpanda-io/browser#3305. Nightly builds since then refuse to start with it:

```
$ lightpanda serve --host 127.0.0.1 --port 19333 --timeout 604800
FATAL app : unknown argument
      mode = serve
      arg = --timeout
```

Because the Lightpanda docs page in this repo installs the **nightly** binary, `agent-browser --engine lightpanda` currently fails on a fresh install with `Lightpanda exited before CDP became ready (status: exit status: 1)`. Downstream, Hermes Agent's Lightpanda engine (which drives agent-browser) silently falls back to Chrome for every command.

## Changes

- Drop `--timeout` / `LIGHTPANDA_SESSION_TIMEOUT_SECS` from the serve argv.
- Update the two argv unit tests.

No behaviour change beyond the argv: session lifetime is already owned by agent-browser's daemon idle timeout, and Lightpanda has been ignoring the value for months.

## Testing

- `cd cli && cargo test lightpanda` — 14 passed.
- Manual: `lightpanda serve --host 127.0.0.1 --port 19333` (current main, `fad4b9707`) starts and answers `/json/version`; the same invocation with `--timeout` is the FATAL above.

Note for downstream: Hermes pins `agent-browser@^0.26.0` (npm semver: `<0.27`), so it won't see this on `latest`; I'll ask them to bump the pin once this is released (or a 0.26.x backport, if you still cut those). Happy to adjust anything.
