### PR TITLE
docs: reuse Chrome sessions before auto-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1473,13 +1473,28 @@ This enables control of:
 Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
 
 ```bash
-# Auto-discover running Chrome with remote debugging
-agent-browser --auto-connect open example.com
-agent-browser --auto-connect snapshot
+# Inspect an existing session without launching or reconnecting
+SESSION="existing-chrome"
+agent-browser session list
+agent-browser --session "$SESSION" session info --json
 
-# Or via environment variable
-AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
+# If status confirms an active attachment, continue without --auto-connect
+agent-browser --session "$SESSION" open example.com
+agent-browser --session "$SESSION" snapshot
+
+# Otherwise warn the user, then attach once in a standalone command
+agent-browser --session "$SESSION" --auto-connect --pin-tab tab list
+
+# Continue without --auto-connect
+agent-browser --session "$SESSION" open example.com
+agent-browser --session "$SESSION" snapshot
 ```
+
+`session list` and `session info` inspect state without launching a browser. If runtime or browser status is missing or uncertain, warn the user before the first browser-touching command. Any browser command, including `tab list`, can attempt stale-session recovery. If the daemon was started with `AGENT_BROWSER_AUTO_CONNECT`, that recovery may reconnect and cause Chrome to show an Allow debugging prompt.
+
+In an interactive agent workflow, warn the user before the attachment command, run that command by itself, and pause with `Action required: Allow debugging in Chrome` if the prompt appears. Never silently retry auto-connect. Reuse the attached named session for the rest of a linear workflow, and create additional sessions only for genuine parallel work or separate browser identities.
+
+If an attached session returns `tab_gone`, the Chrome connection is still available. Recover with `tab list`, `tab new <url>`, or tab selection instead of reconnecting.
 
 Auto-connect discovers Chrome by:
 

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -39,13 +39,28 @@ Root WebSocket endpoints accept query strings with or without an explicit slash,
 Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
 
 ```bash
-# Auto-discover running Chrome with remote debugging
-agent-browser --auto-connect open example.com
-agent-browser --auto-connect snapshot
+# Inspect an existing session without launching or reconnecting
+SESSION="existing-chrome"
+agent-browser session list
+agent-browser --session "$SESSION" session info --json
 
-# Or via environment variable
-AGENT_BROWSER_AUTO_CONNECT=1 agent-browser snapshot
+# If status confirms an active attachment, continue without --auto-connect
+agent-browser --session "$SESSION" open example.com
+agent-browser --session "$SESSION" snapshot
+
+# Otherwise warn the user, then attach once in a standalone command
+agent-browser --session "$SESSION" --auto-connect --pin-tab tab list
+
+# Continue without --auto-connect
+agent-browser --session "$SESSION" open example.com
+agent-browser --session "$SESSION" snapshot
 ```
+
+`session list` and `session info` inspect state without launching a browser. If runtime or browser status is missing or uncertain, warn the user before the first browser-touching command. Any browser command, including `tab list`, can attempt stale-session recovery. If the daemon was started with `AGENT_BROWSER_AUTO_CONNECT`, that recovery may reconnect and cause Chrome to show an Allow debugging prompt.
+
+In an interactive agent workflow, warn the user before the attachment command, run that command by itself, and pause with `Action required: Allow debugging in Chrome` if the prompt appears. Never silently retry auto-connect. Reuse the attached named session for the rest of a linear workflow, and create additional sessions only for genuine parallel work or separate browser identities.
+
+If an attached session returns `tab_gone`, the Chrome connection is still available. Recover with `tab list`, `tab new <url>`, or tab selection instead of reconnecting.
 
 Auto-connect discovers Chrome by:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -317,6 +317,17 @@ agent-browser --session b fill @e1 "bob@test.com"
 
 `AGENT_BROWSER_SESSION=myapp` sets the default session for the current shell.
 
+For a linear workflow in an existing Chrome, reuse one attached session instead of creating a session for each step. Start with the no-launch checks `agent-browser session list` and `agent-browser --session "$SESSION" session info --json`. If the runtime and browser status confirm an active attachment, run the intended browser command without `--auto-connect`.
+
+If runtime or browser status is missing or uncertain, warn the user before the first browser-touching command. Any browser command can attempt stale-session recovery, and a daemon configured with `AGENT_BROWSER_AUTO_CONNECT` may reconnect and make Chrome ask the user to allow debugging. Use an explicit `--auto-connect` only when no reusable attached session exists, and treat the first attachment as a human-intervention boundary:
+
+1. Tell the user before running it that Chrome may request approval.
+2. Run one `--auto-connect` command by itself.
+3. If Chrome shows an Allow debugging prompt, pause and report `Action required: Allow debugging in Chrome`.
+4. After approval, reuse the same named session without `--auto-connect`.
+
+Never silently retry `--auto-connect`. A `tab_gone` error means the connection still exists but its bound tab was closed; recover with `tab list`, `tab new <url>`, or tab selection. Create multiple sessions only for genuine parallel work or separate browser identities. See `references/session-management.md` for the complete workflow.
+
 When several sessions share one Chrome over `--cdp <port>`, add `--pin-tab` so each session sticks to its own tab. Every session remembers its bound tab across daemon restarts; with `--pin-tab` a command whose bound tab was closed fails with a `tab_gone` error instead of acting on another session's tab. JSON output includes `"code": "tab_gone"`, `data.targetId`, and an optional sanitized `data.lastUrl` for recovery. Recover with `tab new <url>` or pick a tab from `tab list`. The flag is sticky per session, so pass it once (`--no-pin-tab` turns it off again). See `references/session-management.md` for details.
 
 ### Mock network requests

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -8,6 +8,7 @@ Multiple isolated browser sessions with state persistence and concurrent browsin
 
 - [Named Sessions](#named-sessions)
 - [Session Isolation Properties](#session-isolation-properties)
+- [Reuse Before Attaching](#reuse-before-attaching)
 - [Tab Pinning in a Shared Browser](#tab-pinning-in-a-shared-browser)
 - [Session State Persistence](#session-state-persistence)
 - [Common Patterns](#common-patterns)
@@ -47,6 +48,32 @@ Each session has independent:
 - Cache
 - Browsing history
 - Open tabs
+
+## Reuse Before Attaching
+
+Use one named session for a linear workflow. Before attaching to an existing Chrome, look for a reusable session and inspect it without starting a new attachment:
+
+```bash
+SESSION="existing-chrome"
+agent-browser session list
+agent-browser --session "$SESSION" session info --json
+```
+
+These are no-launch checks. If runtime and browser status confirm an active attachment, perform the intended browser command without `--auto-connect`.
+
+If runtime or browser status is missing or uncertain, warn the user before the first browser-touching command. Any browser command, including `tab list`, can attempt stale-session recovery. If the daemon was started with `AGENT_BROWSER_AUTO_CONNECT`, that recovery may reconnect and cause Chrome to show an Allow debugging prompt.
+
+Only use an explicit `--auto-connect` when no suitable attached session exists. Before the single attachment attempt, warn the user that Chrome may require approval. Run the command by itself so no dependent navigation or form action can continue while approval is pending:
+
+```bash
+agent-browser --session "$SESSION" --auto-connect --pin-tab tab list
+```
+
+If Chrome requests approval, stop and report `Action required: Allow debugging in Chrome`. Resume only after the user confirms, using the same session without `--auto-connect`. Never silently retry auto-connect, because each new attachment attempt may show another approval prompt.
+
+A closed bound tab is not a lost Chrome connection. When a command returns `tab_gone`, use `tab list`, `tab new <url>`, or tab selection to recover. Create another session only for genuine parallel work or a separate browser identity.
+
+This distinction matters in interactive workflows: repeatedly attaching with new sessions can produce multiple Chrome prompts, while reusing the existing attached session can navigate to another site without prompting again.
 
 ## Tab Pinning in a Shared Browser
 


### PR DESCRIPTION
## Summary

- teach agents to inspect and reuse an existing named Chrome session before attaching again
- make `--auto-connect` a single, standalone human-intervention boundary
- document stale-session uncertainty, `tab_gone` recovery, and when additional sessions are justified

## Motivation

In a real browser workflow, an agent repeatedly invoked `--auto-connect` and created new sessions. Chrome consequently showed several Allow debugging prompts, but the agent neither warned the user nor paused for the required approval. In the follow-up Gmail workflow, the agent reused the existing attached session and Chrome showed no prompt.

The previous examples also repeated `--auto-connect` on consecutive commands, which could reinforce the problematic pattern. The new guidance prescribes reuse-first checks, one attachment attempt, explicit user notification, and no silent retries.

It also records an important implementation detail: `session list` and `session info` are no-launch inspection commands, while browser-touching commands such as `tab list` may invoke stale-session recovery. If the daemon was configured with auto-connect, that recovery may require Chrome approval.

Complementary code change: #1785 makes `session info` report live browser connection state without reconnecting.

## Validation

- `git diff --check`
- reviewed the core skill, session reference, README, and CDP docs for consistent guidance
