### PR TITLE
Remove obsolete Lightpanda serve timeout

### DIFF
--- a/cli/src/native/cdp/lightpanda.rs
+++ b/cli/src/native/cdp/lightpanda.rs
@@ -11,7 +11,6 @@ use super::discovery::discover_cdp_url_with_timeout;
 const LIGHTPANDA_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const LIGHTPANDA_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIGHTPANDA_DISCOVERY_TIMEOUT: Duration = Duration::from_millis(500);
-const LIGHTPANDA_SESSION_TIMEOUT_SECS: u64 = 604800; // 1 week, the documented maximum
 const MAX_LOG_LINES: usize = 40;
 
 pub struct LightpandaProcess {
@@ -47,8 +46,6 @@ fn build_lightpanda_serve_args(port: u16, proxy: Option<&str>) -> Vec<String> {
         "127.0.0.1".to_string(),
         "--port".to_string(),
         port.to_string(),
-        "--timeout".to_string(),
-        LIGHTPANDA_SESSION_TIMEOUT_SECS.to_string(),
     ];
 
     if let Some(proxy) = proxy {
@@ -456,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_lightpanda_serve_args_sets_explicit_session_timeout() {
+    fn test_build_lightpanda_serve_args_uses_supported_options() {
         let args = build_lightpanda_serve_args(9222, None);
 
         assert_eq!(
@@ -467,8 +464,6 @@ mod tests {
                 "127.0.0.1".to_string(),
                 "--port".to_string(),
                 "9222".to_string(),
-                "--timeout".to_string(),
-                "604800".to_string(),
             ]
         );
     }
@@ -485,8 +480,6 @@ mod tests {
                 "127.0.0.1".to_string(),
                 "--port".to_string(),
                 "9333".to_string(),
-                "--timeout".to_string(),
-                "604800".to_string(),
                 "--http_proxy".to_string(),
                 "http://127.0.0.1:8080".to_string(),
             ]


### PR DESCRIPTION
Remove the obsolete `--timeout` argument from the Lightpanda `serve` launch command and update the focused argument-construction expectations, including proxy handling.

Current documented Lightpanda binaries no longer accept this argument and can exit before CDP becomes ready when it is supplied. Passing only supported options keeps the Lightpanda engine compatible so it can start CDP sessions.