### PR TITLE
fix: report browser connection status without reconnecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,9 +682,11 @@ agent-browser session
 # Generate a stable worktree-scoped session id
 agent-browser session id --scope worktree --prefix next-dev-loop
 
-# Inspect daemon, launch, and restore status
+# Inspect daemon and browser connection status without launching or reconnecting
 agent-browser session info --json
 ```
+
+The runtime data reports `browserConnected`, `connectionKind` (`local` or `external-cdp`), and `externalConnection`. A daemon IPC failure is returned in `runtimeError` instead of being mistaken for a missing runtime.
 
 Each session has its own:
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -652,10 +652,21 @@ fn run_session_id(args: &[String], json_mode: bool) {
     }
 }
 
+fn session_runtime_fields(
+    runtime: Option<Result<Response, String>>,
+) -> (Option<serde_json::Value>, Option<String>) {
+    match runtime {
+        Some(Ok(response)) if response.success => (response.data, None),
+        Some(Ok(response)) => (response.data, response.error),
+        Some(Err(error)) => (None, Some(error)),
+        None => (None, None),
+    }
+}
+
 fn run_session_info(session: &str, json_mode: bool) {
     let inventory = walk_daemons();
     let active = inventory.sessions.iter().find(|s| s.name == session);
-    let runtime = active.and_then(|_| {
+    let runtime = active.map(|_| {
         send_command(
             json!({
                 "id": gen_id(),
@@ -663,17 +674,8 @@ fn run_session_info(session: &str, json_mode: bool) {
             }),
             session,
         )
-        .ok()
     });
-
-    let runtime_data = runtime.as_ref().and_then(|resp| resp.data.clone());
-    let runtime_error = runtime.as_ref().and_then(|resp| {
-        if resp.success {
-            None
-        } else {
-            resp.error.clone()
-        }
-    });
+    let (runtime_data, runtime_error) = session_runtime_fields(runtime);
 
     if json_mode {
         print_json_value(json!({
@@ -717,6 +719,12 @@ fn run_session_info(session: &str, json_mode: bool) {
         }
         if let Some(launched) = data.get("browserLaunched").and_then(|v| v.as_bool()) {
             println!("Browser launched: {}", launched);
+        }
+        if let Some(connected) = data.get("browserConnected").and_then(|v| v.as_bool()) {
+            println!("Browser connected: {}", connected);
+        }
+        if let Some(kind) = data.get("connectionKind").and_then(|v| v.as_str()) {
+            println!("Connection kind: {}", kind);
         }
     } else if let Some(err) = runtime_error {
         println!("Runtime info unavailable: {}", err);
@@ -2293,6 +2301,14 @@ fn run_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_runtime_fields_preserves_transport_errors() {
+        let (data, error) = session_runtime_fields(Some(Err("daemon socket closed".to_string())));
+
+        assert!(data.is_none());
+        assert_eq!(error.as_deref(), Some("daemon socket closed"));
+    }
 
     #[test]
     fn dashboard_config_comparison_rejects_unknown_or_changed_settings() {

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1741,7 +1741,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_SESSION_INFO,
             "Session info",
-            "Show session, daemon, launch, and restore diagnostics.",
+            "Show session, daemon, browser connection, launch, and restore diagnostics without launching or reconnecting a browser.",
             json!({}),
             &[],
         ),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6231,13 +6231,29 @@ async fn handle_errors(state: &DaemonState) -> Result<Value, String> {
     Ok(state.event_tracker.get_errors_json())
 }
 
+/// Report daemon and browser state without launching or reconnecting a browser.
 async fn handle_session_info(state: &DaemonState) -> Result<Value, String> {
+    let (browser_connected, connection_kind, external_connection) = match state.browser.as_ref() {
+        Some(mgr) => {
+            let external = mgr.is_cdp_connection();
+            (
+                mgr.is_connection_alive().await,
+                Some(if external { "external-cdp" } else { "local" }),
+                Some(external),
+            )
+        }
+        None => (false, None, None),
+    };
+
     Ok(json!({
         "session": state.session_id,
         "namespace": env::var("AGENT_BROWSER_NAMESPACE").ok(),
         "socketDir": get_socket_dir().to_string_lossy(),
         "backgroundPid": std::process::id(),
         "browserLaunched": state.browser.is_some(),
+        "browserConnected": browser_connected,
+        "connectionKind": connection_kind,
+        "externalConnection": external_connection,
         "pageCount": state.browser.as_ref().map(|mgr| mgr.page_count()).unwrap_or(0),
         "engine": state.engine,
         "launchHash": state.launch_hash,
@@ -12075,6 +12091,63 @@ mod tests {
     use std::fs;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn session_info_without_browser_reports_disconnected() {
+        let state = DaemonState::new();
+
+        let info = handle_session_info(&state).await.unwrap();
+
+        assert_eq!(info["browserConnected"], false);
+        assert_eq!(info["connectionKind"], Value::Null);
+        assert_eq!(info["externalConnection"], Value::Null);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_session_info_reports_live_local_connection() {
+        let mut state = DaemonState::new();
+        let launch = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await;
+        assert_eq!(launch["success"], true);
+
+        let info = handle_session_info(&state).await.unwrap();
+        assert_eq!(info["browserConnected"], true);
+        assert_eq!(info["connectionKind"], "local");
+        assert_eq!(info["externalConnection"], false);
+
+        close_current_browser(&mut state).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_session_info_reports_live_external_cdp_connection() {
+        let mut local = DaemonState::new();
+        let launch = execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut local,
+        )
+        .await;
+        assert_eq!(launch["success"], true);
+        let cdp_url = local.browser.as_ref().unwrap().get_cdp_url().to_string();
+
+        let mut external = DaemonState::new();
+        external.browser = Some(BrowserManager::connect_cdp(&cdp_url).await.unwrap());
+        let info = handle_session_info(&external).await.unwrap();
+        assert_eq!(info["browserConnected"], true);
+        assert_eq!(info["connectionKind"], "external-cdp");
+        assert_eq!(info["externalConnection"], true);
+
+        close_current_browser(&mut local).await.unwrap();
+        let disconnected = handle_session_info(&external).await.unwrap();
+        assert_eq!(disconnected["browserConnected"], false);
+        assert_eq!(disconnected["connectionKind"], "external-cdp");
+
+        close_current_browser(&mut external).await.unwrap();
+    }
 
     /// A binding-recovery failure must tear the connection down: the attach
     /// paths set `state.browser` before calling this, so returning the error

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2958,7 +2958,7 @@ instance with separate cookies, storage, and state.
 Operations:
   (none)               Show current session name
   id                   Generate stable session id (--scope worktree|cwd|git-root, --prefix)
-  info                 Show daemon, launch, and restore diagnostics
+  info                 Show daemon, browser connection, launch, and restore diagnostics
   list                 List all active sessions
 
 Environment:
@@ -4013,7 +4013,7 @@ Examples:
   agent-browser profiles                               # List available Chrome profiles
   SESSION="$(agent-browser session id --scope worktree --prefix myapp)"
   agent-browser --session "$SESSION" --restore open example.com  # Auto-save/restore state
-  agent-browser session info --json                    # Inspect daemon and restore status
+  agent-browser session info --json                    # Inspect daemon and browser connection status
   agent-browser chat "open google.com and search for cats"  # AI chat (single-shot)
   agent-browser chat                                        # AI chat (interactive REPL)
   agent-browser -q chat "summarize this page"               # Quiet mode (text only)

--- a/docs/src/app/sessions/page.mdx
+++ b/docs/src/app/sessions/page.mdx
@@ -23,9 +23,11 @@ agent-browser session
 # Generate a stable worktree-scoped session id
 agent-browser session id --scope worktree --prefix next-dev-loop
 
-# Inspect daemon, launch, and restore status
+# Inspect daemon and browser connection status without launching or reconnecting
 agent-browser session info --json
 ```
+
+The runtime data reports <code>browserConnected</code>, <code>connectionKind</code> (<code>local</code> or <code>external-cdp</code>), and <code>externalConnection</code>. A daemon IPC failure is returned in <code>runtimeError</code> instead of being mistaken for a missing runtime.
 
 ## Session isolation
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -252,6 +252,8 @@ agent-browser --session "$SESSION" --restore --restore-check-text Dashboard open
 agent-browser --session "$SESSION" session info --json
 ```
 
+`session info` checks the existing browser connection without launching or reconnecting. Read `runtime.browserConnected`, `runtime.connectionKind`, and `runtime.externalConnection`; if daemon IPC fails, `runtimeError` contains the failure.
+
 ### Extract data
 
 ```bash

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -94,6 +94,8 @@ Use `agent-browser session info --json` for diagnostics:
 agent-browser --session "$SESSION" session info --json
 ```
 
+This is a read-only connection probe: it checks the existing browser socket without launching or reconnecting. The runtime object includes `browserConnected`, `connectionKind` (`local` or `external-cdp`), and `externalConnection`. Check `runtimeError` for daemon IPC failures.
+
 ### Manual State Files
 
 Use `state save`, `state load`, and `--state <path>` when you need an explicit portable JSON file. Do not make agents construct paths under `~/.agent-browser/sessions/`; prefer `--restore` for reusable agent sessions.


### PR DESCRIPTION
## Summary

`session info` is now a safe way to determine whether a named session still has a live browser connection. It checks the existing CDP socket and never launches, reconnects, or auto-connects.

The runtime payload now includes:

- `browserConnected`
- `connectionKind` (`local` or `external-cdp`)
- `externalConnection`

Daemon IPC transport failures are also preserved in `runtimeError` instead of being discarded.

## Motivation

We encountered a workflow where an agent used ordinary browser commands and repeated `--auto-connect` attempts to test an existing Chrome connection. Ordinary commands may enter stale-connection recovery, and auto-connect can create a new debugger attachment that shows Chrome's **Allow debugging** prompt. Repeated probes therefore caused repeated human approval prompts.

`agent-browser session info --json` already bypassed implicit launch, but it only reported whether a `BrowserManager` existed, not whether its socket was alive, and it discarded transport errors. This change makes it the side-effect-free connection probe agents need before deciding whether auto-connect is necessary.

## Tests

- unit: no browser reports disconnected
- unit: daemon transport failures survive as `runtimeError`
- e2e: live local browser reports `local`
- e2e: live attached browser reports `external-cdp`
- e2e: closed attached browser reports disconnected without reconnecting
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy -- -D warnings`

The focused unit and Chrome e2e tests pass. The full unit suite passed 1,222 tests in the original worktree; 12 unrelated failures came from macOS Unix-socket path length and the resulting poisoned shared test mutex. A retry from a short worktree reached unrelated sandboxed Chrome/network tests, so it was stopped after the changed-path coverage had already passed.
