### PR TITLE
ci: lint test code with clippy --all-targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo fmt --manifest-path cli/Cargo.toml -- --check
 
       - name: Clippy check
-        run: cargo clippy --manifest-path cli/Cargo.toml -- -D warnings
+        run: cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings
 
       - name: Run Rust tests
         run: cargo test --profile ci --manifest-path cli/Cargo.toml

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -3510,12 +3510,14 @@ mod tests {
 
         // Keep sending requests so idle is never reached
         tokio::spawn(async move {
-            for i in 0u64.. {
+            let mut i = 0u64;
+            loop {
                 let _ = tx.send(cdp_event(
                     "Network.requestWillBeSent",
                     session,
                     json!({ "requestId": format!("r{}", i) }),
                 ));
+                i += 1;
                 sleep(Duration::from_millis(100)).await;
             }
         });

--- a/cli/src/native/cdp/client.rs
+++ b/cli/src/native/cdp/client.rs
@@ -537,6 +537,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // The Err type is fixed by tungstenite's Callback trait and cannot be shrunk.
+    #[allow(clippy::result_large_err)]
     async fn root_websocket_url_with_query_sends_slash_request_target() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();


### PR DESCRIPTION
## Summary

Fixes #1774.

- `cli/src/native/browser.rs`: replace the unbounded `for i in 0u64..` in `test_network_idle_overall_timeout` with a `loop` + counter, resolving `clippy::for_unbounded_range`.
- `cli/src/native/cdp/client.rs`: add `#[allow(clippy::result_large_err)]` to `root_websocket_url_with_query_sends_slash_request_target`; the `Err` type is fixed by tungstenite's `Callback` trait and cannot be shrunk.
- `.github/workflows/ci.yml`: run `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings` so `#[cfg(test)]` code is linted going forward.

Verified locally that `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings` no longer reports these two errors. Note: on Windows-only builds a few additional cfg(windows)-specific lints exist (e.g. unused imports that are only used under `#[cfg(unix)]`); those are out of scope here since CI lints on Linux, where `--all-targets` is clean with this change.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — clippy no longer reports `for_unbounded_range` / `result_large_err` (remaining local warnings are Windows-cfg-only, see above).
- [x] `cargo test --bin agent-browser test_network_idle_overall_timeout root_websocket_url_with_query_sends_slash_request_target` — both touched tests pass.
