### PR TITLE
fix: detached daemon no longer wedges MCP server and captured output on Windows

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -789,6 +789,29 @@ fn stop_existing_daemon_for_restart(session: &str) {
     }
 }
 
+/// On Windows a spawned child inherits every inheritable handle we hold. Our
+/// stdout/stderr may be pipes that a parent reads to EOF (the MCP server's
+/// `run_cli`, or a PowerShell capture). The detached daemon we are about to
+/// spawn is long-lived; if it keeps those write ends open the parent blocks
+/// forever waiting for EOF that never arrives. Mark our own stdio handles
+/// non-inheritable so the daemon cannot hold the pipes open.
+#[cfg(windows)]
+pub(crate) fn prevent_stdio_handle_inheritance() {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{SetHandleInformation, HANDLE_FLAG_INHERIT};
+
+    unsafe {
+        for handle in [
+            std::io::stdout().as_raw_handle(),
+            std::io::stderr().as_raw_handle(),
+        ] {
+            if !handle.is_null() {
+                let _ = SetHandleInformation(handle as isize, HANDLE_FLAG_INHERIT, 0);
+            }
+        }
+    }
+}
+
 pub fn ensure_daemon(session: &str, opts: &DaemonOptions) -> Result<DaemonResult, String> {
     let mut restarted = false;
 
@@ -897,6 +920,8 @@ pub fn ensure_daemon(session: &str, opts: &DaemonOptions) -> Result<DaemonResult
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
+
+        prevent_stdio_handle_inheritance();
 
         let mut cmd = Command::new(&exe_path);
         cmd.env("AGENT_BROWSER_DAEMON", "1");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1105,6 +1105,7 @@ fn run_dashboard_start(port: u16, allowed_origins: Vec<String>, json_mode: bool)
         use std::os::windows::process::CommandExt;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
         const DETACHED_PROCESS: u32 = 0x00000008;
+        connection::prevent_stdio_handle_inheritance();
         cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
     }
 

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -11,8 +11,10 @@ use serde_json::{json, Value};
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;
-use std::io::{self, BufRead, Read, Write};
+use std::io::{self, BufRead, Write};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -3764,11 +3766,76 @@ fn append_common_global_args(
     Ok(())
 }
 
-fn run_cli(args: &[String], stdin_body: Option<String>, timeout_ms: u64) -> Result<CliRun, String> {
-    let exe = env::current_exe().map_err(|e| e.to_string())?;
-    let mut command = Command::new(exe);
+/// How long to keep reading child output after the child process has exited.
+///
+/// A detached grandchild (e.g. a daemon spawned on cold start) may still hold
+/// the write ends of our stdout/stderr pipes, in which case `read_to_end`
+/// never sees EOF. Return the partial output after this grace period instead
+/// of blocking the MCP server forever; every later request would otherwise
+/// queue behind the wedge until the server process is killed.
+const POST_EXIT_DRAIN_MS: u64 = 2_000;
+
+struct PipedOutput {
+    buffer: Arc<Mutex<Vec<u8>>>,
+    done: Arc<AtomicBool>,
+}
+
+impl PipedOutput {
+    fn spawn<R: io::Read + Send + 'static>(mut stream: R) -> Self {
+        let output = Self {
+            buffer: Arc::new(Mutex::new(Vec::new())),
+            done: Arc::new(AtomicBool::new(false)),
+        };
+        let buffer = Arc::clone(&output.buffer);
+        let done = Arc::clone(&output.done);
+        // Append each chunk as it arrives instead of buffering locally: if a
+        // grandchild holds the pipe open, read never returns EOF and a local
+        // buffer would never be published for the bounded drain to snapshot.
+        thread::spawn(move || {
+            let mut chunk = [0u8; 8192];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if let Ok(mut guard) = buffer.lock() {
+                            guard.extend_from_slice(&chunk[..n]);
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            done.store(true, Ordering::Release);
+        });
+        output
+    }
+
+    fn is_done(&self) -> bool {
+        self.done.load(Ordering::Acquire)
+    }
+
+    fn snapshot(&self) -> String {
+        let bytes = self
+            .buffer
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
+
+fn drain_piped_outputs(outputs: [&PipedOutput; 2]) {
+    let deadline = Instant::now() + Duration::from_millis(POST_EXIT_DRAIN_MS);
+    while Instant::now() < deadline && outputs.iter().any(|out| !out.is_done()) {
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn run_command(
+    mut command: Command,
+    stdin_body: Option<String>,
+    timeout_ms: u64,
+) -> Result<CliRun, String> {
     command
-        .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .stdin(if stdin_body.is_some() {
@@ -3789,40 +3856,29 @@ fn run_cli(args: &[String], stdin_body: Option<String>, timeout_ms: u64) -> Resu
             .map_err(|e| format!("failed to write child stdin: {}", e))?;
     }
 
-    let mut child_stdout = child
+    let child_stdout = child
         .stdout
         .take()
         .ok_or_else(|| "failed to open child stdout".to_string())?;
-    let mut child_stderr = child
+    let child_stderr = child
         .stderr
         .take()
         .ok_or_else(|| "failed to open child stderr".to_string())?;
-
-    let stdout_thread = thread::spawn(move || {
-        let mut buf = Vec::new();
-        child_stdout.read_to_end(&mut buf).map(|_| buf)
-    });
-    let stderr_thread = thread::spawn(move || {
-        let mut buf = Vec::new();
-        child_stderr.read_to_end(&mut buf).map(|_| buf)
-    });
+    let stdout_output = PipedOutput::spawn(child_stdout);
+    let stderr_output = PipedOutput::spawn(child_stderr);
 
     let started = Instant::now();
     let timeout = Duration::from_millis(timeout_ms);
+    let mut timed_out = false;
     let status = loop {
         match child.try_wait() {
-            Ok(Some(status)) => break status,
+            Ok(Some(status)) => break Some(status),
             Ok(None) => {
                 if started.elapsed() >= timeout {
                     let _ = child.kill();
                     let _ = child.wait();
-                    let stdout = join_output(stdout_thread)?;
-                    let stderr = join_output(stderr_thread)?;
-                    return Ok(CliRun {
-                        exit_code: None,
-                        stdout,
-                        stderr: append_timeout_message(stderr, timeout_ms),
-                    });
+                    timed_out = true;
+                    break None;
                 }
                 thread::sleep(Duration::from_millis(20));
             }
@@ -3830,22 +3886,25 @@ fn run_cli(args: &[String], stdin_body: Option<String>, timeout_ms: u64) -> Resu
         }
     };
 
-    let stdout = join_output(stdout_thread)?;
-    let stderr = join_output(stderr_thread)?;
+    drain_piped_outputs([&stdout_output, &stderr_output]);
+    let stdout = stdout_output.snapshot();
+    let mut stderr = stderr_output.snapshot();
+    if timed_out {
+        stderr = append_timeout_message(stderr, timeout_ms);
+    }
 
     Ok(CliRun {
-        exit_code: status.code(),
+        exit_code: status.as_ref().and_then(|s| s.code()),
         stdout,
         stderr,
     })
 }
 
-fn join_output(handle: thread::JoinHandle<io::Result<Vec<u8>>>) -> Result<String, String> {
-    let bytes = handle
-        .join()
-        .map_err(|_| "failed to join output reader".to_string())?
-        .map_err(|e| e.to_string())?;
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
+fn run_cli(args: &[String], stdin_body: Option<String>, timeout_ms: u64) -> Result<CliRun, String> {
+    let exe = env::current_exe().map_err(|e| e.to_string())?;
+    let mut command = Command::new(exe);
+    command.args(args);
+    run_command(command, stdin_body, timeout_ms)
 }
 
 fn append_timeout_message(stderr: String, timeout_ms: u64) -> String {
@@ -3997,6 +4056,23 @@ fn write_json_line(stdout: &mut io::Stdout, value: &Value) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_returns_partial_output_when_a_grandchild_holds_the_pipe() {
+        // The backgrounded sleep inherits our stdout pipe write end and
+        // outlives the shell. run_command must return the partial output once
+        // the child exits instead of blocking until the sleep finishes.
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("sleep 30 & echo ready");
+        let started = std::time::Instant::now();
+        let run = run_command(command, None, 25_000).expect("run_command should succeed");
+        assert!(run.stdout.contains("ready"), "stdout: {:?}", run.stdout);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(15),
+            "run_command blocked on a grandchild holding the pipe"
+        );
+    }
 
     #[test]
     fn tools_list_contains_typed_tools() {


### PR DESCRIPTION
## Summary

Fixes #1407. Related: #1308, #1713, and #1641 (the same inheritance mechanism, fixed for doctor's Chrome version detection).

On Windows, the detached daemon spawned on cold start inherited the CLI child's stdout/stderr pipe write ends. Any parent that reads that output to EOF then blocked forever:

- The MCP server's `run_cli` spawns `agent-browser --json open <url>` with piped stdout/stderr and waits on `read_to_end`. The child spawns the daemon, does its work, and exits normally, so the child-exit deadline never fires, but EOF never arrives because the long-lived daemon keeps the pipe open. The server wedge also stops the stdio loop from reading further requests, so every subsequent tool call times out until the MCP client is restarted. This reproduces the classic "works after warm-up, breaks again after every restart" pattern on Windows MCP harnesses.
- The same wedge hits plain PowerShell output capture (`$output = agent-browser open ...`), as reported in #1407.

## Changes

- `connection.rs`: new `prevent_stdio_handle_inheritance()` clears `HANDLE_FLAG_INHERIT` on the CLI's own stdout/stderr before spawning the detached daemon, so nothing inherits the pipe write ends. The dashboard spawn in `main.rs` gets the same treatment.
- `mcp.rs`: `run_cli` now drains child output for a bounded window (2s) after the child exits and returns whatever arrived instead of blocking indefinitely on `read_to_end`. Reader threads publish chunks as they arrive so a blocked EOF cannot hide already-emitted output. This also bounds the kill path, which previously joined the same threads.

I'm aware of #1408, which fixes the same root cause by reimplementing daemon spawn with a raw `CreateProcessW(bInheritHandles = FALSE)` call. This PR takes a lighter approach via `SetHandleInformation` on three handles and additionally hardens `run_cli`, which #1408 does not touch. Happy to consolidate with that PR whichever way the maintainers prefer.

## Evidence

Process captures from a Windows 11 host driving agent-browser through an MCP client, posted in #1407:

- During a wedged first call: `agent-browser.exe mcp` plus the argument-less detached daemon present; the `--json open` child already gone; client never receives a response.
- After client restart with the daemon still alive: the `--json open` child completes and the same call succeeds immediately against the warm daemon.

## Testing

- New unit test `run_command_returns_partial_output_when_a_grandchild_holds_the_pipe`: a backgrounded `sleep` inherits the output pipe and outlives the shell; asserts the call returns the partial output instead of blocking for the sleep's lifetime (fails on the old `read_to_end`-and-join implementation).
- `cargo test`: 1233 passed, 0 failed.
- `cargo clippy --all-targets` and `cargo fmt --check` clean; `cargo check --target x86_64-pc-windows-gnu` passes.