### PR TITLE
fix(native): aim clicks at a line box, not the union of an inline element's fragments

### DIFF
--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -9369,3 +9369,125 @@ async fn e2e_find_role_document_matches_root() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+// ---------------------------------------------------------------------------
+// Regression: clicking an inline element that wraps across lines.
+//
+// Such an element has one border box per line fragment, and both
+// DOM.getBoxModel (the ref path) and getBoundingClientRect (the selector path)
+// report only their union. The union's center sits in the gap between the
+// fragments, so a click aimed there is delivered to the parent instead. The
+// hit test does not catch it, because an ancestor at the click point counts as
+// "lands on el", and the command reports success while nothing happens.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn e2e_click_inline_element_wrapped_across_lines() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The 150px column forces the anchor onto two lines. Both the anchor and
+    // its paragraph record who received the click, so a miss is visible rather
+    // than silent.
+    let html = concat!(
+        "data:text/html,<html><body style='font:16px/2.4 serif;margin:40px'>",
+        "<div style='width:150px'>",
+        "<p id='para'>He won the ",
+        "<a id='link' href='x'>Nobel Prize in Literature</a> in 1953.</p>",
+        "</div>",
+        "<script>",
+        "window.hits=[];",
+        "document.getElementById('link').addEventListener('click',function(e){",
+        "e.preventDefault();window.hits.push('link')});",
+        "document.getElementById('para').addEventListener('click',function(e){",
+        "if(e.target.id!=='link')window.hits.push('para')});",
+        "</script>",
+        "</body></html>"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": html }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Guard the fixture: the point of the test is gone if the anchor happens
+    // to fit on one line in this browser's default metrics.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "document.getElementById('link').getClientRects().length"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"], 2,
+        "fixture must wrap the anchor onto two lines"
+    );
+
+    // Selector path.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "click", "selector": "#link" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "window.hits.join(',')" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"], "link",
+        "selector click landed off the wrapped anchor"
+    );
+
+    // Ref path, which computes its point from DOM.getBoxModel instead.
+    let resp = execute_command(&json!({ "id": "6", "action": "snapshot" }), &mut state).await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap();
+    assert!(
+        snapshot.contains("Nobel Prize in Literature"),
+        "snapshot should expose the anchor"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "evaluate", "script": "window.hits=[];'ok'" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "click", "selector": "e1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "evaluate", "script": "window.hits.join(',')" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"], "link",
+        "ref click landed off the wrapped anchor"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+}

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -221,7 +221,8 @@ async fn resolve_center_in_same_process_frame(
             if (!el) return null;
             if (el.scrollIntoViewIfNeeded) el.scrollIntoViewIfNeeded(true);
             else el.scrollIntoView({{ block: 'center', inline: 'center' }});
-            const rect = el.getBoundingClientRect();
+            const clickRect = {CLICK_RECT_JS};
+            const rect = clickRect(el);
             let x = rect.x + rect.width / 2;
             let y = rect.y + rect.height / 2;
             let win = doc.defaultView;
@@ -328,7 +329,7 @@ pub async fn resolve_element_center(
 
             if let Ok(r) = result {
                 let (x, y) = box_model_center(&r.model);
-                check_node_interception(
+                let (x, y) = aim_and_check_click_point(
                     client,
                     effective_session_id,
                     backend_node_id,
@@ -366,7 +367,7 @@ pub async fn resolve_element_center(
             )
             .await?;
         let (x, y) = box_model_center(&result.model);
-        check_node_interception(
+        let (x, y) = aim_and_check_click_point(
             client,
             effective_session_id,
             fresh_id,
@@ -395,18 +396,19 @@ pub async fn resolve_element_center(
     Ok((x, y, session_id.to_string()))
 }
 
-/// Hit-test a ref-resolved node at its computed click point and error if an
-/// unrelated element (overlay, banner, sticky header) would receive the input
-/// instead. Best effort: resolution failures skip the check rather than block
-/// the interaction.
-async fn check_node_interception(
+/// Correct a ref-resolved node's click point onto a line box the node
+/// actually covers, then hit-test it and error if an unrelated element
+/// (overlay, banner, sticky header) would receive the input instead. Returns
+/// the point to aim at. Best effort: resolution failures leave the point
+/// unchanged rather than block the interaction.
+async fn aim_and_check_click_point(
     client: &CdpClient,
     session_id: &str,
     backend_node_id: i64,
     target: &str,
     x: f64,
     y: f64,
-) -> Result<(), String> {
+) -> Result<(f64, f64), String> {
     let resolved: Result<DomResolveNodeResult, String> = client
         .send_command_typed(
             "DOM.resolveNode",
@@ -419,23 +421,32 @@ async fn check_node_interception(
         )
         .await;
     let Ok(resolved) = resolved else {
-        return Ok(());
+        return Ok((x, y));
     };
     let Some(object_id) = resolved.object.object_id else {
-        return Ok(());
+        return Ok((x, y));
     };
     // Box-model coordinates are in the top-level viewport space, so the
     // hit-test starts from the top document. For an OOPIF node the
     // frameElement walk stops at the process boundary, where the frame's own
     // document and session-local coordinates are already consistent.
+    //
+    // The client rects read here are in this document's space rather than that
+    // one, so the aim correction is applied as the delta between two centers
+    // measured in the same space, leaving the caller's coordinate space alone.
     let function = format!(
         r#"function(x, y) {{
+            const clickRect = {CLICK_RECT_JS};
+            const union = this.getBoundingClientRect();
+            const aim = clickRect(this);
+            const dx = (aim.x + aim.width / 2) - (union.x + union.width / 2);
+            const dy = (aim.y + aim.height / 2) - (union.y + union.height / 2);
             let topDoc = this.ownerDocument || document;
             while (topDoc.defaultView && topDoc.defaultView.frameElement) {{
                 topDoc = topDoc.defaultView.frameElement.ownerDocument;
             }}
             const blockerAt = {BLOCKER_AT_JS};
-            return blockerAt(topDoc, this, x, y);
+            return {{ dx: dx, dy: dy, blocker: blockerAt(topDoc, this, x + dx, y + dy) }};
         }}"#,
     );
     let result = client
@@ -450,16 +461,25 @@ async fn check_node_interception(
             Some(session_id),
         )
         .await;
-    if let Ok(value) = result {
-        if let Some(blocker) = value
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(|v| v.as_str())
-        {
-            return Err(intercepted_error(target, blocker));
-        }
+    let Ok(value) = result else {
+        return Ok((x, y));
+    };
+    let value = value.get("result").and_then(|r| r.get("value"));
+    if let Some(blocker) = value
+        .and_then(|v| v.get("blocker"))
+        .and_then(|v| v.as_str())
+    {
+        return Err(intercepted_error(target, blocker));
     }
-    Ok(())
+    let dx = value
+        .and_then(|v| v.get("dx"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let dy = value
+        .and_then(|v| v.get("dy"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    Ok((x + dx, y + dy))
 }
 
 /// Coordinates from DOM.getBoxModel are viewport-relative, and input events
@@ -721,6 +741,23 @@ fn build_count_elements_js(selector: &str) -> String {
     }
 }
 
+/// Pick the rect to aim a click at. An inline element that wraps across lines
+/// has one border box per line fragment, and both `DOM.getBoxModel` and
+/// `getBoundingClientRect` report only their union. The union's center sits in
+/// the gap between the fragments, so a click aimed there lands on whatever is
+/// painted behind the element (usually its own parent) instead of on the
+/// element. Aim at the largest individual client rect, which is a point the
+/// element actually covers, and fall back to the union for elements that have
+/// no client rects of their own.
+const CLICK_RECT_JS: &str = r#"(el) => {
+    let best = null;
+    for (const r of el.getClientRects()) {
+        if (r.width <= 0 || r.height <= 0) continue;
+        if (!best || r.width * r.height > best.width * best.height) best = r;
+    }
+    return best || el.getBoundingClientRect();
+}"#;
+
 /// JS function source for `blockerAt(doc, el, x, y)`: returns a short
 /// description of the element that would actually receive a click at (x, y)
 /// when that element is unrelated to `el`, or null when the click would land
@@ -774,10 +811,11 @@ fn build_selector_js(selector: &str) -> String {
                 r.bottom > 0 && r.right > 0 &&
                 r.top < (window.innerHeight || document.documentElement.clientHeight) &&
                 r.left < (window.innerWidth || document.documentElement.clientWidth);
-            let rect = el.getBoundingClientRect();
+            const clickRect = {CLICK_RECT_JS};
+            let rect = clickRect(el);
             if (!inView(rect)) {{
                 el.scrollIntoView({{ block: 'center', inline: 'center', behavior: 'instant' }});
-                rect = el.getBoundingClientRect();
+                rect = clickRect(el);
             }}
             const x = rect.x + rect.width / 2;
             const y = rect.y + rect.height / 2;


### PR DESCRIPTION
## Problem

`click` reports success and does nothing when the target is an inline element that wraps across lines.

```bash
agent-browser open https://en.wikipedia.org/wiki/Winston_Churchill
agent-browser snapshot -i
# - link "Nobel Prize in Literature" [ref=e147]
agent-browser click @e147
# ✓ Done          <- exit 0
agent-browser get url
# https://en.wikipedia.org/wiki/Winston_Churchill   <- never navigated
```

This is not rare. Counting anchors that wrap onto more than one line, scrolling each to the viewport center as the click path does, and classifying where its bounding-box center actually lands:

| page | anchors | wrapped | click lands on the parent | after this change |
| --- | --- | --- | --- | --- |
| en.wikipedia.org/wiki/Winston_Churchill | 7045 | 770 | 141 | 0 |
| en.wikipedia.org/wiki/World_War_II | 5342 | 908 | 298 | 0 |

Those 141 and 298 are the silent cases specifically: the point lands on an ancestor, which the interception check exempts. Seven more on the World War II page land on an unrelated element and are correctly reported as interceptions today. Smaller pages show the same shape at smaller scale: 2 of 3 wrapped links on react.dev/learn, 1 of 6 on the Jar article.

The failure mode is the expensive part. An agent following the documented loop gets `✓ Done` and exit 0, so it proceeds as if it navigated. Nothing surfaces unless the caller separately reads `get url`, and the skill's own core loop does not do that after every click. The reports this produces get attributed to stale refs, overlays, or framework event handling, because from the outside a click that lands one line away is indistinguishable from one that worked. I believe #1011 is partly this: coordinate dispatch does fire React handlers (the input is trusted), and the reproductions there are long inline links in prose. #1044 is the same symptom from a different cause.

## Cause

An inline element that wraps has one border box per line fragment. Both resolution paths ask for their union and aim at its center, which is the gap between the fragments.

`cli/src/native/element.rs`, ref path:

```rust
let (x, y) = box_model_center(&r.model);
```

```rust
fn box_model_center(model: &BoxModel) -> (f64, f64) {
    // content quad: [x1,y1, x2,y2, x3,y3, x4,y4]
```

`DOM.getBoxModel` returns one quad per box type, so for a two-line anchor that quad is the union and its center is between the lines. `build_selector_js` has the same shape with `getBoundingClientRect`, and `resolve_center_in_same_process_frame` a third time.

Concretely, for `<a>` wrapped in a 150px column:

```
getClientRects() -> [ {x:118, y:50, w:39, h:18}, {x:40, y:88, w:116, h:18} ]
getBoundingClientRect() -> {x:40, y:50, w:117, h:56}
center -> (98, 78)
document.elementFromPoint(98, 78) -> <p>      // not the <a>
```

`check_node_interception` runs at that point and should catch it. It does not, because of this line:

```js
for (let n = el; n; n = up(n)) { if (n === hit) return null; }
```

An ancestor at the click point is treated as "lands on el". For a missed inline element the hit is always the parent, so the guard exempts exactly the case it exists to catch, and the click dispatches onto the paragraph.

The existing tests could not see this. Every click fixture in `e2e_tests.rs` targets a block element or a short inline one on a single line, where the union and the line box are the same rect.

## Fix

Aim at the largest individual client rect rather than the union of them, in all three resolution paths. `getClientRects()` returns document-local coordinates while `DOM.getBoxModel` returns top-level viewport coordinates, so the ref path applies the delta between the two centers measured in the same space rather than replacing the point, leaving the existing coordinate handling untouched.

Largest rather than first: the first fragment of a wrapped link is often a two-character sliver at the end of a line, and the largest fragment is the most forgiving target. Say the word if you would rather match Playwright and take the first.

## Scope

Unchanged: single-fragment elements, where `getClientRects()[0]` is the bounding box and the computed point is identical to before. Overlay detection, label/control association, the shadow-DOM walk, the iframe descent, and the stale-`backendNodeId` fallback all behave as they did.

Not addressed, deliberately: the ancestor exemption in `BLOCKER_AT_JS` quoted above. With the geometry corrected it no longer fires for this case, but it remains a general hole, since an ancestor at the click point always means the point missed the target and `elementFromPoint` only returns one when the target does not cover it. Narrowing it is a behavioral change with its own false-positive surface (`pointer-events: none` pass-through, zero-size inline boxes), so it belongs in its own PR. Happy to write it if you want it.

Also not addressed: `agent-browser` has no way to tell a caller that a click was delivered but changed nothing. That is the reason this bug survived so long in the wild, but it is a design question, not a fix.

## Tests

`e2e_click_inline_element_wrapped_across_lines` in `cli/src/native/e2e_tests.rs`. It renders an anchor forced onto two lines in a 150px column, asserts the fixture actually wrapped (`getClientRects().length == 2`, so the test cannot silently stop testing anything if browser metrics shift), and clicks it through both the selector path and the ref path. Both the anchor and its paragraph push to `window.hits`, so a miss is asserted as `"para"` rather than showing up as an absent side effect.

It fails on `main` and passes here, verified by restoring `element.rs` from `origin/main` and re-running, not inferred.

`cargo test --release`: 1181 passed, 0 failed, 106 ignored. No pre-existing failures to report.

What it does not prove: nothing here exercises a wrapped inline element inside a cross-origin iframe, or one inside a scroll container that `scrollIntoViewIfNeeded` moves between the box-model read and the JS read. Both paths are covered by the delta arithmetic on inspection, not by a test.

Verified against Chrome 151.0.7922.175 on macOS arm64, and the reproduction above was first confirmed on the published 0.33.1 binary before any change. `box_model_center` and the exemption are byte-identical on `main` today, so 0.35.2 has this too.

---

Authored with Claude Opus 5
