### PR TITLE
[cli] Record: require ffmpeg up front, validate output extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ agent-browser trace start             # Start recording trace
 agent-browser trace stop [path]       # Stop and save trace
 agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
-agent-browser record start ./demo.webm           # Start video recording at 30 fps
+agent-browser record start ./demo.webm           # Start video recording at 30 fps (.webm or .mp4; needs ffmpeg on PATH)
 agent-browser record start ./demo.webm --fps 60  # 60 fps for motion-heavy takes (1-60 allowed)
 agent-browser record stop                        # Stop and save the video
 agent-browser record restart ./take2.webm        # Stop the current recording, start a new one

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1677,7 +1677,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     "recording_start",
                     &rest[1..],
                     "record start",
-                    "record start <output.webm> [url] [--fps <n>]",
+                    "record start <output.webm|output.mp4> [url] [--fps <n>]",
                 ),
                 Some("stop") => Ok(json!({ "id": id, "action": "recording_stop" })),
                 Some("restart") => parse_record_take(
@@ -1685,7 +1685,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     "recording_restart",
                     &rest[1..],
                     "record restart",
-                    "record restart <output.webm> [url] [--fps <n>]",
+                    "record restart <output.webm|output.mp4> [url] [--fps <n>]",
                 ),
                 Some(sub) => Err(ParseError::UnknownSubcommand {
                     subcommand: sub.to_string(),
@@ -2324,7 +2324,9 @@ fn parse_read(rest: &[&str], id: &str, flags: &Flags) -> Result<Value, ParseErro
 /// Parse the arguments shared by `record start` and `record restart`:
 /// `<path> [url] [--fps <n>]`.
 ///
-/// `rest` excludes the subcommand. Recording defaults to
+/// `rest` excludes the subcommand. `path` needs an extension so ffmpeg can
+/// pick a container (`.webm` and `.mp4` are the tuned ones). Recording
+/// defaults to
 /// `recording::DEFAULT_FPS`; `--fps` accepts anything up to
 /// `recording::MAX_FPS`, with 60 reserved for motion-heavy takes.
 fn parse_record_take(
@@ -2391,6 +2393,11 @@ fn parse_record_take(
         context: context.to_string(),
         usage,
     })?;
+
+    // ffmpeg picks the container from the extension and only fails at
+    // `record stop`, so reject extensionless paths before the daemon is asked.
+    crate::native::recording::validate_output_path(path)
+        .map_err(|message| ParseError::InvalidValue { message, usage })?;
 
     let mut cmd = json!({ "id": id, "action": action, "path": path });
     if let Some(u) = url {
@@ -4906,6 +4913,69 @@ mod tests {
             result.unwrap_err(),
             ParseError::InvalidValue { .. }
         ));
+    }
+
+    #[test]
+    fn test_record_start_accepts_any_extension() {
+        // .webm and .mp4 are the documented formats; other containers
+        // worked before validation existed and are still passed through.
+        for path in [
+            "demo.mp4",
+            "./out/DEMO.WEBM",
+            "Take.Mp4",
+            "take.mkv",
+            "take.mov",
+            "dir.v2/take.MP4",
+        ] {
+            let cmd = parse_command(&args(&format!("record start {}", path)), &default_flags())
+                .unwrap_or_else(|e| panic!("{} should parse: {:?}", path, e));
+            assert_eq!(cmd["action"], "recording_start");
+            assert_eq!(cmd["path"], path);
+        }
+    }
+
+    #[test]
+    fn test_record_start_rejects_extensionless_path() {
+        for path in ["take", "dir.v2/take", ".hidden"] {
+            let err = parse_command(&args(&format!("record start {}", path)), &default_flags())
+                .unwrap_err();
+            match err {
+                ParseError::InvalidValue { message, usage } => {
+                    assert!(message.contains(path), "should name the path: {}", message);
+                    assert!(message.contains("no extension"), "message was: {}", message);
+                    assert!(
+                        message.contains(".webm"),
+                        "should suggest .webm: {}",
+                        message
+                    );
+                    assert!(message.contains(".mp4"), "should suggest .mp4: {}", message);
+                    assert!(usage.starts_with("record start"), "usage was: {}", usage);
+                }
+                other => panic!("expected InvalidValue for {}, got {:?}", path, other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_record_start_rejects_extensionless_path_with_valid_fps() {
+        // The path is validated once all flags are parsed, so a bad path
+        // is reported even when --fps is fine.
+        let err = parse_command(&args("record start take --fps 60"), &default_flags()).unwrap_err();
+        assert!(
+            matches!(err, ParseError::InvalidValue { ref message, .. } if message.contains("output path"))
+        );
+    }
+
+    #[test]
+    fn test_record_restart_rejects_extensionless_path() {
+        let err = parse_command(&args("record restart take2"), &default_flags()).unwrap_err();
+        match err {
+            ParseError::InvalidValue { message, usage } => {
+                assert!(message.contains("take2"), "message was: {}", message);
+                assert!(usage.starts_with("record restart"), "usage was: {}", usage);
+            }
+            other => panic!("expected InvalidValue, got {:?}", other),
+        }
     }
 
     #[test]

--- a/cli/src/doctor/ffmpeg.rs
+++ b/cli/src/doctor/ffmpeg.rs
@@ -1,0 +1,393 @@
+//! Check the ffmpeg install that `record` pipes frames into: the binary on
+//! PATH, its version, and whether the encoders the recorder selects from the
+//! output extension (libvpx for `.webm`, libx264 for `.mp4`) are compiled in.
+//!
+//! Every outcome here is Pass or Warn, never Fail: recording is the only
+//! feature that needs ffmpeg, so a machine without it is still healthy.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use super::helpers::which_path;
+use super::{Check, Status};
+
+/// Encoders `record` picks from the output extension, with the extension
+/// each one serves. Both come from the same build flags on every common
+/// distribution, so a missing one usually means a stripped-down ffmpeg.
+const REQUIRED_ENCODERS: &[(&str, &str)] = &[("libvpx", ".webm"), ("libx264", ".mp4")];
+
+pub(super) fn check(checks: &mut Vec<Check>) {
+    let probe = match which_path("ffmpeg") {
+        Some(path) => FfmpegProbe::Found {
+            version: run_ffmpeg(&path, &["-version"]).and_then(|out| parse_version(&out)),
+            encoders: run_ffmpeg(&path, &["-hide_banner", "-encoders"])
+                .map(|out| parse_encoders(&out)),
+            path,
+        },
+        None => FfmpegProbe::Missing,
+    };
+    push_checks(checks, &probe, std::env::consts::OS);
+}
+
+/// What the probe learned about ffmpeg, separated from the process calls so
+/// the check logic can be exercised without an ffmpeg install.
+pub(super) enum FfmpegProbe {
+    Missing,
+    Found {
+        path: PathBuf,
+        /// First line of `ffmpeg -version` without the copyright notice.
+        version: Option<String>,
+        /// Encoder names from `ffmpeg -encoders`; `None` when the listing
+        /// could not be read.
+        encoders: Option<Vec<String>>,
+    },
+}
+
+fn push_checks(checks: &mut Vec<Check>, probe: &FfmpegProbe, os: &str) {
+    let category = "Recording";
+
+    let (path, version, encoders) = match probe {
+        FfmpegProbe::Missing => {
+            checks.push(
+                Check::new(
+                    "recording.ffmpeg",
+                    category,
+                    Status::Warn,
+                    "ffmpeg not found on PATH (only needed for `record`)",
+                )
+                .with_fix(install_hint(os)),
+            );
+            return;
+        }
+        FfmpegProbe::Found {
+            path,
+            version,
+            encoders,
+        } => (path, version, encoders),
+    };
+
+    let label = path.display();
+    let message = match version {
+        Some(version) => format!("{} at {}", version, label),
+        None => format!("ffmpeg at {} (version unknown)", label),
+    };
+    checks.push(Check::new(
+        "recording.ffmpeg",
+        category,
+        Status::Pass,
+        message,
+    ));
+
+    let Some(encoders) = encoders else {
+        checks.push(
+            Check::new(
+                "recording.ffmpeg_encoders",
+                category,
+                Status::Warn,
+                "Could not list ffmpeg encoders (`ffmpeg -encoders` failed)",
+            )
+            .with_fix(reinstall_hint(os)),
+        );
+        return;
+    };
+
+    let missing: Vec<&(&str, &str)> = REQUIRED_ENCODERS
+        .iter()
+        .filter(|(name, _)| !encoders.iter().any(|e| e == name))
+        .collect();
+
+    if missing.is_empty() {
+        let available: Vec<String> = REQUIRED_ENCODERS
+            .iter()
+            .map(|(name, ext)| format!("{} ({})", name, ext))
+            .collect();
+        checks.push(Check::new(
+            "recording.ffmpeg_encoders",
+            category,
+            Status::Pass,
+            format!("{} encoders available", available.join(" and ")),
+        ));
+    } else {
+        let names: Vec<String> = missing
+            .iter()
+            .map(|(name, ext)| format!("{} ({} recordings)", name, ext))
+            .collect();
+        checks.push(
+            Check::new(
+                "recording.ffmpeg_encoders",
+                category,
+                Status::Warn,
+                format!(
+                    "ffmpeg build is missing the {} encoder{}; those recordings will fail",
+                    names.join(" and "),
+                    if missing.len() == 1 { "" } else { "s" }
+                ),
+            )
+            .with_fix(reinstall_hint(os)),
+        );
+    }
+}
+
+/// Package-manager command for a machine without ffmpeg.
+fn install_hint(os: &str) -> String {
+    match os {
+        "macos" => "brew install ffmpeg".to_string(),
+        "linux" => "apt install ffmpeg (Debian/Ubuntu)".to_string(),
+        _ => "install ffmpeg from https://ffmpeg.org/download.html and add it to PATH".to_string(),
+    }
+}
+
+/// Hint for a machine whose ffmpeg is present but lacks an encoder.
+fn reinstall_hint(os: &str) -> String {
+    format!(
+        "reinstall ffmpeg with libvpx and libx264: {}",
+        install_hint(os)
+    )
+}
+
+/// Run `binary` with `args`, returning stdout when it exits successfully.
+fn run_ffmpeg(binary: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new(binary)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// `ffmpeg version 8.1` from the banner's first line, dropping the
+/// copyright notice that follows it.
+fn parse_version(stdout: &str) -> Option<String> {
+    let first = stdout.lines().next()?.trim();
+    let version = first.split(" Copyright").next().unwrap_or(first).trim();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version.to_string())
+    }
+}
+
+/// Encoder names from `ffmpeg -encoders`. Each entry is a flags column such
+/// as `V....D` followed by the name; the legend lines above the table pair
+/// a flags column with `=` and are skipped.
+fn parse_encoders(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let mut tokens = line.split_whitespace();
+            let flags = tokens.next()?;
+            let name = tokens.next()?;
+            let is_flags =
+                flags.len() == 6 && flags.chars().all(|c| c == '.' || c.is_ascii_uppercase());
+            if is_flags && name != "=" {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION_OUTPUT: &str = "ffmpeg version 8.1 Copyright (c) 2000-2026 the FFmpeg developers\nbuilt with Apple clang version 21.0.0\nconfiguration: --prefix=/opt/homebrew --enable-libvpx --enable-libx264\n";
+
+    const ENCODERS_OUTPUT: &str = "Encoders:\n V..... = Video\n A..... = Audio\n S..... = Subtitle\n .F.... = Frame-level multithreading\n ..S... = Slice-level multithreading\n ...X.. = Codec is experimental\n ....B. = Supports draw_horiz_band\n .....D = Supports direct rendering method 1\n ------\n V....D a64multi             Multicolor charset for Commodore 64 (codec a64_multi)\n V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)\n V....D libx264rgb           libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)\n V....D libvpx               libvpx VP8 (codec vp8)\n V....D libvpx-vp9           libvpx VP9 (codec vp9)\n A....D aac                  AAC (Advanced Audio Coding)\n";
+
+    fn found(version: Option<&str>, encoders: Option<&[&str]>) -> FfmpegProbe {
+        FfmpegProbe::Found {
+            path: PathBuf::from("/opt/homebrew/bin/ffmpeg"),
+            version: version.map(String::from),
+            encoders: encoders.map(|e| e.iter().map(|s| s.to_string()).collect()),
+        }
+    }
+
+    fn run(probe: &FfmpegProbe, os: &str) -> Vec<Check> {
+        let mut checks = Vec::new();
+        push_checks(&mut checks, probe, os);
+        checks
+    }
+
+    #[test]
+    fn parse_version_drops_copyright_notice() {
+        assert_eq!(
+            parse_version(VERSION_OUTPUT).as_deref(),
+            Some("ffmpeg version 8.1")
+        );
+        assert_eq!(
+            parse_version("ffmpeg version n7.1.1-4ubuntu1\n").as_deref(),
+            Some("ffmpeg version n7.1.1-4ubuntu1")
+        );
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("\n\n"), None);
+    }
+
+    #[test]
+    fn parse_encoders_reads_names_and_skips_legend() {
+        let encoders = parse_encoders(ENCODERS_OUTPUT);
+        assert_eq!(
+            encoders,
+            vec![
+                "a64multi",
+                "libx264",
+                "libx264rgb",
+                "libvpx",
+                "libvpx-vp9",
+                "aac"
+            ]
+        );
+        assert!(parse_encoders("").is_empty());
+        assert!(parse_encoders("Encoders:\n ------\n").is_empty());
+    }
+
+    #[test]
+    fn missing_ffmpeg_is_a_warning_with_an_install_hint() {
+        let checks = run(&FfmpegProbe::Missing, "macos");
+        assert_eq!(checks.len(), 1);
+        let c = &checks[0];
+        assert_eq!(c.id, "recording.ffmpeg");
+        assert_eq!(c.category, "Recording");
+        assert_eq!(c.status, Status::Warn);
+        assert!(c.message.contains("not found"), "message: {}", c.message);
+        assert!(c.message.contains("record"), "message: {}", c.message);
+        assert_eq!(c.fix.as_deref(), Some("brew install ffmpeg"));
+    }
+
+    #[test]
+    fn install_hint_follows_the_platform() {
+        assert_eq!(install_hint("macos"), "brew install ffmpeg");
+        assert!(install_hint("linux").starts_with("apt install ffmpeg"));
+        assert!(install_hint("windows").contains("ffmpeg.org"));
+        assert!(reinstall_hint("linux").contains("libvpx and libx264"));
+        assert!(reinstall_hint("linux").contains("apt install ffmpeg"));
+    }
+
+    #[test]
+    fn complete_build_passes_both_checks() {
+        let checks = run(
+            &found(
+                Some("ffmpeg version 8.1"),
+                Some(&["libx264", "libvpx", "aac"]),
+            ),
+            "macos",
+        );
+        assert_eq!(checks.len(), 2);
+        assert_eq!(checks[0].id, "recording.ffmpeg");
+        assert_eq!(checks[0].status, Status::Pass);
+        assert_eq!(
+            checks[0].message,
+            "ffmpeg version 8.1 at /opt/homebrew/bin/ffmpeg"
+        );
+        assert!(checks[0].fix.is_none());
+        assert_eq!(checks[1].id, "recording.ffmpeg_encoders");
+        assert_eq!(checks[1].status, Status::Pass);
+        assert!(checks[1].message.contains("libvpx (.webm)"));
+        assert!(checks[1].message.contains("libx264 (.mp4)"));
+        assert!(checks[1].fix.is_none());
+    }
+
+    #[test]
+    fn unknown_version_still_passes() {
+        let checks = run(&found(None, Some(&["libx264", "libvpx"])), "linux");
+        assert_eq!(checks[0].status, Status::Pass);
+        assert_eq!(
+            checks[0].message,
+            "ffmpeg at /opt/homebrew/bin/ffmpeg (version unknown)"
+        );
+    }
+
+    #[test]
+    fn missing_encoder_warns_and_names_the_extension_it_breaks() {
+        let checks = run(
+            &found(Some("ffmpeg version 8.1"), Some(&["libx264"])),
+            "linux",
+        );
+        assert_eq!(checks.len(), 2);
+        let c = &checks[1];
+        assert_eq!(c.status, Status::Warn);
+        assert!(
+            c.message.contains("libvpx (.webm recordings)"),
+            "{}",
+            c.message
+        );
+        assert!(!c.message.contains("libx264"), "{}", c.message);
+        assert!(
+            c.message.ends_with("encoder; those recordings will fail"),
+            "{}",
+            c.message
+        );
+        assert!(c.fix.as_deref().unwrap().contains("apt install ffmpeg"));
+
+        let both = run(&found(Some("ffmpeg version 8.1"), Some(&[])), "macos");
+        assert!(
+            both[1]
+                .message
+                .contains("libvpx (.webm recordings) and libx264 (.mp4 recordings) encoders"),
+            "{}",
+            both[1].message
+        );
+    }
+
+    #[test]
+    fn unreadable_encoder_list_warns() {
+        let checks = run(&found(Some("ffmpeg version 8.1"), None), "macos");
+        assert_eq!(checks.len(), 2);
+        assert_eq!(checks[1].id, "recording.ffmpeg_encoders");
+        assert_eq!(checks[1].status, Status::Warn);
+        assert!(checks[1].message.contains("-encoders"));
+        assert!(checks[1].fix.is_some());
+    }
+
+    #[test]
+    fn recording_checks_never_fail() {
+        // Recording is optional, so no ffmpeg state may flip doctor's exit
+        // code to 1.
+        let probes = [
+            FfmpegProbe::Missing,
+            found(None, None),
+            found(None, Some(&[])),
+            found(Some("ffmpeg version 8.1"), Some(&["libvpx", "libx264"])),
+        ];
+        for probe in &probes {
+            for os in ["macos", "linux", "windows"] {
+                for c in run(probe, os) {
+                    assert_ne!(c.status, Status::Fail, "{}: {}", c.id, c.message);
+                }
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn run_ffmpeg_returns_stdout_on_success_only() {
+        let sh = Path::new("/bin/sh");
+        assert_eq!(
+            run_ffmpeg(sh, &["-c", "echo 'ffmpeg version 8.1 Copyright'"]).as_deref(),
+            Some("ffmpeg version 8.1 Copyright\n")
+        );
+        assert_eq!(run_ffmpeg(sh, &["-c", "echo nope; exit 1"]), None);
+        assert_eq!(
+            run_ffmpeg(
+                Path::new("/nonexistent/agent-browser-ffmpeg"),
+                &["-version"]
+            ),
+            None
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn run_ffmpeg_parses_a_scripted_encoder_listing() {
+        let script = format!("printf '%s' '{}'", ENCODERS_OUTPUT);
+        let out = run_ffmpeg(Path::new("/bin/sh"), &["-c", &script]).unwrap();
+        let encoders = parse_encoders(&out);
+        assert!(encoders.iter().any(|e| e == "libvpx"));
+        assert!(encoders.iter().any(|e| e == "libx264"));
+    }
+}

--- a/cli/src/doctor/helpers.rs
+++ b/cli/src/doctor/helpers.rs
@@ -59,18 +59,31 @@ pub(super) fn disk_free_bytes(_path: &Path) -> Option<u64> {
 }
 
 pub(super) fn which_exists(name: &str) -> bool {
+    which_path(name).is_some()
+}
+
+/// Resolve `name` on PATH via `which` / `where`, returning the first match.
+pub(super) fn which_path(name: &str) -> Option<std::path::PathBuf> {
     let probe = if cfg!(target_os = "windows") {
         "where"
     } else {
         "which"
     };
-    std::process::Command::new(probe)
+    let output = std::process::Command::new(probe)
         .arg(name)
-        .stdout(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(std::path::PathBuf::from)
 }
 
 pub(super) fn parse_json_file(path: &Path) -> Result<(), String> {
@@ -142,6 +155,19 @@ mod tests {
         assert!(!which_exists(
             "agent-browser-this-does-not-exist-please-dont-install-it"
         ));
+    }
+
+    #[test]
+    fn test_which_path_returns_an_existing_binary() {
+        let probe = if cfg!(target_os = "windows") {
+            "cmd"
+        } else {
+            "sh"
+        };
+        let path = which_path(probe).expect("probe binary should resolve");
+        assert!(path.is_absolute(), "got {}", path.display());
+        assert!(path.exists(), "got {}", path.display());
+        assert!(which_path("agent-browser-this-does-not-exist-please-dont-install-it").is_none());
     }
 
     #[test]

--- a/cli/src/doctor/mod.rs
+++ b/cli/src/doctor/mod.rs
@@ -1,8 +1,8 @@
 //! Diagnose an agent-browser installation.
 //!
-//! Runs a battery of checks across environment, Chrome install, daemon
-//! state, config files, encryption, providers, network reachability, and
-//! a live headless browser launch test.
+//! Runs a battery of checks across environment, Chrome install, the ffmpeg
+//! install `record` needs, daemon state, config files, encryption,
+//! providers, network reachability, and a live headless browser launch test.
 //!
 //! Auto-cleans stale daemon socket/pid/version sidecar files. Destructive
 //! repairs (reinstalling Chrome, purging old state files, generating a
@@ -12,6 +12,7 @@ mod chrome;
 mod config;
 mod daemon;
 mod environment;
+mod ffmpeg;
 mod fix;
 mod helpers;
 mod launch;
@@ -108,6 +109,7 @@ pub fn run_doctor(opts: DoctorOptions) -> i32 {
 
     environment::check(&mut checks);
     chrome::check(&mut checks);
+    ffmpeg::check(&mut checks);
     daemon::check(&mut checks);
     config::check(&mut checks);
     security::check(&mut checks);

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1370,7 +1370,10 @@ fn parity_tools() -> Vec<Value> {
             "Record start",
             "Start video recording of the current active page. Captures 30 fps by default; pass fps up to 60 for motion-heavy takes. Pass url to navigate the active tab there first. Use agent_browser_tab_new beforehand to record in a separate tab.",
             json!({
-                "path": { "type": "string" },
+                "path": {
+                    "type": "string",
+                    "description": "Output file; .webm (VP8) and .mp4 (H.264) are the supported formats, other extensions are handed to ffmpeg as-is with H.264 video. Must have an extension. Needs ffmpeg on PATH.",
+                },
                 "url": { "type": "string", "description": "Navigate the active tab to this URL before recording starts." },
                 "fps": {
                     "type": "integer",
@@ -1393,7 +1396,10 @@ fn parity_tools() -> Vec<Value> {
             "Record restart",
             "Restart video recording. Captures 30 fps by default; pass fps up to 60 for motion-heavy takes.",
             json!({
-                "path": { "type": "string" },
+                "path": {
+                    "type": "string",
+                    "description": "Output file; .webm (VP8) and .mp4 (H.264) are the supported formats, other extensions are handed to ffmpeg as-is with H.264 video. Must have an extension. Needs ffmpeg on PATH.",
+                },
                 "url": { "type": "string" },
                 "fps": {
                     "type": "integer",
@@ -4557,6 +4563,21 @@ mod tests {
             assert_eq!(fps["minimum"], json!(1));
             // Must stay in sync with the CLI parser's --fps ceiling.
             assert_eq!(fps["maximum"], json!(crate::native::recording::MAX_FPS));
+
+            // The parser requires an extension and the two tuned formats are
+            // the ones to steer callers toward.
+            let path_desc = tool["inputSchema"]["properties"]["path"]["description"]
+                .as_str()
+                .unwrap();
+            for needle in [".webm", ".mp4", "ffmpeg"] {
+                assert!(
+                    path_desc.contains(needle),
+                    "{} path description should mention {}: {}",
+                    name,
+                    needle,
+                    path_desc
+                );
+            }
         }
 
         assert_eq!(

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1075,28 +1075,19 @@ impl DaemonState {
         }
     }
 
-    /// Start ffmpeg, attach the recorder's own CDP session to the page behind
-    /// `session_id`, and spawn the task that screencasts it into ffmpeg. Any
-    /// failure rolls the recording state back so `record start` reports it
-    /// and the next `record start` is not blocked.
+    /// Verify ffmpeg, attach the recorder's own CDP session to the page behind
+    /// `session_id`, and spawn the task that screencasts into it. Any failure
+    /// rolls the recording state back so `record start` reports it and the next
+    /// `record start` is not blocked.
     async fn start_recording_task(
         &mut self,
         client: Arc<CdpClient>,
         session_id: String,
     ) -> Result<(), String> {
-        // ffmpeg first: a missing binary is the common failure, and it costs
-        // nothing to undo.
-        let ffmpeg = match recording::spawn_ffmpeg(
-            &self.recording_state.output_path,
-            self.recording_state.fps,
-        ) {
-            Ok(ffmpeg) => ffmpeg,
-            Err(e) => {
-                // `recording_start` already marked the state active.
-                self.recording_state.active = false;
-                return Err(e);
-            }
-        };
+        if let Err(e) = recording::check_ffmpeg_available().await {
+            self.rollback_failed_recording_start().await;
+            return Err(e);
+        }
         let capture_session = match recording::attach_capture_session(
             &client,
             &session_id,
@@ -1106,11 +1097,21 @@ impl DaemonState {
         {
             Ok(capture_session) => capture_session,
             Err(e) => {
-                // Dropping the child kills ffmpeg (kill_on_drop) and leaves an
-                // empty file behind; remove it.
-                drop(ffmpeg);
-                let _ = std::fs::remove_file(&self.recording_state.output_path);
-                self.recording_state.active = false;
+                self.rollback_failed_recording_start().await;
+                return Err(e);
+            }
+        };
+        let ffmpeg = match recording::spawn_ffmpeg(
+            &self.recording_state.output_path,
+            self.recording_state.fps,
+        ) {
+            Ok(ffmpeg) => ffmpeg,
+            Err(e) => {
+                recording::detach_capture_session(&client, &capture_session).await;
+                if let Ok(mut guard) = self.recording_state.capture_session.lock() {
+                    *guard = None;
+                }
+                self.rollback_failed_recording_start().await;
                 return Err(e);
             }
         };
@@ -1131,6 +1132,14 @@ impl DaemonState {
         self.recording_state.shared_captured_count = Some(shared_captured);
         self.recording_state.cancel_tx = Some(cancel_tx);
         Ok(())
+    }
+
+    /// Reconcile every externally visible recording flag after startup fails.
+    async fn rollback_failed_recording_start(&mut self) {
+        self.recording_state.active = false;
+        if let Some(ref server) = self.stream_server {
+            server.set_recording(false, &self.engine).await;
+        }
     }
 
     async fn stop_recording_task(&mut self) -> Result<(), String> {
@@ -13593,6 +13602,127 @@ mod tests {
         assert!(error.contains("allowed domains"), "got: {}", error);
         assert!(state.recording_state.active);
         assert_eq!(state.recording_state.output_path, "/tmp/current.webm");
+    }
+
+    /// A browser-side attachment failure happens before ffmpeg opens the
+    /// destination, so an existing recording must remain untouched.
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_recording_attach_failure_preserves_existing_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("existing.webm");
+        fs::write(&output_path, b"existing recording").unwrap();
+
+        let mut state = DaemonState::new();
+        handle_launch(&json!({ "action": "launch", "headless": true }), &mut state)
+            .await
+            .expect("browser should launch");
+
+        recording::recording_start(
+            &mut state.recording_state,
+            output_path.to_str().unwrap(),
+            None,
+        )
+        .unwrap();
+        let client = state.browser.as_ref().unwrap().client.clone();
+        let error = state
+            .start_recording_task(client, "invalid-recording-session".to_string())
+            .await
+            .expect_err("invalid session should fail attachment");
+        let contents_after_failure = fs::read(&output_path);
+
+        let _ = close_current_browser(&mut state).await;
+
+        assert!(error.to_ascii_lowercase().contains("session"), "{error}");
+        assert_eq!(
+            contents_after_failure.unwrap(),
+            b"existing recording",
+            "a failed start must preserve the previous destination"
+        );
+    }
+
+    /// A restart failure rolls back both the internal recording state and the
+    /// status published to stream and dashboard clients.
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_recording_failed_restart_clears_stream_status() {
+        use futures_util::StreamExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        let guard = EnvGuard::new(&["PATH", "AGENT_BROWSER_SOCKET_DIR", "AGENT_BROWSER_SESSION"]);
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        let socket_dir = tempfile::tempdir().unwrap();
+        let empty_path = tempfile::tempdir().unwrap();
+        guard.set(
+            "AGENT_BROWSER_SOCKET_DIR",
+            socket_dir.path().to_str().unwrap(),
+        );
+        guard.set("AGENT_BROWSER_SESSION", "failed-record-restart");
+
+        let mut state = DaemonState::new();
+        handle_launch(&json!({ "action": "launch", "headless": true }), &mut state)
+            .await
+            .expect("browser should launch");
+        let status = handle_stream_enable(&json!({ "port": 0 }), &mut state)
+            .await
+            .expect("stream should start");
+        let port = status["port"].as_u64().unwrap() as u16;
+        let previous_path = socket_dir.path().join("previous.webm");
+        handle_recording_start(
+            &json!({
+                "action": "recording_start",
+                "path": previous_path.to_string_lossy()
+            }),
+            &mut state,
+        )
+        .await
+        .expect("initial recording should start");
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        guard.set("PATH", empty_path.path().to_str().unwrap());
+        let error = handle_recording_restart(
+            &json!({
+                "action": "recording_restart",
+                "path": socket_dir.path().join("restarted.webm").to_string_lossy()
+            }),
+            &mut state,
+        )
+        .await;
+        let error = error.expect_err("restart should fail without ffmpeg");
+        let active_after_failure = state.recording_state.active;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}"))
+            .await
+            .expect("stream client should connect");
+        let reported_recording = loop {
+            let message = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+                .await
+                .expect("status should arrive")
+                .expect("stream should stay open")
+                .expect("status should be readable");
+            if let Message::Text(text) = message {
+                let value: Value = serde_json::from_str(&text).unwrap();
+                if value["type"] == "status" {
+                    break value["recording"].as_bool().unwrap();
+                }
+            }
+        };
+
+        guard.set("PATH", &original_path);
+        let _ = ws.close(None).await;
+        let _ = handle_stream_disable(&mut state).await;
+        let _ = close_current_browser(&mut state).await;
+        let _ = fs::remove_file(previous_path);
+
+        assert!(error.contains("ffmpeg"), "{error}");
+        assert!(
+            !active_after_failure,
+            "recording state should be rolled back"
+        );
+        assert!(
+            !reported_recording,
+            "stream clients must not see recording=true after the restart failed"
+        );
     }
 
     #[tokio::test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7350,7 +7350,8 @@ async fn handle_recording_restart(cmd: &Value, state: &mut DaemonState) -> Resul
         .filter(|s| !s.is_empty())
         .map(String::from);
 
-    // Validate the rate before stopping the in-flight take.
+    // Validate the path and rate before stopping the in-flight take.
+    recording::validate_output_path(path)?;
     let fps = recording_fps_from_command(cmd)?;
 
     {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1075,19 +1075,15 @@ impl DaemonState {
         }
     }
 
-    /// Verify ffmpeg, attach the recorder's own CDP session to the page behind
-    /// `session_id`, and spawn the task that screencasts into it. Any failure
-    /// rolls the recording state back so `record start` reports it and the next
-    /// `record start` is not blocked.
+    /// Attach the recorder's own CDP session to the page behind `session_id`
+    /// and spawn the task that screencasts into ffmpeg. The caller verifies
+    /// ffmpeg before any navigation or restart teardown. Failures here roll the
+    /// recording state back so the next `record start` is not blocked.
     async fn start_recording_task(
         &mut self,
         client: Arc<CdpClient>,
         session_id: String,
     ) -> Result<(), String> {
-        if let Err(e) = recording::check_ffmpeg_available().await {
-            self.rollback_failed_recording_start().await;
-            return Err(e);
-        }
         let capture_session = match recording::attach_capture_session(
             &client,
             &session_id,
@@ -7335,6 +7331,13 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
     if state.recording_state.active {
         return Err("Recording already active".to_string());
     }
+    if state.browser.is_none() {
+        return Err("Browser not launched".to_string());
+    }
+
+    // Check the external dependency before an optional navigation mutates the
+    // active page. State is still inactive, so a failure needs no rollback.
+    recording::check_ffmpeg_available().await?;
 
     if let Some(url) = recording_url {
         navigate_active_page(state, url, WaitUntil::Load).await?;
@@ -7388,6 +7391,12 @@ async fn handle_recording_restart(cmd: &Value, state: &mut DaemonState) -> Resul
         if let Some(ref url) = recording_url {
             check_url_allowed_by_filter(domain_filter.as_ref(), url)?;
         }
+    }
+
+    // Preserve the in-flight take when the replacement cannot start. A
+    // restart without a browser keeps its existing state-only behavior.
+    if state.browser.is_some() {
+        recording::check_ffmpeg_available().await?;
     }
 
     let _ = state.stop_recording_task().await;
@@ -10433,6 +10442,7 @@ async fn handle_video_start(cmd: &Value, state: &mut DaemonState) -> Result<Valu
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
+    recording::check_ffmpeg_available().await?;
     recording::recording_start(&mut state.recording_state, path, fps)?;
     state
         .start_recording_task(mgr.client.clone(), session_id)
@@ -13641,11 +13651,11 @@ mod tests {
         );
     }
 
-    /// A restart failure rolls back both the internal recording state and the
+    /// A failed ffmpeg preflight preserves both the active recording and the
     /// status published to stream and dashboard clients.
     #[tokio::test]
     #[ignore]
-    async fn e2e_recording_failed_restart_clears_stream_status() {
+    async fn e2e_recording_failed_restart_preserves_active_recording() {
         use futures_util::StreamExt;
         use tokio_tungstenite::tungstenite::Message;
 
@@ -13679,11 +13689,12 @@ mod tests {
         .expect("initial recording should start");
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
+        let restarted_path = socket_dir.path().join("restarted.webm");
         guard.set("PATH", empty_path.path().to_str().unwrap());
         let error = handle_recording_restart(
             &json!({
                 "action": "recording_restart",
-                "path": socket_dir.path().join("restarted.webm").to_string_lossy()
+                "path": restarted_path.to_string_lossy()
             }),
             &mut state,
         )
@@ -13709,6 +13720,9 @@ mod tests {
         };
 
         guard.set("PATH", &original_path);
+        let stop = handle_recording_stop(&mut state)
+            .await
+            .expect("preserved recording should still stop normally");
         let _ = ws.close(None).await;
         let _ = handle_stream_disable(&mut state).await;
         let _ = close_current_browser(&mut state).await;
@@ -13716,12 +13730,20 @@ mod tests {
 
         assert!(error.contains("ffmpeg"), "{error}");
         assert!(
-            !active_after_failure,
-            "recording state should be rolled back"
+            active_after_failure,
+            "failed replacement must leave the current recording active"
         );
         assert!(
-            !reported_recording,
-            "stream clients must not see recording=true after the restart failed"
+            reported_recording,
+            "stream clients must still see the preserved recording"
+        );
+        assert!(
+            stop["frames"].as_u64().unwrap_or(0) > 0,
+            "preserved recording should keep capturing frames"
+        );
+        assert!(
+            !restarted_path.exists(),
+            "failed preflight must not create the replacement output"
         );
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1075,13 +1075,28 @@ impl DaemonState {
         }
     }
 
-    /// Attach the recorder's own CDP session to the page behind `session_id`
-    /// and spawn the task that screencasts it into ffmpeg.
+    /// Start ffmpeg, attach the recorder's own CDP session to the page behind
+    /// `session_id`, and spawn the task that screencasts it into ffmpeg. Any
+    /// failure rolls the recording state back so `record start` reports it
+    /// and the next `record start` is not blocked.
     async fn start_recording_task(
         &mut self,
         client: Arc<CdpClient>,
         session_id: String,
     ) -> Result<(), String> {
+        // ffmpeg first: a missing binary is the common failure, and it costs
+        // nothing to undo.
+        let ffmpeg = match recording::spawn_ffmpeg(
+            &self.recording_state.output_path,
+            self.recording_state.fps,
+        ) {
+            Ok(ffmpeg) => ffmpeg,
+            Err(e) => {
+                // `recording_start` already marked the state active.
+                self.recording_state.active = false;
+                return Err(e);
+            }
+        };
         let capture_session = match recording::attach_capture_session(
             &client,
             &session_id,
@@ -1091,7 +1106,10 @@ impl DaemonState {
         {
             Ok(capture_session) => capture_session,
             Err(e) => {
-                // `recording_start` already marked the state active.
+                // Dropping the child kills ffmpeg (kill_on_drop) and leaves an
+                // empty file behind; remove it.
+                drop(ffmpeg);
+                let _ = std::fs::remove_file(&self.recording_state.output_path);
                 self.recording_state.active = false;
                 return Err(e);
             }
@@ -1102,7 +1120,7 @@ impl DaemonState {
         let handle = recording::spawn_recording_task(
             client,
             capture_session,
-            self.recording_state.output_path.clone(),
+            ffmpeg,
             self.recording_state.fps,
             shared_count.clone(),
             shared_captured.clone(),
@@ -7293,8 +7311,10 @@ async fn handle_recording_start(cmd: &Value, state: &mut DaemonState) -> Result<
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
 
-    // Validate the rate before any browser work so a bad value costs nothing.
+    // Validate the rate and output path before any browser work so a bad value
+    // costs nothing.
     let fps = recording_fps_from_command(cmd)?;
+    recording::validate_output_path(path)?;
 
     {
         let domain_filter = state.domain_filter.read().await;
@@ -10399,6 +10419,7 @@ async fn handle_video_start(cmd: &Value, state: &mut DaemonState) -> Result<Valu
     }
 
     let fps = recording_fps_from_command(cmd)?;
+    recording::validate_output_path(path)?;
 
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7529,8 +7529,8 @@ async fn e2e_recording_rejects_extensionless_path_before_context() {
     assert_success(&resp);
 }
 
-/// Verify that a missing ffmpeg fails `recording_start` itself, not
-/// `recording_stop`, and rolls the state back so the next start works.
+/// Verify that a missing ffmpeg fails `recording_start` itself before an
+/// optional navigation, and leaves the state ready for the next start.
 #[tokio::test]
 #[ignore]
 async fn e2e_recording_fails_fast_without_ffmpeg() {
@@ -7540,6 +7540,15 @@ async fn e2e_recording_fails_fast_without_ffmpeg() {
 
     let resp = execute_command(
         &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let before_url = "data:text/html,<h1>Before</h1>";
+    let after_url = "data:text/html,<h1>After</h1>";
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": before_url }),
         &mut state,
     )
     .await;
@@ -7555,7 +7564,12 @@ async fn e2e_recording_fails_fast_without_ffmpeg() {
     guard.set("PATH", &empty_dir.to_string_lossy());
 
     let resp = execute_command(
-        &json!({ "id": "2", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &json!({
+            "id": "3",
+            "action": "recording_start",
+            "path": rec_path.to_string_lossy(),
+            "url": after_url
+        }),
         &mut state,
     )
     .await;
@@ -7571,18 +7585,34 @@ async fn e2e_recording_fails_fast_without_ffmpeg() {
         !state.recording_state.active,
         "failed start must not leave the recording active"
     );
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "location.href" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        before_url,
+        "ffmpeg preflight must fail before the requested navigation"
+    );
 
     // With ffmpeg back, the same start succeeds: nothing stale was left behind.
     guard.set("PATH", &original_path);
     let resp = execute_command(
-        &json!({ "id": "3", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &json!({
+            "id": "5",
+            "action": "recording_start",
+            "path": rec_path.to_string_lossy(),
+            "url": after_url
+        }),
         &mut state,
     )
     .await;
     assert_success(&resp);
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     let resp = execute_command(
-        &json!({ "id": "4", "action": "recording_stop" }),
+        &json!({ "id": "6", "action": "recording_stop" }),
         &mut state,
     )
     .await;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7487,8 +7487,116 @@ async fn e2e_recording_honors_requested_fps() {
     assert_success(&resp);
 }
 
+/// Verify that an output path without an extension is rejected before the
+/// recording context exists: no new tab, no file, nothing to stop.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_rejects_extensionless_path_before_context() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let rec_path = std::env::temp_dir().join(format!("ab-e2e-rec-noext-{}", std::process::id()));
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp.get("success").and_then(|v| v.as_bool()), Some(false));
+    let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("no extension"),
+        "error should explain the path: {}",
+        err
+    );
+    assert!(!rec_path.exists(), "no file should be created");
+    assert!(!state.recording_state.active);
+
+    let resp = execute_command(&json!({ "id": "3", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap().len();
+    assert_eq!(
+        tabs, 1,
+        "a rejected path must not leave a recording tab behind"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Verify that a missing ffmpeg fails `recording_start` itself, not
+/// `recording_stop`, and rolls the state back so the next start works.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_fails_fast_without_ffmpeg() {
+    let guard = EnvGuard::new(&["PATH"]);
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-noffmpeg-{}.webm", std::process::id()));
+
+    // A PATH with no ffmpeg on it. Chrome is already running, so nothing else
+    // needs resolving.
+    let empty_dir = tmp_dir.join(format!("ab-e2e-empty-path-{}", std::process::id()));
+    std::fs::create_dir_all(&empty_dir).unwrap();
+    guard.set("PATH", &empty_dir.to_string_lossy());
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(
+        resp.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "record start must fail without ffmpeg: {}",
+        serde_json::to_string_pretty(&resp).unwrap_or_default()
+    );
+    let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(err.contains("ffmpeg"), "error should name ffmpeg: {}", err);
+    assert!(
+        !state.recording_state.active,
+        "failed start must not leave the recording active"
+    );
+
+    // With ffmpeg back, the same start succeeds: nothing stale was left behind.
+    guard.set("PATH", &original_path);
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let _ = std::fs::remove_file(&rec_path);
+    let _ = std::fs::remove_dir(&empty_dir);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// Verify that an out-of-range frame rate is rejected before the recorder
-/// attaches to the page, leaving no file and no active recording behind.
+/// builds its context or attaches to the page, leaving no file and no active
+/// recording behind.
 #[tokio::test]
 #[ignore]
 async fn e2e_recording_rejects_invalid_fps() {

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -49,6 +49,53 @@ const SCREENCAST_QUALITY: u32 = 80;
 /// The page may already be gone by the time a recording stops.
 const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Characters of ffmpeg's stderr kept in a failure message. ffmpeg prints
+/// the cause last, after the banner and stream summaries, so the tail is
+/// the part worth showing.
+const FFMPEG_STDERR_TAIL_CHARS: usize = 400;
+
+/// Lower-cased extension of `path`, if it has one.
+fn output_extension(path: &str) -> Option<String> {
+    std::path::Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+}
+
+/// Reject output paths with no extension. ffmpeg picks the container from
+/// the extension, so a bare name fails at `record stop` with the take
+/// already lost. Anything with an extension is handed to ffmpeg as-is:
+/// `.webm` gets libvpx, everything else libx264 in whatever container
+/// ffmpeg knows for that extension.
+pub fn validate_output_path(path: &str) -> Result<(), String> {
+    match output_extension(path) {
+        Some(ext) if !ext.is_empty() => Ok(()),
+        _ => Err(format!(
+            "Invalid output path: '{}' has no extension (use .webm or .mp4)",
+            path
+        )),
+    }
+}
+
+/// The last [`FFMPEG_STDERR_TAIL_CHARS`] of `stderr`, cut at a line boundary
+/// where one falls inside the window, with trailing whitespace removed.
+fn ffmpeg_error_tail(stderr: &str) -> String {
+    let trimmed = stderr.trim_end();
+    let total = trimmed.chars().count();
+    if total <= FFMPEG_STDERR_TAIL_CHARS {
+        return trimmed.to_string();
+    }
+    let tail: String = trimmed
+        .chars()
+        .skip(total - FFMPEG_STDERR_TAIL_CHARS)
+        .collect();
+    // Drop the partial first line so the message starts on a whole one.
+    match tail.find(['\n', '\r']) {
+        Some(cut) if cut + 1 < tail.len() => tail[cut + 1..].trim_start().to_string(),
+        _ => tail,
+    }
+}
+
 /// Reject frame rates the pipeline cannot honor.
 pub fn validate_fps(fps: u32) -> Result<u32, String> {
     if fps == 0 || fps > MAX_FPS {
@@ -157,6 +204,7 @@ pub fn recording_start(
         return Err("Recording already active".to_string());
     }
 
+    validate_output_path(path)?;
     let fps = validate_fps(fps.unwrap_or(DEFAULT_FPS))?;
 
     state.active = true;
@@ -191,7 +239,9 @@ fn build_ffmpeg_command(output_path: &str, fps: u32) -> tokio::process::Command 
     let mut cmd = tokio::process::Command::new("ffmpeg");
     let high_fps = fps > HIGH_FPS_THRESHOLD;
 
-    cmd.args(["-y"])
+    // -hide_banner keeps the version and build banner out of stderr, so a
+    // failure message is the cause rather than the configure line.
+    cmd.args(["-y", "-hide_banner"])
         .args(["-avioflags", "direct"])
         .args([
             "-fpsprobesize",
@@ -213,7 +263,7 @@ fn build_ffmpeg_command(output_path: &str, fps: u32) -> tokio::process::Command 
         ])
         .args(["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2"]);
 
-    if output_path.ends_with(".webm") {
+    if output_extension(output_path).as_deref() == Some("webm") {
         let bitrate = WEBM_BITRATE_KBPS_AT_BASE_FPS
             .max(WEBM_BITRATE_KBPS_AT_BASE_FPS.saturating_mul(fps) / HIGH_FPS_THRESHOLD.max(1));
         cmd.args(["-c:v", "libvpx", "-crf", "30"])
@@ -389,10 +439,7 @@ pub fn spawn_recording_task(
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!(
-                "ffmpeg failed: {}",
-                stderr.chars().take(300).collect::<String>()
-            ));
+            return Err(format!("ffmpeg failed: {}", ffmpeg_error_tail(&stderr)));
         }
 
         Ok(())
@@ -576,6 +623,121 @@ mod tests {
         let zero = recording_start(&mut state, "/tmp/test.webm", Some(0));
         assert!(zero.is_err());
         assert!(!state.active);
+    }
+
+    #[test]
+    fn test_recording_start_rejects_extensionless_path() {
+        let mut state = RecordingState::new();
+        for path in [
+            "/tmp/take",
+            "/tmp/dir.v2/take",
+            "/tmp/.hidden",
+            "/tmp/take.",
+        ] {
+            let err = recording_start(&mut state, path, None).unwrap_err();
+            assert!(err.contains(path), "error should name the path: {}", err);
+            assert!(err.contains("no extension"), "error was: {}", err);
+            assert!(err.contains(".webm"), "error should suggest .webm: {}", err);
+            assert!(err.contains(".mp4"), "error should suggest .mp4: {}", err);
+            assert!(!state.active);
+        }
+    }
+
+    #[test]
+    fn test_validate_output_path_accepts_any_extension() {
+        // Only the two documented formats are tuned, but ffmpeg muxes
+        // libx264 into .mkv/.mov/.avi fine and those worked before the
+        // check existed, so anything with an extension passes.
+        for path in [
+            "take.webm",
+            "take.mp4",
+            "./out/TAKE.WEBM",
+            "/abs/path/Take.Mp4",
+            "dotted.name.webm",
+            "take.mkv",
+            "take.mov",
+            "take.avi",
+            "take.webm.part",
+            "dir.v2/take.MP4",
+        ] {
+            assert!(validate_output_path(path).is_ok(), "{} should pass", path);
+        }
+    }
+
+    #[test]
+    fn test_validate_output_path_rejects_missing_extension() {
+        for path in ["take", "take.", ".hidden", ".webm", "dir.v2/take", "dir/"] {
+            assert!(validate_output_path(path).is_err(), "{} should fail", path);
+        }
+        assert_eq!(
+            validate_output_path("take").unwrap_err(),
+            "Invalid output path: 'take' has no extension (use .webm or .mp4)"
+        );
+    }
+
+    #[test]
+    fn test_build_ffmpeg_command_matches_extension_case_insensitively() {
+        let cmd = build_ffmpeg_command("/tmp/OUT.WEBM", DEFAULT_FPS);
+        let args: Vec<&std::ffi::OsStr> = cmd.as_std().get_args().collect();
+        let args_str: Vec<&str> = args.iter().filter_map(|a| a.to_str()).collect();
+        assert!(args_str.contains(&"libvpx"));
+        assert!(!args_str.contains(&"libx264"));
+    }
+
+    #[test]
+    fn test_build_ffmpeg_command_hides_banner() {
+        let cmd = build_ffmpeg_command("/tmp/out.webm", DEFAULT_FPS);
+        let args: Vec<&std::ffi::OsStr> = cmd.as_std().get_args().collect();
+        assert!(args.contains(&std::ffi::OsStr::new("-hide_banner")));
+    }
+
+    #[test]
+    fn test_ffmpeg_error_tail_keeps_short_output_whole() {
+        let stderr = "Unable to choose an output format for 'take'\nError opening output files: Invalid argument\n";
+        assert_eq!(
+            ffmpeg_error_tail(stderr),
+            "Unable to choose an output format for 'take'\nError opening output files: Invalid argument"
+        );
+    }
+
+    #[test]
+    fn test_ffmpeg_error_tail_keeps_the_cause_not_the_banner() {
+        // A realistic failure: banner and configure line first, the cause
+        // last. The old 300-character head never reached the cause.
+        let banner = format!(
+            "ffmpeg version 8.1 Copyright (c) 2000-2026 the FFmpeg developers\n  built with clang\n  configuration: {}\n",
+            "--enable-libx264 ".repeat(40)
+        );
+        let cause = "[out#0 @ 0x1] Unable to choose an output format for './take'; use a specific format\nError opening output file ./take.\nError opening output files: Invalid argument";
+        let stderr = format!("{}{}\n", banner, cause);
+
+        let tail = ffmpeg_error_tail(&stderr);
+        assert!(tail.ends_with(cause), "tail was: {}", tail);
+        assert!(!tail.contains("ffmpeg version"), "tail was: {}", tail);
+        assert!(tail.chars().count() <= FFMPEG_STDERR_TAIL_CHARS);
+        // The window opened mid-way through the configure line; that
+        // partial line is dropped so the message starts on a whole one.
+        assert!(tail.starts_with("[out#0"), "tail was: {}", tail);
+    }
+
+    #[test]
+    fn test_ffmpeg_error_tail_keeps_a_single_long_line() {
+        let line = "x".repeat(FFMPEG_STDERR_TAIL_CHARS + 50);
+        let tail = ffmpeg_error_tail(&line);
+        assert_eq!(tail.chars().count(), FFMPEG_STDERR_TAIL_CHARS);
+    }
+
+    #[test]
+    fn test_ffmpeg_error_tail_handles_multibyte_and_progress_lines() {
+        // ffmpeg's progress output uses carriage returns; the cut must not
+        // split a multi-byte character.
+        let stderr = format!(
+            "{}\rframe=   12 fps=0.0 q=0.0\rError: ✗ muxer",
+            "é".repeat(500)
+        );
+        let tail = ffmpeg_error_tail(&stderr);
+        assert!(tail.ends_with("Error: ✗ muxer"), "tail was: {}", tail);
+        assert!(tail.starts_with("frame="), "tail was: {}", tail);
     }
 
     #[test]

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -339,15 +339,32 @@ pub async fn attach_capture_session(
     }
 }
 
-/// Spawn a background task that screencasts `capture_session` into ffmpeg at
-/// `fps`. Chrome pushes a frame on every repaint up to the display rate; a
+/// Start ffmpeg for `output_path`, so `record start` fails right away when it
+/// is missing instead of at `record stop`.
+pub fn spawn_ffmpeg(output_path: &str, fps: u32) -> Result<tokio::process::Child, String> {
+    spawn_ffmpeg_command(&mut build_ffmpeg_command(output_path, fps))
+}
+
+fn spawn_ffmpeg_command(
+    command: &mut tokio::process::Command,
+) -> Result<tokio::process::Child, String> {
+    command.spawn().map_err(|e| {
+        format!(
+            "ffmpeg not found or failed to execute: {}. Install ffmpeg to enable recording.",
+            e
+        )
+    })
+}
+
+/// Spawn a background task that screencasts `capture_session` into the
+/// already running `ffmpeg` at `fps`. Chrome pushes a frame on every repaint up to the display rate; a
 /// wall-clock ticker writes one frame per slot, holding the last one through
 /// gaps, so the file's duration matches the automation it recorded.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_recording_task(
     client: Arc<CdpClient>,
     capture_session: String,
-    output_path: String,
+    mut ffmpeg: tokio::process::Child,
     fps: u32,
     shared_count: Arc<AtomicU64>,
     shared_captured: Arc<AtomicU64>,
@@ -362,14 +379,6 @@ pub fn spawn_recording_task(
         // neither copy them nor overflow on them. Subscribe before starting
         // the screencast: Chrome sends the first frame immediately.
         let events = client.subscribe_session(&capture_session);
-
-        let mut command = build_ffmpeg_command(&output_path, fps);
-        let mut ffmpeg = command.spawn().map_err(|e| {
-            format!(
-                "ffmpeg not found or failed to execute: {}. Install ffmpeg to enable recording.",
-                e
-            )
-        })?;
 
         let stdin = ffmpeg
             .stdin
@@ -873,6 +882,14 @@ mod tests {
         }
 
         assert_eq!(emitted, max_frames + 20);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_ffmpeg_reports_missing_binary() {
+        let mut command = tokio::process::Command::new("agent-browser-no-such-ffmpeg");
+        let err = spawn_ffmpeg_command(&mut command).unwrap_err();
+        assert!(err.contains("ffmpeg not found"), "{err}");
+        assert!(err.contains("Install ffmpeg"), "{err}");
     }
 
     #[test]

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -339,8 +339,46 @@ pub async fn attach_capture_session(
     }
 }
 
-/// Start ffmpeg for `output_path`, so `record start` fails right away when it
-/// is missing instead of at `record stop`.
+/// Detach a capture session that was attached for recording. This is best
+/// effort because the page or browser may already be gone.
+pub async fn detach_capture_session(client: &CdpClient, capture_session: &str) {
+    let _ = tokio::time::timeout(
+        TEARDOWN_TIMEOUT,
+        client.send_command(
+            "Target.detachFromTarget",
+            Some(json!({ "sessionId": capture_session })),
+            None,
+        ),
+    )
+    .await;
+}
+
+fn ffmpeg_launch_error(error: impl std::fmt::Display) -> String {
+    format!(
+        "ffmpeg not found or failed to execute: {}. Install ffmpeg to enable recording.",
+        error
+    )
+}
+
+/// Verify that ffmpeg can run without opening or modifying the destination.
+/// This keeps missing-binary failures ahead of browser attachment while the
+/// real encoder process is deferred until that attachment succeeds.
+pub async fn check_ffmpeg_available() -> Result<(), String> {
+    let status = tokio::process::Command::new("ffmpeg")
+        .arg("-version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map_err(ffmpeg_launch_error)?;
+    if !status.success() {
+        return Err(ffmpeg_launch_error(status));
+    }
+    Ok(())
+}
+
+/// Start the encoder process after the browser capture session is ready.
 pub fn spawn_ffmpeg(output_path: &str, fps: u32) -> Result<tokio::process::Child, String> {
     spawn_ffmpeg_command(&mut build_ffmpeg_command(output_path, fps))
 }
@@ -348,12 +386,7 @@ pub fn spawn_ffmpeg(output_path: &str, fps: u32) -> Result<tokio::process::Child
 fn spawn_ffmpeg_command(
     command: &mut tokio::process::Command,
 ) -> Result<tokio::process::Child, String> {
-    command.spawn().map_err(|e| {
-        format!(
-            "ffmpeg not found or failed to execute: {}. Install ffmpeg to enable recording.",
-            e
-        )
-    })
+    command.spawn().map_err(ffmpeg_launch_error)
 }
 
 /// Spawn a background task that screencasts `capture_session` into the
@@ -429,15 +462,7 @@ pub fn spawn_recording_task(
             client.send_command_no_params("Page.stopScreencast", Some(&capture_session)),
         )
         .await;
-        let _ = tokio::time::timeout(
-            TEARDOWN_TIMEOUT,
-            client.send_command(
-                "Target.detachFromTarget",
-                Some(json!({ "sessionId": capture_session })),
-                None,
-            ),
-        )
-        .await;
+        detach_capture_session(&client, &capture_session).await;
 
         let output = ffmpeg
             .wait_with_output()

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2793,16 +2793,21 @@ The output file can be viewed in:
             r##"
 agent-browser record - Record browser session to video
 
-Usage: agent-browser record start <path.webm> [url] [--fps <n>]
+Usage: agent-browser record start <path.webm|path.mp4> [url] [--fps <n>]
        agent-browser record stop
-       agent-browser record restart <path.webm> [url] [--fps <n>]
+       agent-browser record restart <path.webm|path.mp4> [url] [--fps <n>]
 
-Record the browser to a WebM video file.
+Record the browser to a video file. Supported formats are .webm (VP8 via
+libvpx) and .mp4 (H.264 via libx264); any other extension is handed to
+ffmpeg as-is with H.264 video. A path with no extension is rejected.
 Records the current active page as-is: no new context, no new tab, and no
 navigation unless you pass a URL. Capture starts on the page you already
 have open, so hydration and initial animations are not re-run cold.
 If a URL is provided, the active tab navigates there first.
 To record in a separate tab, run `tab new [url]` before `record start`.
+
+Requires ffmpeg on PATH with the libvpx and libx264 encoders (brew install
+ffmpeg, or apt install ffmpeg). Run `agent-browser doctor` to check.
 
 Recording captures 30 fps, which keeps scrolls and CSS transitions smooth.
 Raise it to 60 for short, motion-heavy takes (drag interactions, animation
@@ -3743,7 +3748,7 @@ Debug:
   trace start                Start Chrome DevTools trace
   trace stop [path]          Stop and save Chrome DevTools trace
   profiler start|stop [path] Record Chrome DevTools profile
-  record start <path> [url]  Start video recording (WebM, 30 fps; --fps 1-60)
+  record start <path> [url]  Start video recording (.webm/.mp4; --fps 1-60; needs ffmpeg)
   record stop                Stop and save video
   console [--clear]          View console logs
   errors [--clear]           View page errors

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -314,7 +314,7 @@ agent-browser stream disable          # Stop runtime streaming and remove the .s
 
 Streaming is enabled automatically for all sessions. Use these commands to check status, re-enable on a specific port, or disable streaming.
 
-Streaming is separate from file-based recordings. Use [Video Recording](/recording) when you need a saved WebM artifact.
+Streaming is separate from file-based recordings. Use [Video Recording](/recording) when you need a saved WebM or MP4 artifact.
 
 ## Debug
 
@@ -323,7 +323,7 @@ agent-browser trace start             # Start trace
 agent-browser trace stop [path]       # Stop and save trace
 agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
-agent-browser record start <path>     # Start video recording of the current page (WebM, 30 fps)
+agent-browser record start <path>     # Start video recording (.webm/.mp4, 30 fps; needs ffmpeg)
 agent-browser record start <path> --fps 60  # Record at 60 fps (--fps accepts 1-60)
 agent-browser record stop             # Stop and save video
 agent-browser record restart <path>   # Stop current and start new recording
@@ -336,7 +336,7 @@ agent-browser highlight <sel>         # Highlight element
 agent-browser inspect                 # Open Chrome DevTools for the active page
 ```
 
-See [Debugging](/debugging) for console, error, dialog, trace, highlight, and DevTools workflows. See [Video Recording](/recording) for `record` workflows and [Profiler](/profiler) for performance profiles.
+Recording requires `ffmpeg` on `PATH`. See [Debugging](/debugging) for console, error, dialog, trace, highlight, and DevTools workflows. See [Video Recording](/recording) for recording requirements and `record` workflows, and [Profiler](/profiler) for performance profiles.
 
 ## Auth vault
 

--- a/docs/src/app/recording/page.mdx
+++ b/docs/src/app/recording/page.mdx
@@ -1,6 +1,18 @@
 # Video Recording
 
-Use `record` to capture browser automation as a WebM video for debugging, CI evidence, product walkthroughs, or repro reports.
+Use `record` to capture browser automation as a WebM or MP4 video for debugging, CI evidence, product walkthroughs, or repro reports.
+
+## Requirements
+
+Recording pipes frames into `ffmpeg`, which must be on `PATH` with the `libvpx` and `libx264` encoders (the default builds from Homebrew and Debian/Ubuntu include both):
+
+```bash
+brew install ffmpeg        # macOS
+sudo apt install ffmpeg    # Debian/Ubuntu
+agent-browser doctor       # reports ffmpeg and its encoders under "Recording"
+```
+
+The supported formats are `.webm` (VP8 via libvpx) and `.mp4` (H.264 via libx264). Any other extension is handed to ffmpeg as-is with H.264 video, so `.mkv` or `.mov` work if ffmpeg knows the container. A path with no extension is rejected before recording starts, since ffmpeg would have nothing to pick a container from. Nothing else in agent-browser needs ffmpeg.
 
 ## Basic workflow
 
@@ -63,9 +75,9 @@ Valid rates are 1 to 60. Frames come from Chrome's screencast, so every repaint 
     <tr><th>Command</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>record start &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Start recording the active page to a WebM file; a URL navigates the active tab first</td></tr>
+    <tr><td><code>record start &lt;path.webm|path.mp4&gt; [url] [--fps &lt;n&gt;]</code></td><td>Start recording the active page to a WebM or MP4 file; a URL navigates the active tab first</td></tr>
     <tr><td><code>record stop</code></td><td>Stop the active recording and save the file</td></tr>
-    <tr><td><code>record restart &lt;path.webm&gt; [url] [--fps &lt;n&gt;]</code></td><td>Stop the current recording and immediately start another on the active page</td></tr>
+    <tr><td><code>record restart &lt;path.webm|path.mp4&gt; [url] [--fps &lt;n&gt;]</code></td><td>Stop the current recording and immediately start another on the active page</td></tr>
   </tbody>
 </table>
 
@@ -115,8 +127,8 @@ Screenshots and videos work well together: screenshots capture precise still sta
     <tr><th>Property</th><th>Value</th></tr>
   </thead>
   <tbody>
-    <tr><td>Container</td><td>WebM</td></tr>
-    <tr><td>Common extension</td><td><code>.webm</code></td></tr>
+    <tr><td>Container</td><td>WebM (<code>.webm</code>, VP8 via libvpx) or MP4 (<code>.mp4</code>, H.264 via libx264), chosen by the extension; other extensions get H.264 in whatever container ffmpeg maps them to</td></tr>
+    <tr><td>Encoder</td><td>ffmpeg on <code>PATH</code></td></tr>
     <tr><td>Frame rate</td><td>30 fps by default, 1 to 60 with <code>--fps</code></td></tr>
     <tr><td>Viewport</td><td>Uses the active browser viewport settings</td></tr>
     <tr><td>State</td><td>Records the active page in place, including its session and in-page state</td></tr>
@@ -129,4 +141,4 @@ Screenshots and videos work well together: screenshots capture precise still sta
 - Long recordings can use significant disk space; 60 fps roughly doubles the bitrate of 30 fps.
 - Distinct frames per second are bounded by how often the page repaints, so a page that renders below 60 fps records below it too.
 - Use `record stop` before closing a session if you need the file flushed.
-- Some constrained headless environments may have codec or GPU limitations.
+- Some constrained headless environments may have codec or GPU limitations. An ffmpeg built without libvpx or libx264 cannot write the matching format; `agent-browser doctor` reports which encoders are present.

--- a/docs/src/app/streaming/page.mdx
+++ b/docs/src/app/streaming/page.mdx
@@ -22,7 +22,7 @@ agent-browser stream disable           # Stop streaming for the session
 
 `stream status` returns the enabled state, active port, browser connection state, and whether screencasting is active. `stream disable` tears the server down and removes the session's `.stream` metadata file.
 
-Use [Video Recording](/recording) when you need a saved WebM artifact instead of a live WebSocket stream.
+Use [Video Recording](/recording) when you need a saved WebM or MP4 artifact instead of a live WebSocket stream. Recording requires `ffmpeg` on `PATH`.
 
 ## Runtime status response
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -342,13 +342,13 @@ agent-browser network har stop /tmp/trace.har
 
 ```bash
 agent-browser open https://example.com
-agent-browser record start demo.webm          # records the current page in place, 30 fps
+agent-browser record start demo.webm          # 30 fps by default; .webm or .mp4
 agent-browser snapshot -i
 agent-browser click @e3
 agent-browser record stop
 ```
 
-`record start` attaches to the active tab as-is (no new context, no navigation unless you pass a URL). To record in a separate tab, run `tab new <url>` first. Pass `--fps 60` for motion-heavy takes (drag, animation, scroll work) or a lower rate for long sessions; `--fps` accepts 1 to 60.
+`record start` attaches to the active tab as-is (no new context, no navigation unless you pass a URL). To record in a separate tab, run `tab new <url>` first. Recording needs `ffmpeg` on PATH (`brew install ffmpeg` / `apt install ffmpeg`); `agent-browser doctor` checks for it. Pass `--fps 60` for motion-heavy takes (drag, animation, scroll work) or a lower rate for long sessions; `--fps` accepts 1 to 60.
 
 See [references/video-recording.md](references/video-recording.md) for frame rate guidance, codec options, and more.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -124,7 +124,7 @@ agent-browser record start ./soak.webm --fps 10    # Lower rate for long session
 agent-browser tab new https://example.com          # Open a separate tab first if you want the recording there
 ```
 
-`--fps` accepts 1 to 60 and defaults to 30. Playback duration always matches the wall clock time recorded, so a slow page holds frames instead of speeding the video up.
+Needs `ffmpeg` on PATH; use a `.webm` or `.mp4` path (other extensions go to ffmpeg as-is, an extensionless path is rejected). `--fps` accepts 1 to 60 and defaults to 30. Playback duration always matches the wall clock time recorded, so a slow page holds frames instead of speeding the video up.
 
 ## Wait
 

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -6,6 +6,7 @@ Capture browser automation as video for debugging, documentation, or verificatio
 
 ## Contents
 
+- [Requirements](#requirements)
 - [Basic Recording](#basic-recording)
 - [Recording Commands](#recording-commands)
 - [Frame Rate](#frame-rate)
@@ -13,6 +14,12 @@ Capture browser automation as video for debugging, documentation, or verificatio
 - [Best Practices](#best-practices)
 - [Output Format](#output-format)
 - [Limitations](#limitations)
+
+## Requirements
+
+Recording pipes frames into `ffmpeg`, which must be on `PATH` with the `libvpx` and `libx264` encoders. Install it with `brew install ffmpeg` (macOS) or `sudo apt install ffmpeg` (Debian/Ubuntu); `agent-browser doctor` reports it under "Recording". Nothing else in agent-browser needs ffmpeg.
+
+Supported formats are `.webm` (VP8 via libvpx) and `.mp4` (H.264 via libx264). Other extensions are handed to ffmpeg as-is with H.264 video. A path with no extension is rejected before recording starts.
 
 ## Basic Recording
 
@@ -200,7 +207,7 @@ agent-browser record stop
 
 ## Output Format
 
-- Default format: WebM (VP8/VP9 codec)
+- Format follows the extension: `.webm` (VP8 via libvpx) or `.mp4` (H.264 via libx264); other extensions get H.264 in that container
 - Default frame rate: 30 fps (`--fps` accepts 1 to 60)
 - Compatible with all modern browsers and video players
 - Compressed but high quality
@@ -210,4 +217,4 @@ agent-browser record stop
 - Recording adds slight overhead to automation, and higher frame rates add more
 - Large recordings can consume significant disk space; 60 fps roughly doubles the bitrate of 30 fps
 - Distinct frames per second are bounded by how often the page repaints, so a page rendering below 60 fps records below it too
-- Some headless environments may have codec limitations
+- Some headless environments may have codec limitations; an ffmpeg built without libvpx or libx264 cannot write the matching format


### PR DESCRIPTION
`record` needs ffmpeg for every output format, but nothing said so until the first take failed, and a path with no extension only failed at `record stop` with the first 300 chars of stderr, which is the version banner. This makes the requirement visible up front and the failure legible. Builds on #1763.

## Before / after

`record start` with an extensionless path, `main` vs this branch:

```
$ agent-browser record start /tmp/take
✓ Recording started: /tmp/take (30 fps)
$ agent-browser record stop
✗ ffmpeg failed: ffmpeg version 8.1 Copyright (c) 2000-2026 the FFmpeg developers
  built with Apple clang version 21.0.0 (clang-2100.0.123.102)
  ...
```

```
$ agent-browser record start /tmp/take
Invalid output path: '/tmp/take' has no extension (use .webm or .mp4)
Usage: agent-browser record start <output.webm|output.mp4> [url] [--fps <n>]
```

`doctor` has no Recording section on `main`. On this branch, with ffmpeg installed and then with it off PATH:

```
Recording
  pass  ffmpeg version 8.1 at /opt/homebrew/bin/ffmpeg
  pass  libvpx (.webm) and libx264 (.mp4) encoders available
```

```
Recording
  warn  ffmpeg not found on PATH (only needed for `record`)
        fix: brew install ffmpeg
```

## Details

**Extension check.** The parser rejects only paths whose file name has no extension (`take`, `dir.v2/take`, `.hidden`), before the daemon is contacted. That's the one case that was already broken: ffmpeg picks the muxer from the extension and had nothing to go on. Anything with an extension is handed to ffmpeg exactly as before, so `.mkv`, `.mov` and `.avi` outputs that worked pre-PR keep working (H.264 in that container). `.webm` and `.mp4` are documented as the supported formats because those are the two the encoder settings are tuned for. `recording_start` in the daemon runs the same check so raw socket callers get the same error, and `record restart` checks the new path before stopping the in-flight take. `build_ffmpeg_command` now matches `.webm` case-insensitively: on `main` an uppercase `.WEBM` path picked libx264, which the WebM muxer rejects, so the take failed at stop with the same banner.

**stderr tail.** ffmpeg prints the cause last, so the error keeps the last 400 characters, cut at a line boundary, instead of the first 300. `-hide_banner` keeps the banner out of stderr entirely. The spawn failure message ("ffmpeg not found ... Install ffmpeg") is unchanged.

**doctor.** New `Recording` section with `recording.ffmpeg` (PATH lookup and version line) and `recording.ffmpeg_encoders` (`ffmpeg -hide_banner -encoders` parsed for `libvpx` and `libx264`). Everything is Pass or Warn, never Fail, because recording is the only feature that needs ffmpeg and a machine without it is otherwise healthy; a Fail would flip doctor's exit code for people who never record. Fix hints are `brew install ffmpeg` on macOS, `apt install ffmpeg` on Linux, and say it's only needed for `record`. The probe is split into process calls and a pure `push_checks`, so the tests cover every probe outcome without an ffmpeg install, plus `/bin/sh` scripted runs for the command wrapper (same style as `chrome.rs`).

**Docs.** Requirements section on the recording docs page and the skill reference, one line each in `SKILL.md`, `commands.md`, README, `record --help`, and the MCP `path` schema descriptions for `record_start`/`record_restart`. They name `.webm` (VP8) and `.mp4` (H.264) as the supported formats and say other extensions go to ffmpeg as-is with H.264 video.

Verified on macOS with ffmpeg 8.1 (Homebrew, libvpx + libx264): `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (1257 passed), `cargo test doctor` (34 passed), and `cargo test e2e_recording -- --ignored --test-threads=1` (3 passed) all clean. With release builds of `main` and this branch side by side: `record start /tmp/take` and `/tmp/dir.v2/take` exit 1 from the parser with the message above, where `main` started and then printed the banner at stop; `.avi`, `.MKV`, `.WEBM` and `.mp4` takes all save on this branch and ffprobe shows `h264`/`avi`, `h264`/`matroska,webm`, `vp8`/`matroska,webm` and `h264`/`mov,mp4`, where `main` failed the `.WEBM` take with the banner; `record --help` mentions the ffmpeg requirement; `doctor` shows the two passes above, the warn with `fix: brew install ffmpeg` under `PATH=/usr/bin:/bin` (exit 0), and `pass ... (version unknown)` plus `warn Could not list ffmpeg encoders` against a stub ffmpeg; a stub ffmpeg that prints a 600-char banner and exits 1 yields `ffmpeg failed: [out#0/webm @ 0x600] Unknown encoder 'libvpx' / Error opening output file /tmp/x.webm.` instead of the banner. Not re-run in this pass: raw socket `recording_start`/`recording_restart` with an extensionless path.

Closes #1772
