### PR TITLE
Prepare v0.35.3 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,30 @@
 # agent-browser
 
-## 0.35.2
+## 0.35.3
 
 <!-- release:start -->
+### Security
+
+- Updated transitive **brace-expansion dependencies** to patched releases, including the associated `minimatch` updates (#1752)
+
+### Bug Fixes
+
+- Fixed **Lightpanda startup** by removing the obsolete `--timeout` option from the `lightpanda serve` command (#1750)
+
+### Improvements
+
+- Upgraded the **Eve integration** to 0.47.3, raised its peer compatibility floor, and updated the example app for the current Eve agent API (#1751)
+
+### Contributors
+
+- @ctate
+- @anupamme
+- @arrufat
+
+<!-- release:end -->
+
+## 0.35.2
+
 ### Security
 
 - Hardened **dashboard origin validation and reverse-proxy access** with same-origin provenance enforcement that defends against DNS rebinding, form/header smuggling, and cross-origin requests. Reverse-proxied origins now require exact HTTPS allowlisting and generated token authentication, while tokenless IPv4 and IPv6 loopback access remains supported. Dashboard options are validated strictly, and CLI and MCP lifecycle behavior is aligned (#1738)
@@ -15,8 +37,6 @@
 
 - @ctate
 - @Railly
-
-<!-- release:end -->
 
 ## 0.35.1
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.35.2"
+version = "0.35.3"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.35.2"
+version = "0.35.3"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.35.3
+
+<p className="text-[#888] text-sm">August 31, 2026</p>
+
+### Security
+
+- Updated transitive **brace-expansion dependencies** to patched releases, including the associated `minimatch` updates (#1752)
+
+### Bug Fixes
+
+- Fixed **Lightpanda startup** by removing the obsolete `--timeout` option from the `lightpanda serve` command (#1750)
+
+### Improvements
+
+- Upgraded the **Eve integration** to 0.47.3, raised its peer compatibility floor, and updated the example app for the current Eve agent API (#1751)
+
+---
+
 ## v0.35.2
 
 <p className="text-[#888] text-sm">August 31, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.35.2";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.35.3";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Prepare the v0.35.3 patch release with synchronized package and Cargo versions and updated release notes.

- Update transitive `brace-expansion` and related `minimatch` dependencies to patched releases for security.
- Remove the obsolete `--timeout` option from `lightpanda serve` to restore compatibility with current Lightpanda startup behavior.
- Upgrade the Eve integration to 0.47.3, raise its peer compatibility floor, and update the example app for the current Eve agent API.
- Publish the changes in the root and documentation changelogs with the release contributors.