### PR TITLE
Support stateful auth login without navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,30 @@ agent-browser provides multiple ways to persist login sessions so you don't re-a
 | **State file** | Load a previously saved state JSON on launch | `--state <path>` / `AGENT_BROWSER_STATE` |
 | **Auth vault** | Store credentials locally (encrypted), login by name | `auth save` / `auth login` |
 
+### Stateful auth vault login
+
+By default, `auth login` navigates to the effective credential URL before it locates the form. Use `--no-navigate` after an in-page click, challenge clearance, consent dismissal, or other stateful setup that must survive credential entry:
+
+```bash
+agent-browser open https://example.com/
+agent-browser click "a[href='/login']"
+agent-browser auth login work --no-navigate
+```
+
+`--no-navigate` suppresses only that initial navigation. It requires an existing active top-level HTTP(S) page, waits for and fills the same selectors, clicks submit, and allows submission to navigate. The effective credential URL is checked as an origin constraint using scheme, host, and effective port. Paths, queries, and fragments may differ. A command-level `--url` takes precedence over stored or provider metadata, which is useful when a stateful flow reaches a hosted identity provider:
+
+```bash
+agent-browser open https://identity.example.com/start
+agent-browser click "button.continue"
+agent-browser auth login work --credential-provider vault --item "Work" --no-navigate --url https://identity.example.com/login
+```
+
+Provider credentials are still resolved directly by the daemon and remain out of process arguments and normal output.
+
+| Auth login option | Description |
+|-------------------|-------------|
+| `--no-navigate` | Use the active top-level page without the initial navigation and require its origin to match the effective credential URL. Form submission may still navigate. |
+
 ### Import auth from your browser
 
 If you are already logged in to a site in Chrome, you can grab that auth state and reuse it:
@@ -805,7 +829,7 @@ agent-browser --session secure --restore open example.com
 
 agent-browser includes security features for safe AI agent deployments. All features are opt-in, and existing workflows are unaffected until you explicitly enable a feature:
 
-- **Authentication Vault**: Store credentials locally (always encrypted), reference by name. The LLM never sees passwords. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). A key is auto-generated at `~/.agent-browser/.encryption-key` if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
+- **Authentication Vault**: Store credentials locally (always encrypted), reference by name. The LLM never sees passwords. `auth login` navigates with `load` and then waits for login form selectors to appear (SPA-friendly, timeout follows the default action timeout). Use `auth login <name> --no-navigate` to preserve an already prepared active page after its origin is checked against the credential URL. A key is auto-generated at `~/.agent-browser/.encryption-key` if `AGENT_BROWSER_ENCRYPTION_KEY` is not set: `echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin` then `agent-browser auth login github`
 - **Plugin System**: Extend agent-browser with external executable plugins. Plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol and declare capabilities such as `credential.read`, `browser.provider`, `launch.mutate`, or `command.run`.
 - **Content Boundary Markers**: Wrap page output in delimiters so LLMs can distinguish tool output from untrusted content: `--content-boundaries`
 - **Domain Allowlist**: Restrict navigation to trusted domains (wildcards like `*.example.com` also match the bare domain): `--allowed-domains "example.com,*.example.com"`. Sub-resource requests (scripts, images, fetch), WebSocket/EventSource connections, and `sendBeacon` calls to non-allowed domains are blocked. WebRTC peer connections are disabled in supported Chromium sessions while the allowlist is active to prevent STUN, TURN, and DNS traffic from bypassing HTTP interception. Dedicated and shared workers are guarded with a bootstrap wrapper; if a page CSP forbids that wrapper, the worker fails closed rather than running without the allowlist guard. Pre-existing CDP sessions, auto-connect, Chrome profiles, direct-page provider plugins, agent-browser restore or state-file replay, raw Chrome args that select profiles, restore sessions, or open startup pages, iOS, and Safari reject this option because agent-browser cannot install equivalent containment before page scripts run. Include any CDN domains your target pages depend on (e.g., `*.cdn.example.com`).
@@ -880,6 +904,7 @@ Use a credential provider plugin for one login:
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
 agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login --username-selector "#email" --password-selector "#password" --submit-selector "button[type=submit]"
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 ```
 
 Use a browser provider plugin:

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1061,7 +1061,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     Ok(cmd)
                 }
                 Some("login") => {
-                    const AUTH_LOGIN_USAGE: &str = "agent-browser auth login <name> [--credential-provider <plugin>] [--item <ref>] [--url <url>] [--username-selector <s>] [--password-selector <s>] [--submit-selector <s>]";
+                    const AUTH_LOGIN_USAGE: &str = "agent-browser auth login <name> [--no-navigate] [--credential-provider <plugin>] [--item <ref>] [--url <url>] [--username-selector <s>] [--password-selector <s>] [--submit-selector <s>]";
                     let name = rest.get(1).ok_or_else(|| ParseError::MissingArguments {
                         context: "auth login".to_string(),
                         usage: AUTH_LOGIN_USAGE,
@@ -1072,10 +1072,24 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     let mut username_selector: Option<String> = None;
                     let mut password_selector: Option<String> = None;
                     let mut submit_selector: Option<String> = None;
+                    let mut no_navigate = false;
 
                     let mut j = 2;
                     while j < rest.len() {
                         match rest[j] {
+                            "--no-navigate" => {
+                                if rest
+                                    .get(j + 1)
+                                    .is_some_and(|value| !value.starts_with("--"))
+                                {
+                                    return Err(ParseError::InvalidValue {
+                                        message: "--no-navigate does not accept a value"
+                                            .to_string(),
+                                        usage: AUTH_LOGIN_USAGE,
+                                    });
+                                }
+                                no_navigate = true;
+                            }
                             "--credential-provider" => {
                                 let Some(value) = rest.get(j + 1).filter(|v| !v.starts_with("--"))
                                 else {
@@ -1172,6 +1186,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     }
                     if let Some(ss) = submit_selector {
                         cmd["submitSelector"] = json!(ss);
+                    }
+                    if no_navigate {
+                        // Invocation-only behavior. This is intentionally not
+                        // stored in AuthProfile or credential provider data.
+                        cmd["noNavigate"] = json!(true);
                     }
                     Ok(cmd)
                 }
@@ -6149,6 +6168,61 @@ mod tests {
         assert_eq!(cmd["usernameSelector"], "#login_field");
         assert_eq!(cmd["passwordSelector"], "#password");
         assert_eq!(cmd["submitSelector"], "input[type=submit]");
+        assert!(cmd.get("noNavigate").is_none());
+    }
+
+    #[test]
+    fn test_auth_login_no_navigate() {
+        let cmd =
+            parse_command(&args("auth login github --no-navigate"), &default_flags()).unwrap();
+
+        assert_eq!(cmd["action"], "auth_login");
+        assert_eq!(cmd["name"], "github");
+        assert_eq!(cmd["noNavigate"], true);
+        assert!(cmd.get("url").is_none());
+    }
+
+    #[test]
+    fn test_auth_login_no_navigate_with_url() {
+        let cmd = parse_command(
+            &args("auth login github --no-navigate --url https://github.com/login"),
+            &default_flags(),
+        )
+        .unwrap();
+
+        assert_eq!(cmd["action"], "auth_login");
+        assert_eq!(cmd["name"], "github");
+        assert_eq!(cmd["noNavigate"], true);
+        assert_eq!(cmd["url"], "https://github.com/login");
+    }
+
+    #[test]
+    fn test_auth_login_no_navigate_combines_with_provider_and_selectors() {
+        let cmd = parse_command(
+            &args(
+                "auth login work --credential-provider vault --item Work --no-navigate --username-selector #email --password-selector #pass --submit-selector #submit",
+            ),
+            &default_flags(),
+        )
+        .unwrap();
+
+        assert_eq!(cmd["credentialProvider"], "vault");
+        assert_eq!(cmd["credentialItem"], "Work");
+        assert_eq!(cmd["noNavigate"], true);
+        assert_eq!(cmd["usernameSelector"], "#email");
+        assert_eq!(cmd["passwordSelector"], "#pass");
+        assert_eq!(cmd["submitSelector"], "#submit");
+    }
+
+    #[test]
+    fn test_auth_login_no_navigate_rejects_value() {
+        let err = parse_command(
+            &args("auth login github --no-navigate true"),
+            &default_flags(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, ParseError::InvalidValue { .. }));
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1461,7 +1461,14 @@ fn parity_tools() -> Vec<Value> {
             TOOL_AUTH_LOGIN,
             "Auth login",
             "Log in with a saved auth profile.",
-            json!({ "name": { "type": "string" } }),
+            json!({
+                "name": { "type": "string" },
+                "noNavigate": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use the active top-level page without performing the initial login navigation. The credential URL must match the page origin."
+                }
+            }),
             &["name"],
         ),
         tool(
@@ -2275,7 +2282,7 @@ fn call_tool(params: Option<&Value>, config: &McpConfig) -> Result<Value, Protoc
         TOOL_CLIPBOARD_COPY => call_literal(arguments, &["clipboard", "copy"]),
         TOOL_CLIPBOARD_PASTE => call_literal(arguments, &["clipboard", "paste"]),
         TOOL_AUTH_SAVE => call_auth_save(arguments),
-        TOOL_AUTH_LOGIN => call_one_string(arguments, "auth login", "name"),
+        TOOL_AUTH_LOGIN => call_auth_login(arguments),
         TOOL_AUTH_LIST => call_literal(arguments, &["auth", "list"]),
         TOOL_AUTH_SHOW => call_one_string(arguments, "auth show", "name"),
         TOOL_AUTH_DELETE => call_one_string(arguments, "auth delete", "name"),
@@ -3094,6 +3101,19 @@ fn call_auth_save(arguments: &Value) -> Result<Value, ProtocolError> {
     }
     args.push("--password-stdin".to_string());
     call_cli_tool(arguments, args, Some(password))
+}
+
+fn auth_login_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
+    let name = required_string(arguments, "name")?;
+    let mut args = vec!["auth".to_string(), "login".to_string(), name];
+    if optional_bool(arguments, "noNavigate")?.unwrap_or(false) {
+        args.push("--no-navigate".to_string());
+    }
+    Ok(args)
+}
+
+fn call_auth_login(arguments: &Value) -> Result<Value, ProtocolError> {
+    call_cli_tool(arguments, auth_login_args(arguments)?, None)
 }
 
 fn call_state_clear(arguments: &Value) -> Result<Value, ProtocolError> {
@@ -4079,6 +4099,32 @@ mod tests {
             }))
             .unwrap(),
             vec!["webmcp", "result", "invocation-1", "--timeout", "250"]
+        );
+    }
+
+    #[test]
+    fn auth_login_tool_exposes_and_forwards_no_navigate() {
+        let tools = tools();
+        let auth_login = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some(TOOL_AUTH_LOGIN))
+            .unwrap();
+        assert_eq!(
+            auth_login["inputSchema"]["properties"]["noNavigate"]["type"],
+            "boolean"
+        );
+
+        assert_eq!(
+            auth_login_args(&json!({ "name": "work" })).unwrap(),
+            vec!["auth", "login", "work"]
+        );
+        assert_eq!(
+            auth_login_args(&json!({ "name": "work", "noNavigate": false })).unwrap(),
+            vec!["auth", "login", "work"]
+        );
+        assert_eq!(
+            auth_login_args(&json!({ "name": "work", "noNavigate": true })).unwrap(),
+            vec!["auth", "login", "work", "--no-navigate"]
         );
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -63,6 +63,8 @@ const AUTH_LOGIN_SELECTOR_POLL_INTERVAL_MS: u64 = 100;
 /// fallback selectors are allowed.
 const AUTH_LOGIN_PREFERRED_SELECTOR_WINDOW_MS: u64 = 5_000;
 
+const AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR: &str = "auth login --no-navigate requires an existing active HTTP(S) browser page; open the login page first";
+
 pub struct PendingConfirmation {
     pub action: String,
     pub cmd: Value,
@@ -2330,6 +2332,13 @@ fn policy_actions_for_command(
 
 pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    // Unlike normal auth login, no-navigation mode must never launch a
+    // browser or manufacture an about:blank page to satisfy the command.
+    let auth_login_no_navigate = action == "auth_login"
+        && cmd
+            .get("noNavigate")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
     let id = cmd
         .get("id")
         .and_then(|v| v.as_str())
@@ -2447,7 +2456,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let restore_key_change_needs_launch = !skip_launch
         && command_changes_restore_key(cmd, state)
         && has_active_browser_session(state);
-    let needs_launch = if !skip_launch {
+    let needs_launch = if !skip_launch && !auth_login_no_navigate {
         // Check if existing connection is stale and needs re-launch.
         // This must happen before policy evaluation so plugin capability
         // actions are gated when recovery relaunches would invoke plugins.
@@ -2533,11 +2542,20 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         }
     }
 
-    let restore_transition_closed_browser =
-        match apply_restore_config_after_confirmation(cmd, state).await {
-            Ok(closed_browser) => closed_browser,
-            Err(err) => return error_response(&id, &err),
-        };
+    let restore_transition_closed_browser = match async {
+        if auth_login_no_navigate && command_changes_restore_key(cmd, state) {
+            return Err(
+                "auth login --no-navigate cannot switch restore sessions; select the session containing the active login page"
+                    .to_string(),
+            );
+        }
+        apply_restore_config_after_confirmation(cmd, state).await
+    }
+    .await
+    {
+        Ok(closed_browser) => closed_browser,
+        Err(err) => return error_response(&id, &err),
+    };
 
     if !skip_launch {
         if needs_launch {
@@ -2557,12 +2575,14 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             lifecycle_reused = true;
         }
 
-        if let Some(ref mut mgr) = state.browser {
-            if mgr.page_count() == 0 {
-                // ensure_page itself skips creation for a pinned tab_gone
-                // session, so a closed sole tab stays tab_gone instead of
-                // silently recovering onto a fresh blank page.
-                let _ = mgr.ensure_page().await;
+        if !auth_login_no_navigate {
+            if let Some(ref mut mgr) = state.browser {
+                if mgr.page_count() == 0 {
+                    // ensure_page itself skips creation for a pinned tab_gone
+                    // session, so a closed sole tab stays tab_gone instead of
+                    // silently recovering onto a fresh blank page.
+                    let _ = mgr.ensure_page().await;
+                }
             }
         }
     }
@@ -11192,15 +11212,151 @@ async fn handle_auth_save(cmd: &Value) -> Result<Value, String> {
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuthLoginOrigin(String);
+
+#[derive(Debug, Clone)]
+struct AuthLoginBoundPage {
+    target_id: String,
+    session_id: String,
+}
+
+/// Parse a URL into the normalized HTTP(S) origin used to constrain
+/// `auth login --no-navigate`. Paths, queries, and fragments are intentionally
+/// excluded, and URL serialization normalizes explicit default ports.
+fn auth_login_origin(raw_url: &str, label: &str) -> Result<AuthLoginOrigin, String> {
+    let has_unambiguous_authority = raw_url
+        .split_once(':')
+        .map(|(_, rest)| rest)
+        .is_some_and(|rest| rest.starts_with("//") && !rest.starts_with("///"));
+    let parsed = url::Url::parse(raw_url).map_err(|_| {
+        format!(
+            "Invalid {} URL: expected an absolute HTTP(S) URL with a host",
+            label
+        )
+    })?;
+    if !has_unambiguous_authority
+        || !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host_str().is_none()
+    {
+        return Err(format!(
+            "Invalid {} URL: expected an absolute HTTP(S) URL with a host",
+            label
+        ));
+    }
+
+    Ok(AuthLoginOrigin(parsed.origin().ascii_serialization()))
+}
+
+/// Bind no-navigation login to the current top-level page before any external
+/// credential provider is invoked. This rejects missing, blank, opaque, and
+/// otherwise unusable pages without reading a secret unnecessarily.
+async fn bind_auth_login_active_page(state: &DaemonState) -> Result<AuthLoginBoundPage, String> {
+    let mgr = state
+        .browser
+        .as_ref()
+        .ok_or(AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR)?;
+    if mgr.page_count() == 0 {
+        return Err(AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR.to_string());
+    }
+    let target_id = mgr
+        .active_target_id()
+        .map_err(|_| AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR.to_string())?
+        .to_string();
+    let session_id = mgr
+        .active_session_id()
+        .map_err(|_| AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR.to_string())?
+        .to_string();
+    let current_url = mgr
+        .get_url()
+        .await
+        .map_err(|_| AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR.to_string())?;
+    auth_login_origin(&current_url, "current page")
+        .map_err(|_| AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR.to_string())?;
+
+    Ok(AuthLoginBoundPage {
+        target_id,
+        session_id,
+    })
+}
+
+/// Ensure credential-bearing work still targets the page that was active
+/// when no-navigation login began, and that its live document remains on the
+/// expected origin. Diagnostics contain origins only, never URL paths or
+/// credential values.
+async fn validate_auth_login_active_page(
+    mgr: &BrowserManager,
+    bound_page: &AuthLoginBoundPage,
+    expected_origin: &AuthLoginOrigin,
+) -> Result<(), String> {
+    let active_target_id = mgr.active_target_id().map_err(|_| {
+        "Active browser page changed during auth login --no-navigate; retry on the intended login page"
+            .to_string()
+    })?;
+    let active_session_id = mgr.active_session_id().map_err(|_| {
+        "Active browser page changed during auth login --no-navigate; retry on the intended login page"
+            .to_string()
+    })?;
+    if active_target_id != bound_page.target_id || active_session_id != bound_page.session_id {
+        return Err(
+            "Active browser page changed during auth login --no-navigate; retry on the intended login page"
+                .to_string(),
+        );
+    }
+
+    let current_url = mgr.get_url().await.map_err(|_| {
+        "Active browser page changed during auth login --no-navigate; retry on the intended login page"
+            .to_string()
+    })?;
+    let current_origin = auth_login_origin(&current_url, "current page")?;
+    ensure_auth_login_origin_matches(&current_origin, expected_origin)
+}
+
+fn ensure_auth_login_origin_matches(
+    current_origin: &AuthLoginOrigin,
+    expected_origin: &AuthLoginOrigin,
+) -> Result<(), String> {
+    if current_origin == expected_origin {
+        return Ok(());
+    }
+    Err(format!(
+        "Current page origin {} does not match credential origin {}",
+        current_origin.0, expected_origin.0
+    ))
+}
+
 async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let name = cmd
         .get("name")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'name'")?;
-    if state.browser.is_none() {
+    let no_navigate = cmd
+        .get("noNavigate")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let bound_page = if no_navigate {
+        Some(bind_auth_login_active_page(state).await?)
+    } else {
+        None
+    };
+    if !no_navigate && state.browser.is_none() {
         return Err("Browser not launched".to_string());
     }
     let url_override = cmd.get("url").and_then(|v| v.as_str());
+    let override_origin = if no_navigate {
+        url_override
+            .map(|url| auth_login_origin(url, "credential"))
+            .transpose()?
+    } else {
+        None
+    };
+    if let (Some(bound_page), Some(override_origin)) = (&bound_page, &override_origin) {
+        let mgr = state
+            .browser
+            .as_ref()
+            .ok_or(AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR)?;
+        validate_auth_login_active_page(mgr, bound_page, override_origin).await?;
+    }
     let cred = if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
         let command_plugins = cmd
             .get("plugins")
@@ -11254,7 +11410,25 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
 
     let auth_timeout_ms = state.timeout_ms(cmd);
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-    mgr.navigate(&url, AUTH_LOGIN_WAIT_UNTIL).await?;
+    let expected_origin = if no_navigate {
+        let origin = auth_login_origin(&url, "credential")?;
+        validate_auth_login_active_page(
+            mgr,
+            bound_page
+                .as_ref()
+                .expect("no-navigation login must bind an active page"),
+            &origin,
+        )
+        .await?;
+        // Auth login always locates its form in the top-level document. Ignore
+        // a prior `frame` selection for this command without mutating the
+        // caller's persistent frame selection.
+        super::element::set_active_frame(None);
+        Some(origin)
+    } else {
+        mgr.navigate(&url, AUTH_LOGIN_WAIT_UNTIL).await?;
+        None
+    };
 
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -11346,6 +11520,9 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
             }
         }
     };
+    if let (Some(bound_page), Some(expected_origin)) = (&bound_page, &expected_origin) {
+        validate_auth_login_active_page(mgr, bound_page, expected_origin).await?;
+    }
     interaction::fill(
         &mgr.client,
         &session_id,
@@ -11367,6 +11544,9 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
     )
     .await
     .map_err(|_| format!("Timed out waiting for password selector '{}'", pass_sel))?;
+    if let (Some(bound_page), Some(expected_origin)) = (&bound_page, &expected_origin) {
+        validate_auth_login_active_page(mgr, bound_page, expected_origin).await?;
+    }
     interaction::fill(
         &mgr.client,
         &session_id,
@@ -11398,6 +11578,9 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
             )
         })?
     };
+    if let (Some(bound_page), Some(expected_origin)) = (&bound_page, &expected_origin) {
+        validate_auth_login_active_page(mgr, bound_page, expected_origin).await?;
+    }
     interaction::click(
         &mgr.client,
         &session_id,
@@ -13369,6 +13552,50 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{
         let err = handle_auth_login(&cmd, &mut state).await.unwrap_err();
 
         assert_eq!(err, "Browser not launched");
+        assert!(!marker_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_auth_login_no_navigate_rejects_missing_page_before_plugin_resolution() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let marker_path = dir.path().join("credential-plugin-invoked");
+        let plugin_path = dir.path().join("mock-credential-plugin");
+        fs::write(
+            &plugin_path,
+            r#"#!/bin/sh
+printf invoked > "$1"
+cat >/dev/null
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{"username":"user","password":"pass","url":"https://example.com/login"}}'
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&plugin_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&plugin_path, perms).unwrap();
+
+        let mut state = DaemonState::new();
+        let cmd = json!({
+            "id": "auth-plugin-no-page",
+            "action": "auth_login",
+            "name": "example",
+            "noNavigate": true,
+            "credentialProvider": "mock",
+            "plugins": [
+                {
+                    "name": "mock",
+                    "command": plugin_path.to_string_lossy(),
+                    "args": [marker_path.to_string_lossy()],
+                    "capabilities": ["credential.read"]
+                }
+            ]
+        });
+
+        let err = handle_auth_login(&cmd, &mut state).await.unwrap_err();
+
+        assert_eq!(err, AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR);
         assert!(!marker_path.exists());
     }
 
@@ -15451,6 +15678,98 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
             "auth_login should navigate with Load and then wait for form \
              selectors explicitly"
         );
+    }
+
+    #[test]
+    fn test_auth_login_origin_ignores_path_query_and_fragment() {
+        let first = auth_login_origin(
+            "https://example.com/login?credential-path-sentinel#credential-fragment-sentinel",
+            "credential",
+        )
+        .unwrap();
+        let second = auth_login_origin(
+            "https://example.com/consent?current-path-sentinel#current-fragment-sentinel",
+            "current page",
+        )
+        .unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.0, "https://example.com");
+    }
+
+    #[test]
+    fn test_auth_login_origin_normalizes_default_ports() {
+        assert_eq!(
+            auth_login_origin("http://example.com:80/login", "credential").unwrap(),
+            auth_login_origin("http://example.com/flow", "current page").unwrap()
+        );
+        assert_eq!(
+            auth_login_origin("https://example.com:443/login", "credential").unwrap(),
+            auth_login_origin("https://example.com/flow", "current page").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_auth_login_origin_rejects_mismatched_origins() {
+        let expected = auth_login_origin("https://example.com/login", "credential").unwrap();
+        assert_ne!(
+            expected,
+            auth_login_origin("http://example.com/login", "current page").unwrap()
+        );
+        assert_ne!(
+            expected,
+            auth_login_origin("https://id.example.com/login", "current page").unwrap()
+        );
+        assert_ne!(
+            expected,
+            auth_login_origin("https://example.com:8443/login", "current page").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_auth_login_origin_rejects_malformed_opaque_and_non_http_urls() {
+        for value in [
+            "not a url",
+            "about:blank",
+            "data:text/html,login",
+            "file:///tmp/login.html",
+            "https://",
+            "https:///login",
+            "https:example.com/login",
+        ] {
+            let error = auth_login_origin(value, "credential").unwrap_err();
+            assert!(error.contains("absolute HTTP(S) URL with a host"));
+            assert!(!error.contains(value));
+        }
+    }
+
+    #[test]
+    fn test_auth_login_origin_mismatch_error_is_sanitized() {
+        let current = auth_login_origin(
+            "https://login.example.com/current-path-sentinel?current-query-sentinel#current-fragment-sentinel",
+            "current page",
+        )
+        .unwrap();
+        let expected = auth_login_origin(
+            "https://example.com/credential-path-sentinel?credential-query-sentinel#credential-fragment-sentinel",
+            "credential",
+        )
+        .unwrap();
+        let error = ensure_auth_login_origin_matches(&current, &expected).unwrap_err();
+
+        assert_eq!(
+            error,
+            "Current page origin https://login.example.com does not match credential origin https://example.com"
+        );
+        for sentinel in [
+            "current-path-sentinel",
+            "current-query-sentinel",
+            "current-fragment-sentinel",
+            "credential-path-sentinel",
+            "credential-query-sentinel",
+            "credential-fragment-sentinel",
+        ] {
+            assert!(!error.contains(sentinel));
+        }
     }
 
     #[test]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -10,6 +10,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 use futures_util::StreamExt;
 use serde_json::{json, Value};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -5204,6 +5205,400 @@ async fn start_delayed_login_server(
     (base_url, handle)
 }
 
+/// Starts a stateful login page whose form appears only after an in-page
+/// action. The counter covers top-level documents so tests can prove that
+/// no-navigation login did not reload or replace the page.
+async fn start_stateful_auth_login_server(
+) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let base_url = format!("http://127.0.0.1:{}", port);
+    let document_requests = Arc::new(AtomicUsize::new(0));
+    let counter = document_requests.clone();
+
+    let handle = tokio::spawn(async move {
+        for _ in 0..100 {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let counter = counter.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 8192];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                if !path.starts_with("/favicon") {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+
+                let body = r#"<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Stateful Login</title><link rel="icon" href="data:," /></head>
+  <body>
+    <button id="reveal" type="button">Continue to login</button>
+    <form id="login-form" style="display:none">
+      <input type="email" name="email" />
+      <input type="password" name="password" />
+      <button type="submit">Sign in</button>
+    </form>
+    <script>
+      document.getElementById('reveal').addEventListener('click', () => {
+        document.getElementById('login-form').style.display = 'block';
+        window.__revealed = true;
+      });
+      document.getElementById('login-form').addEventListener('submit', (event) => {
+        event.preventDefault();
+        window.__submitted = true;
+      });
+    </script>
+  </body>
+</html>"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    (base_url, document_requests, handle)
+}
+
+fn unique_auth_profile_name(suffix: &str) -> String {
+    format!(
+        "e2e-auth-login-{}-{}",
+        suffix,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_else(|_| std::time::Duration::from_secs(0))
+            .as_nanos()
+    )
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_auth_login_no_navigate_preserves_active_page_state() {
+    let (base_url, document_requests, _server) = start_stateful_auth_login_server().await;
+    let mut state = DaemonState::new();
+    let profile_name = unique_auth_profile_name("no-navigate");
+
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": format!("{}/flow/start?state=ready#login", base_url) }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#reveal" }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "4", "action": "evaluate", "script": "window.__marker = 'preserved'" }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({
+                "id": "5",
+                "action": "auth_save",
+                "name": profile_name.clone(),
+                "url": format!("{}/credentials/login?credential-query-sentinel#credential-fragment-sentinel", base_url),
+                "username": "stateful-user@example.com",
+                "password": "stateful-password-secret",
+            }),
+            &mut state,
+        )
+        .await,
+    );
+    let request_count_before = document_requests.load(Ordering::SeqCst);
+
+    let login = execute_command(
+        &json!({ "id": "6", "action": "auth_login", "name": profile_name.clone(), "noNavigate": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&login);
+    assert_eq!(get_data(&login)["loggedIn"], true);
+    assert_eq!(
+        document_requests.load(Ordering::SeqCst),
+        request_count_before
+    );
+
+    let verify = execute_command(
+        &json!({
+            "id": "7",
+            "action": "evaluate",
+            "script": "({ marker: window.__marker, revealed: !!window.__revealed, submitted: !!window.__submitted, user: document.querySelector('input[type=email]').value, pass: document.querySelector('input[type=password]').value })",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&verify);
+    let result = &get_data(&verify)["result"];
+    assert_eq!(result["marker"], "preserved");
+    assert_eq!(result["revealed"], true);
+    assert_eq!(result["submitted"], true);
+    assert_eq!(result["user"], "stateful-user@example.com");
+    assert_eq!(result["pass"], "stateful-password-secret");
+
+    let _ = execute_command(
+        &json!({ "id": "8", "action": "auth_delete", "name": profile_name }),
+        &mut state,
+    )
+    .await;
+    assert_success(&execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore]
+async fn e2e_auth_login_no_navigate_preserves_state_with_credential_provider() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (base_url, document_requests, _server) = start_stateful_auth_login_server().await;
+    let plugin_dir = tempfile::tempdir().unwrap();
+    let plugin_path = plugin_dir.path().join("stateful-credential-provider");
+    std::fs::write(
+        &plugin_path,
+        format!(
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{{"protocol":"agent-browser.plugin.v1","success":true,"credential":{{"username":"provider-user@example.com","password":"provider-password-secret","url":"{}/provider/login"}}}}'
+"#,
+            base_url
+        ),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&plugin_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&plugin_path, permissions).unwrap();
+
+    let mut state = DaemonState::new();
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": format!("{}/flow/provider", base_url) }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#reveal" }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "4", "action": "evaluate", "script": "window.__marker = 'provider-preserved'" }),
+            &mut state,
+        )
+        .await,
+    );
+    let request_count_before = document_requests.load(Ordering::SeqCst);
+
+    let login = execute_command(
+        &json!({
+            "id": "5",
+            "action": "auth_login",
+            "name": "provider-stateful-login",
+            "noNavigate": true,
+            "credentialProvider": "mock",
+            "plugins": [{
+                "name": "mock",
+                "command": plugin_path.to_string_lossy(),
+                "capabilities": ["credential.read"]
+            }]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&login);
+    let serialized_login = serde_json::to_string(&login).unwrap();
+    assert!(!serialized_login.contains("provider-user@example.com"));
+    assert!(!serialized_login.contains("provider-password-secret"));
+    assert_eq!(
+        document_requests.load(Ordering::SeqCst),
+        request_count_before
+    );
+
+    let verify = execute_command(
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "({ marker: window.__marker, submitted: !!window.__submitted, user: document.querySelector('input[type=email]').value, pass: document.querySelector('input[type=password]').value })",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&verify);
+    let result = &get_data(&verify)["result"];
+    assert_eq!(result["marker"], "provider-preserved");
+    assert_eq!(result["submitted"], true);
+    assert_eq!(result["user"], "provider-user@example.com");
+    assert_eq!(result["pass"], "provider-password-secret");
+
+    assert_success(&execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_auth_login_rejects_cross_origin_no_navigate() {
+    let (active_origin, _, _active_server) = start_stateful_auth_login_server().await;
+    let (credential_origin, credential_requests, _credential_server) =
+        start_stateful_auth_login_server().await;
+    let mut state = DaemonState::new();
+    let profile_name = unique_auth_profile_name("origin-mismatch");
+
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": format!("{}/flow/current-path-sentinel", active_origin) }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "3", "action": "click", "selector": "#reveal" }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({
+                "id": "4",
+                "action": "auth_save",
+                "name": profile_name.clone(),
+                "url": format!("{}/credential-path-sentinel?credential-query-sentinel#credential-fragment-sentinel", credential_origin),
+                "username": "username-secret-sentinel",
+                "password": "password-secret-sentinel",
+            }),
+            &mut state,
+        )
+        .await,
+    );
+
+    let login = execute_command(
+        &json!({ "id": "5", "action": "auth_login", "name": profile_name.clone(), "noNavigate": true }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(login["success"], false);
+    let error = login["error"].as_str().unwrap_or_default();
+    assert!(error.contains("does not match credential origin"));
+    for sentinel in [
+        "current-path-sentinel",
+        "credential-path-sentinel",
+        "credential-query-sentinel",
+        "credential-fragment-sentinel",
+        "username-secret-sentinel",
+        "password-secret-sentinel",
+    ] {
+        assert!(!error.contains(sentinel));
+    }
+    assert_eq!(credential_requests.load(Ordering::SeqCst), 0);
+
+    let verify = execute_command(
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "({ user: document.querySelector('input[type=email]').value, pass: document.querySelector('input[type=password]').value, submitted: !!window.__submitted })",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&verify);
+    let result = &get_data(&verify)["result"];
+    assert_eq!(result["user"], "");
+    assert_eq!(result["pass"], "");
+    assert_eq!(result["submitted"], false);
+
+    let _ = execute_command(
+        &json!({ "id": "7", "action": "auth_delete", "name": profile_name }),
+        &mut state,
+    )
+    .await;
+    assert_success(&execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_auth_login_no_navigate_requires_usable_active_page() {
+    let mut state = DaemonState::new();
+    let profile_name = unique_auth_profile_name("missing-page");
+
+    assert_success(
+        &execute_command(
+            &json!({
+                "id": "1",
+                "action": "auth_save",
+                "name": profile_name.clone(),
+                "url": "https://example.com/login",
+                "username": "unused-user",
+                "password": "unused-password",
+            }),
+            &mut state,
+        )
+        .await,
+    );
+    let login = execute_command(
+        &json!({ "id": "2", "action": "auth_login", "name": profile_name.clone(), "noNavigate": true }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(login["success"], false);
+    assert!(login["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("requires an existing active HTTP(S) browser page"));
+    assert!(
+        state.browser.is_none(),
+        "no-navigation login must not launch a browser"
+    );
+
+    let _ = execute_command(
+        &json!({ "id": "3", "action": "auth_delete", "name": profile_name }),
+        &mut state,
+    )
+    .await;
+}
+
 #[tokio::test]
 #[ignore]
 async fn e2e_auth_login_waits_for_delayed_spa_form_render() {
@@ -5246,6 +5641,13 @@ async fn e2e_auth_login_waits_for_delayed_spa_form_render() {
     .await;
     assert_success(&login);
     assert_eq!(get_data(&login)["loggedIn"], true);
+
+    let current_url = execute_command(&json!({ "id": "3b", "action": "url" }), &mut state).await;
+    assert_success(&current_url);
+    assert!(get_data(&current_url)["url"]
+        .as_str()
+        .unwrap_or_default()
+        .starts_with(&format!("{}/login", base_url)));
 
     let verify = execute_command(
         &json!({

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2597,16 +2597,19 @@ Save Options:
   --password-selector <s>  Custom CSS selector for password field
   --submit-selector <s>    Custom CSS selector for submit button
 
-Plugin Login Options:
+Login Options:
   --credential-provider <p> Resolve credentials from configured plugin <p>
   --item <ref>              Provider-specific vault item reference
   --url <url>               Login URL override
+  --no-navigate             Use the active top-level page without initial navigation
   --username-selector <s>   Username selector override for this login
   --password-selector <s>   Password selector override for this login
   --submit-selector <s>     Submit selector override for this login
 
 Login behavior:
-  auth login waits for form selectors to appear before filling/clicking.
+  auth login navigates, then waits for form selectors before filling/clicking.
+  --no-navigate preserves the active top-level page and checks its origin
+  against the effective credential URL. Submit-triggered navigation is allowed.
   Selector wait timeout follows the default action timeout.
   Plugin credentials are resolved just-in-time and are not saved locally.
 
@@ -2618,6 +2621,7 @@ Examples:
   echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
   agent-browser auth save github --url https://github.com/login --username user --password pass
   agent-browser auth login github
+  agent-browser auth login github --no-navigate
   agent-browser auth login my-app --credential-provider vault --item "My App"
   agent-browser auth list
   agent-browser auth show github
@@ -3726,6 +3730,8 @@ Batch:
 Auth Vault:
   auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)
   auth login <name>          Login using saved credentials (waits for form fields)
+  auth login <name> --no-navigate
+                             Use active page after verifying credential URL origin
   auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
                              Resolve credentials from a configured plugin
   auth login <name> --username-selector <s> --password-selector <s>

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -338,6 +338,8 @@ See [Debugging](/debugging) for console, error, dialog, trace, highlight, and De
 ```bash
 agent-browser auth save <name> [opts]    # Save auth profile
 agent-browser auth login <name>          # Login using saved credentials
+agent-browser auth login <name> --no-navigate
+                                          # Use active page after origin validation
 agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
                                           # Resolve credentials from plugin
 agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>]
@@ -364,11 +366,22 @@ Save options:
 
 `auth login` navigates with `load` and then waits for the username/password/submit selectors to appear before interacting. This improves reliability on SPA login pages where fields render after initial page load.
 
+Use `--no-navigate` after an in-page click, challenge clearance, consent dismissal, or other stateful setup that must survive credential entry:
+
+```bash
+agent-browser open https://example.com/
+agent-browser click "a[href='/login']"
+agent-browser auth login work --no-navigate
+```
+
+The flag suppresses only the initial auth-login navigation. It requires an existing active top-level HTTP(S) page and compares that page with the effective credential URL by scheme, host, and effective port. Paths, queries, and fragments may differ. Waiting, filling, clicking submit, and any submit-triggered navigation are unchanged. A command-level `--url` overrides profile or provider URL metadata and acts as the expected-origin constraint rather than a navigation destination.
+
 Plugin login options:
 
 - `--credential-provider <plugin>`: resolve credentials from a configured plugin
 - `--item <ref>`: provider-specific vault item reference
 - `--url <url>`: login URL override
+- `--no-navigate`: use the active top-level page after validating it against the effective credential origin
 - `--username-selector <sel>`: selector override for this login
 - `--password-selector <sel>`: selector override for this login
 - `--submit-selector <sel>`: selector override for this login
@@ -388,6 +401,7 @@ echo "pass" | agent-browser auth save github --url https://github.com/login --us
 agent-browser auth login github
 agent-browser plugin add agent-browser-plugin-vault --name vault
 agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 agent-browser --provider cloud-browser open https://example.com
 agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
 agent-browser auth list

--- a/docs/src/app/plugins/page.mdx
+++ b/docs/src/app/plugins/page.mdx
@@ -69,6 +69,7 @@ Then use it through the command path for its capability:
 
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 agent-browser --provider cloud-browser open https://example.com
 agent-browser open https://example.com
 agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"abc","url":"https://example.com"}'
@@ -315,6 +316,12 @@ Use it for one login:
 
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+For a login form reached through stateful in-page setup, add `--no-navigate`. The active top-level page must have the same scheme, host, and effective port as the effective credential URL. Command-level `--url` overrides provider URL metadata and supplies this expected origin without navigating. The provider secret remains outside generated process arguments and normal output:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 ```
 
 For external vaults, prefer calling the vendor CLI from the plugin and relying on its existing local session. Do not pass vault tokens in `agent-browser.json`.

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -55,6 +55,16 @@ agent-browser auth delete github
 
 `auth login` navigates with the `load` lifecycle event and then waits for form selectors to appear before filling/clicking. This makes delayed SPA login pages more reliable while avoiding `networkidle` hangs on pages with long-lived background requests.
 
+If a login form depends on state established by an in-page click, challenge clearance, consent dismissal, or another setup step, use `--no-navigate` to retain the active document:
+
+```bash
+agent-browser open https://example.com/
+agent-browser click "a[href='/login']"
+agent-browser auth login work --no-navigate
+```
+
+No-navigation mode requires an existing active top-level HTTP(S) page. It compares the page origin with the effective credential URL by scheme, host, and effective port before either credential is filled, and rechecks before each credential-bearing fill. Paths, queries, and fragments may differ. The flag suppresses only the initial navigation; selector waits, fills, the submit click, and submit-triggered navigation remain enabled. A command-level `--url` takes precedence over profile or provider URL metadata and becomes the origin constraint.
+
 Custom selectors can be specified if auto-detection fails:
 
 ```bash
@@ -114,6 +124,7 @@ Use the plugin for login:
 
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 ```
 
 Use a plugin as a browser provider:

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -217,6 +217,16 @@ agent-browser auth save my-app --url https://app.example.com/login \
 agent-browser auth login my-app    # fills + clicks, waits for form
 ```
 
+By default, `auth login` navigates to the effective credential URL. If an in-page click, challenge clearance, consent dismissal, or similar setup revealed the login form, preserve that state with `--no-navigate`:
+
+```bash
+agent-browser open https://app.example.com/
+agent-browser click "a[href='/login']"
+agent-browser auth login my-app --no-navigate
+```
+
+This mode requires an active top-level HTTP(S) page and verifies that its scheme, host, and effective port match the effective credential URL. Different paths, queries, and fragments are allowed. It skips only the initial navigation; waiting, filling, submitting, and submit-triggered navigation are unchanged. A command-level `--url` overrides stored or provider URL metadata and acts as the origin constraint.
+
 If credentials live in an external vault, use a configured credential provider plugin instead of putting secrets in the command line:
 
 ```bash
@@ -224,6 +234,7 @@ agent-browser plugin add agent-browser-plugin-vault --name vault
 agent-browser plugin list
 agent-browser auth login my-app --credential-provider vault --item "My App"
 agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login --username-selector "#email" --password-selector "#password"
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 ```
 
 Plugins can also provide browser providers, launch mutators such as stealth setup, and arbitrary namespaced commands:

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -144,6 +144,22 @@ agent-browser wait --load networkidle
 agent-browser get url  # Should be dashboard, not login
 ```
 
+For a form reached through an in-page click, challenge clearance, consent dismissal, or another stateful step, use the auth vault without discarding the prepared document:
+
+```bash
+agent-browser open https://app.example.com/
+agent-browser click "a[href='/login']"
+agent-browser auth login my-app --no-navigate
+```
+
+`--no-navigate` suppresses only the initial navigation that `auth login` normally performs. An existing active top-level HTTP(S) page is required. Before either credential is filled, agent-browser compares the page origin with the effective credential URL using scheme, host, and effective port. Paths, queries, and fragments may differ. Selector waits, credential filling, submit clicking, and submit-triggered navigation remain unchanged.
+
+The command-level `--url` override takes precedence over stored profile or credential-provider URL metadata. In no-navigation mode it is an expected-origin constraint, not a navigation destination. This supports hosted identity-provider flows:
+
+```bash
+agent-browser auth login work --no-navigate --url https://identity.example.com/login
+```
+
 ## Plugins
 
 Use credential provider plugins when credentials live in external vault software. Plugins are configured in `agent-browser.json` and run as external executables over the `agent-browser.plugin.v1` stdio JSON protocol.
@@ -194,6 +210,12 @@ Resolve credentials just-in-time for one login:
 
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
+```
+
+After stateful setup, combine the provider with no-navigation mode. The provider secret remains in memory and does not enter generated process arguments or normal output:
+
+```bash
+agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
 ```
 
 Use a plugin as a browser provider or a generic domain command:

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -302,6 +302,8 @@ EOF
 ```bash
 agent-browser auth save <name> --url <url> --username <user> --password-stdin
 agent-browser auth login <name>          # Login using saved credentials
+agent-browser auth login <name> --no-navigate
+                                          # Use active page after same-origin validation
 agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
 agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>]
 agent-browser auth list                  # List saved auth profiles
@@ -313,6 +315,8 @@ agent-browser plugin show <name>         # Show one configured plugin
 agent-browser plugin run <name> <type> --payload <json>
                                           # Run an arbitrary plugin request
 ```
+
+`auth login` normally navigates to the effective credential URL. `--no-navigate` requires an existing active top-level HTTP(S) page, checks that its scheme, host, and effective port match the effective credential URL, then uses the normal selector waits, fills, and submit click without replacing the document. Paths, queries, and fragments may differ, and submit-triggered navigation remains enabled. Command-level `--url` takes precedence over stored or provider metadata and becomes the expected-origin constraint in this mode.
 
 Credential provider plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol and must declare `credential.read`. Use `--confirm-actions plugin:<name>:credential.read` to require explicit approval before a plugin resolves secrets.
 


### PR DESCRIPTION
## Summary

- Add an opt-in `--no-navigate` mode to `auth login`, with a matching `noNavigate` MCP option, so saved or provider-backed credentials can fill forms reached through stateful in-page flows without replacing the active document.
- Require an existing active top-level HTTP(S) page and bind the login to that page. The mode validates its normalized origin against the effective credential URL and rechecks the active page before credential-bearing interactions, while still allowing form submission to navigate.
- Preserve the existing navigational login behavior by default. In no-navigation mode, a command-level `--url` overrides saved or provider URL metadata and serves as the origin constraint, while provider credentials remain outside generated process arguments and normal output.
- Document the workflow and its security constraints in CLI help, the README, the core skill references, and the application documentation.

Closes #1728