### PR TITLE
[cli] record: capture the current page instead of a fresh context

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4929,10 +4929,12 @@ mod tests {
     #[test]
     fn test_record_start_rejects_unknown_flag() {
         let result = parse_command(&args("record start demo.webm --smooth"), &default_flags());
-        assert!(matches!(
-            result.unwrap_err(),
-            ParseError::InvalidValue { .. }
-        ));
+        match result.unwrap_err() {
+            ParseError::InvalidValue { message, .. } => {
+                assert!(message.contains("--smooth"), "got: {message}");
+            }
+            other => panic!("expected InvalidValue, got {other:?}"),
+        }
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1368,10 +1368,10 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_RECORD_START,
             "Record start",
-            "Start video recording. Captures 30 fps by default; pass fps up to 60 for motion-heavy takes.",
+            "Start video recording of the current active page. Captures 30 fps by default; pass fps up to 60 for motion-heavy takes. Pass url to navigate the active tab there first. Use agent_browser_tab_new beforehand to record in a separate tab.",
             json!({
                 "path": { "type": "string" },
-                "url": { "type": "string" },
+                "url": { "type": "string", "description": "Navigate the active tab to this URL before recording starts." },
                 "fps": {
                     "type": "integer",
                     "minimum": 1,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -18,10 +18,9 @@ use super::browser::{should_track_target, BrowserManager, WaitUntil};
 use super::cdp::chrome::{prepare_nss_home, LaunchOptions};
 use super::cdp::client::CdpClient;
 use super::cdp::types::{
-    AttachToTargetParams, AttachToTargetResult, CdpEvent, CreateTargetResult,
-    DispatchMouseEventParams, ExceptionThrownEvent, GetFullAXTreeResult,
-    JavascriptDialogOpeningEvent, TargetCreatedEvent, TargetDestroyedEvent, TargetInfo,
-    TargetInfoChangedEvent,
+    AttachToTargetParams, AttachToTargetResult, CdpEvent, DispatchMouseEventParams,
+    ExceptionThrownEvent, GetFullAXTreeResult, JavascriptDialogOpeningEvent, TargetCreatedEvent,
+    TargetDestroyedEvent, TargetInfo, TargetInfoChangedEvent,
 };
 use super::cookies;
 use super::diff;
@@ -6969,6 +6968,12 @@ fn recording_fps_from_command(cmd: &Value) -> Result<Option<u32>, String> {
     }
 }
 
+/// Start recording the current active page. The recorder attaches to the
+/// active session as-is: no new browser context, no new tab, and no
+/// navigation unless a URL is given (in which case the active tab navigates
+/// there first). Capture therefore starts on an already-hydrated page instead
+/// of at `load` on a cold navigation. Use `tab new` first to record in a
+/// separate tab.
 async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let path = cmd
         .get("path")
@@ -6980,155 +6985,31 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
 
-    // Validate the rate before spinning up a recording context so a bad value
-    // costs nothing.
+    // Validate the rate before any browser work so a bad value costs nothing.
     let fps = recording_fps_from_command(cmd)?;
 
-    let viewport = state.viewport;
-    let domain_filter = state.domain_filter.read().await.clone();
-    if let Some(url) = recording_url {
-        check_url_allowed_by_filter(domain_filter.as_ref(), url)?;
+    {
+        let domain_filter = state.domain_filter.read().await;
+        if let Some(url) = recording_url {
+            check_url_allowed_by_filter(domain_filter.as_ref(), url)?;
+        }
     }
 
-    let (client, new_session_id, nav_url) = {
+    if state.recording_state.active {
+        return Err("Recording already active".to_string());
+    }
+
+    let (client, session_id) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-        let old_session_id = mgr.active_session_id()?.to_string();
-
-        // Capture current URL if no URL specified
-        let nav_url = if let Some(u) = recording_url {
-            u.to_string()
-        } else {
-            mgr.get_url()
-                .await
-                .unwrap_or_else(|_| "about:blank".to_string())
-        };
-        check_url_allowed_by_filter(domain_filter.as_ref(), &nav_url)?;
-
-        // Capture current cookies
-        let cookies_result = mgr
-            .client
-            .send_command_no_params("Network.getAllCookies", Some(&old_session_id))
-            .await
-            .ok();
-
-        // Create new browser context
-        let ctx_result = mgr
-            .client
-            .send_command_no_params("Target.createBrowserContext", None)
-            .await?;
-        let context_id = ctx_result
-            .get("browserContextId")
-            .and_then(|v| v.as_str())
-            .ok_or("Failed to get browserContextId")?
-            .to_string();
-
-        // Create page in new context
-        let create_result: CreateTargetResult = mgr
-            .client
-            .send_command_typed(
-                "Target.createTarget",
-                &json!({ "url": "about:blank", "browserContextId": context_id }),
-                None,
-            )
-            .await?;
-
-        let attach_result: AttachToTargetResult = mgr
-            .client
-            .send_command_typed(
-                "Target.attachToTarget",
-                &AttachToTargetParams {
-                    target_id: create_result.target_id.clone(),
-                    flatten: true,
-                },
-                None,
-            )
-            .await?;
-
-        let new_session_id = attach_result.session_id.clone();
-        mgr.prepare_domains_pub(&new_session_id).await?;
-
-        // Re-apply download behavior to the recording context.
-        // Without this, downloads in the recording context are silently dropped
-        // because Browser.setDownloadBehavior at launch only applies to the default context.
-        if let Some(ref dl_path) = mgr.download_path {
-            let _ = mgr
-                .client
-                .send_command(
-                    "Browser.setDownloadBehavior",
-                    Some(json!({
-                        "behavior": "allow",
-                        "downloadPath": dl_path,
-                        "browserContextId": context_id,
-                        "eventsEnabled": true
-                    })),
-                    None,
-                )
-                .await;
+        if let Some(url) = recording_url {
+            mgr.navigate(url, WaitUntil::Load).await?;
         }
-
-        // Re-apply HTTPS error ignore to the recording context.
-        // Security.setIgnoreCertificateErrors at launch only applies to the session it was sent on.
-        if mgr.ignore_https_errors {
-            let _ = mgr
-                .client
-                .send_command(
-                    "Security.setIgnoreCertificateErrors",
-                    Some(json!({ "ignore": true })),
-                    Some(&new_session_id),
-                )
-                .await;
-        }
-
-        // Transfer cookies to new context
-        if let Some(ref cr) = cookies_result {
-            if let Some(cookie_arr) = cr.get("cookies").and_then(|v| v.as_array()) {
-                if !cookie_arr.is_empty() {
-                    let _ = mgr
-                        .client
-                        .send_command(
-                            "Network.setCookies",
-                            Some(json!({ "cookies": cookie_arr })),
-                            Some(&new_session_id),
-                        )
-                        .await;
-                }
-            }
-        }
-
-        // Add page and switch to it
-        let tab_id = mgr.assign_tab_id();
-        mgr.add_page(super::browser::PageInfo {
-            tab_id,
-            label: None,
-            target_id: create_result.target_id,
-            session_id: new_session_id.clone(),
-            url: "about:blank".to_string(),
-            title: String::new(),
-            target_type: "page".to_string(),
-        });
-
-        (mgr.client.clone(), new_session_id, nav_url)
+        let session_id = mgr.active_session_id()?.to_string();
+        (mgr.client.clone(), session_id)
     };
 
-    let has_proxy_creds = state.proxy_credentials.read().await.is_some();
-    install_network_controls_or_resume_prepared_session(state, has_proxy_creds, &new_session_id)
-        .await?;
-    state.drain_cdp_events_background().await?;
-
-    {
-        let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-        if let Some((w, h, scale, mobile)) = viewport {
-            let _ = mgr.set_viewport(w, h, scale, mobile).await;
-        }
-
-        // Navigate only after domain filtering and WebRTC containment are active.
-        if nav_url != "about:blank" {
-            mgr.navigate(&nav_url, WaitUntil::Load).await?;
-        }
-    }
-
     let result = recording::recording_start(&mut state.recording_state, path, fps)?;
-    state.start_recording_task(client, new_session_id).await?;
+    state.start_recording_task(client, session_id).await?;
 
     if let Some(ref server) = state.stream_server {
         server.set_recording(true, &state.engine).await;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4843,38 +4843,16 @@ async fn handle_navigate(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         }
     }
 
-    if let Some(session_id) = state
-        .browser
-        .as_ref()
-        .and_then(|browser| browser.active_session_id().ok())
-        .map(ToString::to_string)
-    {
-        state.webmcp.clear_page_scope(&session_id);
-    } else {
-        state.webmcp.clear_invocations();
-    }
-    let _ = enable_webmcp_events(state).await;
-
     // WebDriver backend path
     if let Some(ref wb) = state.webdriver_backend {
         if state.browser.is_none() {
+            state.webmcp.clear_invocations();
             state.ref_map.clear();
             wb.navigate(url).await?;
             let new_url = wb.get_url().await.unwrap_or_else(|_| url.to_string());
             let title = wb.get_title().await.unwrap_or_default();
             return Ok(json!({ "url": new_url, "title": title }));
         }
-    }
-
-    // With one tab, every tracked iframe belongs to the page being replaced.
-    // With multiple tabs, retain the other tabs' sessions so switching back to
-    // an already-attached OOPIF does not lose its execution context.
-    let has_background_tabs = state
-        .browser
-        .as_ref()
-        .is_some_and(|browser| browser.page_count() > 1);
-    if !has_background_tabs {
-        state.iframe_sessions.clear();
     }
 
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
@@ -4927,9 +4905,45 @@ async fn handle_navigate(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         }
     }
 
+    navigate_active_page(state, url, wait_until).await
+}
+
+/// Navigate the active page and drop the state that belonged to the document
+/// being replaced: element refs, frame scope, and WebMCP page state. Every
+/// command that replaces the active document must go through here, or a
+/// stale `@e3` from the previous page keeps resolving.
+async fn navigate_active_page(
+    state: &mut DaemonState,
+    url: &str,
+    wait_until: WaitUntil,
+) -> Result<Value, String> {
+    if let Some(session_id) = state
+        .browser
+        .as_ref()
+        .and_then(|browser| browser.active_session_id().ok())
+        .map(ToString::to_string)
+    {
+        state.webmcp.clear_page_scope(&session_id);
+    } else {
+        state.webmcp.clear_invocations();
+    }
+    let _ = enable_webmcp_events(state).await;
+
+    // With one tab, every tracked iframe belongs to the page being replaced.
+    // With multiple tabs, retain the other tabs' sessions so switching back to
+    // an already-attached OOPIF does not lose its execution context.
+    let has_background_tabs = state
+        .browser
+        .as_ref()
+        .is_some_and(|browser| browser.page_count() > 1);
+    if !has_background_tabs {
+        state.iframe_sessions.clear();
+    }
+
     state.ref_map.clear();
     state.active_iframe_sessions.clear();
     state.active_frame_id = None;
+    let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     let result = mgr.navigate(url, wait_until).await?;
     state.refresh_active_iframe_sessions().await;
     Ok(result)
@@ -6999,13 +7013,12 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         return Err("Recording already active".to_string());
     }
 
+    if let Some(url) = recording_url {
+        navigate_active_page(state, url, WaitUntil::Load).await?;
+    }
     let (client, session_id) = {
-        let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-        if let Some(url) = recording_url {
-            mgr.navigate(url, WaitUntil::Load).await?;
-        }
-        let session_id = mgr.active_session_id()?.to_string();
-        (mgr.client.clone(), session_id)
+        let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+        (mgr.client.clone(), mgr.active_session_id()?.to_string())
     };
 
     let result = recording::recording_start(&mut state.recording_state, path, fps)?;
@@ -7062,12 +7075,15 @@ async fn handle_recording_restart(cmd: &Value, state: &mut DaemonState) -> Resul
         None
     };
 
-    let recording_target = if let Some(ref mut browser) = state.browser {
-        if let Some(url) = recording_url {
-            browser.navigate(&url, WaitUntil::Load).await?;
+    let recording_target = if state.browser.is_some() {
+        if let Some(ref url) = recording_url {
+            navigate_active_page(state, url, WaitUntil::Load).await?;
         }
-        let session_id = browser.active_session_id()?.to_string();
-        Some((browser.client.clone(), session_id))
+        let browser = state.browser.as_ref().ok_or("Browser not launched")?;
+        Some((
+            browser.client.clone(),
+            browser.active_session_id()?.to_string(),
+        ))
     } else {
         None
     };

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7280,11 +7280,24 @@ async fn e2e_recording_default_with_url_navigates_active_tab() {
     assert_success(&resp);
 
     let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Before</h1>" }),
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": "data:text/html,<button id='before'>Before</button>"
+        }),
         &mut state,
     )
     .await;
     assert_success(&resp);
+
+    // Refs from the page being replaced must not survive the navigation.
+    let resp = execute_command(
+        &json!({ "id": "2b", "action": "snapshot", "selector": "#before" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(state.ref_map.get("e1").is_some());
 
     let target_url = "data:text/html,<h1>Recorded</h1>";
     let tmp_dir = std::env::temp_dir();
@@ -7300,6 +7313,10 @@ async fn e2e_recording_default_with_url_navigates_active_tab() {
     )
     .await;
     assert_success(&resp);
+    assert!(
+        state.ref_map.entries_sorted().is_empty(),
+        "record start <url> must clear refs like navigate does"
+    );
 
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7157,15 +7157,15 @@ async fn e2e_upload_with_css_selector() {
 }
 
 // ---------------------------------------------------------------------------
-// Recording: viewport inheritance
+// Recording: default records the current active page
 // ---------------------------------------------------------------------------
 
-/// Verify that `recording_start` inherits the current viewport dimensions
-/// into the newly created recording context. Without this, the recording
-/// context falls back to the default 1280×720 regardless of what the user set.
+/// `recording_start` attaches the recorder to the active page
+/// as-is: no new browser context, no new tab, no navigation. Page state set
+/// before `record start` must survive, and the viewport must be untouched.
 #[tokio::test]
 #[ignore]
-async fn e2e_recording_inherits_viewport() {
+async fn e2e_recording_default_records_active_page() {
     let mut state = DaemonState::new();
 
     let resp = execute_command(
@@ -7175,8 +7175,9 @@ async fn e2e_recording_inherits_viewport() {
     .await;
     assert_success(&resp);
 
+    let page_url = "data:text/html,<h1>Current</h1>";
     let resp = execute_command(
-        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Viewport</h1>" }),
+        &json!({ "id": "2", "action": "navigate", "url": page_url }),
         &mut state,
     )
     .await;
@@ -7189,10 +7190,112 @@ async fn e2e_recording_inherits_viewport() {
     .await;
     assert_success(&resp);
 
-    let tmp_dir = std::env::temp_dir();
-    let rec_path = tmp_dir.join(format!("ab-e2e-rec-viewport-{}.webm", std::process::id()));
+    // In-memory page state: a cold navigation or a new page would lose this.
     let resp = execute_command(
-        &json!({ "id": "4", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &json!({ "id": "4", "action": "evaluate", "script": "window.__abMarker = 42; window.__abMarker" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], 42);
+
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-current-{}.webm", std::process::id()));
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(700)).await;
+
+    // Still exactly one tab: no recording tab was added.
+    let resp = execute_command(&json!({ "id": "6", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert_eq!(
+        tabs.len(),
+        1,
+        "default record start must not open a new tab, got {tabs:?}"
+    );
+
+    // Same page, same JS heap: the marker survived and the URL is unchanged.
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "evaluate", "script": "window.__abMarker" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        42,
+        "default record start must not navigate or replace the page"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "evaluate", "script": "location.href" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], page_url);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "evaluate", "script": "[window.innerWidth, window.innerHeight]" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], json!([800, 600]));
+
+    let resp = execute_command(
+        &json!({ "id": "10", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(
+        get_data(&resp)["frames"].as_u64().unwrap_or(0) > 0,
+        "recorder attached to the active page should have captured frames"
+    );
+
+    let _ = std::fs::remove_file(&rec_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// `recording_start` with a URL navigates the active
+/// tab to that URL before recording. No new tab is created.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_default_with_url_navigates_active_tab() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Before</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let target_url = "data:text/html,<h1>Recorded</h1>";
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-url-{}.webm", std::process::id()));
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "recording_start",
+            "path": rec_path.to_string_lossy(),
+            "url": target_url
+        }),
         &mut state,
     )
     .await;
@@ -7200,33 +7303,25 @@ async fn e2e_recording_inherits_viewport() {
 
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert_eq!(
+        tabs.len(),
+        1,
+        "record start <url> must reuse the active tab"
+    );
+
     let resp = execute_command(
-        &json!({ "id": "5", "action": "evaluate", "script": "window.innerWidth" }),
+        &json!({ "id": "5", "action": "evaluate", "script": "location.href" }),
         &mut state,
     )
     .await;
     assert_success(&resp);
-    let rec_width = get_data(&resp)["result"].as_i64().unwrap();
+    assert_eq!(get_data(&resp)["result"], target_url);
 
     let resp = execute_command(
-        &json!({ "id": "6", "action": "evaluate", "script": "window.innerHeight" }),
-        &mut state,
-    )
-    .await;
-    assert_success(&resp);
-    let rec_height = get_data(&resp)["result"].as_i64().unwrap();
-
-    assert_eq!(
-        rec_width, 800,
-        "Recording context width should be 800 (inherited from viewport), got {rec_width}"
-    );
-    assert_eq!(
-        rec_height, 600,
-        "Recording context height should be 600 (inherited from viewport), got {rec_height}"
-    );
-
-    let resp = execute_command(
-        &json!({ "id": "7", "action": "recording_stop" }),
+        &json!({ "id": "6", "action": "recording_stop" }),
         &mut state,
     )
     .await;
@@ -7283,14 +7378,11 @@ async fn e2e_recording_honors_requested_fps() {
     assert_eq!(get_data(&resp)["fps"].as_u64(), Some(FPS));
 
     // The recorder screencasts on its own CDP session attached to the
-    // recording page. That attachment must not surface as a tab.
+    // active page. That attachment must not surface as a tab.
     let resp = execute_command(&json!({ "id": "3b", "action": "tab_list" }), &mut state).await;
     assert_success(&resp);
     let tabs = get_data(&resp)["tabs"].as_array().unwrap().len();
-    assert_eq!(
-        tabs, 2,
-        "original page plus the recording page, nothing else"
-    );
+    assert_eq!(tabs, 1, "the recorded page only, nothing else");
 
     tokio::time::sleep(tokio::time::Duration::from_millis(RECORD_MS)).await;
 
@@ -7326,7 +7418,7 @@ async fn e2e_recording_honors_requested_fps() {
 }
 
 /// Verify that an out-of-range frame rate is rejected before the recorder
-/// builds its context, leaving no file and no active recording behind.
+/// attaches to the page, leaving no file and no active recording behind.
 #[tokio::test]
 #[ignore]
 async fn e2e_recording_rejects_invalid_fps() {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2774,15 +2774,18 @@ Usage: agent-browser record start <path.webm> [url] [--fps <n>]
        agent-browser record restart <path.webm> [url] [--fps <n>]
 
 Record the browser to a WebM video file.
-Creates a fresh browser context but preserves cookies and localStorage.
-If no URL is provided, automatically navigates to your current page.
+Records the current active page as-is: no new context, no new tab, and no
+navigation unless you pass a URL. Capture starts on the page you already
+have open, so hydration and initial animations are not re-run cold.
+If a URL is provided, the active tab navigates there first.
+To record in a separate tab, run `tab new [url]` before `record start`.
 
 Recording captures 30 fps, which keeps scrolls and CSS transitions smooth.
 Raise it to 60 for short, motion-heavy takes (drag interactions, animation
 work); lower it for long sessions where file size matters more than motion.
 
 Operations:
-  start <path> [url]     Start recording (defaults to current URL if omitted)
+  start <path> [url]     Start recording the active page (navigates first if url given)
   stop                   Stop recording and save video
   restart <path> [url]   Stop current recording (if any) and start a new one
 
@@ -2794,15 +2797,19 @@ Global Options:
   --session <name>     Use specific session
 
 Examples:
-  # Record from current page (preserves login state)
+  # Record the page you are on (keeps login state and page state)
   agent-browser open https://app.example.com/dashboard
   agent-browser snapshot -i            # Explore and plan
   agent-browser record start ./demo.webm
   agent-browser click @e3              # Execute planned actions
   agent-browser record stop
 
-  # Or specify a different URL
+  # Navigate the active tab, then record
   agent-browser record start ./demo.webm https://example.com
+
+  # Record in a separate tab
+  agent-browser tab new https://example.com
+  agent-browser record start ./demo.webm
 
   # 60 fps for a scroll or animation capture
   agent-browser record start ./scroll.webm --fps 60

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -319,7 +319,7 @@ agent-browser trace start             # Start trace
 agent-browser trace stop [path]       # Stop and save trace
 agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
-agent-browser record start <path>     # Start video recording (WebM, 30 fps)
+agent-browser record start <path>     # Start video recording of the current page (WebM, 30 fps)
 agent-browser record start <path> --fps 60  # Record at 60 fps (--fps accepts 1-60)
 agent-browser record stop             # Stop and save video
 agent-browser record restart <path>   # Stop current and start new recording

--- a/docs/src/app/recording/page.mdx
+++ b/docs/src/app/recording/page.mdx
@@ -20,7 +20,14 @@ agent-browser open
 agent-browser record start ./demo.webm https://example.com
 ```
 
-If no URL is provided, recording starts from the current page. The recording context copies cookies from the active session.
+`record start` records the current active page as-is. With no URL, nothing is navigated or replaced: the recorder attaches to the tab you already have open, so capture begins on a hydrated page rather than at `load` on a cold navigation. With a URL, the active tab navigates there first and recording starts once the page has loaded. No extra tab or browser context is created.
+
+To record in a separate tab, open one first:
+
+```bash
+agent-browser tab new https://example.com
+agent-browser record start ./demo.webm
+```
 
 ## Frame rate
 
@@ -56,9 +63,9 @@ Valid rates are 1 to 60. Frames come from Chrome's screencast, so every repaint 
     <tr><th>Command</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>record start &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Start recording to a WebM file</td></tr>
+    <tr><td><code>record start &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Start recording the active page to a WebM file; a URL navigates the active tab first</td></tr>
     <tr><td><code>record stop</code></td><td>Stop the active recording and save the file</td></tr>
-    <tr><td><code>record restart &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Stop the current recording and immediately start another</td></tr>
+    <tr><td><code>record restart &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Stop the current recording and immediately start another on the active page</td></tr>
   </tbody>
 </table>
 
@@ -112,7 +119,7 @@ Screenshots and videos work well together: screenshots capture precise still sta
     <tr><td>Common extension</td><td><code>.webm</code></td></tr>
     <tr><td>Frame rate</td><td>30 fps by default, 1 to 60 with <code>--fps</code></td></tr>
     <tr><td>Viewport</td><td>Uses the active browser viewport settings</td></tr>
-    <tr><td>State</td><td>Copies cookies from the active session</td></tr>
+    <tr><td>State</td><td>Records the active page in place, including its session and in-page state</td></tr>
   </tbody>
 </table>
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -338,13 +338,13 @@ agent-browser network har stop /tmp/trace.har
 
 ```bash
 agent-browser open https://example.com
-agent-browser record start demo.webm          # 30 fps by default
+agent-browser record start demo.webm          # records the current page in place, 30 fps
 agent-browser snapshot -i
 agent-browser click @e3
 agent-browser record stop
 ```
 
-Pass `--fps 60` for motion-heavy takes (drag, animation, scroll work) or a lower rate for long sessions; `--fps` accepts 1 to 60.
+`record start` attaches to the active tab as-is (no new context, no navigation unless you pass a URL). To record in a separate tab, run `tab new <url>` first. Pass `--fps 60` for motion-heavy takes (drag, animation, scroll work) or a lower rate for long sessions; `--fps` accepts 1 to 60.
 
 See [references/video-recording.md](references/video-recording.md) for frame rate guidance, codec options, and more.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -114,13 +114,14 @@ Headless Chromium screenshots hide native scrollbars for consistent image output
 
 ```bash
 agent-browser open https://example.com     # Launch a browser session first
-agent-browser record start ./demo.webm    # Start recording at 30 fps
+agent-browser record start ./demo.webm    # Start recording the current page at 30 fps
 agent-browser click @e1                   # Perform actions
 agent-browser record stop                 # Stop and save video
 agent-browser record restart ./take2.webm # Stop current + start new
 
 agent-browser record start ./scroll.webm --fps 60  # 60 fps for motion-heavy takes
 agent-browser record start ./soak.webm --fps 10    # Lower rate for long sessions
+agent-browser tab new https://example.com          # Open a separate tab first if you want the recording there
 ```
 
 `--fps` accepts 1 to 60 and defaults to 30. Playback duration always matches the wall clock time recorded, so a slow page holds frames instead of speeding the video up.

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -16,6 +16,8 @@ Capture browser automation as video for debugging, documentation, or verificatio
 
 ## Basic Recording
 
+`record start` records the current active page as-is. Without a URL it attaches to the tab you already have open (no navigation, no new tab, page state and hydration intact). With a URL it navigates the active tab there first.
+
 ```bash
 # Launch the browser, then start recording
 agent-browser open https://example.com
@@ -47,6 +49,13 @@ agent-browser record stop
 
 # Restart with new file (stops current + starts new)
 agent-browser record restart ./take2.webm --fps 60
+
+# Navigate the active tab, then record
+agent-browser record start ./output.webm https://example.com/checkout
+
+# Record in a separate tab: open it first, then start recording
+agent-browser tab new https://example.com
+agent-browser record start ./output.webm
 ```
 
 ## Frame Rate


### PR DESCRIPTION
`record start` now records the page you already have open instead of creating a fresh browser context, a new tab, and a cold navigation. The fresh-context flow is removed; `tab new` followed by `record start` covers the isolation case.

Same session, same steps (`open https://vercel.com/oss/deepsec`, `wait --load networkidle`, `record start /tmp/out.webm --fps 60`, `tab list`), release builds, headless:

```
# main @ 4a98df7            record start: 0.835 s
  [t1] deepsec: Full-Repository Security Review - Vercel - https://vercel.com/oss/deepsec
→ [t2] deepsec: Full-Repository Security Review - Vercel - https://vercel.com/oss/deepsec

# this branch @ d624811     record start: 0.012 s
→ [t1] deepsec: Full-Repository Security Review - Vercel - https://vercel.com/oss/deepsec
```

A `window.__marker` set before `record start` reads back as `null` on main (the recorder attached to a new page) and `"still here"` on this branch.

## Details

**Design.** `handle_recording_start` used to build a new browser context, copy cookies into it via `Network.getAllCookies`/`setCookies`, re-apply download behaviour, HTTPS error handling, network controls and viewport, add the page as a tab, navigate it cold, and only then attach the recorder. That existed because Playwright's `recordVideo` was a context-creation option. The recorder (`start_recording_task(client, session_id)`) doesn't care which page it attaches to, so the handler now resolves the active session and attaches there. With a URL, the active tab navigates to it first (domain filter checked up front as before, `WaitUntil::Load` as before). With no URL, nothing is navigated or replaced. `record restart` already worked this way, so `start` and `restart` are now consistent.

**Behavioural differences to weigh.**
- Isolation: the recording shares the active tab's context and in-memory state. Whatever is already on the page (dialogs, scroll position, JS state) is what gets recorded. `tab new [url]` then `record start` replaces the old isolation behaviour.
- Tab list: no extra tab appears during a recording.
- Cookie copying into a separate context is gone; there is no separate context to copy into. The recording-context-handoff work (inheriting download path, HTTPS errors, network controls and viewport into the recording context) has nothing left to apply to.
- `record start` while a recording is active now errors before any navigation; previously it created the context and tab first and then failed.
- `record start <url>` navigates your current tab, which replaces whatever it was showing.

**Measurement notes.** The visible win in headless is the extra tab and the start latency, not the video itself. Recording the deepsec hero from both binaries and comparing the first 30 frames (320 px gray, mean absolute difference per transition): both clips open on the fully painted hero and show the same scroll jump at frame 3 (9.24 on main, 9.37 here); the only difference is the phase of the hero's sweep animation, which loops. Main's cold load finishes inside the 0.8 s before `record start` returns, so the recorder never sees it. An earlier frame-by-frame pass on the same recorder showed the same: on main, 3 identical frames right after the cold load (about 50 ms held); here, 0 identical frames. So no before/after video is attached; the two clips are not distinguishable by eye.

**Related.** Rebased onto #1763 (30 fps default, `--fps` up to 60, `Page.startScreencast` on a dedicated session); all of that is kept, and `recording_fps_from_command` still runs before any browser work. #1763's fps e2e test asserted two tabs during a recording (page plus recording page); it now asserts one. Unknown `--flags` and a third positional on `record start` were already rejected on `main`; this branch only tightens that test's assertion to check the flag name.

**Pre-existing, not from this change.** `record stop` immediately after `record start <url>` fails with `ffmpeg failed: ...` on both `main` and this branch (too few captured frames), and the error text is truncated to ffmpeg's version banner so the real reason is hidden. With a 1 s wait between them it succeeds. Worth a follow-up.

**Verified.** In `cli/` on d624811: `cargo fmt --check` clean; `cargo clippy -- -D warnings` clean; `cargo test` 1232 passed, 0 failed, 110 ignored (4 of 5 runs; 1 run had a single unrelated failure that did not reproduce); `cargo test e2e_recording -- --ignored --test-threads=1` 4 passed (`e2e_recording_default_records_active_page`, which also covers the viewport assertion from the removed `e2e_recording_inherits_viewport`, `e2e_recording_default_with_url_navigates_active_tab`, `e2e_recording_honors_requested_fps`, `e2e_recording_rejects_invalid_fps`). Manual, release builds of 4a98df7 and d624811 against unique `--session` names, closed afterwards: the sequence above, plus `record start out.webm https://vercel.com/oss/swr` then `get url` returning `https://vercel.com/oss/swr` on both, `record start x.webm --fresh` returning `Unknown flag for record start: --fresh` on both, and `record stop --json` after a 1.5 s recording returning `frames: 93, capturedFrames: 92, fps: 60` here versus `frames: 93, capturedFrames: 93` on main.
