### PR TITLE
Prepare v0.37.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@
 ### Improvements
 
 - **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so recordings no longer open with a second of hydration jank, no extra tab appears during a recording, and the page keeps its state. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
-- **Output extension validation** - `record start` rejects output paths that do not end in `.webm` or `.mp4` before touching the browser, matches the extension case-insensitively, and reports the tail of ffmpeg's output instead of its version banner when encoding fails (#1778)
+- **Clearer recording errors** - `record start` rejects an output path with no extension up front instead of failing at `record stop`, `.WEBM` is matched case-insensitively so it encodes VP8, and an ffmpeg failure now shows the tail of its output instead of the version banner (#1778)
 
 ### Bug Fixes
 
-- Fixed **new tabs not inheriting session setup**: `tab new` now applies the session's user agent, extra and origin-scoped headers, init scripts, routes, color scheme, timezone, locale, geolocation, and offline mode to the new page before its first document loads (#1777)
 - Fixed **`record restart` output** printing `Saved to <new path>` instead of the restart line with the previous path (#1763)
 - Fixed a failed capture task leaving a **recording marked active**, which blocked the next `record start` (#1763)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Improvements
 
-- **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so recordings no longer open with a second of hydration jank, no extra tab appears during a recording, and the page keeps its state. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
+- **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so a recording starts from the warm page you were already on, keeps its state, and no longer adds a second tab. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
 - **Clearer recording errors** - `record start` rejects an output path with no extension up front instead of failing at `record stop`, `.WEBM` is matched case-insensitively so it encodes VP8, and an ffmpeg failure now shows the tail of its output instead of the version banner (#1778)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
 # agent-browser
 
-## 0.36.0
+## 0.37.0
 
 <!-- release:start -->
+### New Features
+
+- **Recording frame rate** - `record start` and `record restart` accept `--fps` from 1 to 60 and default to 30 instead of 10, so scrolls, hover states, and CSS transitions record as motion rather than a slideshow. Frames now come from Chrome's screencast on a dedicated CDP session instead of polling `Page.captureScreenshot`, so a 60 fps take of a scroll holds 60 distinct pictures per second, and the file's duration matches wall clock even when the page is static. `record stop` reports `capturedFrames` alongside `frames`, and the MCP `record_start` / `record_restart` tools expose `fps` (#1763)
+- **ffmpeg check in doctor** - `doctor` reports whether `ffmpeg` is on PATH and whether its libvpx and libx264 encoders are available, with install hints. Recording requires ffmpeg and now says so in the docs and `record --help` (#1778)
+
+### Improvements
+
+- **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so recordings no longer open with a second of hydration jank, no extra tab appears during a recording, and the page keeps its state. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
+- **Output extension validation** - `record start` rejects output paths that do not end in `.webm` or `.mp4` before touching the browser, matches the extension case-insensitively, and reports the tail of ffmpeg's output instead of its version banner when encoding fails (#1778)
+
+### Bug Fixes
+
+- Fixed **new tabs not inheriting session setup**: `tab new` now applies the session's user agent, extra and origin-scoped headers, init scripts, routes, color scheme, timezone, locale, geolocation, and offline mode to the new page before its first document loads (#1777)
+- Fixed **`record restart` output** printing `Saved to <new path>` instead of the restart line with the previous path (#1763)
+- Fixed a failed capture task leaving a **recording marked active**, which blocked the next `record start` (#1763)
+
+### Contributors
+
+- @jamesvclements
+<!-- release:end -->
+
+## 0.36.0
+
 ### New Features
 
 - Added experimental **WebMCP support** for discovering and invoking tools provided by the current page, including frame-aware tool selection, detached results, cancellation, bounded metadata and output handling, and an opt-in MCP tool profile. WebMCP is enabled by default for locally managed Chrome and can be disabled with `--no-webmcp` or `AGENT_BROWSER_NO_WEBMCP`.
@@ -24,7 +47,6 @@
 - @anupamme
 - @arrufat
 
-<!-- release:end -->
 
 ## 0.35.2
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.37.0
+
+<p className="text-[#888] text-sm">September 3, 2026</p>
+
+### New Features
+
+- **Recording frame rate** - `record start` and `record restart` accept `--fps` from 1 to 60 and default to 30 instead of 10, so scrolls, hover states, and CSS transitions record as motion rather than a slideshow. Frames now come from Chrome's screencast on a dedicated CDP session instead of polling `Page.captureScreenshot`, so a 60 fps take of a scroll holds 60 distinct pictures per second, and the file's duration matches wall clock even when the page is static. `record stop` reports `capturedFrames` alongside `frames`, and the MCP `record_start` / `record_restart` tools expose `fps` (#1763)
+- **ffmpeg check in doctor** - `doctor` reports whether `ffmpeg` is on PATH and whether its libvpx and libx264 encoders are available, with install hints. Recording requires ffmpeg and now says so in the docs and `record --help` (#1778)
+
+### Improvements
+
+- **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so recordings no longer open with a second of hydration jank, no extra tab appears during a recording, and the page keeps its state. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
+- **Output extension validation** - `record start` rejects output paths that do not end in `.webm` or `.mp4` before touching the browser, matches the extension case-insensitively, and reports the tail of ffmpeg's output instead of its version banner when encoding fails (#1778)
+
+### Bug Fixes
+
+- Fixed **new tabs not inheriting session setup**: `tab new` now applies the session's user agent, extra and origin-scoped headers, init scripts, routes, color scheme, timezone, locale, geolocation, and offline mode to the new page before its first document loads (#1777)
+- Fixed **`record restart` output** printing `Saved to <new path>` instead of the restart line with the previous path (#1763)
+- Fixed a failed capture task leaving a **recording marked active**, which blocked the next `record start` (#1763)
+
+---
+
 ## v0.36.0
 
 <p className="text-[#888] text-sm">September 1, 2026</p>

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -12,11 +12,10 @@
 ### Improvements
 
 - **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so recordings no longer open with a second of hydration jank, no extra tab appears during a recording, and the page keeps its state. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
-- **Output extension validation** - `record start` rejects output paths that do not end in `.webm` or `.mp4` before touching the browser, matches the extension case-insensitively, and reports the tail of ffmpeg's output instead of its version banner when encoding fails (#1778)
+- **Clearer recording errors** - `record start` rejects an output path with no extension up front instead of failing at `record stop`, `.WEBM` is matched case-insensitively so it encodes VP8, and an ffmpeg failure now shows the tail of its output instead of the version banner (#1778)
 
 ### Bug Fixes
 
-- Fixed **new tabs not inheriting session setup**: `tab new` now applies the session's user agent, extra and origin-scoped headers, init scripts, routes, color scheme, timezone, locale, geolocation, and offline mode to the new page before its first document loads (#1777)
 - Fixed **`record restart` output** printing `Saved to <new path>` instead of the restart line with the previous path (#1763)
 - Fixed a failed capture task leaving a **recording marked active**, which blocked the next `record start` (#1763)
 

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -11,7 +11,7 @@
 
 ### Improvements
 
-- **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so recordings no longer open with a second of hydration jank, no extra tab appears during a recording, and the page keeps its state. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
+- **Recording captures the current page** - `record start` attaches to the active page as-is instead of creating a fresh browser context and cold-loading the URL, so a recording starts from the warm page you were already on, keeps its state, and no longer adds a second tab. Passing a URL navigates the active tab. Use `tab new` first if you want a separate tab (#1776)
 - **Clearer recording errors** - `record start` rejects an output path with no extension up front instead of failing at `record stop`, `.WEBM` is matched case-insensitively so it encodes VP8, and an ffmpeg failure now shows the tail of its output instead of the version banner (#1778)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.36.0";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.37.0";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps to 0.37.0 and writes the changelog. Merging this publishes to npm and cuts the GitHub release, so it stays a draft until the PRs it describes are in.

## Details

Bundles the recording work (#1777, `tab new` inheritance, is deferred to the next release):

- #1763 (merged): 30 fps default, `--fps` up to 60, screencast recorder
- #1776: `record start` captures the current page, no fresh context

- #1778: ffmpeg in `doctor`, output extension validation, docs

Before marking ready: confirm #1776 and #1778 have merged (drop any that didn't from both changelog entries), update the date line in `docs/src/app/changelog/page.mdx`, and add any other contributors from `git log v0.36.0..main`. Version sync covers `cli/Cargo.toml`, `cli/Cargo.lock`, and the package manifests; `<!-- release:start/end -->` markers moved from 0.36.0 to 0.37.0.
