### PR TITLE
[cli] Record at 30 fps by default, up to 60, from Page.startScreencast

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ agent-browser trace start             # Start recording trace
 agent-browser trace stop [path]       # Stop and save trace
 agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
+agent-browser record start ./demo.webm           # Start video recording at 30 fps
+agent-browser record start ./demo.webm --fps 60  # 60 fps for motion-heavy takes (1-60 allowed)
+agent-browser record stop                        # Stop and save the video
+agent-browser record restart ./take2.webm        # Stop the current recording, start a new one
 agent-browser console                 # View console messages (log, error, warn, info)
 agent-browser console --json          # JSON output with raw CDP args for programmatic access
 agent-browser console --clear         # Clear console

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1672,52 +1672,28 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         "record" => {
             const VALID: &[&str] = &["start", "stop", "restart"];
             match rest.first().copied() {
-                Some("start") => {
-                    let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                        context: "record start".to_string(),
-                        usage: "record start <output.webm> [url]",
-                    })?;
-                    // Optional URL parameter
-                    let url = rest.get(2);
-                    let mut cmd = json!({ "id": id, "action": "recording_start", "path": path });
-                    if let Some(u) = url {
-                        // Add https:// prefix if needed (preserve special schemes)
-                        let url_str = if u.starts_with("http") || u.contains("://") {
-                            u.to_string()
-                        } else {
-                            format!("https://{}", u)
-                        };
-                        cmd["url"] = json!(url_str);
-                    }
-                    Ok(cmd)
-                }
+                Some("start") => parse_record_take(
+                    &id,
+                    "recording_start",
+                    &rest[1..],
+                    "record start",
+                    "record start <output.webm> [url] [--fps <n>]",
+                ),
                 Some("stop") => Ok(json!({ "id": id, "action": "recording_stop" })),
-                Some("restart") => {
-                    let path = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
-                        context: "record restart".to_string(),
-                        usage: "record restart <output.webm> [url]",
-                    })?;
-                    // Optional URL parameter
-                    let url = rest.get(2);
-                    let mut cmd = json!({ "id": id, "action": "recording_restart", "path": path });
-                    if let Some(u) = url {
-                        // Add https:// prefix if needed (preserve special schemes)
-                        let url_str = if u.starts_with("http") || u.contains("://") {
-                            u.to_string()
-                        } else {
-                            format!("https://{}", u)
-                        };
-                        cmd["url"] = json!(url_str);
-                    }
-                    Ok(cmd)
-                }
+                Some("restart") => parse_record_take(
+                    &id,
+                    "recording_restart",
+                    &rest[1..],
+                    "record restart",
+                    "record restart <output.webm> [url] [--fps <n>]",
+                ),
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
                     valid_options: VALID,
                 }),
                 None => Err(ParseError::MissingArguments {
                     context: "record".to_string(),
-                    usage: "record <start|stop|restart> [path] [url]",
+                    usage: "record <start|stop|restart> [path] [url] [--fps <n>]",
                 }),
             }
         }
@@ -2341,6 +2317,93 @@ fn parse_read(rest: &[&str], id: &str, flags: &Flags) -> Result<Value, ParseErro
     }
     if let Some(ref allowed_domains) = flags.allowed_domains {
         cmd["allowedDomains"] = json!(allowed_domains);
+    }
+    Ok(cmd)
+}
+
+/// Parse the arguments shared by `record start` and `record restart`:
+/// `<path> [url] [--fps <n>]`.
+///
+/// `rest` excludes the subcommand. Recording defaults to
+/// `recording::DEFAULT_FPS`; `--fps` accepts anything up to
+/// `recording::MAX_FPS`, with 60 reserved for motion-heavy takes.
+fn parse_record_take(
+    id: &str,
+    action: &str,
+    rest: &[&str],
+    context: &str,
+    usage: &'static str,
+) -> Result<Value, ParseError> {
+    let max_fps = crate::native::recording::MAX_FPS;
+    let mut path: Option<&str> = None;
+    let mut url: Option<&str> = None;
+    let mut fps: Option<u32> = None;
+
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i] {
+            "--fps" => {
+                let value = rest
+                    .get(i + 1)
+                    .ok_or_else(|| ParseError::MissingArguments {
+                        context: format!("{} --fps", context),
+                        usage,
+                    })?;
+                let parsed = value.parse::<u32>().map_err(|_| ParseError::InvalidValue {
+                    message: format!("Invalid fps: '{}' is not a valid integer", value),
+                    usage,
+                })?;
+                if parsed == 0 || parsed > max_fps {
+                    return Err(ParseError::InvalidValue {
+                        message: format!(
+                            "Invalid fps: {} is out of range (valid range: 1-{})",
+                            parsed, max_fps
+                        ),
+                        usage,
+                    });
+                }
+                fps = Some(parsed);
+                i += 2;
+            }
+            flag if flag.starts_with("--") => {
+                return Err(ParseError::InvalidValue {
+                    message: format!("Unknown flag for {}: {}", context, flag),
+                    usage,
+                });
+            }
+            positional => {
+                if path.is_none() {
+                    path = Some(positional);
+                } else if url.is_none() {
+                    url = Some(positional);
+                } else {
+                    return Err(ParseError::InvalidValue {
+                        message: format!("Unexpected argument for {}: {}", context, positional),
+                        usage,
+                    });
+                }
+                i += 1;
+            }
+        }
+    }
+
+    let path = path.ok_or_else(|| ParseError::MissingArguments {
+        context: context.to_string(),
+        usage,
+    })?;
+
+    let mut cmd = json!({ "id": id, "action": action, "path": path });
+    if let Some(u) = url {
+        // Add https:// prefix if needed (preserve special schemes)
+        let url_str = if u.starts_with("http") || u.contains("://") {
+            u.to_string()
+        } else {
+            format!("https://{}", u)
+        };
+        cmd["url"] = json!(url_str);
+    }
+    if let Some(rate) = fps {
+        cmd["fps"] = json!(rate);
     }
     Ok(cmd)
 }
@@ -4790,6 +4853,110 @@ mod tests {
         assert_eq!(cmd["action"], "recording_start");
         assert_eq!(cmd["path"], "output.webm");
         assert!(cmd.get("url").is_none());
+        // Omitting --fps lets the daemon apply its 30 fps default.
+        assert!(cmd.get("fps").is_none());
+    }
+
+    #[test]
+    fn test_record_start_with_fps() {
+        let cmd =
+            parse_command(&args("record start output.webm --fps 60"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "recording_start");
+        assert_eq!(cmd["path"], "output.webm");
+        assert_eq!(cmd["fps"], 60);
+    }
+
+    #[test]
+    fn test_record_start_with_url_and_fps() {
+        let cmd = parse_command(
+            &args("record start demo.webm example.com --fps 24"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["path"], "demo.webm");
+        assert_eq!(cmd["url"], "https://example.com");
+        assert_eq!(cmd["fps"], 24);
+    }
+
+    #[test]
+    fn test_record_start_with_fps_before_url() {
+        let cmd = parse_command(
+            &args("record start demo.webm --fps 60 https://example.com"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["path"], "demo.webm");
+        assert_eq!(cmd["url"], "https://example.com");
+        assert_eq!(cmd["fps"], 60);
+    }
+
+    #[test]
+    fn test_record_start_rejects_fps_above_max() {
+        let result = parse_command(&args("record start demo.webm --fps 120"), &default_flags());
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::InvalidValue { .. }
+        ));
+    }
+
+    #[test]
+    fn test_record_start_rejects_zero_fps() {
+        let result = parse_command(&args("record start demo.webm --fps 0"), &default_flags());
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::InvalidValue { .. }
+        ));
+    }
+
+    #[test]
+    fn test_record_start_rejects_non_numeric_fps() {
+        let result = parse_command(&args("record start demo.webm --fps fast"), &default_flags());
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::InvalidValue { .. }
+        ));
+    }
+
+    #[test]
+    fn test_record_start_rejects_fps_without_value() {
+        let result = parse_command(&args("record start demo.webm --fps"), &default_flags());
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::MissingArguments { .. }
+        ));
+    }
+
+    #[test]
+    fn test_record_start_rejects_unknown_flag() {
+        let result = parse_command(&args("record start demo.webm --smooth"), &default_flags());
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::InvalidValue { .. }
+        ));
+    }
+
+    #[test]
+    fn test_record_start_rejects_extra_positional() {
+        let result = parse_command(
+            &args("record start demo.webm example.com extra"),
+            &default_flags(),
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::InvalidValue { .. }
+        ));
+    }
+
+    #[test]
+    fn test_record_restart_with_fps() {
+        let cmd = parse_command(
+            &args("record restart take2.webm --fps 60"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "recording_restart");
+        assert_eq!(cmd["path"], "take2.webm");
+        assert_eq!(cmd["fps"], 60);
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -1457,6 +1457,14 @@ mod tests {
     }
 
     #[test]
+    fn test_clean_args_keeps_record_fps() {
+        // --fps belongs to `record`, so it must reach the command parser even
+        // when global flags are mixed in.
+        let cleaned = clean_args(&args("--json record start demo.webm --fps 60"));
+        assert_eq!(cleaned, vec!["record", "start", "demo.webm", "--fps", "60"]);
+    }
+
+    #[test]
     fn test_parse_idle_timeout_flag_converts_to_ms() {
         let flags = parse_flags(&args("--idle-timeout 10s open example.com"));
         assert_eq!(flags.idle_timeout.as_deref(), Some("10000"));

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1368,8 +1368,17 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_RECORD_START,
             "Record start",
-            "Start video recording.",
-            json!({ "path": { "type": "string" }, "url": { "type": "string" } }),
+            "Start video recording. Captures 30 fps by default; pass fps up to 60 for motion-heavy takes.",
+            json!({
+                "path": { "type": "string" },
+                "url": { "type": "string" },
+                "fps": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": crate::native::recording::MAX_FPS,
+                    "description": "Capture rate in frames per second (default 30, max 60).",
+                },
+            }),
             &["path"],
         ),
         tool(
@@ -1382,8 +1391,17 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_RECORD_RESTART,
             "Record restart",
-            "Restart video recording.",
-            json!({ "path": { "type": "string" }, "url": { "type": "string" } }),
+            "Restart video recording. Captures 30 fps by default; pass fps up to 60 for motion-heavy takes.",
+            json!({
+                "path": { "type": "string" },
+                "url": { "type": "string" },
+                "fps": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": crate::native::recording::MAX_FPS,
+                    "description": "Capture rate in frames per second (default 30, max 60).",
+                },
+            }),
             &["path"],
         ),
         tool(
@@ -3052,12 +3070,21 @@ fn call_profiler_start(arguments: &Value) -> Result<Value, ProtocolError> {
     call_cli_tool(arguments, args, None)
 }
 
-fn call_record_start(arguments: &Value, action: &str) -> Result<Value, ProtocolError> {
+fn record_command_args(arguments: &Value, action: &str) -> Result<Vec<String>, ProtocolError> {
     let path = required_string(arguments, "path")?;
     let mut args = vec!["record".to_string(), action.to_string(), path];
     if let Some(url) = optional_string(arguments, "url")? {
         args.push(url);
     }
+    if let Some(fps) = optional_u64(arguments, "fps")? {
+        args.push("--fps".to_string());
+        args.push(fps.to_string());
+    }
+    Ok(args)
+}
+
+fn call_record_start(arguments: &Value, action: &str) -> Result<Value, ProtocolError> {
+    let args = record_command_args(arguments, action)?;
     call_cli_tool(arguments, args, None)
 }
 
@@ -4513,6 +4540,46 @@ mod tests {
             .unwrap();
         // Must stay in sync with the CLI parser's accepted --content values.
         assert_eq!(modes, &vec![json!("all"), json!("text"), json!("none")]);
+    }
+
+    #[test]
+    fn record_schema_and_args_include_fps() {
+        for name in [TOOL_RECORD_START, TOOL_RECORD_RESTART] {
+            let tool = tools()
+                .into_iter()
+                .find(|tool| tool["name"].as_str() == Some(name))
+                .unwrap();
+            let fps = &tool["inputSchema"]["properties"]["fps"];
+            assert_eq!(fps["type"], "integer");
+            assert_eq!(fps["minimum"], json!(1));
+            // Must stay in sync with the CLI parser's --fps ceiling.
+            assert_eq!(fps["maximum"], json!(crate::native::recording::MAX_FPS));
+        }
+
+        assert_eq!(
+            record_command_args(&json!({ "path": "demo.webm", "fps": 60 }), "start").unwrap(),
+            vec!["record", "start", "demo.webm", "--fps", "60"]
+        );
+        assert_eq!(
+            record_command_args(
+                &json!({ "path": "take2.webm", "url": "https://example.com", "fps": 24 }),
+                "restart"
+            )
+            .unwrap(),
+            vec![
+                "record",
+                "restart",
+                "take2.webm",
+                "https://example.com",
+                "--fps",
+                "24"
+            ]
+        );
+        // Omitting fps leaves the default to the CLI parser and daemon.
+        assert_eq!(
+            record_command_args(&json!({ "path": "demo.webm" }), "start").unwrap(),
+            vec!["record", "start", "demo.webm"]
+        );
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -972,6 +972,7 @@ impl DaemonState {
             client,
             session_id,
             self.recording_state.output_path.clone(),
+            self.recording_state.fps,
             shared_count.clone(),
             cancel_rx,
         );
@@ -6916,6 +6917,21 @@ async fn handle_profiler_stop(cmd: &Value, state: &mut DaemonState) -> Result<Va
     native_tracing::profiler_stop(&mgr.client, &session_id, &mut state.tracing_state, path).await
 }
 
+/// Read an optional `fps` field from a recording command, rejecting rates the
+/// recorder cannot honor before any browser work happens.
+fn recording_fps_from_command(cmd: &Value) -> Result<Option<u32>, String> {
+    match cmd.get("fps") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let raw = value
+                .as_u64()
+                .filter(|v| *v <= u32::MAX as u64)
+                .ok_or_else(|| format!("Invalid fps: {} is not a positive integer", value))?;
+            recording::validate_fps(raw as u32).map(Some)
+        }
+    }
+}
+
 async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let path = cmd
         .get("path")
@@ -6926,6 +6942,10 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         .get("url")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
+
+    // Validate the rate before spinning up a recording context so a bad value
+    // costs nothing.
+    let fps = recording_fps_from_command(cmd)?;
 
     let viewport = state.viewport;
     let domain_filter = state.domain_filter.read().await.clone();
@@ -7070,7 +7090,7 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         }
     }
 
-    let result = recording::recording_start(&mut state.recording_state, path)?;
+    let result = recording::recording_start(&mut state.recording_state, path, fps)?;
     state.start_recording_task(client, new_session_id).await?;
 
     if let Some(ref server) = state.stream_server {
@@ -7102,6 +7122,9 @@ async fn handle_recording_restart(cmd: &Value, state: &mut DaemonState) -> Resul
         .filter(|s| !s.is_empty())
         .map(String::from);
 
+    // Validate the rate before stopping the in-flight take.
+    let fps = recording_fps_from_command(cmd)?;
+
     {
         let domain_filter = state.domain_filter.read().await;
         if let Some(ref url) = recording_url {
@@ -7128,7 +7151,7 @@ async fn handle_recording_restart(cmd: &Value, state: &mut DaemonState) -> Resul
         None
     };
 
-    recording::recording_start(&mut state.recording_state, path)?;
+    recording::recording_start(&mut state.recording_state, path, fps)?;
 
     if let Some((client, session_id)) = recording_target {
         state.start_recording_task(client, session_id).await?;
@@ -7138,6 +7161,7 @@ async fn handle_recording_restart(cmd: &Value, state: &mut DaemonState) -> Resul
         "restarted": true,
         "previousPath": previous_path,
         "path": path,
+        "fps": state.recording_state.fps,
     }))
 }
 
@@ -10085,16 +10109,19 @@ async fn handle_video_start(cmd: &Value, state: &mut DaemonState) -> Result<Valu
         return Err("A recording is already in progress".to_string());
     }
 
+    let fps = recording_fps_from_command(cmd)?;
+
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
-    recording::recording_start(&mut state.recording_state, path)?;
+    recording::recording_start(&mut state.recording_state, path, fps)?;
     state
         .start_recording_task(mgr.client.clone(), session_id)
         .await?;
 
     Ok(json!({
         "started": true,
+        "fps": state.recording_state.fps,
         "note": "Video recording started. Use video_stop to save the recording."
     }))
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -710,6 +710,7 @@ impl DaemonState {
         let routes = self.routes.clone();
         let origin_headers = self.origin_headers.clone();
         let proxy_credentials = self.proxy_credentials.clone();
+        let capture_session = self.recording_state.capture_session.clone();
 
         self.fetch_handler_task = Some(tokio::spawn(async move {
             loop {
@@ -765,6 +766,16 @@ impl DaemonState {
                         let target_info = event.params.get("targetInfo").and_then(|value| {
                             serde_json::from_value::<TargetInfo>(value.clone()).ok()
                         });
+                        // The recorder's screencast session shares a target
+                        // with a page session that already carries the
+                        // controls; installing them twice would pause every
+                        // request twice.
+                        let is_recorder_session = target_info.as_ref().is_some_and(|target| {
+                            recording::owns_attachment(&capture_session, &target.target_id, &sid)
+                        });
+                        if is_recorder_session {
+                            continue;
+                        }
                         let target_needs_controls = target_info
                             .as_ref()
                             .is_some_and(target_supports_network_controls);
@@ -960,24 +971,42 @@ impl DaemonState {
         }
     }
 
-    /// Spawn a background task that polls screenshots and pipes them to ffmpeg.
+    /// Attach the recorder's own CDP session to the page behind `session_id`
+    /// and spawn the task that screencasts it into ffmpeg.
     async fn start_recording_task(
         &mut self,
         client: Arc<CdpClient>,
         session_id: String,
     ) -> Result<(), String> {
+        let capture_session = match recording::attach_capture_session(
+            &client,
+            &session_id,
+            &self.recording_state.capture_session,
+        )
+        .await
+        {
+            Ok(capture_session) => capture_session,
+            Err(e) => {
+                // `recording_start` already marked the state active.
+                self.recording_state.active = false;
+                return Err(e);
+            }
+        };
         let shared_count = Arc::new(AtomicU64::new(0));
+        let shared_captured = Arc::new(AtomicU64::new(0));
         let (cancel_tx, cancel_rx) = oneshot::channel();
         let handle = recording::spawn_recording_task(
             client,
-            session_id,
+            capture_session,
             self.recording_state.output_path.clone(),
             self.recording_state.fps,
             shared_count.clone(),
+            shared_captured.clone(),
             cancel_rx,
         );
         self.recording_state.capture_task = Some(handle);
         self.recording_state.shared_frame_count = Some(shared_count);
+        self.recording_state.shared_captured_count = Some(shared_captured);
         self.recording_state.cancel_tx = Some(cancel_tx);
         Ok(())
     }
@@ -1473,6 +1502,13 @@ impl DaemonState {
                                 match serde_json::from_value::<TargetInfo>(
                                     target_info_value.clone(),
                                 ) {
+                                    // The recorder's own screencast session
+                                    // is not a tab and must not have page
+                                    // domains enabled on it.
+                                    Ok(target_info)
+                                        if self
+                                            .recording_state
+                                            .owns_attachment(&target_info.target_id, sid) => {}
                                     Ok(target_info) if target_info.target_type == "iframe" => {
                                         // For OOPIF targets, Chrome uses the frameId as
                                         // the targetId, so we can key iframe_sessions by it.
@@ -1866,6 +1902,14 @@ impl DaemonState {
                         // stream server's background CDP event loop. Here we just
                         // collect acks as a fallback for non-streaming mode.
                         "Page.screencastFrame" if self.stream_server.is_none() => {
+                            // The recorder acks its own frames.
+                            let from_recorder = event
+                                .session_id
+                                .as_deref()
+                                .is_some_and(|sid| self.recording_state.owns_session(sid));
+                            if from_recorder {
+                                continue;
+                            }
                             if let Some(sid) =
                                 event.params.get("sessionId").and_then(|v| v.as_i64())
                             {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -768,8 +768,7 @@ impl DaemonState {
                         });
                         // The recorder's screencast session shares a target
                         // with a page session that already carries the
-                        // controls; installing them twice would pause every
-                        // request twice.
+                        // controls.
                         let is_recorder_session = target_info.as_ref().is_some_and(|target| {
                             recording::owns_attachment(&capture_session, &target.target_id, &sid)
                         });
@@ -1502,13 +1501,15 @@ impl DaemonState {
                                 match serde_json::from_value::<TargetInfo>(
                                     target_info_value.clone(),
                                 ) {
-                                    // The recorder's own screencast session
-                                    // is not a tab and must not have page
+                                    // The recorder's screencast session is
+                                    // not a tab and must not have page
                                     // domains enabled on it.
                                     Ok(target_info)
-                                        if self
-                                            .recording_state
-                                            .owns_attachment(&target_info.target_id, sid) => {}
+                                        if recording::owns_attachment(
+                                            &self.recording_state.capture_session,
+                                            &target_info.target_id,
+                                            sid,
+                                        ) => {}
                                     Ok(target_info) if target_info.target_type == "iframe" => {
                                         // For OOPIF targets, Chrome uses the frameId as
                                         // the targetId, so we can key iframe_sessions by it.
@@ -1902,14 +1903,6 @@ impl DaemonState {
                         // stream server's background CDP event loop. Here we just
                         // collect acks as a fallback for non-streaming mode.
                         "Page.screencastFrame" if self.stream_server.is_none() => {
-                            // The recorder acks its own frames.
-                            let from_recorder = event
-                                .session_id
-                                .as_deref()
-                                .is_some_and(|sid| self.recording_state.owns_session(sid));
-                            if from_recorder {
-                                continue;
-                            }
                             if let Some(sid) =
                                 event.params.get("sessionId").and_then(|v| v.as_i64())
                             {
@@ -7145,8 +7138,11 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
 }
 
 async fn handle_recording_stop(state: &mut DaemonState) -> Result<Value, String> {
-    state.stop_recording_task().await?;
+    // Clear the recording state even when the capture task failed, so a
+    // broken take does not block the next `record start`.
+    let task_result = state.stop_recording_task().await;
     let result = recording::recording_stop(&mut state.recording_state);
+    task_result?;
 
     if let Some(ref server) = state.stream_server {
         server.set_recording(false, &state.engine).await;

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
-use tokio::sync::{broadcast, oneshot, Mutex};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::Message;
@@ -13,6 +13,14 @@ use tokio_tungstenite::tungstenite::Message;
 use super::types::{CdpCommand, CdpEvent, CdpMessage};
 
 type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<CdpMessage>>>>;
+
+/// Sessions whose events go to one private receiver instead of the broadcast.
+type PrivateSessions = Arc<std::sync::Mutex<HashMap<String, mpsc::Sender<CdpEvent>>>>;
+
+/// Events buffered for a private session receiver that has fallen behind.
+/// Newer events are dropped once it is full; a screencast consumer that
+/// cannot keep up should lose frames, not stall the reader.
+const PRIVATE_SESSION_BUFFER: usize = 16;
 
 /// Interval between WebSocket ping frames sent to keep the connection alive
 /// through intermediate proxies (reverse proxies, load balancers, service meshes).
@@ -56,6 +64,7 @@ pub struct CdpClient {
     pending: PendingMap,
     event_tx: broadcast::Sender<CdpEvent>,
     raw_tx: broadcast::Sender<RawCdpMessage>,
+    private_sessions: PrivateSessions,
     _reader_handle: tokio::task::JoinHandle<()>,
     _keepalive_handle: tokio::task::JoinHandle<()>,
 }
@@ -132,9 +141,12 @@ impl CdpClient {
         let (event_tx, _) = broadcast::channel(4096);
         let (raw_tx, _) = broadcast::channel(4096);
 
+        let private_sessions: PrivateSessions = Arc::new(std::sync::Mutex::new(HashMap::new()));
+
         let pending_clone = pending.clone();
         let event_tx_clone = event_tx.clone();
         let raw_tx_clone = raw_tx.clone();
+        let private_clone = private_sessions.clone();
 
         // Notify used to stop the keepalive task when the reader loop exits.
         let (cancel_tx, mut cancel_rx) = tokio::sync::watch::channel(false);
@@ -202,7 +214,22 @@ impl CdpClient {
                         params: parsed.params.clone().unwrap_or(Value::Null),
                         session_id: parsed.session_id.clone(),
                     };
-                    let _ = event_tx_clone.send(event);
+                    let routed = event.session_id.as_deref().is_some_and(|sid| {
+                        let mut routes = private_clone.lock().unwrap_or_else(|e| e.into_inner());
+                        match routes.get(sid) {
+                            Some(tx) => match tx.try_send(event.clone()) {
+                                Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => true,
+                                Err(mpsc::error::TrySendError::Closed(_)) => {
+                                    routes.remove(sid);
+                                    false
+                                }
+                            },
+                            None => false,
+                        }
+                    });
+                    if !routed {
+                        let _ = event_tx_clone.send(event);
+                    }
                 }
             }
 
@@ -240,6 +267,7 @@ impl CdpClient {
             pending,
             event_tx,
             raw_tx,
+            private_sessions,
             _reader_handle: reader_handle,
             _keepalive_handle: keepalive_handle,
         })
@@ -310,6 +338,28 @@ impl CdpClient {
 
     pub fn subscribe(&self) -> broadcast::Receiver<CdpEvent> {
         self.event_tx.subscribe()
+    }
+
+    /// Deliver every event carrying `session_id` to the returned receiver
+    /// instead of the broadcast, so a high-volume session (a screencast) is
+    /// neither cloned to every subscriber nor able to overflow their buffers.
+    /// Events without a session id are unaffected. Call
+    /// [`unsubscribe_session`](Self::unsubscribe_session) when done; a dropped
+    /// receiver also ends the route on the next event for that session.
+    pub fn subscribe_session(&self, session_id: &str) -> mpsc::Receiver<CdpEvent> {
+        let (tx, rx) = mpsc::channel(PRIVATE_SESSION_BUFFER);
+        self.private_sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(session_id.to_string(), tx);
+        rx
+    }
+
+    pub fn unsubscribe_session(&self, session_id: &str) {
+        self.private_sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(session_id);
     }
 
     /// Subscribe to all raw incoming CDP messages (responses + events).
@@ -521,5 +571,65 @@ mod tests {
 
         assert_eq!(path_rx.await.unwrap(), "/?token=a%2Fb&scope=browser%20test");
         server.await.unwrap();
+    }
+    /// Events on a privately subscribed session reach only that receiver;
+    /// everything else still reaches broadcast subscribers.
+    #[tokio::test]
+    async fn private_session_events_bypass_the_broadcast() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (ready_tx, ready_rx) = oneshot::channel::<()>();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            ready_rx.await.unwrap();
+            for (method, session) in [
+                ("Page.screencastFrame", Some("S-REC")),
+                ("Page.screencastFrame", Some("S-PAGE")),
+                ("Target.detachedFromTarget", None),
+            ] {
+                let mut msg = serde_json::json!({ "method": method, "params": {} });
+                if let Some(sid) = session {
+                    msg["sessionId"] = serde_json::json!(sid);
+                }
+                ws.send(Message::Text(msg.to_string())).await.unwrap();
+            }
+            // Keep the connection open until the client is done reading.
+            let _ = ws.next().await;
+        });
+
+        let client = CdpClient::connect(&format!("ws://127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        let mut broadcast_rx = client.subscribe();
+        let mut private_rx = client.subscribe_session("S-REC");
+        ready_tx.send(()).unwrap();
+
+        let wait = std::time::Duration::from_secs(2);
+        let first = tokio::time::timeout(wait, broadcast_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.session_id.as_deref(), Some("S-PAGE"));
+        let second = tokio::time::timeout(wait, broadcast_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(second.method, "Target.detachedFromTarget");
+
+        let private = tokio::time::timeout(wait, private_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(private.session_id.as_deref(), Some("S-REC"));
+        assert!(
+            private_rx.try_recv().is_err(),
+            "only S-REC events are routed privately"
+        );
+
+        client.unsubscribe_session("S-REC");
+        drop(client);
+        server.abort();
     }
 }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7242,9 +7242,9 @@ async fn e2e_recording_inherits_viewport() {
 // ---------------------------------------------------------------------------
 
 /// Verify that `recording_start` honors an explicit frame rate and that the
-/// frame count tracks wall clock. Frames are paced against the clock, so a
-/// capture that overruns its budget holds the previous picture instead of
-/// shortening playback: roughly `fps * seconds` frames must reach ffmpeg.
+/// frame count tracks wall clock. Screencast frames arrive only when the page
+/// repaints, and the ticker holds the last frame through gaps, so roughly
+/// `fps * seconds` frames must reach ffmpeg even for a static page.
 #[tokio::test]
 #[ignore]
 async fn e2e_recording_honors_requested_fps() {
@@ -7282,6 +7282,16 @@ async fn e2e_recording_honors_requested_fps() {
     assert_success(&resp);
     assert_eq!(get_data(&resp)["fps"].as_u64(), Some(FPS));
 
+    // The recorder screencasts on its own CDP session attached to the
+    // recording page. That attachment must not surface as a tab.
+    let resp = execute_command(&json!({ "id": "3b", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap().len();
+    assert_eq!(
+        tabs, 2,
+        "original page plus the recording page, nothing else"
+    );
+
     tokio::time::sleep(tokio::time::Duration::from_millis(RECORD_MS)).await;
 
     let resp = execute_command(
@@ -7298,6 +7308,13 @@ async fn e2e_recording_honors_requested_fps() {
     assert!(
         frames >= expected / 2 && frames <= expected * 2,
         "expected roughly {expected} frames at {FPS} fps over {RECORD_MS}ms, got {frames}"
+    );
+    // A static page repaints once, so the file is one captured frame held
+    // for the whole take.
+    let captured = data["capturedFrames"].as_u64().unwrap();
+    assert!(
+        (1..frames).contains(&captured),
+        "static page should yield a few captured frames held across {frames} written, got {captured}"
     );
 
     let size = std::fs::metadata(&rec_path).map(|m| m.len()).unwrap_or(0);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7238,6 +7238,125 @@ async fn e2e_recording_inherits_viewport() {
 }
 
 // ---------------------------------------------------------------------------
+// Recording: requested frame rate
+// ---------------------------------------------------------------------------
+
+/// Verify that `recording_start` honors an explicit frame rate and that the
+/// frame count tracks wall clock. Frames are paced against the clock, so a
+/// capture that overruns its budget holds the previous picture instead of
+/// shortening playback: roughly `fps * seconds` frames must reach ffmpeg.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_honors_requested_fps() {
+    const FPS: u64 = 60;
+    const RECORD_MS: u64 = 1000;
+
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Frame rate</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-fps-{}.webm", std::process::id()));
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "recording_start",
+            "path": rec_path.to_string_lossy(),
+            "fps": FPS,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["fps"].as_u64(), Some(FPS));
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(RECORD_MS)).await;
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["fps"].as_u64(), Some(FPS));
+
+    let frames = data["frames"].as_u64().unwrap();
+    let expected = FPS * RECORD_MS / 1000;
+    assert!(
+        frames >= expected / 2 && frames <= expected * 2,
+        "expected roughly {expected} frames at {FPS} fps over {RECORD_MS}ms, got {frames}"
+    );
+
+    let size = std::fs::metadata(&rec_path).map(|m| m.len()).unwrap_or(0);
+    assert!(size > 0, "recording file should not be empty");
+
+    let _ = std::fs::remove_file(&rec_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Verify that an out-of-range frame rate is rejected before the recorder
+/// builds its context, leaving no file and no active recording behind.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_rejects_invalid_fps() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-badfps-{}.webm", std::process::id()));
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "recording_start",
+            "path": rec_path.to_string_lossy(),
+            "fps": 240,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "240 fps should be rejected: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(err.contains("fps"), "error should name the field: {}", err);
+    assert!(!rec_path.exists(), "no file should be created");
+
+    // Nothing was started, so there is nothing to stop.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+// ---------------------------------------------------------------------------
 // --state / storageState flag: cookies should be loaded at launch time
 // ---------------------------------------------------------------------------
 

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -9,12 +9,67 @@ use tokio::sync::oneshot;
 use super::cdp::client::CdpClient;
 use super::cdp::types::{CaptureScreenshotParams, CaptureScreenshotResult};
 
-const CAPTURE_INTERVAL_MS: u64 = 100;
-const CAPTURE_FPS: u32 = 10;
+/// Capture rate used when the caller does not ask for one. 30 fps reads as
+/// smooth motion, so scrolls, hovers, and CSS transitions survive the
+/// recording instead of turning into a slideshow.
+pub const DEFAULT_FPS: u32 = 30;
+
+/// Highest capture rate the recorder accepts. 60 fps is worth asking for on
+/// short, motion-heavy clips (drag interactions, animation, scroll polish
+/// work) where the extra temporal detail is the point.
+pub const MAX_FPS: u32 = 60;
+
+/// Rate above which the encoder switches to its high-frame-rate profile:
+/// twice the bitrate budget and a second encoder thread, so the pipe does not
+/// become the bottleneck and stall the capture loop.
+const HIGH_FPS_THRESHOLD: u32 = 30;
+
+/// Bitrate budget for WebM at [`HIGH_FPS_THRESHOLD`], scaled linearly with
+/// the requested rate. VP8 at 60 fps needs roughly twice the bits to hold the
+/// same per-frame quality.
+const WEBM_BITRATE_KBPS_AT_BASE_FPS: u32 = 1000;
+
+/// Longest stall a single lagging capture may backfill with held frames, in
+/// seconds. Bounds file growth when a page hangs for minutes.
+const MAX_BACKFILL_SECS: u64 = 5;
+
+/// Reject frame rates the pipeline cannot honor.
+pub fn validate_fps(fps: u32) -> Result<u32, String> {
+    if fps == 0 || fps > MAX_FPS {
+        return Err(format!(
+            "Invalid fps: {} is out of range (valid range: 1-{})",
+            fps, MAX_FPS
+        ));
+    }
+    Ok(fps)
+}
+
+/// Wall-clock duration of one frame at `fps`.
+fn frame_period(fps: u32) -> Duration {
+    Duration::from_micros(1_000_000 / fps.clamp(1, MAX_FPS) as u64)
+}
+
+/// Number of frames to emit for a capture that landed `elapsed` into the
+/// recording, given `written` frames already in the stream.
+///
+/// The capture loop can fall behind: `Page.captureScreenshot` on a busy page
+/// takes longer than the frame budget, and at 60 fps that budget is under
+/// 17ms. ffmpeg reads the pipe as a constant-rate stream, so a dropped frame
+/// shortens playback rather than holding the picture, and a ten second
+/// interaction plays back in five. Repeating the frame that was on screen
+/// during the gap keeps playback aligned with wall clock at any rate.
+fn frames_due(elapsed: Duration, period: Duration, written: u64, max_frames: u64) -> u64 {
+    let period_us = period.as_micros().max(1);
+    let slot = (elapsed.as_micros() / period_us) as u64;
+    let due = slot.saturating_add(1).saturating_sub(written);
+    due.clamp(1, max_frames.max(1))
+}
 
 pub struct RecordingState {
     pub active: bool,
     pub output_path: String,
+    /// Capture rate for the active (or most recent) recording.
+    pub fps: u32,
     pub frame_count: u64,
     pub capture_task: Option<tokio::task::JoinHandle<Result<(), String>>>,
     pub shared_frame_count: Option<Arc<AtomicU64>>,
@@ -26,6 +81,7 @@ impl RecordingState {
         Self {
             active: false,
             output_path: String::new(),
+            fps: DEFAULT_FPS,
             frame_count: 0,
             capture_task: None,
             shared_frame_count: None,
@@ -34,16 +90,23 @@ impl RecordingState {
     }
 }
 
-pub fn recording_start(state: &mut RecordingState, path: &str) -> Result<Value, String> {
+pub fn recording_start(
+    state: &mut RecordingState,
+    path: &str,
+    fps: Option<u32>,
+) -> Result<Value, String> {
     if state.active {
         return Err("Recording already active".to_string());
     }
 
+    let fps = validate_fps(fps.unwrap_or(DEFAULT_FPS))?;
+
     state.active = true;
     state.output_path = path.to_string();
+    state.fps = fps;
     state.frame_count = 0;
 
-    Ok(json!({ "started": true, "path": path }))
+    Ok(json!({ "started": true, "path": path, "fps": fps }))
 }
 
 pub fn recording_stop(state: &mut RecordingState) -> Result<Value, String> {
@@ -57,10 +120,22 @@ pub fn recording_stop(state: &mut RecordingState) -> Result<Value, String> {
         return Err("No frames captured".to_string());
     }
 
-    Ok(json!({ "path": &state.output_path, "frames": state.frame_count }))
+    Ok(json!({
+        "path": &state.output_path,
+        "frames": state.frame_count,
+        "fps": state.fps,
+    }))
 }
 
-pub fn recording_restart(state: &mut RecordingState, path: &str) -> Result<Value, String> {
+pub fn recording_restart(
+    state: &mut RecordingState,
+    path: &str,
+    fps: Option<u32>,
+) -> Result<Value, String> {
+    // Validate before tearing down the active recording so a bad rate cannot
+    // stop a good take.
+    let fps = validate_fps(fps.unwrap_or(DEFAULT_FPS))?;
+
     let previous = if state.active {
         let stop_result = recording_stop(state);
         stop_result
@@ -70,17 +145,19 @@ pub fn recording_restart(state: &mut RecordingState, path: &str) -> Result<Value
         None
     };
 
-    recording_start(state, path)?;
+    recording_start(state, path, Some(fps))?;
 
     Ok(json!({
         "restarted": true,
         "previousPath": previous,
         "path": path,
+        "fps": fps,
     }))
 }
 
-fn build_ffmpeg_command(output_path: &str) -> tokio::process::Command {
+fn build_ffmpeg_command(output_path: &str, fps: u32) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("ffmpeg");
+    let high_fps = fps > HIGH_FPS_THRESHOLD;
 
     cmd.args(["-y"])
         .args(["-avioflags", "direct"])
@@ -98,19 +175,25 @@ fn build_ffmpeg_command(output_path: &str) -> tokio::process::Command {
             "-c:v",
             "mjpeg",
             "-framerate",
-            &CAPTURE_FPS.to_string(),
+            &fps.to_string(),
             "-i",
             "pipe:0",
         ])
         .args(["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2"]);
 
     if output_path.ends_with(".webm") {
-        cmd.args(["-c:v", "libvpx", "-crf", "30", "-b:v", "1M"]);
+        let bitrate = WEBM_BITRATE_KBPS_AT_BASE_FPS
+            .max(WEBM_BITRATE_KBPS_AT_BASE_FPS.saturating_mul(fps) / HIGH_FPS_THRESHOLD.max(1));
+        cmd.args(["-c:v", "libvpx", "-crf", "30"])
+            .args(["-b:v", &format!("{}k", bitrate)]);
     } else {
         cmd.args(["-c:v", "libx264", "-preset", "ultrafast"]);
     }
 
-    cmd.args(["-pix_fmt", "yuv420p", "-threads", "1"])
+    // One encoder thread keeps CPU away from the browser at ordinary rates;
+    // above 30 fps the encoder needs a second one to drain the pipe in time.
+    cmd.args(["-pix_fmt", "yuv420p"])
+        .args(["-threads", if high_fps { "2" } else { "1" }])
         .arg(output_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
@@ -120,19 +203,30 @@ fn build_ffmpeg_command(output_path: &str) -> tokio::process::Command {
     cmd
 }
 
-/// Spawn a background task that captures screenshots at a fixed interval
-/// and pipes them to ffmpeg in real-time.
+/// Spawn a background task that captures screenshots at `fps` and pipes them
+/// to ffmpeg in real-time.
+///
+/// Frames are paced against wall clock rather than against the tick count, so
+/// a capture that overruns its budget holds the previous picture instead of
+/// speeding up playback. That is what makes 30 fps (and 60 fps on shorter
+/// clips) produce a video whose duration matches the automation it recorded.
 pub fn spawn_recording_task(
     client: Arc<CdpClient>,
     session_id: String,
     output_path: String,
+    fps: u32,
     shared_count: Arc<AtomicU64>,
     cancel_rx: oneshot::Receiver<()>,
 ) -> tokio::task::JoinHandle<Result<(), String>> {
     tokio::spawn(async move {
         let mut cancel_rx = std::pin::pin!(cancel_rx);
 
-        let mut ffmpeg = build_ffmpeg_command(&output_path).spawn().map_err(|e| {
+        let fps = validate_fps(fps)?;
+        let period = frame_period(fps);
+        let max_frames_per_capture = MAX_BACKFILL_SECS * fps as u64 + 1;
+
+        let mut command = build_ffmpeg_command(&output_path, fps);
+        let mut ffmpeg = command.spawn().map_err(|e| {
             format!(
                 "ffmpeg not found or failed to execute: {}. Install ffmpeg to enable recording.",
                 e
@@ -144,7 +238,7 @@ pub fn spawn_recording_task(
             .take()
             .ok_or_else(|| "Failed to open ffmpeg stdin".to_string())?;
 
-        let mut interval = tokio::time::interval(Duration::from_millis(CAPTURE_INTERVAL_MS));
+        let mut interval = tokio::time::interval(period);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let params = CaptureScreenshotParams {
@@ -154,6 +248,11 @@ pub fn spawn_recording_task(
             from_surface: Some(true),
             capture_beyond_viewport: None,
         };
+
+        let started = tokio::time::Instant::now();
+        let mut written: u64 = 0;
+        // Last frame written, repeated to cover gaps left by slow captures.
+        let mut held: Option<Vec<u8>> = None;
 
         loop {
             tokio::select! {
@@ -183,10 +282,23 @@ pub fn spawn_recording_task(
                 Err(_) => continue,
             };
 
-            if stdin.write_all(&bytes).await.is_err() {
+            let frames = frames_due(started.elapsed(), period, written, max_frames_per_capture);
+
+            let mut write_failed = false;
+            for _ in 1..frames {
+                let filler: &[u8] = held.as_deref().unwrap_or(&bytes);
+                if stdin.write_all(filler).await.is_err() {
+                    write_failed = true;
+                    break;
+                }
+            }
+            if write_failed || stdin.write_all(&bytes).await.is_err() {
                 break;
             }
-            shared_count.fetch_add(1, Ordering::Relaxed);
+
+            written += frames;
+            shared_count.fetch_add(frames, Ordering::Relaxed);
+            held = Some(bytes);
         }
 
         drop(stdin);
@@ -243,23 +355,46 @@ mod tests {
         assert!(!state.active);
         assert!(state.output_path.is_empty());
         assert_eq!(state.frame_count, 0);
+        assert_eq!(state.fps, DEFAULT_FPS);
     }
 
     #[test]
     fn test_recording_start_sets_active() {
         let mut state = RecordingState::new();
-        let result = recording_start(&mut state, "/tmp/test.mp4");
+        let result = recording_start(&mut state, "/tmp/test.mp4", None);
         assert!(result.is_ok());
         assert!(state.active);
         assert_eq!(state.output_path, "/tmp/test.mp4");
         assert_eq!(state.frame_count, 0);
+        assert_eq!(state.fps, 30);
+        assert_eq!(result.unwrap()["fps"], 30);
+    }
+
+    #[test]
+    fn test_recording_start_honors_requested_fps() {
+        let mut state = RecordingState::new();
+        let result = recording_start(&mut state, "/tmp/test.webm", Some(60)).unwrap();
+        assert_eq!(state.fps, 60);
+        assert_eq!(result["fps"], 60);
+    }
+
+    #[test]
+    fn test_recording_start_rejects_out_of_range_fps() {
+        let mut state = RecordingState::new();
+        let too_high = recording_start(&mut state, "/tmp/test.webm", Some(61));
+        assert!(too_high.unwrap_err().contains("valid range: 1-60"));
+        assert!(!state.active);
+
+        let zero = recording_start(&mut state, "/tmp/test.webm", Some(0));
+        assert!(zero.is_err());
+        assert!(!state.active);
     }
 
     #[test]
     fn test_recording_start_while_active() {
         let mut state = RecordingState::new();
-        recording_start(&mut state, "/tmp/test1.mp4").unwrap();
-        let result = recording_start(&mut state, "/tmp/test2.mp4");
+        recording_start(&mut state, "/tmp/test1.mp4", None).unwrap();
+        let result = recording_start(&mut state, "/tmp/test2.mp4", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("already active"));
     }
@@ -275,7 +410,7 @@ mod tests {
     #[test]
     fn test_recording_stop_no_frames() {
         let mut state = RecordingState::new();
-        recording_start(&mut state, "/tmp/test.mp4").unwrap();
+        recording_start(&mut state, "/tmp/test.mp4", None).unwrap();
         let result = recording_stop(&mut state);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("No frames"));
@@ -283,41 +418,157 @@ mod tests {
     }
 
     #[test]
+    fn test_recording_stop_reports_fps() {
+        let mut state = RecordingState::new();
+        recording_start(&mut state, "/tmp/test.webm", Some(60)).unwrap();
+        state.frame_count = 120;
+        let result = recording_stop(&mut state).unwrap();
+        assert_eq!(result["frames"], 120);
+        assert_eq!(result["fps"], 60);
+    }
+
+    #[test]
     fn test_recording_restart_while_inactive() {
         let mut state = RecordingState::new();
-        let result = recording_restart(&mut state, "/tmp/new.webm");
+        let result = recording_restart(&mut state, "/tmp/new.webm", None);
         assert!(result.is_ok());
         assert!(state.active);
         assert_eq!(state.output_path, "/tmp/new.webm");
+        assert_eq!(state.fps, DEFAULT_FPS);
     }
 
     #[test]
     fn test_recording_restart_while_active() {
         let mut state = RecordingState::new();
-        recording_start(&mut state, "/tmp/old.webm").unwrap();
+        recording_start(&mut state, "/tmp/old.webm", None).unwrap();
         state.frame_count = 10;
-        let result = recording_restart(&mut state, "/tmp/new.webm").unwrap();
+        let result = recording_restart(&mut state, "/tmp/new.webm", Some(60)).unwrap();
         assert!(state.active);
         assert_eq!(state.output_path, "/tmp/new.webm");
         assert_eq!(state.frame_count, 0);
+        assert_eq!(state.fps, 60);
         assert_eq!(result["previousPath"], "/tmp/old.webm");
+        assert_eq!(result["fps"], 60);
+    }
+
+    #[test]
+    fn test_recording_restart_rejects_bad_fps_without_stopping() {
+        let mut state = RecordingState::new();
+        recording_start(&mut state, "/tmp/old.webm", None).unwrap();
+        state.frame_count = 10;
+        let result = recording_restart(&mut state, "/tmp/new.webm", Some(120));
+        assert!(result.is_err());
+        // The in-flight take survives an invalid rate.
+        assert!(state.active);
+        assert_eq!(state.output_path, "/tmp/old.webm");
+        assert_eq!(state.frame_count, 10);
+    }
+
+    #[test]
+    fn test_validate_fps_range() {
+        assert_eq!(validate_fps(1).unwrap(), 1);
+        assert_eq!(validate_fps(DEFAULT_FPS).unwrap(), 30);
+        assert_eq!(validate_fps(MAX_FPS).unwrap(), 60);
+        assert!(validate_fps(0).is_err());
+        assert!(validate_fps(MAX_FPS + 1).is_err());
+    }
+
+    #[test]
+    fn test_frame_period_matches_fps() {
+        assert_eq!(frame_period(1), Duration::from_millis(1000));
+        assert_eq!(frame_period(30), Duration::from_micros(33333));
+        assert_eq!(frame_period(60), Duration::from_micros(16666));
+    }
+
+    #[test]
+    fn test_frames_due_on_schedule_emits_one_frame() {
+        let period = frame_period(30);
+        for slot in 0..5u64 {
+            let elapsed = period * slot as u32;
+            assert_eq!(frames_due(elapsed, period, slot, 151), 1);
+        }
+    }
+
+    #[test]
+    fn test_frames_due_backfills_a_lagging_capture() {
+        let period = frame_period(60);
+        // Capture landed in slot 3 but only slot 0 has been written, so the
+        // two skipped slots are held before the fresh frame.
+        assert_eq!(frames_due(period * 3, period, 1, 301), 3);
+    }
+
+    #[test]
+    fn test_frames_due_clamps_long_stalls() {
+        let period = frame_period(30);
+        let max_frames = MAX_BACKFILL_SECS * 30 + 1;
+        let stall = Duration::from_secs(60);
+        assert_eq!(frames_due(stall, period, 0, max_frames), max_frames);
+    }
+
+    #[test]
+    fn test_frames_due_never_returns_zero() {
+        let period = frame_period(30);
+        // A capture that arrives early (or a clock that has not advanced)
+        // still contributes exactly one frame.
+        assert_eq!(frames_due(Duration::ZERO, period, 10, 151), 1);
     }
 
     #[test]
     fn test_build_ffmpeg_command_webm() {
-        let cmd = build_ffmpeg_command("/tmp/out.webm");
+        let cmd = build_ffmpeg_command("/tmp/out.webm", DEFAULT_FPS);
         let args: Vec<&std::ffi::OsStr> = cmd.as_std().get_args().collect();
         let args_str: Vec<&str> = args.iter().filter_map(|a| a.to_str()).collect();
         assert!(args_str.contains(&"libvpx"));
         assert!(args_str.contains(&"/tmp/out.webm"));
+        assert!(args_str.contains(&"1000k"));
     }
 
     #[test]
     fn test_build_ffmpeg_command_mp4() {
-        let cmd = build_ffmpeg_command("/tmp/out.mp4");
+        let cmd = build_ffmpeg_command("/tmp/out.mp4", DEFAULT_FPS);
         let args: Vec<&std::ffi::OsStr> = cmd.as_std().get_args().collect();
         let args_str: Vec<&str> = args.iter().filter_map(|a| a.to_str()).collect();
         assert!(args_str.contains(&"libx264"));
         assert!(args_str.contains(&"/tmp/out.mp4"));
+    }
+
+    #[test]
+    fn test_build_ffmpeg_command_passes_framerate() {
+        let cmd = build_ffmpeg_command("/tmp/out.webm", 60);
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .filter_map(|a| a.to_str().map(String::from))
+            .collect();
+        let framerate = args
+            .iter()
+            .position(|a| a == "-framerate")
+            .and_then(|i| args.get(i + 1))
+            .map(String::as_str);
+        assert_eq!(framerate, Some("60"));
+        // 60 fps doubles the VP8 bitrate budget and adds an encoder thread.
+        assert!(args.iter().any(|a| a == "2000k"));
+        let threads = args
+            .iter()
+            .position(|a| a == "-threads")
+            .and_then(|i| args.get(i + 1))
+            .map(String::as_str);
+        assert_eq!(threads, Some("2"));
+    }
+
+    #[test]
+    fn test_build_ffmpeg_command_single_thread_at_default_fps() {
+        let cmd = build_ffmpeg_command("/tmp/out.mp4", DEFAULT_FPS);
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .filter_map(|a| a.to_str().map(String::from))
+            .collect();
+        let threads = args
+            .iter()
+            .position(|a| a == "-threads")
+            .and_then(|i| args.get(i + 1))
+            .map(String::as_str);
+        assert_eq!(threads, Some("1"));
     }
 }

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::{AttachToTargetParams, AttachToTargetResult};
@@ -65,48 +65,37 @@ fn frame_period(fps: u32) -> Duration {
     Duration::from_micros(1_000_000 / fps.clamp(1, MAX_FPS) as u64)
 }
 
-/// Number of frames owed to the stream at `elapsed` into the recording, given
-/// `written` frames already sent. Zero when the current frame slot is filled.
-///
-/// Screencast frames arrive whenever the compositor repaints, which is
-/// irregular: a burst during a scroll, nothing at all on a static page. ffmpeg
-/// reads the pipe as a constant-rate stream, so the recorder emits exactly one
-/// frame per wall-clock slot, repeating the frame on screen through any gap.
-/// That keeps playback aligned with wall clock at any rate.
+/// Frames owed to the constant-rate stream at `elapsed` into the recording,
+/// given `written` frames already sent. Zero when the current slot is filled.
 fn frames_due(elapsed: Duration, period: Duration, written: u64) -> u64 {
     let period_us = period.as_micros().max(1);
     let slot = (elapsed.as_micros() / period_us) as u64;
     slot.saturating_add(1).saturating_sub(written)
 }
 
-/// The dedicated CDP session a recording attaches to its page target.
+/// The CDP session a recording attaches to its page target for its screencast.
 ///
-/// Chrome keeps one screencast per session, and the live stream already runs
+/// Chrome keeps one screencast per session and the live stream already runs
 /// one on the page session, so the recorder attaches a second flattened
-/// session to the same target and screencasts there. The daemon must not
-/// manage that session as a tab, so it is published here for the event
-/// handlers to recognise.
+/// session to the same target. The daemon's event handlers use this to avoid
+/// treating that attachment as a tab.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CaptureSession {
     pub target_id: String,
-    /// `None` while `Target.attachToTarget` is in flight. Chrome emits
-    /// `Target.attachedToTarget` before it answers the command, so during that
-    /// window the attachment is recognised by target instead.
+    /// `None` while `Target.attachToTarget` is in flight: Chrome emits
+    /// `Target.attachedToTarget` before it answers, so in that window the
+    /// attachment is recognised by target instead.
     pub session_id: Option<String>,
 }
 
 impl CaptureSession {
-    /// Whether a `Target.attachedToTarget` event describes this recorder's
-    /// own attachment rather than a tab the daemon should track.
+    /// Whether a `Target.attachedToTarget` event is this recorder's own
+    /// attachment rather than a tab the daemon should track.
     pub fn owns_attachment(&self, target_id: &str, session_id: &str) -> bool {
         match self.session_id.as_deref() {
             Some(own) => own == session_id,
             None => self.target_id == target_id,
         }
-    }
-
-    pub fn owns_session(&self, session_id: &str) -> bool {
-        self.session_id.as_deref() == Some(session_id)
     }
 }
 
@@ -125,8 +114,7 @@ pub struct RecordingState {
     pub shared_frame_count: Option<Arc<AtomicU64>>,
     pub shared_captured_count: Option<Arc<AtomicU64>>,
     pub cancel_tx: Option<oneshot::Sender<()>>,
-    /// Shared with the daemon's background event handlers, which must ignore
-    /// the recorder's session.
+    /// Shared with the daemon's event handlers.
     pub capture_session: SharedCaptureSession,
 }
 
@@ -145,25 +133,9 @@ impl RecordingState {
             capture_session: Arc::new(Mutex::new(None)),
         }
     }
-
-    /// Whether `Target.attachedToTarget` for this session belongs to the
-    /// active recording's screencast session.
-    pub fn owns_attachment(&self, target_id: &str, session_id: &str) -> bool {
-        owns_attachment(&self.capture_session, target_id, session_id)
-    }
-
-    /// Whether events on this session belong to the recorder's screencast.
-    pub fn owns_session(&self, session_id: &str) -> bool {
-        self.capture_session
-            .lock()
-            .ok()
-            .and_then(|guard| guard.as_ref().map(|c| c.owns_session(session_id)))
-            .unwrap_or(false)
-    }
 }
 
-/// [`CaptureSession::owns_attachment`] against a shared slot, for background
-/// tasks that hold a clone of it rather than the recording state.
+/// [`CaptureSession::owns_attachment`] against the shared slot.
 pub fn owns_attachment(shared: &SharedCaptureSession, target_id: &str, session_id: &str) -> bool {
     shared
         .lock()
@@ -215,34 +187,6 @@ pub fn recording_stop(state: &mut RecordingState) -> Result<Value, String> {
     }))
 }
 
-pub fn recording_restart(
-    state: &mut RecordingState,
-    path: &str,
-    fps: Option<u32>,
-) -> Result<Value, String> {
-    // Validate before tearing down the active recording so a bad rate cannot
-    // stop a good take.
-    let fps = validate_fps(fps.unwrap_or(DEFAULT_FPS))?;
-
-    let previous = if state.active {
-        let stop_result = recording_stop(state);
-        stop_result
-            .ok()
-            .and_then(|v| v.get("path").and_then(|p| p.as_str()).map(String::from))
-    } else {
-        None
-    };
-
-    recording_start(state, path, Some(fps))?;
-
-    Ok(json!({
-        "restarted": true,
-        "previousPath": previous,
-        "path": path,
-        "fps": fps,
-    }))
-}
-
 fn build_ffmpeg_command(output_path: &str, fps: u32) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("ffmpeg");
     let high_fps = fps > HIGH_FPS_THRESHOLD;
@@ -291,10 +235,9 @@ fn build_ffmpeg_command(output_path: &str, fps: u32) -> tokio::process::Command 
     cmd
 }
 
-/// Attach a dedicated flattened session to the target behind `page_session_id`
-/// for the recorder's screencast. Publishes the attachment in `shared` before
-/// the command is sent, so the daemon's event handlers can recognise the
-/// resulting `Target.attachedToTarget` as the recorder's own.
+/// Attach the recorder's own flattened session to the target behind
+/// `page_session_id`, publishing it in `shared` before the command is sent so
+/// the resulting `Target.attachedToTarget` is recognised as the recorder's.
 pub async fn attach_capture_session(
     client: &CdpClient,
     page_session_id: &str,
@@ -346,14 +289,10 @@ pub async fn attach_capture_session(
     }
 }
 
-/// Spawn a background task that screencasts the page on `capture_session` and
-/// pipes frames to ffmpeg at `fps` in real time.
-///
-/// Chrome pushes a frame whenever the page repaints, up to the display rate,
-/// so motion is captured at its true rate rather than at the pace
-/// `Page.captureScreenshot` can answer. A wall-clock ticker then writes the
-/// most recent frame once per slot, holding it through gaps, so the file's
-/// duration matches the automation it recorded.
+/// Spawn a background task that screencasts `capture_session` into ffmpeg at
+/// `fps`. Chrome pushes a frame on every repaint up to the display rate; a
+/// wall-clock ticker writes one frame per slot, holding the last one through
+/// gaps, so the file's duration matches the automation it recorded.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_recording_task(
     client: Arc<CdpClient>,
@@ -369,9 +308,10 @@ pub fn spawn_recording_task(
         let period = frame_period(fps);
         let max_frames_per_tick = MAX_BACKFILL_SECS * fps as u64 + 1;
 
-        // Subscribe before starting the screencast so the first frame, which
-        // Chrome sends immediately, is not missed.
-        let events = client.subscribe();
+        // Frames go to a private channel so the daemon's other subscribers
+        // neither copy them nor overflow on them. Subscribe before starting
+        // the screencast: Chrome sends the first frame immediately.
+        let events = client.subscribe_session(&capture_session);
 
         let mut command = build_ffmpeg_command(&output_path, fps);
         let mut ffmpeg = command.spawn().map_err(|e| {
@@ -392,6 +332,9 @@ pub fn spawn_recording_task(
                 Some(json!({
                     "format": "jpeg",
                     "quality": SCREENCAST_QUALITY,
+                    // Always 1: Chrome skips frames by count, and a static
+                    // page produces exactly one, which a higher value would
+                    // drop, leaving nothing to record.
                     "everyNthFrame": 1,
                 })),
                 Some(&capture_session),
@@ -418,6 +361,8 @@ pub fn spawn_recording_task(
                 Err(format!("Failed to start screencast: {}", e))
             }
         };
+
+        client.unsubscribe_session(&capture_session);
 
         // Best effort: the page may already be closed.
         let _ = tokio::time::timeout(
@@ -460,7 +405,7 @@ pub fn spawn_recording_task(
 async fn capture_frames(
     client: &CdpClient,
     capture_session: &str,
-    mut events: broadcast::Receiver<super::cdp::types::CdpEvent>,
+    mut events: mpsc::Receiver<super::cdp::types::CdpEvent>,
     mut stdin: tokio::process::ChildStdin,
     period: Duration,
     max_frames_per_tick: u64,
@@ -486,13 +431,8 @@ async fn capture_frames(
         tokio::select! {
             _ = &mut cancel_rx => break,
             event = events.recv() => {
-                let event = match event {
-                    Ok(event) => event,
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                    Err(broadcast::error::RecvError::Closed) => break,
-                };
-                let on_capture_session = event.session_id.as_deref() == Some(capture_session);
-                if on_capture_session && event.method == "Page.screencastFrame" {
+                let Some(event) = event else { break };
+                if event.method == "Page.screencastFrame" {
                     if let Some(sid) = event.params.get("sessionId").and_then(Value::as_i64) {
                         let _ = client
                             .send_command_no_wait(
@@ -520,9 +460,7 @@ async fn capture_frames(
                         }
                         shared_captured.fetch_add(1, Ordering::Relaxed);
                     }
-                } else if event.method == "Target.detachedFromTarget"
-                    && event.params.get("sessionId").and_then(Value::as_str) == Some(capture_session)
-                {
+                } else if event.method == "Inspector.detached" {
                     // The recorded page was closed; finish the file.
                     break;
                 }
@@ -678,40 +616,30 @@ mod tests {
     }
 
     #[test]
-    fn test_recording_restart_while_inactive() {
-        let mut state = RecordingState::new();
-        let result = recording_restart(&mut state, "/tmp/new.webm", None);
-        assert!(result.is_ok());
-        assert!(state.active);
-        assert_eq!(state.output_path, "/tmp/new.webm");
-        assert_eq!(state.fps, DEFAULT_FPS);
+    fn test_capture_session_matches_by_target_while_attach_is_in_flight() {
+        let shared: SharedCaptureSession = Arc::new(Mutex::new(Some(CaptureSession {
+            target_id: "T-REC".into(),
+            session_id: None,
+        })));
+        assert!(owns_attachment(&shared, "T-REC", "S-ANY"));
+        assert!(!owns_attachment(&shared, "T-OTHER", "S-ANY"));
     }
 
     #[test]
-    fn test_recording_restart_while_active() {
-        let mut state = RecordingState::new();
-        recording_start(&mut state, "/tmp/old.webm", None).unwrap();
-        state.frame_count = 10;
-        let result = recording_restart(&mut state, "/tmp/new.webm", Some(60)).unwrap();
-        assert!(state.active);
-        assert_eq!(state.output_path, "/tmp/new.webm");
-        assert_eq!(state.frame_count, 0);
-        assert_eq!(state.fps, 60);
-        assert_eq!(result["previousPath"], "/tmp/old.webm");
-        assert_eq!(result["fps"], 60);
-    }
-
-    #[test]
-    fn test_recording_restart_rejects_bad_fps_without_stopping() {
-        let mut state = RecordingState::new();
-        recording_start(&mut state, "/tmp/old.webm", None).unwrap();
-        state.frame_count = 10;
-        let result = recording_restart(&mut state, "/tmp/new.webm", Some(120));
-        assert!(result.is_err());
-        // The in-flight take survives an invalid rate.
-        assert!(state.active);
-        assert_eq!(state.output_path, "/tmp/old.webm");
-        assert_eq!(state.frame_count, 10);
+    fn test_capture_session_matches_by_session_once_attached() {
+        let shared: SharedCaptureSession = Arc::new(Mutex::new(Some(CaptureSession {
+            target_id: "T-REC".into(),
+            session_id: Some("S-REC".into()),
+        })));
+        assert!(owns_attachment(&shared, "T-REC", "S-REC"));
+        // A later attachment to the same target (e.g. the daemon's own) is
+        // not the recorder's.
+        assert!(!owns_attachment(&shared, "T-REC", "S-OTHER"));
+        assert!(!owns_attachment(
+            &Arc::new(Mutex::new(None)),
+            "T-REC",
+            "S-REC"
+        ));
     }
 
     #[test]

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -1,13 +1,14 @@
 use serde_json::{json, Value};
+use std::collections::VecDeque;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, oneshot};
 
 use super::cdp::client::CdpClient;
-use super::cdp::types::{CaptureScreenshotParams, CaptureScreenshotResult};
+use super::cdp::types::{AttachToTargetParams, AttachToTargetResult};
 
 /// Capture rate used when the caller does not ask for one. 30 fps reads as
 /// smooth motion, so scrolls, hovers, and CSS transitions survive the
@@ -29,9 +30,24 @@ const HIGH_FPS_THRESHOLD: u32 = 30;
 /// same per-frame quality.
 const WEBM_BITRATE_KBPS_AT_BASE_FPS: u32 = 1000;
 
-/// Longest stall a single lagging capture may backfill with held frames, in
-/// seconds. Bounds file growth when a page hangs for minutes.
+/// Longest gap the recorder fills with held frames, in seconds. A page that
+/// produces no frames for longer than this (a hang, or a tab left in the
+/// background) is held for this long and the remainder is dropped from the
+/// timeline, so a stalled page cannot inflate the file.
 const MAX_BACKFILL_SECS: u64 = 5;
+
+/// Screencast frames buffered ahead of the ticker. Two absorbs the jitter
+/// between Chrome's frame clock and the recorder's without letting a lower
+/// recording rate fall behind the page.
+const MAX_PENDING_FRAMES: usize = 2;
+
+/// JPEG quality requested from `Page.startScreencast`. Matches the quality the
+/// recorder used to request from `Page.captureScreenshot`.
+const SCREENCAST_QUALITY: u32 = 80;
+
+/// Upper bound on waiting for Chrome to acknowledge screencast teardown.
+/// The page may already be gone by the time a recording stops.
+const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Reject frame rates the pipeline cannot honor.
 pub fn validate_fps(fps: u32) -> Result<u32, String> {
@@ -49,31 +65,69 @@ fn frame_period(fps: u32) -> Duration {
     Duration::from_micros(1_000_000 / fps.clamp(1, MAX_FPS) as u64)
 }
 
-/// Number of frames to emit for a capture that landed `elapsed` into the
-/// recording, given `written` frames already in the stream.
+/// Number of frames owed to the stream at `elapsed` into the recording, given
+/// `written` frames already sent. Zero when the current frame slot is filled.
 ///
-/// The capture loop can fall behind: `Page.captureScreenshot` on a busy page
-/// takes longer than the frame budget, and at 60 fps that budget is under
-/// 17ms. ffmpeg reads the pipe as a constant-rate stream, so a dropped frame
-/// shortens playback rather than holding the picture, and a ten second
-/// interaction plays back in five. Repeating the frame that was on screen
-/// during the gap keeps playback aligned with wall clock at any rate.
-fn frames_due(elapsed: Duration, period: Duration, written: u64, max_frames: u64) -> u64 {
+/// Screencast frames arrive whenever the compositor repaints, which is
+/// irregular: a burst during a scroll, nothing at all on a static page. ffmpeg
+/// reads the pipe as a constant-rate stream, so the recorder emits exactly one
+/// frame per wall-clock slot, repeating the frame on screen through any gap.
+/// That keeps playback aligned with wall clock at any rate.
+fn frames_due(elapsed: Duration, period: Duration, written: u64) -> u64 {
     let period_us = period.as_micros().max(1);
     let slot = (elapsed.as_micros() / period_us) as u64;
-    let due = slot.saturating_add(1).saturating_sub(written);
-    due.clamp(1, max_frames.max(1))
+    slot.saturating_add(1).saturating_sub(written)
 }
+
+/// The dedicated CDP session a recording attaches to its page target.
+///
+/// Chrome keeps one screencast per session, and the live stream already runs
+/// one on the page session, so the recorder attaches a second flattened
+/// session to the same target and screencasts there. The daemon must not
+/// manage that session as a tab, so it is published here for the event
+/// handlers to recognise.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CaptureSession {
+    pub target_id: String,
+    /// `None` while `Target.attachToTarget` is in flight. Chrome emits
+    /// `Target.attachedToTarget` before it answers the command, so during that
+    /// window the attachment is recognised by target instead.
+    pub session_id: Option<String>,
+}
+
+impl CaptureSession {
+    /// Whether a `Target.attachedToTarget` event describes this recorder's
+    /// own attachment rather than a tab the daemon should track.
+    pub fn owns_attachment(&self, target_id: &str, session_id: &str) -> bool {
+        match self.session_id.as_deref() {
+            Some(own) => own == session_id,
+            None => self.target_id == target_id,
+        }
+    }
+
+    pub fn owns_session(&self, session_id: &str) -> bool {
+        self.session_id.as_deref() == Some(session_id)
+    }
+}
+
+pub type SharedCaptureSession = Arc<Mutex<Option<CaptureSession>>>;
 
 pub struct RecordingState {
     pub active: bool,
     pub output_path: String,
     /// Capture rate for the active (or most recent) recording.
     pub fps: u32,
+    /// Frames written to the file, including frames held through gaps.
     pub frame_count: u64,
+    /// Distinct frames received from the screencast.
+    pub captured_count: u64,
     pub capture_task: Option<tokio::task::JoinHandle<Result<(), String>>>,
     pub shared_frame_count: Option<Arc<AtomicU64>>,
+    pub shared_captured_count: Option<Arc<AtomicU64>>,
     pub cancel_tx: Option<oneshot::Sender<()>>,
+    /// Shared with the daemon's background event handlers, which must ignore
+    /// the recorder's session.
+    pub capture_session: SharedCaptureSession,
 }
 
 impl RecordingState {
@@ -83,11 +137,43 @@ impl RecordingState {
             output_path: String::new(),
             fps: DEFAULT_FPS,
             frame_count: 0,
+            captured_count: 0,
             capture_task: None,
             shared_frame_count: None,
+            shared_captured_count: None,
             cancel_tx: None,
+            capture_session: Arc::new(Mutex::new(None)),
         }
     }
+
+    /// Whether `Target.attachedToTarget` for this session belongs to the
+    /// active recording's screencast session.
+    pub fn owns_attachment(&self, target_id: &str, session_id: &str) -> bool {
+        owns_attachment(&self.capture_session, target_id, session_id)
+    }
+
+    /// Whether events on this session belong to the recorder's screencast.
+    pub fn owns_session(&self, session_id: &str) -> bool {
+        self.capture_session
+            .lock()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(|c| c.owns_session(session_id)))
+            .unwrap_or(false)
+    }
+}
+
+/// [`CaptureSession::owns_attachment`] against a shared slot, for background
+/// tasks that hold a clone of it rather than the recording state.
+pub fn owns_attachment(shared: &SharedCaptureSession, target_id: &str, session_id: &str) -> bool {
+    shared
+        .lock()
+        .ok()
+        .and_then(|guard| {
+            guard
+                .as_ref()
+                .map(|c| c.owns_attachment(target_id, session_id))
+        })
+        .unwrap_or(false)
 }
 
 pub fn recording_start(
@@ -105,6 +191,7 @@ pub fn recording_start(
     state.output_path = path.to_string();
     state.fps = fps;
     state.frame_count = 0;
+    state.captured_count = 0;
 
     Ok(json!({ "started": true, "path": path, "fps": fps }))
 }
@@ -123,6 +210,7 @@ pub fn recording_stop(state: &mut RecordingState) -> Result<Value, String> {
     Ok(json!({
         "path": &state.output_path,
         "frames": state.frame_count,
+        "capturedFrames": state.captured_count,
         "fps": state.fps,
     }))
 }
@@ -203,27 +291,87 @@ fn build_ffmpeg_command(output_path: &str, fps: u32) -> tokio::process::Command 
     cmd
 }
 
-/// Spawn a background task that captures screenshots at `fps` and pipes them
-/// to ffmpeg in real-time.
+/// Attach a dedicated flattened session to the target behind `page_session_id`
+/// for the recorder's screencast. Publishes the attachment in `shared` before
+/// the command is sent, so the daemon's event handlers can recognise the
+/// resulting `Target.attachedToTarget` as the recorder's own.
+pub async fn attach_capture_session(
+    client: &CdpClient,
+    page_session_id: &str,
+    shared: &SharedCaptureSession,
+) -> Result<String, String> {
+    let info = client
+        .send_command_no_params("Target.getTargetInfo", Some(page_session_id))
+        .await?;
+    let target_id = info
+        .get("targetInfo")
+        .and_then(|t| t.get("targetId"))
+        .and_then(Value::as_str)
+        .ok_or("Failed to resolve recording target")?
+        .to_string();
+
+    if let Ok(mut guard) = shared.lock() {
+        *guard = Some(CaptureSession {
+            target_id: target_id.clone(),
+            session_id: None,
+        });
+    }
+
+    let attached: Result<AttachToTargetResult, String> = client
+        .send_command_typed(
+            "Target.attachToTarget",
+            &AttachToTargetParams {
+                target_id,
+                flatten: true,
+            },
+            None,
+        )
+        .await;
+
+    match attached {
+        Ok(result) => {
+            if let Ok(mut guard) = shared.lock() {
+                if let Some(capture) = guard.as_mut() {
+                    capture.session_id = Some(result.session_id.clone());
+                }
+            }
+            Ok(result.session_id)
+        }
+        Err(e) => {
+            if let Ok(mut guard) = shared.lock() {
+                *guard = None;
+            }
+            Err(format!("Failed to attach recording session: {}", e))
+        }
+    }
+}
+
+/// Spawn a background task that screencasts the page on `capture_session` and
+/// pipes frames to ffmpeg at `fps` in real time.
 ///
-/// Frames are paced against wall clock rather than against the tick count, so
-/// a capture that overruns its budget holds the previous picture instead of
-/// speeding up playback. That is what makes 30 fps (and 60 fps on shorter
-/// clips) produce a video whose duration matches the automation it recorded.
+/// Chrome pushes a frame whenever the page repaints, up to the display rate,
+/// so motion is captured at its true rate rather than at the pace
+/// `Page.captureScreenshot` can answer. A wall-clock ticker then writes the
+/// most recent frame once per slot, holding it through gaps, so the file's
+/// duration matches the automation it recorded.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_recording_task(
     client: Arc<CdpClient>,
-    session_id: String,
+    capture_session: String,
     output_path: String,
     fps: u32,
     shared_count: Arc<AtomicU64>,
+    shared_captured: Arc<AtomicU64>,
     cancel_rx: oneshot::Receiver<()>,
 ) -> tokio::task::JoinHandle<Result<(), String>> {
     tokio::spawn(async move {
-        let mut cancel_rx = std::pin::pin!(cancel_rx);
-
         let fps = validate_fps(fps)?;
         let period = frame_period(fps);
-        let max_frames_per_capture = MAX_BACKFILL_SECS * fps as u64 + 1;
+        let max_frames_per_tick = MAX_BACKFILL_SECS * fps as u64 + 1;
+
+        // Subscribe before starting the screencast so the first frame, which
+        // Chrome sends immediately, is not missed.
+        let events = client.subscribe();
 
         let mut command = build_ffmpeg_command(&output_path, fps);
         let mut ffmpeg = command.spawn().map_err(|e| {
@@ -233,80 +381,66 @@ pub fn spawn_recording_task(
             )
         })?;
 
-        let mut stdin = ffmpeg
+        let stdin = ffmpeg
             .stdin
             .take()
             .ok_or_else(|| "Failed to open ffmpeg stdin".to_string())?;
 
-        let mut interval = tokio::time::interval(period);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let started = client
+            .send_command(
+                "Page.startScreencast",
+                Some(json!({
+                    "format": "jpeg",
+                    "quality": SCREENCAST_QUALITY,
+                    "everyNthFrame": 1,
+                })),
+                Some(&capture_session),
+            )
+            .await;
 
-        let params = CaptureScreenshotParams {
-            format: Some("jpeg".to_string()),
-            quality: Some(80),
-            clip: None,
-            from_surface: Some(true),
-            capture_beyond_viewport: None,
+        let capture = match started {
+            Ok(_) => {
+                capture_frames(
+                    &client,
+                    &capture_session,
+                    events,
+                    stdin,
+                    period,
+                    max_frames_per_tick,
+                    &shared_count,
+                    &shared_captured,
+                    cancel_rx,
+                )
+                .await
+            }
+            Err(e) => {
+                drop(stdin);
+                Err(format!("Failed to start screencast: {}", e))
+            }
         };
 
-        let started = tokio::time::Instant::now();
-        let mut written: u64 = 0;
-        // Last frame written, repeated to cover gaps left by slow captures.
-        let mut held: Option<Vec<u8>> = None;
-
-        loop {
-            tokio::select! {
-                _ = &mut cancel_rx => break,
-                _ = interval.tick() => {}
-            }
-
-            let result: Result<CaptureScreenshotResult, _> = client
-                .send_command_typed("Page.captureScreenshot", &params, Some(&session_id))
-                .await;
-
-            let screenshot = match result {
-                Ok(s) => s,
-                Err(e) => {
-                    if e.contains("Target closed") || e.contains("not found") {
-                        break;
-                    }
-                    continue;
-                }
-            };
-
-            let bytes = match base64::Engine::decode(
-                &base64::engine::general_purpose::STANDARD,
-                &screenshot.data,
-            ) {
-                Ok(b) => b,
-                Err(_) => continue,
-            };
-
-            let frames = frames_due(started.elapsed(), period, written, max_frames_per_capture);
-
-            let mut write_failed = false;
-            for _ in 1..frames {
-                let filler: &[u8] = held.as_deref().unwrap_or(&bytes);
-                if stdin.write_all(filler).await.is_err() {
-                    write_failed = true;
-                    break;
-                }
-            }
-            if write_failed || stdin.write_all(&bytes).await.is_err() {
-                break;
-            }
-
-            written += frames;
-            shared_count.fetch_add(frames, Ordering::Relaxed);
-            held = Some(bytes);
-        }
-
-        drop(stdin);
+        // Best effort: the page may already be closed.
+        let _ = tokio::time::timeout(
+            TEARDOWN_TIMEOUT,
+            client.send_command_no_params("Page.stopScreencast", Some(&capture_session)),
+        )
+        .await;
+        let _ = tokio::time::timeout(
+            TEARDOWN_TIMEOUT,
+            client.send_command(
+                "Target.detachFromTarget",
+                Some(json!({ "sessionId": capture_session })),
+                None,
+            ),
+        )
+        .await;
 
         let output = ffmpeg
             .wait_with_output()
             .await
             .map_err(|e| format!("ffmpeg wait failed: {}", e))?;
+
+        capture?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -320,12 +454,123 @@ pub fn spawn_recording_task(
     })
 }
 
+/// Pump screencast frames into ffmpeg until cancelled, the page goes away, or
+/// the pipe closes. Takes ownership of `stdin` so ffmpeg sees EOF on return.
+#[allow(clippy::too_many_arguments)]
+async fn capture_frames(
+    client: &CdpClient,
+    capture_session: &str,
+    mut events: broadcast::Receiver<super::cdp::types::CdpEvent>,
+    mut stdin: tokio::process::ChildStdin,
+    period: Duration,
+    max_frames_per_tick: u64,
+    shared_count: &AtomicU64,
+    shared_captured: &AtomicU64,
+    cancel_rx: oneshot::Receiver<()>,
+) -> Result<(), String> {
+    let mut cancel_rx = std::pin::pin!(cancel_rx);
+    let started = tokio::time::Instant::now();
+    let mut interval = tokio::time::interval(period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // Frames waiting to be written, in arrival order, and the last frame
+    // written (repeated through gaps). Chrome's frame clock and the ticker
+    // are not phase-locked, so a slot sometimes receives two frames and the
+    // next none; the queue carries the spare across instead of dropping it
+    // and repeating its predecessor.
+    let mut pending: VecDeque<Vec<u8>> = VecDeque::new();
+    let mut last: Option<Vec<u8>> = None;
+    let mut written: u64 = 0;
+
+    loop {
+        tokio::select! {
+            _ = &mut cancel_rx => break,
+            event = events.recv() => {
+                let event = match event {
+                    Ok(event) => event,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
+                let on_capture_session = event.session_id.as_deref() == Some(capture_session);
+                if on_capture_session && event.method == "Page.screencastFrame" {
+                    if let Some(sid) = event.params.get("sessionId").and_then(Value::as_i64) {
+                        let _ = client
+                            .send_command_no_wait(
+                                "Page.screencastFrameAck",
+                                Some(json!({ "sessionId": sid })),
+                                Some(capture_session),
+                            )
+                            .await;
+                    }
+                    let decoded = event
+                        .params
+                        .get("data")
+                        .and_then(Value::as_str)
+                        .and_then(|data| {
+                            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, data)
+                                .ok()
+                        });
+                    if let Some(bytes) = decoded {
+                        pending.push_back(bytes);
+                        // Only a lower recording rate lets the queue grow (a
+                        // 60 Hz screencast into a 30 fps file); dropping the
+                        // oldest keeps the picture current.
+                        if pending.len() > MAX_PENDING_FRAMES {
+                            pending.pop_front();
+                        }
+                        shared_captured.fetch_add(1, Ordering::Relaxed);
+                    }
+                } else if event.method == "Target.detachedFromTarget"
+                    && event.params.get("sessionId").and_then(Value::as_str) == Some(capture_session)
+                {
+                    // The recorded page was closed; finish the file.
+                    break;
+                }
+            }
+            _ = interval.tick() => {
+                if pending.is_empty() && last.is_none() {
+                    continue;
+                }
+                let due = frames_due(started.elapsed(), period, written);
+                if due == 0 {
+                    continue;
+                }
+                // A gap longer than MAX_BACKFILL_SECS is held for that long
+                // and the rest is dropped, so a hung page does not inflate
+                // the file. Advancing `written` by the full amount is what
+                // stops the excess being paid off on later ticks.
+                let emit = due.min(max_frames_per_tick);
+                let mut write_failed = false;
+                for _ in 0..emit {
+                    if let Some(next) = pending.pop_front() {
+                        last = Some(next);
+                    }
+                    let Some(frame) = last.as_deref() else { break };
+                    if stdin.write_all(frame).await.is_err() {
+                        write_failed = true;
+                        break;
+                    }
+                }
+                if write_failed {
+                    break;
+                }
+                written += due;
+                shared_count.fetch_add(emit, Ordering::Relaxed);
+            }
+        }
+    }
+
+    drop(stdin);
+    Ok(())
+}
+
 pub async fn stop_recording_task(state: &mut RecordingState) -> Result<(), String> {
     if let Some(tx) = state.cancel_tx.take() {
         let _ = tx.send(());
     }
 
     let counter = state.shared_frame_count.take();
+    let captured = state.shared_captured_count.take();
     let handle = state.capture_task.take();
 
     let result = if let Some(h) = handle {
@@ -341,10 +586,15 @@ pub async fn stop_recording_task(state: &mut RecordingState) -> Result<(), Strin
     if let Some(c) = counter {
         state.frame_count = c.load(Ordering::Relaxed);
     }
+    if let Some(c) = captured {
+        state.captured_count = c.load(Ordering::Relaxed);
+    }
+    if let Ok(mut guard) = state.capture_session.lock() {
+        *guard = None;
+    }
 
     result
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -485,32 +735,54 @@ mod tests {
         let period = frame_period(30);
         for slot in 0..5u64 {
             let elapsed = period * slot as u32;
-            assert_eq!(frames_due(elapsed, period, slot, 151), 1);
+            assert_eq!(frames_due(elapsed, period, slot), 1);
         }
     }
 
     #[test]
-    fn test_frames_due_backfills_a_lagging_capture() {
+    fn test_frames_due_is_zero_when_slot_already_written() {
         let period = frame_period(60);
-        // Capture landed in slot 3 but only slot 0 has been written, so the
-        // two skipped slots are held before the fresh frame.
-        assert_eq!(frames_due(period * 3, period, 1, 301), 3);
+        // Two screencast frames in one slot: the second waits for the next
+        // tick rather than stretching the file.
+        assert_eq!(frames_due(period / 2, period, 1), 0);
+        assert_eq!(frames_due(Duration::ZERO, period, 10), 0);
     }
 
     #[test]
-    fn test_frames_due_clamps_long_stalls() {
-        let period = frame_period(30);
-        let max_frames = MAX_BACKFILL_SECS * 30 + 1;
-        let stall = Duration::from_secs(60);
-        assert_eq!(frames_due(stall, period, 0, max_frames), max_frames);
+    fn test_frames_due_backfills_missed_slots() {
+        let period = frame_period(60);
+        // The ticker wakes in slot 3 with only slot 0 written, so the two
+        // skipped slots are held along with the current one.
+        assert_eq!(frames_due(period * 3, period, 1), 3);
     }
 
+    /// Replays the ticker's bookkeeping for a 60s stall followed by on-time
+    /// ticks. The cap must bound the file, not just one tick: without
+    /// advancing `written` by the full deficit, every later tick would emit
+    /// another five seconds of held frames until the stall was paid off.
     #[test]
-    fn test_frames_due_never_returns_zero() {
-        let period = frame_period(30);
-        // A capture that arrives early (or a clock that has not advanced)
-        // still contributes exactly one frame.
-        assert_eq!(frames_due(Duration::ZERO, period, 10, 151), 1);
+    fn test_backfill_cap_bounds_a_long_stall() {
+        let fps = 30u32;
+        let period = frame_period(fps);
+        let max_frames = MAX_BACKFILL_SECS * fps as u64 + 1;
+        let mut written = 0u64;
+        let mut emitted = 0u64;
+
+        let mut elapsed = Duration::from_secs(60);
+        let due = frames_due(elapsed, period, written);
+        assert!(due > max_frames);
+        emitted += due.min(max_frames);
+        written += due;
+
+        for _ in 0..20 {
+            elapsed += period;
+            let due = frames_due(elapsed, period, written);
+            assert_eq!(due, 1, "ticks after the stall must emit one frame each");
+            emitted += due.min(max_frames);
+            written += due;
+        }
+
+        assert_eq!(emitted, max_frames + 20);
     }
 
     #[test]

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -323,12 +323,7 @@ pub(super) async fn cdp_event_loop(
                                                 }
                                             }
                                         }
-                                    } else if evt.method == "Page.screencastFrame"
-                                        && session_matches(session_id.as_deref(), evt.session_id.as_deref())
-                                    {
-                                        // Video recording runs its own screencast on a
-                                        // separate session of the same page; those frames
-                                        // are not the stream's to ack or broadcast.
+                                    } else if evt.method == "Page.screencastFrame" {
                                         if let Some(sid) = evt.params.get("sessionId").and_then(|v| v.as_i64()) {
                                             let _ = client_arc.send_command(
                                                 "Page.screencastFrameAck",

--- a/cli/src/native/stream/cdp_loop.rs
+++ b/cli/src/native/stream/cdp_loop.rs
@@ -323,7 +323,12 @@ pub(super) async fn cdp_event_loop(
                                                 }
                                             }
                                         }
-                                    } else if evt.method == "Page.screencastFrame" {
+                                    } else if evt.method == "Page.screencastFrame"
+                                        && session_matches(session_id.as_deref(), evt.session_id.as_deref())
+                                    {
+                                        // Video recording runs its own screencast on a
+                                        // separate session of the same page; those frames
+                                        // are not the stream's to ack or broadcast.
                                         if let Some(sid) = evt.params.get("sessionId").and_then(|v| v.as_i64()) {
                                             let _ = client_arc.send_command(
                                                 "Page.screencastFrameAck",

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1030,21 +1030,28 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 return;
             }
         }
-        // Recording restart (has "stopped" field - from recording_restart action)
-        if data.get("stopped").is_some() {
+        // Recording restart (has "restarted" field - from recording_restart action)
+        if data.get("restarted").is_some() {
             let path = data
                 .get("path")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown");
+            let rate = recording_fps_suffix(data);
             if let Some(prev_path) = data.get("previousPath").and_then(|v| v.as_str()) {
                 println!(
-                    "{} Recording restarted: {} (previous saved to {})",
+                    "{} Recording restarted: {}{} (previous saved to {})",
                     color::success_indicator(),
                     path,
+                    rate,
                     prev_path
                 );
             } else {
-                println!("{} Recording started: {}", color::success_indicator(), path);
+                println!(
+                    "{} Recording started: {}{}",
+                    color::success_indicator(),
+                    path,
+                    rate
+                );
             }
             return;
         }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -433,6 +433,15 @@ fn format_a11y_target(target: &serde_json::Value) -> Option<String> {
     }
 }
 
+/// Render a recording's capture rate as a trailing " (30 fps)", or nothing
+/// when the payload predates the field.
+fn recording_fps_suffix(data: &serde_json::Value) -> String {
+    data.get("fps")
+        .and_then(|v| v.as_u64())
+        .map(|fps| format!(" ({} fps)", fps))
+        .unwrap_or_default()
+}
+
 pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &OutputOptions) {
     if opts.json {
         if opts.content_boundaries {
@@ -1005,10 +1014,16 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                         println!("{} HAR recording started", color::success_indicator());
                     }
                     _ => {
+                        let rate = recording_fps_suffix(data);
                         if let Some(path) = data.get("path").and_then(|v| v.as_str()) {
-                            println!("{} Recording started: {}", color::success_indicator(), path);
+                            println!(
+                                "{} Recording started: {}{}",
+                                color::success_indicator(),
+                                path,
+                                rate
+                            );
                         } else {
-                            println!("{} Recording started", color::success_indicator());
+                            println!("{} Recording started{}", color::success_indicator(), rate);
                         }
                     }
                 }
@@ -1044,7 +1059,12 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                         error
                     );
                 } else {
-                    println!("{} Recording saved to {}", color::success_indicator(), path);
+                    println!(
+                        "{} Recording saved to {}{}",
+                        color::success_indicator(),
+                        path,
+                        recording_fps_suffix(data)
+                    );
                 }
             } else {
                 println!("{} Recording stopped", color::success_indicator());
@@ -2742,18 +2762,25 @@ The output file can be viewed in:
             r##"
 agent-browser record - Record browser session to video
 
-Usage: agent-browser record start <path.webm> [url]
+Usage: agent-browser record start <path.webm> [url] [--fps <n>]
        agent-browser record stop
-       agent-browser record restart <path.webm> [url]
+       agent-browser record restart <path.webm> [url] [--fps <n>]
 
 Record the browser to a WebM video file.
 Creates a fresh browser context but preserves cookies and localStorage.
 If no URL is provided, automatically navigates to your current page.
 
+Recording captures 30 fps, which keeps scrolls and CSS transitions smooth.
+Raise it to 60 for short, motion-heavy takes (drag interactions, animation
+work); lower it for long sessions where file size matters more than motion.
+
 Operations:
   start <path> [url]     Start recording (defaults to current URL if omitted)
   stop                   Stop recording and save video
   restart <path> [url]   Stop current recording (if any) and start a new one
+
+Options:
+  --fps <n>            Capture rate, 1-60 (default: 30)
 
 Global Options:
   --json               Output as JSON
@@ -2769,6 +2796,12 @@ Examples:
 
   # Or specify a different URL
   agent-browser record start ./demo.webm https://example.com
+
+  # 60 fps for a scroll or animation capture
+  agent-browser record start ./scroll.webm --fps 60
+
+  # 10 fps for a long session where size matters more than motion
+  agent-browser record start ./soak.webm --fps 10
 
   # Restart recording with a new file (stops previous, starts new)
   agent-browser record restart ./take2.webm
@@ -3672,7 +3705,7 @@ Debug:
   trace start                Start Chrome DevTools trace
   trace stop [path]          Stop and save Chrome DevTools trace
   profiler start|stop [path] Record Chrome DevTools profile
-  record start <path> [url]  Start video recording (WebM)
+  record start <path> [url]  Start video recording (WebM, 30 fps; --fps 1-60)
   record stop                Stop and save video
   console [--clear]          View console logs
   errors [--clear]           View page errors

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -319,7 +319,8 @@ agent-browser trace start             # Start trace
 agent-browser trace stop [path]       # Stop and save trace
 agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
-agent-browser record start <path>     # Start video recording (WebM)
+agent-browser record start <path>     # Start video recording (WebM, 30 fps)
+agent-browser record start <path> --fps 60  # Record at 60 fps (--fps accepts 1-60)
 agent-browser record stop             # Stop and save video
 agent-browser record restart <path>   # Stop current and start new recording
 agent-browser console                 # View console messages

--- a/docs/src/app/recording/page.mdx
+++ b/docs/src/app/recording/page.mdx
@@ -45,7 +45,9 @@ agent-browser record start ./soak.webm --fps 10
   </tbody>
 </table>
 
-Valid rates are 1 to 60. The saved file always carries the requested rate and its duration matches the wall clock time it recorded: when a capture takes longer than one frame budget, the frame already on screen is held for the gap rather than dropped, so playback never runs fast. On a busy page or a loaded machine, the number of distinct frames can fall below the requested rate even though timing stays correct.
+Valid rates are 1 to 60. Frames come from Chrome's screencast, which delivers a new frame every time the page repaints, up to the display rate, so a 60 fps recording of a scroll or animation holds 60 distinct pictures per second rather than repeats of the last screenshot. The file's duration matches the wall clock time it recorded: while the page is static the last frame is held, so playback never runs fast. A gap longer than five seconds (a hung page, a tab left in the background) is held for five seconds and the rest is left out.
+
+`record stop` reports both `frames`, the number written to the file, and `capturedFrames`, the number of distinct frames the page produced. A static page shows a small `capturedFrames` against a full `frames` count; that is the hold working, not a problem.
 
 ## Commands
 
@@ -118,6 +120,6 @@ Screenshots and videos work well together: screenshots capture precise still sta
 
 - Recording adds overhead to automation, and higher frame rates add more.
 - Long recordings can use significant disk space; 60 fps roughly doubles the bitrate of 30 fps.
-- Distinct frames per second are bounded by how fast the browser can produce screenshots, so a heavy page may repeat frames at 60 fps.
+- Distinct frames per second are bounded by how often the page repaints, so a page that renders below 60 fps records below it too.
 - Use `record stop` before closing a session if you need the file flushed.
 - Some constrained headless environments may have codec or GPU limitations.

--- a/docs/src/app/recording/page.mdx
+++ b/docs/src/app/recording/page.mdx
@@ -22,6 +22,31 @@ agent-browser record start ./demo.webm https://example.com
 
 If no URL is provided, recording starts from the current page. The recording context copies cookies from the active session.
 
+## Frame rate
+
+Recording captures 30 frames per second by default, which is enough for scrolling, hover states, and CSS transitions to read as motion rather than as a slideshow. Use `--fps` to change it:
+
+```bash
+# 60 fps for a short, motion-heavy take
+agent-browser record start ./scroll.webm --fps 60
+
+# 10 fps for a long soak run where file size matters more than motion
+agent-browser record start ./soak.webm --fps 10
+```
+
+<table>
+  <thead>
+    <tr><th>Rate</th><th>When to use it</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>60</td><td>Drag interactions, animation and scroll polish work, anything where a single frame is the evidence. Best on short clips.</td></tr>
+    <tr><td>30 (default)</td><td>Everything else: flows, CI evidence, walkthroughs.</td></tr>
+    <tr><td>1 to 15</td><td>Long sessions where the video is a timeline rather than a motion study.</td></tr>
+  </tbody>
+</table>
+
+Valid rates are 1 to 60. The saved file always carries the requested rate and its duration matches the wall clock time it recorded: when a capture takes longer than one frame budget, the frame already on screen is held for the gap rather than dropped, so playback never runs fast. On a busy page or a loaded machine, the number of distinct frames can fall below the requested rate even though timing stays correct.
+
 ## Commands
 
 <table>
@@ -29,9 +54,9 @@ If no URL is provided, recording starts from the current page. The recording con
     <tr><th>Command</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>record start &lt;path.webm&gt; [url]</code></td><td>Start recording to a WebM file</td></tr>
+    <tr><td><code>record start &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Start recording to a WebM file</td></tr>
     <tr><td><code>record stop</code></td><td>Stop the active recording and save the file</td></tr>
-    <tr><td><code>record restart &lt;path.webm&gt; [url]</code></td><td>Stop the current recording and immediately start another</td></tr>
+    <tr><td><code>record restart &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Stop the current recording and immediately start another</td></tr>
   </tbody>
 </table>
 
@@ -83,6 +108,7 @@ Screenshots and videos work well together: screenshots capture precise still sta
   <tbody>
     <tr><td>Container</td><td>WebM</td></tr>
     <tr><td>Common extension</td><td><code>.webm</code></td></tr>
+    <tr><td>Frame rate</td><td>30 fps by default, 1 to 60 with <code>--fps</code></td></tr>
     <tr><td>Viewport</td><td>Uses the active browser viewport settings</td></tr>
     <tr><td>State</td><td>Copies cookies from the active session</td></tr>
   </tbody>
@@ -90,7 +116,8 @@ Screenshots and videos work well together: screenshots capture precise still sta
 
 ## Limitations
 
-- Recording adds overhead to automation.
-- Long recordings can use significant disk space.
+- Recording adds overhead to automation, and higher frame rates add more.
+- Long recordings can use significant disk space; 60 fps roughly doubles the bitrate of 30 fps.
+- Distinct frames per second are bounded by how fast the browser can produce screenshots, so a heavy page may repeat frames at 60 fps.
 - Use `record stop` before closing a session if you need the file flushed.
 - Some constrained headless environments may have codec or GPU limitations.

--- a/docs/src/app/recording/page.mdx
+++ b/docs/src/app/recording/page.mdx
@@ -45,9 +45,9 @@ agent-browser record start ./soak.webm --fps 10
   </tbody>
 </table>
 
-Valid rates are 1 to 60. Frames come from Chrome's screencast, which delivers a new frame every time the page repaints, up to the display rate, so a 60 fps recording of a scroll or animation holds 60 distinct pictures per second rather than repeats of the last screenshot. The file's duration matches the wall clock time it recorded: while the page is static the last frame is held, so playback never runs fast. A gap longer than five seconds (a hung page, a tab left in the background) is held for five seconds and the rest is left out.
+Valid rates are 1 to 60. Frames come from Chrome's screencast, so every repaint up to the display rate is captured and a 60 fps take of a scroll holds 60 distinct pictures per second. While the page is static the last frame is held, so the file's duration matches wall clock; a gap longer than five seconds is held for five and the rest left out.
 
-`record stop` reports both `frames`, the number written to the file, and `capturedFrames`, the number of distinct frames the page produced. A static page shows a small `capturedFrames` against a full `frames` count; that is the hold working, not a problem.
+`record stop` reports `frames` (written to the file) and `capturedFrames` (distinct frames the page produced). A static page shows a small `capturedFrames` against a full `frames` count; that is the hold working.
 
 ## Commands
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -338,13 +338,15 @@ agent-browser network har stop /tmp/trace.har
 
 ```bash
 agent-browser open https://example.com
-agent-browser record start demo.webm
+agent-browser record start demo.webm          # 30 fps by default
 agent-browser snapshot -i
 agent-browser click @e3
 agent-browser record stop
 ```
 
-See [references/video-recording.md](references/video-recording.md) for codec options, GIF export, and more.
+Pass `--fps 60` for motion-heavy takes (drag, animation, scroll work) or a lower rate for long sessions; `--fps` accepts 1 to 60.
+
+See [references/video-recording.md](references/video-recording.md) for frame rate guidance, codec options, and more.
 
 ### Iframes
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -114,11 +114,16 @@ Headless Chromium screenshots hide native scrollbars for consistent image output
 
 ```bash
 agent-browser open https://example.com     # Launch a browser session first
-agent-browser record start ./demo.webm    # Start recording
+agent-browser record start ./demo.webm    # Start recording at 30 fps
 agent-browser click @e1                   # Perform actions
 agent-browser record stop                 # Stop and save video
 agent-browser record restart ./take2.webm # Stop current + start new
+
+agent-browser record start ./scroll.webm --fps 60  # 60 fps for motion-heavy takes
+agent-browser record start ./soak.webm --fps 10    # Lower rate for long sessions
 ```
+
+`--fps` accepts 1 to 60 and defaults to 30. Playback duration always matches the wall clock time recorded, so a slow page holds frames instead of speeding the video up.
 
 ## Wait
 

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -70,7 +70,7 @@ agent-browser record stop
 agent-browser record start ./soak.webm --fps 5
 ```
 
-The saved file carries the requested rate, and its duration matches the wall clock time it recorded: a capture that overruns its frame budget holds the current frame rather than dropping it, so playback never runs fast. On a heavy page the number of distinct frames can still fall short of the requested rate. 60 fps roughly doubles the bitrate of 30 fps.
+Frames come from Chrome's screencast, so every repaint up to the display rate is captured and a 60 fps take of a scroll or animation holds 60 distinct pictures per second. The file's duration matches the wall clock time it recorded: while the page is static the last frame is held, so playback never runs fast, and a gap longer than five seconds is held for five and the rest left out. `record stop --json` reports `frames` (written to the file) and `capturedFrames` (distinct frames the page produced). 60 fps roughly doubles the bitrate of 30 fps.
 
 ## Use Cases
 
@@ -200,5 +200,5 @@ agent-browser record stop
 
 - Recording adds slight overhead to automation, and higher frame rates add more
 - Large recordings can consume significant disk space; 60 fps roughly doubles the bitrate of 30 fps
-- Distinct frames per second are bounded by how fast the browser produces screenshots, so a heavy page may repeat frames at 60 fps
+- Distinct frames per second are bounded by how often the page repaints, so a page rendering below 60 fps records below it too
 - Some headless environments may have codec limitations

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -70,7 +70,7 @@ agent-browser record stop
 agent-browser record start ./soak.webm --fps 5
 ```
 
-Frames come from Chrome's screencast, so every repaint up to the display rate is captured and a 60 fps take of a scroll or animation holds 60 distinct pictures per second. The file's duration matches the wall clock time it recorded: while the page is static the last frame is held, so playback never runs fast, and a gap longer than five seconds is held for five and the rest left out. `record stop --json` reports `frames` (written to the file) and `capturedFrames` (distinct frames the page produced). 60 fps roughly doubles the bitrate of 30 fps.
+Frames come from Chrome's screencast, so a 60 fps take of a scroll holds 60 distinct pictures per second. While the page is static the last frame is held, so duration matches wall clock; a gap longer than five seconds is held for five and the rest left out. `record stop --json` reports `frames` (written) and `capturedFrames` (distinct frames the page produced). 60 fps roughly doubles the bitrate of 30 fps.
 
 ## Use Cases
 

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -8,6 +8,7 @@ Capture browser automation as video for debugging, documentation, or verificatio
 
 - [Basic Recording](#basic-recording)
 - [Recording Commands](#recording-commands)
+- [Frame Rate](#frame-rate)
 - [Use Cases](#use-cases)
 - [Best Practices](#best-practices)
 - [Output Format](#output-format)
@@ -35,15 +36,41 @@ agent-browser record stop
 # Launch a session first
 agent-browser open
 
-# Start recording to file
+# Start recording to file (30 fps)
 agent-browser record start ./output.webm
+
+# Start recording at a specific rate (1-60)
+agent-browser record start ./output.webm --fps 60
 
 # Stop current recording
 agent-browser record stop
 
 # Restart with new file (stops current + starts new)
-agent-browser record restart ./take2.webm
+agent-browser record restart ./take2.webm --fps 60
 ```
+
+## Frame Rate
+
+Recording captures 30 fps by default, so scrolling, hover states, and CSS transitions read as motion instead of a slideshow. `--fps` takes any rate from 1 to 60.
+
+| Rate | Use it for |
+| --- | --- |
+| 60 | Short, motion-heavy takes: drag interactions, animation, scroll polish work |
+| 30 (default) | Flows, CI evidence, walkthroughs |
+| 1-15 | Long sessions where the video is a timeline, not a motion study |
+
+```bash
+# Animation review
+agent-browser record start ./transition.webm --fps 60
+agent-browser click @e1
+agent-browser wait 1500
+agent-browser record stop
+
+# Hour-long soak run
+agent-browser record start ./soak.webm --fps 5
+```
+
+The saved file carries the requested rate, and its duration matches the wall clock time it recorded: a capture that overruns its frame budget holds the current frame rather than dropping it, so playback never runs fast. On a heavy page the number of distinct frames can still fall short of the requested rate. 60 fps roughly doubles the bitrate of 30 fps.
 
 ## Use Cases
 
@@ -165,11 +192,13 @@ agent-browser record stop
 ## Output Format
 
 - Default format: WebM (VP8/VP9 codec)
+- Default frame rate: 30 fps (`--fps` accepts 1 to 60)
 - Compatible with all modern browsers and video players
 - Compressed but high quality
 
 ## Limitations
 
-- Recording adds slight overhead to automation
-- Large recordings can consume significant disk space
+- Recording adds slight overhead to automation, and higher frame rates add more
+- Large recordings can consume significant disk space; 60 fps roughly doubles the bitrate of 30 fps
+- Distinct frames per second are bounded by how fast the browser produces screenshots, so a heavy page may repeat frames at 60 fps
 - Some headless environments may have codec limitations


### PR DESCRIPTION
<!-- before-and-after:start -->
<table>
  <tr>
    <th width="50%">Before: <code>Page.captureScreenshot</code> polling (~10fps)</th>
    <th width="50%">After: <code>Page.startScreencast</code> (60fps)</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/5d77bdf2-8f59-4d9e-82f0-086ec2e19099" width="100%" controls></video></td>
    <td><video src="https://github.com/user-attachments/assets/b6d86b71-d1ac-464e-b81b-eaef3bc4228a" width="100%" controls></video></td>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/c97ef058-6ef4-4764-8540-d1dea8c72c50" width="100%" controls></video></td>
    <td><video src="https://github.com/user-attachments/assets/99c4674f-97c9-4a0c-8c60-e37209f949fe" width="100%" controls></video></td>
  </tr>
</table>

Top row `vercel.com/oss/swr`, bottom row `vercel.com/oss/deepsec`. Both recorded at 60 fps during the same 240 px/s scroll; the before column holds each frame for 4 to 5 slots, the after column advances 4 px every frame.

<!-- before-and-after:end -->

Video recording captured 10 fps by polling `Page.captureScreenshot` on a fixed interval, so scrolls, hovers, and transitions came out as a slideshow. Recording now defaults to 30 fps, accepts `--fps` from 1 to 60, and takes its frames from `Page.startScreencast` on a dedicated CDP session, so a 60 fps take actually holds 60 distinct pictures per second.

```bash
agent-browser record start ./demo.webm            # 30 fps
agent-browser record start ./scroll.webm --fps 60 # motion-heavy take
agent-browser record start ./soak.webm --fps 10   # long session, smaller file
agent-browser record restart ./take2.webm --fps 60
```


## Details

**Why screencast, and why a second session.** `captureScreenshot` answers about 15 times a second on a real page whatever rate you ask for, so raising the rate alone just repeats frames. Chrome's screencast pushes a frame on every repaint up to the display rate, but it keeps one screencast per CDP session and the live stream already runs one on the page session (stopping and restarting it on viewer, tab, and viewport changes). The recorder attaches its own flattened session to the recording target and screencasts there. The daemon recognises that attachment (`RecordingState::capture_session`) so it isn't registered as a tab and doesn't get page domains or network controls installed.

**Frames stay off the shared broadcast.** `CdpClient::subscribe_session` routes one session's events to a private channel. Without it every ~100 KB frame was cloned to the stream loop, the fetch handler, and the daemon's own receiver, which is only drained when a command runs; at 60 fps a take with no commands for about a minute overflowed it and dropped events.

**Pacing.** Screencast frames are irregular and ffmpeg reads the pipe as a constant-rate stream, so a wall-clock ticker writes one frame per slot from a two-deep in-order buffer and holds the last frame through gaps. The buffer matters: Chrome's frame clock and the ticker aren't phase-locked, and without it jitter dropped about one frame in six at 60 fps. A gap longer than five seconds is held for five and the rest dropped, so a hung page can't inflate the file.

**Surface.**
- `record start` / `record restart` take `--fps <n>` (1-60), validated in the CLI and again in the daemon before any browser work; unknown flags and stray positionals are rejected
- `record stop` reports `fps`, `frames` (written) and `capturedFrames` (distinct frames from the page); `record restart` output now shows the rate and previous path instead of a misleading `Saved to <new path>`
- MCP `agent_browser_record_start` / `agent_browser_record_restart` expose `fps`
- WebM bitrate scales with fps and rates above 30 get a second encoder thread

**Verified.** `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (1232 unit tests, including the new session-routing and `CaptureSession` tests), `node --test test/launcher.test.mjs`, version sync. `cargo test e2e_recording -- --ignored` (3 passed) covers the real pipeline, including that the dedicated session doesn't appear as a tab and that a static page records at all (`everyNthFrame` must stay 1: Chrome skips by count and a static page produces exactly one frame).

Recorded `vercel.com/oss/swr` and `vercel.com/oss/deepsec` at 60 fps during a constant 240 px/s scroll (4 px per frame), same page, same machine, release builds. "Scrolled frames" is measured from the decoded video by estimating the vertical shift between consecutive frames, independent of the recorder's own counters.

| Page | Recorder | Scrolled frames per second | Median step |
| --- | --- | --- | --- |
| swr | `captureScreenshot` polling (previous revision) | 14 15 15 15 15 15 | 16 px |
| swr | screencast (this PR) | 58 60 60 60 60 60 | 4 px |
| deepsec | `captureScreenshot` polling | 13 15 15 15 15 15 | 16 px |
| deepsec | screencast | 57 60 60 60 60 60 | 4 px |

Recording at 60 fps while a live-stream viewer was connected to the same page: the viewer kept receiving 58 to 60 frames per second for the whole take and the recorder captured 241 frames in 4 seconds.

**Limits.** Distinct frames per second are bounded by how often the page repaints; headless Chrome composites at 60 Hz (also with `--disable-frame-rate-limit`), which is why `MAX_FPS` is 60. The recording context still only carries cookies over from the page session (no headers, init scripts, or localStorage); that predates this PR and is a separate fix. Docs cover the default, the range, and `capturedFrames`.

