### PR TITLE
[cli] New tabs inherit the session's setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ agent-browser set credentials <u> <p> # HTTP basic auth
 agent-browser set media [dark|light]  # Emulate color scheme
 ```
 
+`set offline off` and `set headers '{}'` restore the default setup for tabs opened later.
+
 ### Cookies & Storage
 
 ```bash
@@ -368,6 +370,8 @@ agent-browser snapshot               # populate refs for docs
 agent-browser click @e3              # click uses docs's refs
 agent-browser tab close docs         # close by label
 ```
+
+Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, init scripts, routes, and emulation overrides before their first document loads.
 
 `tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts, so they're the right handle for scripts coordinating multiple sessions on one browser.
 

--- a/README.md
+++ b/README.md
@@ -305,11 +305,11 @@ agent-browser set device <name>       # Emulate device ("iPhone 14")
 agent-browser set geo <lat> <lng>     # Set geolocation
 agent-browser set offline [on|off]    # Toggle offline mode
 agent-browser set headers <json>      # Extra HTTP headers
-agent-browser set credentials <u> <p> # HTTP basic auth
+agent-browser set credentials <u> <p> # HTTP basic auth for current and future tabs
 agent-browser set media [dark|light]  # Emulate color scheme
 ```
 
-`set offline off` and `set headers '{}'` restore the default setup for tabs opened later.
+`set credentials` applies HTTP Basic Authentication to the current tab and tabs opened later. `set offline off` and `set headers '{}'` restore the default setup for future tabs.
 
 ### Cookies & Storage
 
@@ -371,7 +371,7 @@ agent-browser click @e3              # click uses docs's refs
 agent-browser tab close docs         # close by label
 ```
 
-Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, init scripts, routes, and emulation overrides before their first document loads.
+Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, HTTP credentials, init scripts, routes, and emulation overrides before their first document loads.
 
 `tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts, so they're the right handle for scripts coordinating multiple sessions on one browser.
 

--- a/README.md
+++ b/README.md
@@ -519,8 +519,10 @@ axe-core: 4.12.1  violations: 2  incomplete: 0  passes: 24
 agent-browser open --init-script <path>           # Register page init script before first navigation
                                                   # (repeatable; also AGENT_BROWSER_INIT_SCRIPTS env)
 agent-browser addinitscript <js>                  # Register at runtime (returns identifier)
-agent-browser removeinitscript <identifier>       # Remove a previously registered init script
+agent-browser removeinitscript <identifier>       # Remove from every tab in the session
 ```
+
+Runtime init-script identifiers are session-wide. `removeinitscript` removes the script from every open tab where it was registered and prevents it from being replayed into tabs opened later.
 
 ### Setup
 

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1171,7 +1171,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_SET_CREDENTIALS,
             "Set credentials",
-            "Set HTTP credentials.",
+            "Set HTTP credentials for the current tab and tabs opened later.",
             json!({ "username": { "type": "string" }, "password": { "type": "string" } }),
             &["username", "password"],
         ),

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -850,7 +850,7 @@ fn tools() -> Vec<Value> {
             "Click an element by @ref or CSS selector.",
             json!({
                 "selector": selector_schema(),
-                "newTab": { "type": "boolean", "default": false, "description": "Open link targets in a new tab." }
+                "newTab": { "type": "boolean", "default": false, "description": "Open link targets in a new tab after applying session setup." }
             }),
             &["selector"],
         ),

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1276,7 +1276,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_TAB_NEW,
             "Tab new",
-            "Open a new tab.",
+            "Open a new tab after applying session setup before its first navigation.",
             json!({ "url": { "type": "string" }, "label": { "type": "string" } }),
             &[],
         ),
@@ -1665,7 +1665,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_REMOVE_INIT_SCRIPT,
             "Remove init script",
-            "Remove a registered init script.",
+            "Remove a registered init script from every tab in the session.",
             json!({ "id": { "type": "string" } }),
             &["id"],
         ),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -414,6 +414,70 @@ fn apply_effective_ca_cert(
     options.ca_cert_digest = effective_ca_cert.as_ref().map(|ca| *ca.bundle.digest());
 }
 
+/// Arguments of the last `Emulation.setEmulatedMedia` call, kept so the same
+/// emulation can be replayed onto a new page session.
+#[derive(Debug, Clone)]
+pub struct EmulatedMedia {
+    pub media: Option<String>,
+    /// `(name, value)` media features, e.g. `("prefers-color-scheme", "dark")`.
+    pub features: Vec<(String, String)>,
+}
+
+/// Page-level setup the daemon has applied to the active page session.
+///
+/// CDP scopes all of these to a single target session, so a tab the daemon
+/// creates itself starts without them. This record lets
+/// [`apply_session_setup`] replay them onto the new tab before its first
+/// navigation. Reset whenever a browser is (re)launched. Permissions are not
+/// tracked: `Browser.grantPermissions` is context-scoped and already covers
+/// new tabs in the default context.
+#[derive(Debug, Default, Clone)]
+pub struct SessionSetup {
+    /// `--user-agent`, `useragent`, or the UA half of `device`.
+    pub user_agent: Option<String>,
+    /// Last `Emulation.setEmulatedMedia` call: `--color-scheme` at launch or
+    /// `set_media` / `emulatemedia`.
+    pub emulated_media: Option<EmulatedMedia>,
+    pub timezone: Option<String>,
+    pub locale: Option<String>,
+    /// `(latitude, longitude, accuracy)`.
+    pub geolocation: Option<(f64, f64, Option<f64>)>,
+    /// Global headers from the `headers` command (`Network.setExtraHTTPHeaders`).
+    /// Origin-scoped `--headers` live in `DaemonState::origin_headers`.
+    pub extra_headers: Option<HashMap<String, String>>,
+    pub offline: Option<bool>,
+    /// Init scripts registered with `Page.addScriptToEvaluateOnNewDocument`:
+    /// `--enable`, `--init-script`, plugin init scripts, and `addinitscript`.
+    /// The identifier is the one Chrome returned on the original session so
+    /// `removeinitscript` can drop the matching entry.
+    pub init_scripts: Vec<(String, String)>,
+}
+
+impl SessionSetup {
+    fn from_launch_options(options: &LaunchOptions) -> Self {
+        Self {
+            user_agent: options.user_agent.clone(),
+            emulated_media: options.color_scheme.as_ref().map(|scheme| EmulatedMedia {
+                media: None,
+                features: vec![("prefers-color-scheme".to_string(), scheme.clone())],
+            }),
+            ..Self::default()
+        }
+    }
+
+    /// True when nothing has been configured, so there is nothing to replay.
+    fn is_empty(&self) -> bool {
+        self.user_agent.is_none()
+            && self.emulated_media.is_none()
+            && self.timezone.is_none()
+            && self.locale.is_none()
+            && self.geolocation.is_none()
+            && self.extra_headers.is_none()
+            && self.offline.is_none()
+            && self.init_scripts.is_empty()
+    }
+}
+
 pub struct DaemonState {
     pub browser: Option<BrowserManager>,
     pub appium: Option<AppiumManager>,
@@ -514,6 +578,9 @@ pub struct DaemonState {
     /// Last viewport settings (width, height, deviceScaleFactor, mobile),
     /// re-applied to new contexts (e.g., recording).
     pub viewport: Option<(i32, i32, f64, bool)>,
+    /// Session-scoped setup applied to the active page, re-applied to tabs the
+    /// daemon creates. See [`SessionSetup`].
+    pub session_setup: SessionSetup,
     /// Init script sources returned by launch mutator plugins for this launch.
     pub plugin_init_scripts: Vec<String>,
     /// Provider cleanup metadata for the active external browser session.
@@ -630,6 +697,7 @@ impl DaemonState {
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(25_000),
             viewport: None,
+            session_setup: SessionSetup::default(),
             plugin_init_scripts: Vec::new(),
             active_provider_session: None,
             active_provider_connection: false,
@@ -3526,6 +3594,125 @@ async fn install_network_controls_or_resume_prepared_session(
     }
 }
 
+/// True when [`apply_session_setup`] has anything to replay onto a new tab.
+async fn session_setup_pending(state: &DaemonState) -> bool {
+    !state.session_setup.is_empty()
+        || !state.routes.read().await.is_empty()
+        || !state.origin_headers.read().await.is_empty()
+}
+
+/// Replay the session-scoped setup the user configured on the active page
+/// (see [`SessionSetup`]) onto a tab the daemon just created, plus the
+/// `Fetch.enable` needed for `route` and origin-scoped `--headers` to reach
+/// the shared fetch handler from that tab.
+///
+/// Call after `Page`/`Network` are enabled on `session_id` and before its
+/// first navigation, so init scripts, UA, and headers cover the initial
+/// document. Emulation failures are ignored: a call the engine rejects
+/// should not abort creating the tab.
+async fn apply_session_setup(state: &DaemonState, session_id: &str) -> Result<(), String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let client = &mgr.client;
+    let setup = &state.session_setup;
+
+    if let Some(ref ua) = setup.user_agent {
+        let _ = client
+            .send_command(
+                "Emulation.setUserAgentOverride",
+                Some(json!({ "userAgent": ua })),
+                Some(session_id),
+            )
+            .await;
+    }
+
+    if let Some(ref emulated) = setup.emulated_media {
+        let mut params = json!({});
+        if let Some(ref m) = emulated.media {
+            params["media"] = Value::String(m.clone());
+        }
+        if !emulated.features.is_empty() {
+            params["features"] = Value::Array(
+                emulated
+                    .features
+                    .iter()
+                    .map(|(name, value)| json!({ "name": name, "value": value }))
+                    .collect(),
+            );
+        }
+        let _ = client
+            .send_command("Emulation.setEmulatedMedia", Some(params), Some(session_id))
+            .await;
+    }
+
+    if let Some(ref tz) = setup.timezone {
+        let _ = client
+            .send_command(
+                "Emulation.setTimezoneOverride",
+                Some(json!({ "timezoneId": tz })),
+                Some(session_id),
+            )
+            .await;
+    }
+
+    if let Some(ref locale) = setup.locale {
+        let _ = client
+            .send_command(
+                "Emulation.setLocaleOverride",
+                Some(json!({ "locale": locale })),
+                Some(session_id),
+            )
+            .await;
+    }
+
+    if let Some((lat, lon, accuracy)) = setup.geolocation {
+        let _ = client
+            .send_command(
+                "Emulation.setGeolocationOverride",
+                Some(json!({
+                    "latitude": lat,
+                    "longitude": lon,
+                    "accuracy": accuracy.unwrap_or(1.0),
+                })),
+                Some(session_id),
+            )
+            .await;
+    }
+
+    if let Some(ref headers) = setup.extra_headers {
+        let _ = network::set_extra_headers(client, session_id, headers).await;
+    }
+
+    if let Some(offline) = setup.offline {
+        let _ = network::set_offline(client, session_id, offline).await;
+    }
+
+    for (_, source) in &setup.init_scripts {
+        let _ = client
+            .send_command(
+                "Page.addScriptToEvaluateOnNewDocument",
+                Some(json!({ "source": source })),
+                Some(session_id),
+            )
+            .await;
+    }
+
+    // `route` and origin-scoped `--headers` are resolved by the background
+    // fetch handler for any session, but only sessions with Fetch enabled
+    // emit requestPaused. Domain filtering and proxy auth install their own
+    // Fetch.enable; this covers the case where neither is active.
+    let has_routes = !state.routes.read().await.is_empty();
+    let has_origin_headers = !state.origin_headers.read().await.is_empty();
+    if has_routes || has_origin_headers {
+        let patterns = build_fetch_patterns(state).await;
+        let params = build_fetch_enable_params(state, patterns).await;
+        client
+            .send_command("Fetch.enable", Some(params), Some(session_id))
+            .await?;
+    }
+
+    Ok(())
+}
+
 async fn auto_launch(
     state: &mut DaemonState,
     plugins: Vec<crate::plugins::PluginConfig>,
@@ -3534,6 +3721,7 @@ async fn auto_launch(
     let effective_ca_cert = state.effective_ca_cert.clone();
     apply_effective_ca_cert(&mut options, &effective_ca_cert);
     state.plugin_init_scripts.clear();
+    state.session_setup = SessionSetup::default();
 
     // Use the stream server's viewport dimensions for --window-size so the
     // content area matches the desired viewport from the start.
@@ -3767,6 +3955,7 @@ async fn auto_launch(
     if let Some(ref ca) = effective_ca_cert {
         options.prepared_nss_home = Some(prepare_nss_home(&ca.bundle)?);
     }
+    state.session_setup = SessionSetup::from_launch_options(&options);
     let mgr = BrowserManager::launch(options, engine.as_deref()).await?;
     state.reset_input_state();
     state.browser = Some(mgr);
@@ -3838,18 +4027,16 @@ fn allowed_domains_from_launch_command(cmd: &Value) -> Option<Vec<String>> {
 }
 
 async fn apply_launch_init_scripts(
-    state: &DaemonState,
+    state: &mut DaemonState,
     enable_features: &[String],
     init_script_paths: &[String],
 ) {
-    let Some(mgr) = state.browser.as_ref() else {
-        return;
-    };
+    let mut sources: Vec<String> = Vec::new();
 
     for feature in enable_features {
         match feature.as_str() {
             "react-devtools" | "react" => {
-                let _ = mgr.add_script_to_evaluate(react::INSTALL_HOOK_JS).await;
+                sources.push(react::INSTALL_HOOK_JS.to_string());
             }
             other => {
                 eprintln!("warning: unknown --enable feature '{}'", other);
@@ -3859,18 +4046,28 @@ async fn apply_launch_init_scripts(
 
     for path in init_script_paths {
         match fs::read_to_string(path) {
-            Ok(source) => {
-                let _ = mgr.add_script_to_evaluate(&source).await;
-            }
+            Ok(source) => sources.push(source),
             Err(e) => {
                 eprintln!("warning: failed to read --init-script '{}': {}", path, e);
             }
         }
     }
 
-    for source in &state.plugin_init_scripts {
-        let _ = mgr.add_script_to_evaluate(source).await;
+    sources.extend(state.plugin_init_scripts.iter().cloned());
+
+    let Some(mgr) = state.browser.as_ref() else {
+        return;
+    };
+
+    let mut registered = Vec::with_capacity(sources.len());
+    for source in sources {
+        let identifier = mgr
+            .add_script_to_evaluate(&source)
+            .await
+            .unwrap_or_default();
+        registered.push((identifier, source));
     }
+    state.session_setup.init_scripts.extend(registered);
 }
 
 async fn apply_launch_mutator_plugins(
@@ -4530,6 +4727,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         return Ok(json!({ "launched": true, "reused": true, "relaunchedBrowser": false }));
     }
     state.ref_map.clear();
+    state.session_setup = SessionSetup::default();
 
     let has_cdp = cdp_url.is_some() || cdp_port.is_some();
     super::browser::validate_launch_options(
@@ -4716,6 +4914,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     write_engine_file(&state.session_id, &state.engine);
     write_extensions_file_from_paths(&state.session_id, launch_options.extensions.as_deref());
     state.reset_input_state();
+    state.session_setup = SessionSetup::from_launch_options(&launch_options);
     state.browser = Some(BrowserManager::launch(launch_options, engine.as_deref()).await?);
     state.launch_hash = Some(new_hash);
     state.subscribe_to_browser_events();
@@ -5097,6 +5296,7 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
         let mut map = state.origin_headers.write().await;
         map.clear();
     }
+    state.session_setup = SessionSetup::default();
 
     if let Some(server) = state.inspect_server.take() {
         server.shutdown();
@@ -6189,7 +6389,7 @@ async fn handle_setcontent(cmd: &Value, state: &DaemonState) -> Result<Value, St
     Ok(json!({ "set": true }))
 }
 
-async fn handle_headers(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_headers(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -6205,14 +6405,16 @@ async fn handle_headers(cmd: &Value, state: &DaemonState) -> Result<Value, Strin
         .unwrap_or_default();
 
     network::set_extra_headers(&mgr.client, &session_id, &headers).await?;
+    state.session_setup.extra_headers = Some(headers);
     Ok(json!({ "set": true }))
 }
 
-async fn handle_offline(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_offline(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
     let offline = cmd.get("offline").and_then(|v| v.as_bool()).unwrap_or(true);
     network::set_offline(&mgr.client, &session_id, offline).await?;
+    state.session_setup.offline = Some(offline);
     Ok(json!({ "offline": offline }))
 }
 
@@ -6573,21 +6775,29 @@ async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
     let has_proxy_creds = state.proxy_credentials.read().await.is_some();
     let defer_url_until_controls =
         should_defer_url_until_network_controls(domain_filter.as_ref(), has_proxy_creds, url)?;
+    // UA, init scripts, headers, and routes are per-session in CDP, so when
+    // any are configured the tab is created blank and navigated only after
+    // they are replayed onto it; otherwise the first document would miss them.
+    let defer_url =
+        defer_url_until_controls || (url.is_some() && session_setup_pending(state).await);
 
     state.ref_map.clear();
     state.active_iframe_sessions.clear();
     state.active_frame_id = None;
     state.webmcp.clear_invocations();
-    let mut result = {
+    let (mut result, new_session_id) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-        mgr.tab_new(if defer_url_until_controls { None } else { url }, label)
-            .await?
+        let result = mgr
+            .tab_new(if defer_url { None } else { url }, label)
+            .await?;
+        (result, mgr.active_session_id()?.to_string())
     };
 
+    apply_session_setup(state, &new_session_id).await?;
     install_network_controls_or_close(state, has_proxy_creds).await?;
     state.drain_cdp_events_background().await?;
 
-    if defer_url_until_controls {
+    if defer_url {
         if let Some(url) = url {
             let nav = {
                 let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
@@ -6718,17 +6928,18 @@ async fn handle_viewport(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     Ok(json!({ "width": width, "height": height, "deviceScaleFactor": scale, "mobile": mobile }))
 }
 
-async fn handle_user_agent(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_user_agent(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let ua = cmd
         .get("userAgent")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'userAgent' parameter")?;
     mgr.set_user_agent(ua).await?;
+    state.session_setup.user_agent = Some(ua.to_string());
     Ok(json!({ "userAgent": ua }))
 }
 
-async fn handle_set_media(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_set_media(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let media = cmd.get("media").and_then(|v| v.as_str());
 
@@ -6750,10 +6961,14 @@ async fn handle_set_media(cmd: &Value, state: &DaemonState) -> Result<Value, Str
     let features = if feat_list.is_empty() {
         None
     } else {
-        Some(feat_list)
+        Some(feat_list.clone())
     };
 
     mgr.set_emulated_media(media, features).await?;
+    state.session_setup.emulated_media = Some(EmulatedMedia {
+        media: media.map(String::from),
+        features: feat_list,
+    });
     Ok(json!({ "set": true }))
 }
 
@@ -7550,7 +7765,7 @@ async fn handle_bringtofront(state: &DaemonState) -> Result<Value, String> {
     Ok(json!({ "broughtToFront": true }))
 }
 
-async fn handle_timezone(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_timezone(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let timezone = cmd
         .get("timezoneId")
@@ -7558,20 +7773,22 @@ async fn handle_timezone(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
         .and_then(|v| v.as_str())
         .ok_or("Missing 'timezoneId' parameter")?;
     mgr.set_timezone(timezone).await?;
+    state.session_setup.timezone = Some(timezone.to_string());
     Ok(json!({ "timezoneId": timezone }))
 }
 
-async fn handle_locale(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_locale(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let locale = cmd
         .get("locale")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'locale' parameter")?;
     mgr.set_locale(locale).await?;
+    state.session_setup.locale = Some(locale.to_string());
     Ok(json!({ "locale": locale }))
 }
 
-async fn handle_geolocation(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_geolocation(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let latitude = cmd
         .get("latitude")
@@ -7584,6 +7801,7 @@ async fn handle_geolocation(cmd: &Value, state: &DaemonState) -> Result<Value, S
     let accuracy = cmd.get("accuracy").and_then(|v| v.as_f64());
 
     mgr.set_geolocation(latitude, longitude, accuracy).await?;
+    state.session_setup.geolocation = Some((latitude, longitude, accuracy));
     Ok(json!({ "latitude": latitude, "longitude": longitude }))
 }
 
@@ -7716,7 +7934,7 @@ async fn handle_addscript(cmd: &Value, state: &DaemonState) -> Result<Value, Str
     Ok(json!({ "added": true }))
 }
 
-async fn handle_addinitscript(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_addinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let source = cmd
         .get("script")
@@ -7726,16 +7944,24 @@ async fn handle_addinitscript(cmd: &Value, state: &DaemonState) -> Result<Value,
         .ok_or("Missing 'script' parameter")?;
 
     let identifier = mgr.add_script_to_evaluate(source).await?;
+    state
+        .session_setup
+        .init_scripts
+        .push((identifier.clone(), source.to_string()));
     Ok(json!({ "added": true, "identifier": identifier }))
 }
 
-async fn handle_removeinitscript(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_removeinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let identifier = cmd
         .get("identifier")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'identifier' parameter")?;
     mgr.remove_script_to_evaluate(identifier).await?;
+    state
+        .session_setup
+        .init_scripts
+        .retain(|(id, _)| id != identifier);
     Ok(json!({ "removed": true, "identifier": identifier }))
 }
 
@@ -8177,6 +8403,7 @@ async fn handle_device(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     mgr.set_user_agent(ua).await?;
 
     state.viewport = Some((width, height, scale, mobile));
+    state.session_setup.user_agent = Some(ua.to_string());
 
     // Update stream server viewport so status messages and screencast use the new dimensions
     if let Some(ref server) = state.stream_server {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -455,8 +455,9 @@ pub struct SessionSetup {
     pub locale: Option<String>,
     /// `(latitude, longitude, accuracy)`.
     pub geolocation: Option<(f64, f64, Option<f64>)>,
-    /// Global headers from the `headers` command (`Network.setExtraHTTPHeaders`).
-    /// Origin-scoped `--headers` live in `DaemonState::origin_headers`.
+    /// Global headers from the `headers` and `credentials` commands
+    /// (`Network.setExtraHTTPHeaders`). Origin-scoped `--headers` live in
+    /// `DaemonState::origin_headers`.
     pub extra_headers: Option<HashMap<String, String>>,
     pub offline: Option<bool>,
     /// Init scripts registered with `Page.addScriptToEvaluateOnNewDocument`:
@@ -11405,7 +11406,7 @@ async fn handle_request_detail(cmd: &Value, state: &mut DaemonState) -> Result<V
     Ok(result)
 }
 
-async fn handle_http_credentials(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_http_credentials(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
     let username = cmd
@@ -11425,6 +11426,9 @@ async fn handle_http_credentials(cmd: &Value, state: &DaemonState) -> Result<Val
     let mut headers = HashMap::new();
     headers.insert("Authorization".to_string(), format!("Basic {}", encoded));
     network::set_extra_headers(&mgr.client, &session_id, &headers).await?;
+    // Network.setExtraHTTPHeaders replaces the target's complete global
+    // header set, so keep the same replacement ready for tabs opened later.
+    state.session_setup.extra_headers = Some(headers);
 
     Ok(json!({ "set": true }))
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -425,10 +425,11 @@ pub struct EmulatedMedia {
 
 /// An init script tracked across target sessions.
 ///
-/// Chrome assigns a different script identifier in each target session. The
-/// identifier returned when the script was first registered remains the
-/// user-facing identifier, while `session_identifiers` records the identifier
-/// to send when removing it from a particular target.
+/// Chrome assigns script identifiers independently in each target session, so
+/// two tabs can both return the same identifier for different scripts. The
+/// daemon-owned `identifier` is the user-facing handle, while
+/// `session_identifiers` records the target-local identifier to send when
+/// removing it from a particular target.
 #[derive(Debug, Clone)]
 pub struct InitScriptSetup {
     pub identifier: String,
@@ -463,6 +464,10 @@ pub struct SessionSetup {
     /// Init scripts registered with `Page.addScriptToEvaluateOnNewDocument`:
     /// `--enable`, `--init-script`, plugin init scripts, and `addinitscript`.
     pub init_scripts: Vec<InitScriptSetup>,
+    /// Monotonic source for daemon-owned init-script handles. CDP identifiers
+    /// cannot be used here because each target session allocates them
+    /// independently, commonly starting at `1`.
+    next_init_script_handle: u64,
 }
 
 impl SessionSetup {
@@ -487,6 +492,24 @@ impl SessionSetup {
             && self.extra_headers.as_ref().is_none_or(HashMap::is_empty)
             && !self.offline.unwrap_or(false)
             && self.init_scripts.is_empty()
+    }
+
+    fn register_init_script(
+        &mut self,
+        source: String,
+        session_id: String,
+        session_identifier: String,
+    ) -> String {
+        self.next_init_script_handle += 1;
+        let identifier = format!("init-script-{}", self.next_init_script_handle);
+        let mut session_identifiers = HashMap::new();
+        session_identifiers.insert(session_id, session_identifier);
+        self.init_scripts.push(InitScriptSetup {
+            identifier: identifier.clone(),
+            source,
+            session_identifiers,
+        });
+        identifier
     }
 }
 
@@ -4089,19 +4112,17 @@ async fn apply_launch_init_scripts(
 
     let mut registered = Vec::with_capacity(sources.len());
     for source in sources {
-        let identifier = mgr
+        let session_identifier = mgr
             .add_script_to_evaluate(&source)
             .await
             .unwrap_or_default();
-        let mut session_identifiers = HashMap::new();
-        session_identifiers.insert(session_id.clone(), identifier.clone());
-        registered.push(InitScriptSetup {
-            identifier,
-            source,
-            session_identifiers,
-        });
+        registered.push((source, session_identifier));
     }
-    state.session_setup.init_scripts.extend(registered);
+    for (source, session_identifier) in registered {
+        state
+            .session_setup
+            .register_init_script(source, session_id.clone(), session_identifier);
+    }
 }
 
 async fn apply_launch_mutator_plugins(
@@ -7984,14 +8005,12 @@ async fn handle_addinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Va
         .and_then(|v| v.as_str())
         .ok_or("Missing 'script' parameter")?;
 
-    let identifier = mgr.add_script_to_evaluate(source).await?;
-    let mut session_identifiers = HashMap::new();
-    session_identifiers.insert(session_id, identifier.clone());
-    state.session_setup.init_scripts.push(InitScriptSetup {
-        identifier: identifier.clone(),
-        source: source.to_string(),
-        session_identifiers,
-    });
+    let session_identifier = mgr.add_script_to_evaluate(source).await?;
+    let identifier = state.session_setup.register_init_script(
+        source.to_string(),
+        session_id,
+        session_identifier,
+    );
     Ok(json!({ "added": true, "identifier": identifier }))
 }
 
@@ -8002,19 +8021,23 @@ async fn handle_removeinitscript(cmd: &Value, state: &mut DaemonState) -> Result
         .and_then(|v| v.as_str())
         .ok_or("Missing 'identifier' parameter")?;
     let session_id = mgr.active_session_id()?;
-    let session_identifier = state
+    let tracked_index = state
         .session_setup
         .init_scripts
         .iter()
-        .find(|script| script.identifier == identifier)
-        .and_then(|script| script.session_identifiers.get(session_id))
-        .map(String::as_str)
-        .unwrap_or(identifier);
-    mgr.remove_script_to_evaluate(session_identifier).await?;
-    state
-        .session_setup
-        .init_scripts
-        .retain(|script| script.identifier != identifier);
+        .position(|script| script.identifier == identifier);
+    let session_identifier = tracked_index
+        .and_then(|index| {
+            state.session_setup.init_scripts[index]
+                .session_identifiers
+                .get(session_id)
+        })
+        .cloned()
+        .unwrap_or_else(|| identifier.to_string());
+    mgr.remove_script_to_evaluate(&session_identifier).await?;
+    if let Some(index) = tracked_index {
+        state.session_setup.init_scripts.remove(index);
+    }
     Ok(json!({ "removed": true, "identifier": identifier }))
 }
 
@@ -14063,6 +14086,27 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             .unwrap()
             .insert("X-Test".to_string(), "set".to_string());
         assert!(!setup.is_empty());
+    }
+
+    #[test]
+    fn test_init_script_handles_are_independent_from_session_identifiers() {
+        let mut setup = SessionSetup::default();
+        let first = setup.register_init_script(
+            "window.first = true".to_string(),
+            "session-a".to_string(),
+            "1".to_string(),
+        );
+        let second = setup.register_init_script(
+            "window.second = true".to_string(),
+            "session-b".to_string(),
+            "1".to_string(),
+        );
+
+        assert_eq!(first, "init-script-1");
+        assert_eq!(second, "init-script-2");
+        assert_eq!(setup.init_scripts.len(), 2);
+        assert_eq!(setup.init_scripts[0].session_identifiers["session-a"], "1");
+        assert_eq!(setup.init_scripts[1].session_identifiers["session-b"], "1");
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3718,30 +3718,33 @@ async fn apply_session_setup(state: &mut DaemonState, session_id: &str) -> Resul
     }
 
     if let Some(ref headers) = setup.extra_headers {
-        let _ = network::set_extra_headers(&client, session_id, headers).await;
+        network::set_extra_headers(&client, session_id, headers).await?;
     }
 
     if let Some(offline) = setup.offline {
-        let _ = network::set_offline(&client, session_id, offline).await;
+        network::set_offline(&client, session_id, offline).await?;
     }
 
     for (index, script) in setup.init_scripts.iter().enumerate() {
-        if let Ok(result) = client
+        let result = client
             .send_command(
                 "Page.addScriptToEvaluateOnNewDocument",
                 Some(json!({ "source": &script.source })),
                 Some(session_id),
             )
-            .await
-        {
-            if let Some(identifier) = result.get("identifier").and_then(Value::as_str) {
-                if let Some(tracked) = state.session_setup.init_scripts.get_mut(index) {
-                    tracked
-                        .session_identifiers
-                        .insert(session_id.to_string(), identifier.to_string());
-                }
-            }
-        }
+            .await?;
+        let identifier = result
+            .get("identifier")
+            .and_then(Value::as_str)
+            .ok_or("Page.addScriptToEvaluateOnNewDocument returned no identifier")?;
+        let tracked = state
+            .session_setup
+            .init_scripts
+            .get_mut(index)
+            .ok_or("Init script setup changed while it was being applied")?;
+        tracked
+            .session_identifiers
+            .insert(session_id.to_string(), identifier.to_string());
     }
 
     // `route` and origin-scoped `--headers` are resolved by the background
@@ -8015,28 +8018,57 @@ async fn handle_addinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Va
 }
 
 async fn handle_removeinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
-    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let identifier = cmd
         .get("identifier")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'identifier' parameter")?;
-    let session_id = mgr.active_session_id()?;
+    let (client, active_session_id, live_session_ids) = {
+        let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+        (
+            mgr.client.clone(),
+            mgr.active_session_id()?.to_string(),
+            mgr.pages_list()
+                .into_iter()
+                .map(|page| page.session_id)
+                .collect::<HashSet<_>>(),
+        )
+    };
     let tracked_index = state
         .session_setup
         .init_scripts
         .iter()
         .position(|script| script.identifier == identifier);
-    let session_identifier = tracked_index
-        .and_then(|index| {
+
+    // Daemon-owned handles are session-wide. Remove each target-local CDP
+    // registration before dropping the source that would reach future tabs.
+    if let Some(index) = tracked_index {
+        let session_identifiers = state.session_setup.init_scripts[index]
+            .session_identifiers
+            .clone();
+        for (session_id, session_identifier) in session_identifiers {
+            if !live_session_ids.contains(&session_id) {
+                continue;
+            }
+            client
+                .send_command(
+                    "Page.removeScriptToEvaluateOnNewDocument",
+                    Some(json!({ "identifier": session_identifier })),
+                    Some(&session_id),
+                )
+                .await?;
             state.session_setup.init_scripts[index]
                 .session_identifiers
-                .get(session_id)
-        })
-        .cloned()
-        .unwrap_or_else(|| identifier.to_string());
-    mgr.remove_script_to_evaluate(&session_identifier).await?;
-    if let Some(index) = tracked_index {
+                .remove(&session_id);
+        }
         state.session_setup.init_scripts.remove(index);
+    } else {
+        client
+            .send_command(
+                "Page.removeScriptToEvaluateOnNewDocument",
+                Some(json!({ "identifier": identifier })),
+                Some(&active_session_id),
+            )
+            .await?;
     }
     Ok(json!({ "removed": true, "identifier": identifier }))
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -423,6 +423,19 @@ pub struct EmulatedMedia {
     pub features: Vec<(String, String)>,
 }
 
+/// An init script tracked across target sessions.
+///
+/// Chrome assigns a different script identifier in each target session. The
+/// identifier returned when the script was first registered remains the
+/// user-facing identifier, while `session_identifiers` records the identifier
+/// to send when removing it from a particular target.
+#[derive(Debug, Clone)]
+pub struct InitScriptSetup {
+    pub identifier: String,
+    pub source: String,
+    pub session_identifiers: HashMap<String, String>,
+}
+
 /// Page-level setup the daemon has applied to the active page session.
 ///
 /// CDP scopes all of these to a single target session, so a tab the daemon
@@ -448,9 +461,7 @@ pub struct SessionSetup {
     pub offline: Option<bool>,
     /// Init scripts registered with `Page.addScriptToEvaluateOnNewDocument`:
     /// `--enable`, `--init-script`, plugin init scripts, and `addinitscript`.
-    /// The identifier is the one Chrome returned on the original session so
-    /// `removeinitscript` can drop the matching entry.
-    pub init_scripts: Vec<(String, String)>,
+    pub init_scripts: Vec<InitScriptSetup>,
 }
 
 impl SessionSetup {
@@ -472,8 +483,8 @@ impl SessionSetup {
             && self.timezone.is_none()
             && self.locale.is_none()
             && self.geolocation.is_none()
-            && self.extra_headers.is_none()
-            && self.offline.is_none()
+            && self.extra_headers.as_ref().is_none_or(HashMap::is_empty)
+            && !self.offline.unwrap_or(false)
             && self.init_scripts.is_empty()
     }
 }
@@ -3610,10 +3621,14 @@ async fn session_setup_pending(state: &DaemonState) -> bool {
 /// first navigation, so init scripts, UA, and headers cover the initial
 /// document. Emulation failures are ignored: a call the engine rejects
 /// should not abort creating the tab.
-async fn apply_session_setup(state: &DaemonState, session_id: &str) -> Result<(), String> {
-    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-    let client = &mgr.client;
-    let setup = &state.session_setup;
+async fn apply_session_setup(state: &mut DaemonState, session_id: &str) -> Result<(), String> {
+    let client = state
+        .browser
+        .as_ref()
+        .ok_or("Browser not launched")?
+        .client
+        .clone();
+    let setup = state.session_setup.clone();
 
     if let Some(ref ua) = setup.user_agent {
         let _ = client
@@ -3679,21 +3694,30 @@ async fn apply_session_setup(state: &DaemonState, session_id: &str) -> Result<()
     }
 
     if let Some(ref headers) = setup.extra_headers {
-        let _ = network::set_extra_headers(client, session_id, headers).await;
+        let _ = network::set_extra_headers(&client, session_id, headers).await;
     }
 
     if let Some(offline) = setup.offline {
-        let _ = network::set_offline(client, session_id, offline).await;
+        let _ = network::set_offline(&client, session_id, offline).await;
     }
 
-    for (_, source) in &setup.init_scripts {
-        let _ = client
+    for (index, script) in setup.init_scripts.iter().enumerate() {
+        if let Ok(result) = client
             .send_command(
                 "Page.addScriptToEvaluateOnNewDocument",
-                Some(json!({ "source": source })),
+                Some(json!({ "source": &script.source })),
                 Some(session_id),
             )
-            .await;
+            .await
+        {
+            if let Some(identifier) = result.get("identifier").and_then(Value::as_str) {
+                if let Some(tracked) = state.session_setup.init_scripts.get_mut(index) {
+                    tracked
+                        .session_identifiers
+                        .insert(session_id.to_string(), identifier.to_string());
+                }
+            }
+        }
     }
 
     // `route` and origin-scoped `--headers` are resolved by the background
@@ -4058,6 +4082,9 @@ async fn apply_launch_init_scripts(
     let Some(mgr) = state.browser.as_ref() else {
         return;
     };
+    let Ok(session_id) = mgr.active_session_id().map(str::to_string) else {
+        return;
+    };
 
     let mut registered = Vec::with_capacity(sources.len());
     for source in sources {
@@ -4065,7 +4092,13 @@ async fn apply_launch_init_scripts(
             .add_script_to_evaluate(&source)
             .await
             .unwrap_or_default();
-        registered.push((identifier, source));
+        let mut session_identifiers = HashMap::new();
+        session_identifiers.insert(session_id.clone(), identifier.clone());
+        registered.push(InitScriptSetup {
+            identifier,
+            source,
+            session_identifiers,
+        });
     }
     state.session_setup.init_scripts.extend(registered);
 }
@@ -5548,28 +5581,31 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
             has_proxy_creds,
             Some(&href),
         )?;
+        // `click --new-tab` creates the same kind of daemon-owned tab as
+        // `tab new`, so it must use the same pre-navigation setup path.
+        let defer_url = defer_url_until_controls || session_setup_pending(state).await;
 
         state.ref_map.clear();
-        {
+        state.active_iframe_sessions.clear();
+        state.active_frame_id = None;
+        state.webmcp.clear_invocations();
+        let new_session_id = {
             let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-            mgr.tab_new(
-                if defer_url_until_controls {
-                    None
-                } else {
-                    Some(&href)
-                },
-                None,
-            )
-            .await?;
-        }
+            mgr.tab_new(if defer_url { None } else { Some(&href) }, None)
+                .await?;
+            mgr.active_session_id()?.to_string()
+        };
 
+        apply_session_setup(state, &new_session_id).await?;
         install_network_controls_or_close(state, has_proxy_creds).await?;
         state.drain_cdp_events_background().await?;
 
-        if defer_url_until_controls {
+        if defer_url {
             let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
             mgr.navigate(&href, WaitUntil::Load).await?;
         }
+
+        state.refresh_active_iframe_sessions().await;
 
         return Ok(json!({ "clicked": selector, "newTab": true, "url": href }));
     }
@@ -6405,7 +6441,9 @@ async fn handle_headers(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
         .unwrap_or_default();
 
     network::set_extra_headers(&mgr.client, &session_id, &headers).await?;
-    state.session_setup.extra_headers = Some(headers);
+    // A fresh target already has no extra headers, so an empty map clears the
+    // inherited setup instead of forcing later tabs through deferred loading.
+    state.session_setup.extra_headers = (!headers.is_empty()).then_some(headers);
     Ok(json!({ "set": true }))
 }
 
@@ -6414,7 +6452,8 @@ async fn handle_offline(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
     let session_id = mgr.active_session_id()?.to_string();
     let offline = cmd.get("offline").and_then(|v| v.as_bool()).unwrap_or(true);
     network::set_offline(&mgr.client, &session_id, offline).await?;
-    state.session_setup.offline = Some(offline);
+    // Online is the default for a fresh target and needs no replay.
+    state.session_setup.offline = offline.then_some(true);
     Ok(json!({ "offline": offline }))
 }
 
@@ -7936,6 +7975,7 @@ async fn handle_addscript(cmd: &Value, state: &DaemonState) -> Result<Value, Str
 
 async fn handle_addinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
     let source = cmd
         .get("script")
         .or_else(|| cmd.get("source"))
@@ -7944,10 +7984,13 @@ async fn handle_addinitscript(cmd: &Value, state: &mut DaemonState) -> Result<Va
         .ok_or("Missing 'script' parameter")?;
 
     let identifier = mgr.add_script_to_evaluate(source).await?;
-    state
-        .session_setup
-        .init_scripts
-        .push((identifier.clone(), source.to_string()));
+    let mut session_identifiers = HashMap::new();
+    session_identifiers.insert(session_id, identifier.clone());
+    state.session_setup.init_scripts.push(InitScriptSetup {
+        identifier: identifier.clone(),
+        source: source.to_string(),
+        session_identifiers,
+    });
     Ok(json!({ "added": true, "identifier": identifier }))
 }
 
@@ -7957,11 +8000,20 @@ async fn handle_removeinitscript(cmd: &Value, state: &mut DaemonState) -> Result
         .get("identifier")
         .and_then(|v| v.as_str())
         .ok_or("Missing 'identifier' parameter")?;
-    mgr.remove_script_to_evaluate(identifier).await?;
+    let session_id = mgr.active_session_id()?;
+    let session_identifier = state
+        .session_setup
+        .init_scripts
+        .iter()
+        .find(|script| script.identifier == identifier)
+        .and_then(|script| script.session_identifiers.get(session_id))
+        .map(String::as_str)
+        .unwrap_or(identifier);
+    mgr.remove_script_to_evaluate(session_identifier).await?;
     state
         .session_setup
         .init_scripts
-        .retain(|(id, _)| id != identifier);
+        .retain(|script| script.identifier != identifier);
     Ok(json!({ "removed": true, "identifier": identifier }))
 }
 
@@ -13986,6 +14038,27 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
         assert_eq!(state.mouse_state.x, 0.0);
         assert_eq!(state.mouse_state.y, 0.0);
         assert_eq!(state.mouse_state.buttons, 0);
+    }
+
+    #[test]
+    fn test_session_setup_treats_cleared_values_as_empty() {
+        let mut setup = SessionSetup {
+            extra_headers: Some(HashMap::new()),
+            offline: Some(false),
+            ..SessionSetup::default()
+        };
+        assert!(setup.is_empty());
+
+        setup.offline = Some(true);
+        assert!(!setup.is_empty());
+
+        setup.offline = None;
+        setup
+            .extra_headers
+            .as_mut()
+            .unwrap()
+            .insert("X-Test".to_string(), "set".to_string());
+        assert!(!setup.is_empty());
     }
 
     #[test]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7374,6 +7374,122 @@ async fn e2e_recording_rejects_invalid_fps() {
 }
 
 // ---------------------------------------------------------------------------
+// tab new: session setup inheritance
+// ---------------------------------------------------------------------------
+
+/// `tab new <url>` must replay the session's setup onto the new tab before
+/// its first document: an init script registered on the primary page has to
+/// run on the initial load, not only after a later navigation.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_new_inherits_init_script_on_first_load() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "addinitscript", "script": "window.__abTab = 'seeded';" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3", "action": "tab_new",
+            "url": "data:text/html,<script>document.title = String(window.__abTab)</script>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "document.title" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "seeded",
+        "init script should run on the new tab's first document"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// The launch `--user-agent` (Emulation.setUserAgentOverride) and global
+/// `set headers` (Network.setExtraHTTPHeaders) are per CDP session. A new tab
+/// opened with a URL must send both on its very first document request.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_new_inherits_user_agent_and_headers() {
+    let (base_url, _server) = start_echo_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1", "action": "launch", "headless": true,
+            "userAgent": "ab-tab-new-test/1.0",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "headers", "headers": { "X-Global": "global" } }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_new", "url": format!("{}/tab", base_url) }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4", "action": "evaluate",
+            "script": "JSON.parse(document.body.innerText)",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let headers = &get_data(&resp)["result"]["headers"];
+    assert_eq!(
+        headers["X-Global"], "global",
+        "global `headers` should apply to the new tab's first document request, got {headers}"
+    );
+    assert_eq!(
+        headers["User-Agent"], "ab-tab-new-test/1.0",
+        "new tab's first document request should carry the launch user agent, got {headers}"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "navigator.userAgent" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], "ab-tab-new-test/1.0");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+// ---------------------------------------------------------------------------
 // --state / storageState flag: cookies should be loaded at launch time
 // ---------------------------------------------------------------------------
 

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7675,6 +7675,58 @@ async fn e2e_tab_new_inherits_user_agent_and_headers() {
     assert_success(&resp);
 }
 
+/// `set credentials` uses target-scoped extra headers, so a new tab must send
+/// the resulting Authorization header on its first document request.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_new_inherits_http_credentials_on_first_load() {
+    let (base_url, _server) = start_echo_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2", "action": "credentials",
+            "username": "tab-user", "password": "tab-password",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_new", "url": format!("{}/credentials", base_url) }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4", "action": "evaluate",
+            "script": "JSON.parse(document.body.innerText)",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let expected = format!("Basic {}", STANDARD.encode("tab-user:tab-password"));
+    assert_eq!(
+        get_data(&resp)["result"]["headers"]["Authorization"],
+        expected,
+        "HTTP credentials should apply to the new tab's first document request"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // --state / storageState flag: cookies should be loaded at launch time
 // ---------------------------------------------------------------------------

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7425,6 +7425,192 @@ async fn e2e_tab_new_inherits_init_script_on_first_load() {
     assert_success(&resp);
 }
 
+/// Replayed init scripts receive target-specific CDP identifiers. Removing a
+/// script from the new tab must translate the original user-facing identifier
+/// to the identifier Chrome assigned in that target.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_new_removes_replayed_init_script_by_original_identifier() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let first = execute_command(
+        &json!({
+            "id": "2", "action": "addinitscript",
+            "script": "window.__abFirstInit = true;",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&first);
+    let first_id = get_data(&first)["identifier"]
+        .as_str()
+        .expect("first init script should return an identifier")
+        .to_string();
+
+    let second = execute_command(
+        &json!({
+            "id": "3", "action": "addinitscript",
+            "script": "window.__abSecondInit = true;",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&second);
+    let second_id = get_data(&second)["identifier"]
+        .as_str()
+        .expect("second init script should return an identifier")
+        .to_string();
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "removeinitscript", "identifier": first_id }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5", "action": "tab_new",
+            "url": "data:text/html,<title>new tab</title>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "removeinitscript", "identifier": second_id }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "7", "action": "navigate",
+            "url": "data:text/html,<title>after removal</title>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "8", "action": "evaluate",
+            "script": "window.__abSecondInit === true",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], false);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// `click --new-tab` creates a tab through a separate handler from `tab new`,
+/// but it must apply the same session setup before the first request.
+#[tokio::test]
+#[ignore]
+async fn e2e_click_new_tab_inherits_user_agent_and_headers() {
+    let (base_url, _server) = start_echo_server().await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1", "action": "launch", "headless": true,
+            "userAgent": "ab-click-new-tab-test/1.0",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "headers", "headers": { "X-Global": "global" } }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3", "action": "navigate",
+            "url": format!("data:text/html,<a id='next' href='{}/click'>next</a>", base_url),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "click", "selector": "#next", "newTab": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5", "action": "evaluate",
+            "script": "JSON.parse(document.body.innerText)",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let headers = &get_data(&resp)["result"]["headers"];
+    assert_eq!(headers["X-Global"], "global");
+    assert_eq!(headers["User-Agent"], "ab-click-new-tab-test/1.0");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Clearing headers and offline mode restores the default setup, so future
+/// tabs can use the non-blocking target creation path.
+#[tokio::test]
+#[ignore]
+async fn e2e_cleared_session_setup_is_not_pending() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "offline", "offline": false }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "headers", "headers": {} }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    assert!(state.session_setup.offline.is_none());
+    assert!(state.session_setup.extra_headers.is_none());
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// The launch `--user-agent` (Emulation.setUserAgentOverride) and global
 /// `set headers` (Network.setExtraHTTPHeaders) are per CDP session. A new tab
 /// opened with a URL must send both on its very first document request.

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7427,7 +7427,7 @@ async fn e2e_tab_new_inherits_init_script_on_first_load() {
 
 /// Replayed init scripts receive target-specific CDP identifiers. Removing a
 /// script from the new tab must translate the original user-facing identifier
-/// to the identifier Chrome assigned in that target.
+/// for every tab where Chrome registered it.
 #[tokio::test]
 #[ignore]
 async fn e2e_tab_new_removes_replayed_init_script_by_original_identifier() {
@@ -7512,6 +7512,38 @@ async fn e2e_tab_new_removes_replayed_init_script_by_original_identifier() {
     .await;
     assert_success(&resp);
     assert_eq!(get_data(&resp)["result"], false);
+
+    let resp = execute_command(
+        &json!({ "id": "9", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "10", "action": "navigate",
+            "url": "data:text/html,<title>original after removal</title>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "11", "action": "evaluate",
+            "script": "window.__abSecondInit === true",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        false,
+        "removing a replayed script should also remove its original registration"
+    );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7517,6 +7517,100 @@ async fn e2e_tab_new_removes_replayed_init_script_by_original_identifier() {
     assert_success(&resp);
 }
 
+/// CDP allocates init-script identifiers independently in each target. Two
+/// pre-existing tabs can therefore both return `1` for different scripts, but
+/// the daemon must expose distinct handles and remove only the requested one.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_init_script_handles_are_unique_across_preexisting_tabs() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "2", "action": "tab_new" }), &mut state).await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_switch", "tabId": "t1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let first = execute_command(
+        &json!({
+            "id": "4", "action": "addinitscript",
+            "script": "window.__abFirstExistingTab = true;",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&first);
+    let first_id = get_data(&first)["identifier"]
+        .as_str()
+        .expect("first init script should return an identifier")
+        .to_string();
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "tab_switch", "tabId": "t2" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let second = execute_command(
+        &json!({
+            "id": "6", "action": "addinitscript",
+            "script": "window.__abSecondExistingTab = true;",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&second);
+    let second_id = get_data(&second)["identifier"]
+        .as_str()
+        .expect("second init script should return an identifier")
+        .to_string();
+
+    assert_ne!(first_id, second_id, "user-facing handles must be unique");
+
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "removeinitscript", "identifier": second_id }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "8", "action": "tab_new",
+            "url": "data:text/html,<title>future tab</title>",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "9", "action": "evaluate",
+            "script": "[window.__abFirstExistingTab === true, window.__abSecondExistingTab === true]",
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], json!([true, false]));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// `click --new-tab` creates a tab through a separate handler from `tab new`,
 /// but it must apply the same session setup before the first request.
 #[tokio::test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1623,8 +1623,9 @@ If another element covers the click point, agent-browser reports the
 covering element instead of dispatching a click to the wrong target.
 
 Options:
-  --new-tab            Open link in a new tab instead of navigating current tab
-                       (only works on elements with href attribute)
+  --new-tab            Open link in a new tab instead of navigating current tab.
+                       The new tab inherits session setup before its first load.
+                       Only works on elements with an href attribute.
 
 Global Options:
   --json               Output as JSON
@@ -2355,8 +2356,8 @@ Settings:
   viewport <w> <h> [scale]   Set viewport size (scale = deviceScaleFactor, e.g. 2 for retina)
   device <name>              Emulate device (e.g., "iPhone 12")
   geo <lat> <lng>            Set geolocation
-  offline [on|off]           Toggle offline mode
-  headers <json>             Set extra HTTP headers
+  offline [on|off]           Toggle offline mode; off restores the new-tab default
+  headers <json>             Set extra HTTP headers; use {} to clear them for new tabs
   credentials <user> <pass>  Set HTTP authentication
   media [dark|light]         Set color scheme preference
         [reduced-motion]     Enable reduced motion
@@ -2520,6 +2521,10 @@ referring to the same tab across commands. Optional user-assigned labels
 (e.g. `docs`, `app`) are interchangeable with ids everywhere a tab ref is
 accepted. CDP target ids (from `tab list --json`) are also accepted as tab
 refs; unlike `t<N>` ids they stay stable across daemon restarts.
+
+Tabs opened with `tab new` or `click --new-tab` inherit the session's user
+agent, headers, init scripts, routes, and emulation overrides before their
+first document loads.
 
 Each session remembers its active tab (bound by CDP target id) and returns
 to it after a daemon restart. With --pin-tab, commands fail with a

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2358,7 +2358,7 @@ Settings:
   geo <lat> <lng>            Set geolocation
   offline [on|off]           Toggle offline mode; off restores the new-tab default
   headers <json>             Set extra HTTP headers; use {} to clear them for new tabs
-  credentials <user> <pass>  Set HTTP authentication
+  credentials <user> <pass>  Set HTTP authentication for current and future tabs
   media [dark|light]         Set color scheme preference
         [reduced-motion]     Enable reduced motion
 
@@ -2523,8 +2523,8 @@ accepted. CDP target ids (from `tab list --json`) are also accepted as tab
 refs; unlike `t<N>` ids they stay stable across daemon restarts.
 
 Tabs opened with `tab new` or `click --new-tab` inherit the session's user
-agent, headers, init scripts, routes, and emulation overrides before their
-first document loads.
+agent, headers, HTTP credentials, init scripts, routes, and emulation
+overrides before their first document loads.
 
 Each session remembers its active tab (bound by CDP target id) and returns
 to it after a daemon restart. With --pin-tab, commands fail with a

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3762,7 +3762,7 @@ SPA:
                              history.pushState + popstate/navigate events for other frameworks
 
 Init scripts:
-  removeinitscript <id>      Remove a script registered via --init-script or addinitscript
+  removeinitscript <id>      Remove a registered script from every tab in the session
 
 Batch:
   batch [--bail] ["cmd" ...]  Execute multiple commands sequentially (args or stdin)

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -251,6 +251,8 @@ agent-browser tab close docs    # close by label
 
 Labels are never auto-generated and never rewritten on navigation — an agent that names a tab `docs` keeps that name until the tab is closed. Labels are unique within a session; creating a second tab with an existing label errors.
 
+New tabs inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline).
+
 `tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts. Each session is bound to its active tab by target id and returns to it after a daemon restart; with `--pin-tab` the binding is strict and a closed bound tab produces a `tab_gone` error instead of a silent fallback. JSON errors include <code>code: "tab_gone"</code>, <code>data.targetId</code>, and optional sanitized <code>data.lastUrl</code>. Batch output carries the recovery object under <code>result</code>. See [CDP Mode](/cdp-mode) for the multi-session workflow.
 
 Refs (`@e1`, etc.) are scoped to the tab that was active when the snapshot ran, so switch tabs first, then snapshot and interact:

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -173,7 +173,7 @@ agent-browser set device <name>       # Emulate device ("iPhone 14")
 agent-browser set geo <lat> <lng>     # Set geolocation
 agent-browser set offline [on|off]    # Toggle offline mode
 agent-browser set headers <json>      # Extra HTTP headers
-agent-browser set credentials <u> <p> # HTTP basic auth
+agent-browser set credentials <u> <p> # HTTP basic auth for current and future tabs
 agent-browser set media [dark|light]  # Emulate color scheme (persists for session)
 ```
 
@@ -251,7 +251,7 @@ agent-browser tab close docs    # close by label
 
 Labels are never auto-generated and never rewritten on navigation — an agent that names a tab `docs` keeps that name until the tab is closed. Labels are unique within a session; creating a second tab with an existing label errors.
 
-Tabs opened through `tab new` or `click --new-tab` inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline). Turning offline mode off or setting headers to `{}` restores the default setup for future tabs.
+Tabs opened through `tab new` or `click --new-tab` inherit the session's setup before their first document loads: user agent, `set headers`, `set credentials`, origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline). Turning offline mode off or setting headers to `{}` restores the default setup for future tabs.
 
 `tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts. Each session is bound to its active tab by target id and returns to it after a daemon restart; with `--pin-tab` the binding is strict and a closed bound tab produces a `tab_gone` error instead of a silent fallback. JSON errors include <code>code: "tab_gone"</code>, <code>data.targetId</code>, and optional sanitized <code>data.lastUrl</code>. Batch output carries the recovery object under <code>result</code>. See [CDP Mode](/cdp-mode) for the multi-session workflow.
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -251,7 +251,7 @@ agent-browser tab close docs    # close by label
 
 Labels are never auto-generated and never rewritten on navigation — an agent that names a tab `docs` keeps that name until the tab is closed. Labels are unique within a session; creating a second tab with an existing label errors.
 
-New tabs inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline).
+Tabs opened through `tab new` or `click --new-tab` inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline). Turning offline mode off or setting headers to `{}` restores the default setup for future tabs.
 
 `tab list --json` also reports each tab's CDP `targetId`, and target ids are accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Unlike `t<N>` ids, which are per-daemon counters, target ids stay stable across daemon restarts. Each session is bound to its active tab by target id and returns to it after a daemon restart; with `--pin-tab` the binding is strict and a closed bound tab produces a `tab_gone` error instead of a silent fallback. JSON errors include <code>code: "tab_gone"</code>, <code>data.targetId</code>, and optional sanitized <code>data.lastUrl</code>. Batch output carries the recovery object under <code>result</code>. See [CDP Mode](/cdp-mode) for the multi-session workflow.
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -548,7 +548,7 @@ The default output lists violations and incomplete checks with impact, rule ID, 
 ```bash
 agent-browser open --init-script <path>           # Register before first navigation (repeatable)
 agent-browser addinitscript <js>                  # Register at runtime (returns identifier)
-agent-browser removeinitscript <identifier>       # Remove a previously registered init script
+agent-browser removeinitscript <identifier>       # Remove from every tab in the session
 ```
 
 See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime scripts, built-in React DevTools, and extensions.

--- a/docs/src/app/init-scripts/page.mdx
+++ b/docs/src/app/init-scripts/page.mdx
@@ -37,6 +37,8 @@ agent-browser removeinitscript <identifier>
 
 Runtime init scripts are useful after a session has started. They are still init scripts, so they affect future documents and navigations rather than rewriting already-executed page code.
 
+Runtime init-script identifiers are session-wide. `removeinitscript` removes the script from every open tab where it was registered and prevents it from being replayed into tabs opened later.
+
 ## Pre-navigation setup
 
 For flows that need routes, cookies, or scripts installed before the first real navigation, start the browser without a URL:

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -299,6 +299,8 @@ agent-browser tab close t2             # close tab t2
 
 Stable `tabId`s mean `t2` points at the same tab across commands even when other tabs open or close. After switching, refs from a prior snapshot on a different tab no longer apply — re-snapshot. `tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted; target ids stay stable across daemon restarts, unlike `t<N>` ids.
 
+Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, init scripts, routes, and emulation overrides before their first document loads.
+
 Switching has two special cases worth knowing:
 
 - **Discarded tab (Chrome Memory Saver).** A backgrounded tab may have its renderer dropped. Switching to it reactivates the tab, which reloads the page and discards unsaved state (form input, scroll position). The switch result then includes `"revived": true`, so treat prior in-page state as gone and re-snapshot. Closing the active tab onto a discarded successor reports `"activeTabRevived": true` for the same reason.

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -301,6 +301,8 @@ Stable `tabId`s mean `t2` points at the same tab across commands even when other
 
 Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, HTTP credentials, init scripts, routes, and emulation overrides before their first document loads.
 
+Runtime init-script identifiers are session-wide. Removing one clears it from every open tab where it was registered and from the setup replayed into future tabs.
+
 Switching has two special cases worth knowing:
 
 - **Discarded tab (Chrome Memory Saver).** A backgrounded tab may have its renderer dropped. Switching to it reactivates the tab, which reloads the page and discards unsaved state (form input, scroll position). The switch result then includes `"revived": true`, so treat prior in-page state as gone and re-snapshot. Closing the active tab onto a discarded successor reports `"activeTabRevived": true` for the same reason.

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -299,7 +299,7 @@ agent-browser tab close t2             # close tab t2
 
 Stable `tabId`s mean `t2` points at the same tab across commands even when other tabs open or close. After switching, refs from a prior snapshot on a different tab no longer apply — re-snapshot. `tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted; target ids stay stable across daemon restarts, unlike `t<N>` ids.
 
-Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, init scripts, routes, and emulation overrides before their first document loads.
+Tabs opened through `tab new` or `click --new-tab` inherit the session's user agent, headers, HTTP credentials, init scripts, routes, and emulation overrides before their first document loads.
 
 Switching has two special cases worth knowing:
 

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -306,6 +306,8 @@ agent-browser set credentials username password
 agent-browser open https://protected.example.com/api
 ```
 
+The credentials also apply to tabs opened later through `tab new` or `click --new-tab`, including their first document request.
+
 ## Cookie-Based Auth
 
 Manually set authentication cookies:

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -234,6 +234,8 @@ agent-browser tab close docs             # close by label
 
 Labels are never auto-generated, never rewritten on navigation, and must be unique within a session. To interact with another tab, switch to it first: the daemon maintains a single active tab, so refs (`@eN`) belong to the tab that was active when the snapshot ran.
 
+New tabs inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline).
+
 `tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Target ids stay stable across daemon restarts, unlike `t<N>` ids, which are per-daemon counters. With `--pin-tab` the session is pinned to its bound tab: if that tab is closed, commands fail with a `tab_gone` error instead of falling back to another tab, and `tab new` or `tab list` recover. JSON errors include `code: "tab_gone"` and a recovery object with `data.targetId` plus optional sanitized `data.lastUrl`; batch uses `result` for the same object.
 
 Switching to a tab that the browser discarded to save memory reactivates it, since a discarded tab has no renderer to drive. Reactivation reloads the page and resets its unsaved state, and the switch result adds `"revived": true` so the reload is not silent. A tab whose page is paused by a JavaScript dialog is alive rather than discarded: the switch leaves it untouched and adds `"dialogBlocked": true`. Resolve the dialog with `dialog accept`/`dialog dismiss` and its state is preserved. Closing the active tab onto a discarded successor revives it the same way and reports `"activeTabRevived": true`.

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -234,7 +234,7 @@ agent-browser tab close docs             # close by label
 
 Labels are never auto-generated, never rewritten on navigation, and must be unique within a session. To interact with another tab, switch to it first: the daemon maintains a single active tab, so refs (`@eN`) belong to the tab that was active when the snapshot ran.
 
-New tabs inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline).
+Tabs opened through `tab new` or `click --new-tab` inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline). Turning offline mode off or setting headers to `{}` restores the default setup for future tabs.
 
 `tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Target ids stay stable across daemon restarts, unlike `t<N>` ids, which are per-daemon counters. With `--pin-tab` the session is pinned to its bound tab: if that tab is closed, commands fail with a `tab_gone` error instead of falling back to another tab, and `tab new` or `tab list` recover. JSON errors include `code: "tab_gone"` and a recovery object with `data.targetId` plus optional sanitized `data.lastUrl`; batch uses `result` for the same object.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -487,8 +487,10 @@ agent-browser a11y <url> --json                     # Structured results for aut
 ```bash
 agent-browser open --init-script <path>             # Register before first navigation (repeatable)
 agent-browser addinitscript <js>                    # Register at runtime (returns identifier)
-agent-browser removeinitscript <identifier>         # Remove a previously registered init script
+agent-browser removeinitscript <identifier>         # Remove from every tab in the session
 ```
+
+Runtime init-script identifiers are session-wide. Removing one clears it from every open tab where it was registered and from the setup replayed into future tabs.
 
 ## cURL cookie import
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -171,7 +171,7 @@ agent-browser set device "iPhone 14"          # Emulate device
 agent-browser set geo 37.7749 -122.4194       # Set geolocation (alias: geolocation)
 agent-browser set offline on                  # Toggle offline mode
 agent-browser set headers '{"X-Key":"v"}'     # Extra HTTP headers
-agent-browser set credentials user pass       # HTTP basic auth (alias: auth)
+agent-browser set credentials user pass       # HTTP basic auth for current and future tabs (alias: auth)
 agent-browser set media dark                  # Emulate color scheme
 agent-browser set media light reduced-motion  # Light mode + reduced motion
 ```
@@ -234,7 +234,7 @@ agent-browser tab close docs             # close by label
 
 Labels are never auto-generated, never rewritten on navigation, and must be unique within a session. To interact with another tab, switch to it first: the daemon maintains a single active tab, so refs (`@eN`) belong to the tab that was active when the snapshot ran.
 
-Tabs opened through `tab new` or `click --new-tab` inherit the session's setup before their first document loads: user agent, `set headers` and origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline). Turning offline mode off or setting headers to `{}` restores the default setup for future tabs.
+Tabs opened through `tab new` or `click --new-tab` inherit the session's setup before their first document loads: user agent, `set headers`, `set credentials`, origin-scoped `--headers`, init scripts, `route` rules, and emulation overrides (color scheme, timezone, locale, geolocation, offline). Turning offline mode off or setting headers to `{}` restores the default setup for future tabs.
 
 `tab list --json` also reports each tab's CDP `targetId`, accepted anywhere a tab ref is accepted (`tab <targetId>`, `tab close <targetId>`). Target ids stay stable across daemon restarts, unlike `t<N>` ids, which are per-daemon counters. With `--pin-tab` the session is pinned to its bound tab: if that tab is closed, commands fail with a `tab_gone` error instead of falling back to another tab, and `tab new` or `tab list` recover. JSON errors include `code: "tab_gone"` and a recovery object with `data.targetId` plus optional sanitized `data.lastUrl`; batch uses `result` for the same object.
 


### PR DESCRIPTION
`tab new <url>` created the tab with the URL already loading and never re-applied the session's page-level setup, so the new tab's first document ran without the user agent, init scripts, headers, routes, or emulation configured on the primary tab. The daemon now tracks what it applied and replays it onto the new tab before its first navigation.

<!-- before-and-after:start -->
| Before (New tab: echoed request headers) | After (New tab: echoed request headers) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/fc7fa1a0-77e9-4c29-946f-4b129d7a5ea1) | ![After](https://github.com/user-attachments/assets/e1b9509c-fc92-4353-969f-cbfa27de20ec) |

<!-- before-and-after:end -->

## Details

Deferred from the 0.37.0 release (#1779) to the next one.

What the primary session applies, and whether `tab new` already inherited it. Everything marked "no" is what this PR replays; the two "no, unchanged" rows are out of scope.

| Setting | Applied on the primary session via | Inherited by `tab new` before |
|---|---|---|
| Cookies, localStorage | browser profile, shared within the default context | yes |
| Download path | `Browser.setDownloadBehavior` in `BrowserManager::launch` (context-wide) | yes |
| `permissions` | `Browser.grantPermissions` (context-wide) | yes |
| Domain filter, proxy auth, WebRTC containment | `install_network_controls_*` per session | yes |
| Ignore HTTPS errors | `Security.setIgnoreCertificateErrors` on the launch session | no, unchanged |
| Viewport, device metrics | `viewport` and `device` handlers, `state.viewport` | no, unchanged (a tab has its own window size) |
| `--user-agent`, `useragent`, `device` UA | `Emulation.setUserAgentOverride` on the active session | no |
| `--color-scheme`, `set_media` | `Emulation.setEmulatedMedia` on the active session | no |
| `--init-script`, `--enable`, plugin init scripts, `addinitscript` | `Page.addScriptToEvaluateOnNewDocument` on the active session | no |
| `set headers` (global) | `Network.setExtraHTTPHeaders` on the active session | no |
| `--headers` (origin-scoped) | `state.origin_headers` + `Fetch.enable` on the active session | no (the fetch handler is shared, but the new session never emitted `requestPaused`) |
| `route` | `state.routes` + `Fetch.enable` on the active session | no (same) |
| Timezone, locale, geolocation | `Emulation.*Override` on the active session | no |
| `offline` | `Network.emulateNetworkConditions` on the active session | no |

Design. None of the missing settings were tracked; each handler fired a CDP call at the active session and forgot it. `DaemonState::session_setup` (a `SessionSetup` struct plus `EmulatedMedia`) is seeded by the launch paths from `LaunchOptions`, updated by each handler, and reset on `close` and relaunch. `apply_session_setup(state, session_id)` replays it onto a session and sends `Fetch.enable` with the current route and origin-header patterns when either exists. `handle_tab_new` calls it right after creating the tab. When there is anything to replay (or, as before, when network controls require it) the tab is created blank and navigated afterwards so the first document gets the setup; in that case `tab new` waits for load and prints the title like `open` does, which is what the network-controls path already did. With nothing configured, `tab new` is unchanged.

Emulation failures are ignored so an engine that rejects a call does not abort creating the tab; `Fetch.enable` failures propagate like they do in `route`. Permissions are not tracked because `Browser.grantPermissions` is context-scoped and already covers new tabs. Init scripts added by `react renders start` and `react vitals start` are diagnostic and are not tracked.

Verified. `node scripts/sync-version.js` (no changes), `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (1232 passed, 111 ignored). `cargo test -- --ignored --test-threads=1 e2e_tab`: 9 passed, including the new `e2e_tab_new_inherits_init_script_on_first_load` and `e2e_tab_new_inherits_user_agent_and_headers`. Manual check with release builds of `main` (4a98df7) and this branch: launch with `--user-agent ab-test/1 --init-script ... --headers '{"X-Test":"inherited"}'`, then `tab new https://httpbin.org/headers`. On `main` the new tab reports the stock HeadlessChrome UA, `window.__init` unset, and no `X-Test` in the echoed headers; on this branch it reports `ab-test/1`, `"ran"`, and `X-Test: inherited`. The screenshots above are the same steps against a local echo server.
