### PR TITLE
feat: add side-effect-free Chrome auto-connect readiness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ agent-browser removeinitscript <identifier>       # Remove a previously register
 agent-browser install                 # Download Chrome from Chrome for Testing (Google's official automation channel)
 agent-browser install --with-deps     # Also install system deps (Linux)
 agent-browser upgrade                 # Upgrade agent-browser to the latest version
+agent-browser chrome status           # Check auto-connect readiness without attaching
 agent-browser doctor                  # Diagnose the install and auto-clean stale daemon files
 agent-browser doctor --fix            # Also run destructive repairs (reinstall Chrome, purge old state, ...)
 agent-browser doctor --offline --quick  # Skip network probes and the live launch test
@@ -563,7 +564,7 @@ Profiles:
 - `core` — Default. Navigation, snapshots, interaction, waits, reads, screenshots, JavaScript eval, close, tab basics, and profile discovery
 - `network` — Network routes, request inspection, HAR, headers, credentials, offline
 - `state` — Cookies, storage, auth, saved state, sessions, profiles, skills
-- `debug` — Console/errors, tracing, profiling, recording, a11y audit, clipboard, plugins, doctor, dashboard, install, upgrade, chat, diff, batch, confirm/deny
+- `debug` — Console/errors, tracing, profiling, recording, a11y audit, clipboard, plugins, Chrome status, doctor, dashboard, install, upgrade, chat, diff, batch, confirm/deny
 - `tabs` — Back/forward/reload, tabs, windows, frames, dialogs
 - `react` — React tree/inspect/renders/suspense, vitals, pushstate
 - `mobile` — Viewport/device/geolocation/media, touch, swipe, mouse, keyboard
@@ -1473,6 +1474,9 @@ This enables control of:
 Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
 
 ```bash
+# Check first without attaching or triggering Chrome's approval prompt
+agent-browser chrome status
+
 # Auto-discover running Chrome with remote debugging
 agent-browser --auto-connect open example.com
 agent-browser --auto-connect snapshot
@@ -1492,6 +1496,10 @@ This is useful when:
 - Chrome 144+ has remote debugging enabled via `chrome://inspect/#remote-debugging` (which uses a dynamic port)
 - You want a zero-configuration connection to your existing browser
 - You don't want to track which port Chrome is using
+
+`chrome status` reads `DevToolsActivePort` from the platform's standard Chrome, Chrome Canary, Chromium, and Brave user-data directories, then checks loopback TCP reachability. If no active-port file is present, it also checks the same common ports as auto-connect, 9222 and 9229. It never sends HTTP, opens a WebSocket, or attaches a debugger. The command works on the published macOS x64/ARM64, Linux glibc/musl x64/ARM64, and Windows x64 binaries (including the x64 fallback on Windows ARM64).
+
+The result is deliberately conservative: `ready` means a Chrome-advertised local port is listening; `candidate` means a common auto-connect port is listening but cannot be verified as Chrome/CDP without a protocol request; `not-running` means no active-port file or common listener was found, which cannot distinguish a closed browser from a disabled setting; `stale` means a file exists but its port is closed; and `unknown` covers malformed or unreadable state. Use `--json` for these stable status names. When setup is needed, open `chrome://inspect/#remote-debugging` in Chrome and enable Remote debugging. Normal agent-browser launches do not require this security-sensitive setting; it is only for reusing an existing browser with `--auto-connect`.
 
 ## Streaming (Browser Preview)
 

--- a/README.md
+++ b/README.md
@@ -1501,6 +1501,8 @@ This is useful when:
 
 The result is deliberately conservative: `ready` means a Chrome-advertised local port is listening; `candidate` means a common auto-connect port is listening but cannot be verified as Chrome/CDP without a protocol request; `not-running` means no active-port file or common listener was found, which cannot distinguish a closed browser from a disabled setting; `stale` means a file exists but its port is closed; and `unknown` covers malformed or unreadable state. Use `--json` for these stable status names. When setup is needed, open `chrome://inspect/#remote-debugging` in Chrome and enable Remote debugging. Normal agent-browser launches do not require this security-sensitive setting; it is only for reusing an existing browser with `--auto-connect`.
 
+This readiness check is only for desktop Chrome-family auto-connect. iOS/Safari, remote providers, and locally launched Chrome (including `--extension`) use their existing connection paths and do not need it. Electron apps on ports other than 9222 or 9229 should use `--cdp <port>` directly.
+
 ## Streaming (Browser Preview)
 
 Stream the browser viewport via WebSocket for live preview or "pair browsing" where a human can watch and interact alongside an AI agent.

--- a/cli/src/chrome_status.rs
+++ b/cli/src/chrome_status.rs
@@ -1,0 +1,98 @@
+//! Read-only Chrome remote-debugging readiness command.
+
+use serde_json::json;
+
+use crate::color;
+use crate::native::cdp::chrome::{chrome_debugging_status, ChromeDebuggingStatus};
+
+const ENABLE_HINT: &str =
+    "Open chrome://inspect/#remote-debugging in Chrome and enable Remote debugging.";
+
+/// Print whether `--auto-connect` can discover Chrome without attaching to it.
+pub async fn run(json_output: bool) -> i32 {
+    let status = chrome_debugging_status().await;
+    let (name, message, action, exit_code) = match &status {
+        ChromeDebuggingStatus::Ready { port, .. } => (
+            "ready",
+            format!("Chrome remote debugging is ready on loopback port {}", port),
+            None,
+            0,
+        ),
+        ChromeDebuggingStatus::Candidate { port } => (
+            "candidate",
+            format!(
+                "Common auto-connect port {} is reachable, but this check did not verify CDP",
+                port
+            ),
+            None,
+            0,
+        ),
+        ChromeDebuggingStatus::NotRunning => (
+            "not-running",
+            "Chrome remote debugging is not active (Chrome may be closed or the setting may be disabled)".to_string(),
+            Some(ENABLE_HINT),
+            1,
+        ),
+        ChromeDebuggingStatus::Stale { port, .. } => (
+            "stale",
+            format!("Chrome advertised loopback port {}, but nothing is listening", port),
+            Some("Restart Chrome, then check remote debugging again."),
+            2,
+        ),
+        ChromeDebuggingStatus::Unknown { reason, .. } => (
+            "unknown",
+            format!("Chrome remote-debugging state could not be determined: {}", reason),
+            Some("Check the Chrome user-data directory permissions, then retry."),
+            2,
+        ),
+    };
+
+    if json_output {
+        let (user_data_dir, port) = match &status {
+            ChromeDebuggingStatus::Ready {
+                user_data_dir,
+                port,
+            }
+            | ChromeDebuggingStatus::Stale {
+                user_data_dir,
+                port,
+            } => (Some(user_data_dir.display().to_string()), Some(*port)),
+            ChromeDebuggingStatus::Candidate { port } => (None, Some(*port)),
+            ChromeDebuggingStatus::Unknown { user_data_dir, .. } => {
+                (Some(user_data_dir.display().to_string()), None)
+            }
+            ChromeDebuggingStatus::NotRunning => (None, None),
+        };
+        println!(
+            "{}",
+            json!({
+                "success": exit_code == 0,
+                "status": name,
+                "message": message,
+                "actionRequired": action,
+                "userDataDir": user_data_dir,
+                "port": port,
+            })
+        );
+    } else if exit_code == 0 {
+        println!("{} {}", color::success_indicator(), message);
+    } else {
+        println!("{} {}", color::warning_indicator(), message);
+        if let Some(action) = action {
+            println!("  {}", action);
+        }
+        println!("  This check did not attach to Chrome or show an approval prompt.");
+    }
+
+    exit_code
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enable_hint_points_to_chromes_remote_debugging_setting() {
+        assert!(ENABLE_HINT.contains("chrome://inspect/#remote-debugging"));
+    }
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -166,6 +166,7 @@ pub fn is_top_level_command(value: &str) -> bool {
             | "removeinitscript"
             | "session"
             | "mcp"
+            | "chrome"
             | "doctor"
             | "install"
             | "upgrade"

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -456,6 +456,7 @@ pub fn run_install(with_deps: bool) {
                 color::success_indicator(),
                 version
             );
+            print_auto_connect_setup_hint();
             return;
         }
     }
@@ -488,6 +489,7 @@ pub fn run_install(with_deps: bool) {
                 );
                 println!("  agent-browser install --with-deps");
             }
+            print_auto_connect_setup_hint();
         }
         Err(e) => {
             let _ = fs::remove_dir_all(&dest);
@@ -495,6 +497,13 @@ pub fn run_install(with_deps: bool) {
             exit(1);
         }
     }
+}
+
+fn print_auto_connect_setup_hint() {
+    println!();
+    println!("Optional: to reuse your signed-in Chrome with --auto-connect, run:");
+    println!("  agent-browser chrome status");
+    println!("If Chrome is open and status is not-running, enable it at chrome://inspect/#remote-debugging.");
 }
 
 fn install_status_result(status: io::Result<ExitStatus>) -> Result<(), String> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod ca_bundle;
 mod chat;
+mod chrome_status;
 mod color;
 mod commands;
 mod connection;
@@ -1393,6 +1394,25 @@ fn main() {
     if clean.is_empty() {
         print_help();
         return;
+    }
+
+    // Read-only readiness probe for attaching to the user's existing Chrome.
+    // It deliberately runs without a daemon or CDP connection.
+    if clean.first().map(|s| s.as_str()) == Some("chrome") {
+        if clean.get(1).map(|s| s.as_str()) != Some("status") || clean.len() != 2 {
+            let message = "Usage: agent-browser chrome status [--json]";
+            if flags.json {
+                print_json_error(message);
+            } else {
+                eprintln!("{} {}", color::error_indicator(), message);
+            }
+            exit(1);
+        }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create runtime");
+        exit(rt.block_on(chrome_status::run(flags.json)));
     }
 
     // Handle install separately

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -167,6 +167,7 @@ const TOOL_PLUGIN_ADD: &str = "agent_browser_plugin_add";
 const TOOL_PLUGIN_LIST: &str = "agent_browser_plugin_list";
 const TOOL_PLUGIN_SHOW: &str = "agent_browser_plugin_show";
 const TOOL_PLUGIN_RUN: &str = "agent_browser_plugin_run";
+const TOOL_CHROME_STATUS: &str = "agent_browser_chrome_status";
 const TOOL_DOCTOR: &str = "agent_browser_doctor";
 const TOOL_DASHBOARD_START: &str = "agent_browser_dashboard_start";
 const TOOL_DASHBOARD_STOP: &str = "agent_browser_dashboard_stop";
@@ -263,7 +264,7 @@ impl ToolProfile {
             Self::Core => "Everyday browser automation with navigation, snapshots, common interaction, waits, screenshots, basic reads, tab basics, JavaScript eval, close, and profile discovery.",
             Self::Network => "Network interception, request inspection, HAR capture, headers, credentials, and offline mode.",
             Self::State => "Cookies, storage, auth profiles, saved browser state, sessions, Chrome profiles, and bundled skills.",
-            Self::Debug => "Console/errors, highlighting, DevTools, tracing, profiling, accessibility audits, PDF, downloads/uploads, recording, clipboard, plugin registry and plugin command.run, doctor, dashboard, install, upgrade, and chat.",
+            Self::Debug => "Console/errors, highlighting, DevTools, tracing, profiling, accessibility audits, PDF, downloads/uploads, recording, clipboard, plugin registry and plugin command.run, Chrome status, doctor, dashboard, install, upgrade, and chat.",
             Self::Tabs => "Tab, window, frame, and JavaScript dialog management.",
             Self::React => "React tree inspection, render recording, Suspense inspection, Web Vitals, SPA pushstate, and init-script removal.",
             Self::Mobile => "Viewport/device/geolocation/media emulation plus touch, swipe, and lower-level mouse tools.",
@@ -450,6 +451,7 @@ const DEBUG_PROFILE_TOOLS: &[&str] = &[
     TOOL_PLUGIN_LIST,
     TOOL_PLUGIN_SHOW,
     TOOL_PLUGIN_RUN,
+    TOOL_CHROME_STATUS,
     TOOL_DOCTOR,
     TOOL_DASHBOARD_START,
     TOOL_DASHBOARD_STOP,
@@ -1812,6 +1814,13 @@ fn parity_tools() -> Vec<Value> {
             &["name", "requestType"],
         ),
         tool(
+            TOOL_CHROME_STATUS,
+            "Chrome status",
+            "Check whether Chrome is ready for auto-connect without attaching a debugger or triggering Chrome approval.",
+            json!({}),
+            &[],
+        ),
+        tool(
             TOOL_DOCTOR,
             "Doctor",
             "Diagnose the installation.",
@@ -2099,6 +2108,7 @@ fn is_read_only_tool(name: &str) -> bool {
             | TOOL_SKILLS_PATH
             | TOOL_PLUGIN_LIST
             | TOOL_PLUGIN_SHOW
+            | TOOL_CHROME_STATUS
     )
 }
 
@@ -2115,6 +2125,7 @@ fn is_open_world_tool(name: &str) -> bool {
             | TOOL_SKILLS_PATH
             | TOOL_PLUGIN_LIST
             | TOOL_PLUGIN_SHOW
+            | TOOL_CHROME_STATUS
             | TOOL_DOCTOR
             | TOOL_DASHBOARD_START
             | TOOL_DASHBOARD_STOP
@@ -2342,6 +2353,7 @@ fn call_tool(params: Option<&Value>, config: &McpConfig) -> Result<Value, Protoc
         TOOL_PLUGIN_LIST => call_literal(arguments, &["plugin", "list"]),
         TOOL_PLUGIN_SHOW => call_one_string(arguments, "plugin show", "name"),
         TOOL_PLUGIN_RUN => call_plugin_run(arguments),
+        TOOL_CHROME_STATUS => call_literal(arguments, &["chrome", "status"]),
         TOOL_DOCTOR => call_doctor(arguments),
         TOOL_DASHBOARD_START => call_dashboard_start(arguments),
         TOOL_DASHBOARD_STOP => call_literal(arguments, &["dashboard", "stop"]),
@@ -4123,6 +4135,14 @@ mod tests {
         assert!(props.get("webgpu").is_some());
         assert!(props.get("headed").is_some());
         assert!(props.get("debug").is_some());
+    }
+
+    #[test]
+    fn chrome_status_tool_is_read_only_and_in_debug_profile() {
+        let profile = McpConfig::from_profiles(vec![ToolProfile::Debug]);
+        assert!(profile.allows(TOOL_CHROME_STATUS));
+        assert!(is_read_only_tool(TOOL_CHROME_STATUS));
+        assert!(!is_open_world_tool(TOOL_CHROME_STATUS));
     }
 
     #[test]

--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -1137,6 +1137,116 @@ pub fn read_devtools_active_port(user_data_dir: &Path) -> Option<(u16, String)> 
     Some((port, ws_path))
 }
 
+/// Side-effect-free readiness state for attaching to an existing Chrome.
+///
+/// This only reads Chrome's `DevToolsActivePort` files and checks whether the
+/// advertised loopback port accepts TCP connections. It never sends HTTP,
+/// opens a WebSocket, or attaches a debugger, so it cannot trigger Chrome's
+/// remote-debugging approval prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChromeDebuggingStatus {
+    Ready {
+        user_data_dir: PathBuf,
+        port: u16,
+    },
+    Candidate {
+        port: u16,
+    },
+    NotRunning,
+    Stale {
+        user_data_dir: PathBuf,
+        port: u16,
+    },
+    Unknown {
+        user_data_dir: PathBuf,
+        reason: String,
+    },
+}
+
+/// Inspect the default Chrome-family user-data directories without attaching.
+pub async fn chrome_debugging_status() -> ChromeDebuggingStatus {
+    chrome_debugging_status_in(
+        &get_chrome_user_data_dirs(),
+        &[9222, 9229],
+        |port| async move {
+            let address = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+            matches!(
+                tokio::time::timeout(
+                    Duration::from_millis(200),
+                    tokio::net::TcpStream::connect(address)
+                )
+                .await,
+                Ok(Ok(_))
+            )
+        },
+    )
+    .await
+}
+
+async fn chrome_debugging_status_in<F, Fut>(
+    user_data_dirs: &[PathBuf],
+    common_ports: &[u16],
+    mut port_is_reachable: F,
+) -> ChromeDebuggingStatus
+where
+    F: FnMut(u16) -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let mut fallback = ChromeDebuggingStatus::NotRunning;
+
+    for dir in user_data_dirs {
+        let path = dir.join("DevToolsActivePort");
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                if matches!(fallback, ChromeDebuggingStatus::NotRunning) {
+                    fallback = ChromeDebuggingStatus::Unknown {
+                        user_data_dir: dir.clone(),
+                        reason: error.to_string(),
+                    };
+                }
+                continue;
+            }
+        };
+
+        let Some(port) = content
+            .lines()
+            .next()
+            .and_then(|line| line.trim().parse::<u16>().ok())
+        else {
+            if matches!(fallback, ChromeDebuggingStatus::NotRunning) {
+                fallback = ChromeDebuggingStatus::Unknown {
+                    user_data_dir: dir.clone(),
+                    reason: "DevToolsActivePort does not contain a valid port".to_string(),
+                };
+            }
+            continue;
+        };
+
+        if port_is_reachable(port).await {
+            return ChromeDebuggingStatus::Ready {
+                user_data_dir: dir.clone(),
+                port,
+            };
+        }
+        if matches!(fallback, ChromeDebuggingStatus::NotRunning) {
+            fallback = ChromeDebuggingStatus::Stale {
+                user_data_dir: dir.clone(),
+                port,
+            };
+        }
+    }
+
+    for &port in common_ports {
+        if port_is_reachable(port).await {
+            return ChromeDebuggingStatus::Candidate { port };
+        }
+    }
+
+    fallback
+}
+
 pub async fn auto_connect_cdp() -> Result<String, String> {
     let user_data_dirs = get_chrome_user_data_dirs();
 
@@ -1158,7 +1268,7 @@ pub async fn auto_connect_cdp() -> Result<String, String> {
         }
     }
 
-    Err("No running Chrome instance found. Launch Chrome with --remote-debugging-port or use --cdp.".to_string())
+    Err("No running Chrome instance with remote debugging found. Run `agent-browser chrome status`; for Chrome 144+, enable Remote debugging at chrome://inspect/#remote-debugging, or use --cdp.".to_string())
 }
 
 /// Resolve a CDP WebSocket URL from a DevToolsActivePort entry.
@@ -2672,6 +2782,67 @@ mod tests {
             result.args.iter().any(|a| a == "--password-store=basic"),
             "profile path should keep keychain flags"
         );
+    }
+
+    #[tokio::test]
+    async fn chrome_debugging_status_is_ready_without_protocol_attach() {
+        let dir = TempDir::new("chrome-debugging-ready");
+        std::fs::create_dir_all(&*dir).unwrap();
+        std::fs::write(
+            dir.join("DevToolsActivePort"),
+            "43123\n/devtools/browser/test\n",
+        )
+        .unwrap();
+
+        let status =
+            chrome_debugging_status_in(&[dir.0.clone()], &[], |port| async move { port == 43123 })
+                .await;
+
+        assert_eq!(
+            status,
+            ChromeDebuggingStatus::Ready {
+                user_data_dir: dir.0.clone(),
+                port: 43123,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn chrome_debugging_status_distinguishes_missing_stale_and_invalid_files() {
+        let missing = TempDir::new("chrome-debugging-missing");
+        assert_eq!(
+            chrome_debugging_status_in(&[missing.0.clone()], &[], |_| async { false }).await,
+            ChromeDebuggingStatus::NotRunning
+        );
+
+        std::fs::create_dir_all(&*missing).unwrap();
+        std::fs::write(missing.join("DevToolsActivePort"), "43123\n").unwrap();
+        assert_eq!(
+            chrome_debugging_status_in(&[missing.0.clone()], &[], |_| async { false }).await,
+            ChromeDebuggingStatus::Stale {
+                user_data_dir: missing.0.clone(),
+                port: 43123,
+            }
+        );
+
+        std::fs::write(missing.join("DevToolsActivePort"), "not-a-port\n").unwrap();
+        assert!(matches!(
+            chrome_debugging_status_in(&[missing.0.clone()], &[], |_| async { false }).await,
+            ChromeDebuggingStatus::Unknown { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn chrome_debugging_status_reports_reachable_common_port_as_candidate() {
+        let dir = TempDir::new("chrome-debugging-common-port");
+
+        let status =
+            chrome_debugging_status_in(&[dir.0.clone()], &[9222, 9229], |port| async move {
+                port == 9222
+            })
+            .await;
+
+        assert_eq!(status, ChromeDebuggingStatus::Candidate { port: 9222 });
     }
 
     // -------------------------------------------------------------------

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2979,6 +2979,27 @@ Examples:
 "##
         }
 
+        // === Chrome ===
+        "chrome" => {
+            r##"
+agent-browser chrome - Inspect Chrome integration
+
+Usage: agent-browser chrome status [--json]
+
+Checks whether Chrome remote debugging is ready for --auto-connect without
+sending HTTP, opening a WebSocket, or attaching a debugger.
+
+Exit codes:
+  0  Ready or a common-port candidate is reachable for auto-connect
+  1  Not active (Chrome may be closed or remote debugging may be disabled)
+  2  Stale or unknown state
+
+Examples:
+  agent-browser chrome status
+  agent-browser chrome status --json
+"##
+        }
+
         // === Install ===
         "install" => {
             r##"
@@ -3804,6 +3825,7 @@ Dashboard:
   dashboard stop             Stop the dashboard server
 
 Setup:
+  chrome status              Check --auto-connect readiness without attaching
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
   upgrade                    Upgrade to the latest version

--- a/cli/tests/chrome_status_cli.rs
+++ b/cli/tests/chrome_status_cli.rs
@@ -1,0 +1,58 @@
+//! Integration tests for the read-only Chrome readiness probe.
+
+use std::process::Command;
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_agent-browser");
+
+fn command(tmp: &TempDir, args: &[&str]) -> Command {
+    let home = tmp.path().join("home");
+    let local_app_data = tmp.path().join("local-app-data");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&local_app_data).unwrap();
+
+    let mut command = Command::new(BIN);
+    command
+        .args(args)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("LOCALAPPDATA", &local_app_data)
+        .env("NO_COLOR", "1");
+    command
+}
+
+#[test]
+fn chrome_status_json_reports_local_readiness_without_creating_state() {
+    let tmp = TempDir::new().unwrap();
+    let output = command(&tmp, &["chrome", "status", "--json"])
+        .output()
+        .expect("failed to run chrome status");
+
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let status = payload["status"].as_str().unwrap();
+    assert!(["candidate", "not-running"].contains(&status));
+    assert_eq!(payload["success"], status == "candidate");
+    assert_eq!(output.status.success(), status == "candidate");
+    if status == "not-running" {
+        assert!(payload["actionRequired"]
+            .as_str()
+            .unwrap()
+            .contains("chrome://inspect/#remote-debugging"));
+    }
+    assert!(!tmp.path().join("home/.config/google-chrome").exists());
+    assert!(!tmp.path().join("local-app-data/Google/Chrome").exists());
+}
+
+#[test]
+fn chrome_status_help_documents_side_effect_free_probe() {
+    let tmp = TempDir::new().unwrap();
+    let output = command(&tmp, &["chrome", "--help"])
+        .output()
+        .expect("failed to run chrome --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("agent-browser chrome status"));
+    assert!(stdout.contains("without"));
+    assert!(stdout.contains("attaching"));
+}

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -39,6 +39,9 @@ Root WebSocket endpoints accept query strings with or without an explicit slash,
 Use `--auto-connect` to automatically discover and connect to a running Chrome instance without specifying a port:
 
 ```bash
+# Check first without attaching or triggering Chrome's approval prompt
+agent-browser chrome status
+
 # Auto-discover running Chrome with remote debugging
 agent-browser --auto-connect open example.com
 agent-browser --auto-connect snapshot
@@ -58,6 +61,21 @@ This is useful when:
 - Chrome 144+ has remote debugging enabled via `chrome://inspect/#remote-debugging` (which uses a dynamic port)
 - You want a zero-configuration connection to your existing browser
 - You don't want to track which port Chrome is using
+
+`chrome status` reads `DevToolsActivePort` from the platform's standard Chrome, Chrome Canary, Chromium, and Brave user-data directories, then checks loopback TCP reachability. If no active-port file is present, it also checks the same common ports as auto-connect, 9222 and 9229. It never sends HTTP, opens a WebSocket, or attaches a debugger. The command works on the published macOS x64/ARM64, Linux glibc/musl x64/ARM64, and Windows x64 binaries, including the x64 fallback on Windows ARM64.
+
+<table>
+  <thead><tr><th>Status</th><th>Meaning</th></tr></thead>
+  <tbody>
+    <tr><td><code>ready</code></td><td>The advertised local port is listening.</td></tr>
+    <tr><td><code>candidate</code></td><td>A common auto-connect port is listening, but the read-only check cannot verify it as Chrome/CDP.</td></tr>
+    <tr><td><code>not-running</code></td><td>No active-port file or common listener was found. This cannot distinguish a closed browser from a disabled setting.</td></tr>
+    <tr><td><code>stale</code></td><td>An active-port file exists, but its port is closed.</td></tr>
+    <tr><td><code>unknown</code></td><td>The state file is malformed or unreadable.</td></tr>
+  </tbody>
+</table>
+
+Use `agent-browser chrome status --json` for machine-readable output. When setup is needed, open `chrome://inspect/#remote-debugging` in Chrome and enable Remote debugging. Normal agent-browser launches do not require this security-sensitive setting; it is only for reusing an existing browser with `--auto-connect`.
 
 ## Tab pinning
 

--- a/docs/src/app/cdp-mode/page.mdx
+++ b/docs/src/app/cdp-mode/page.mdx
@@ -77,6 +77,8 @@ This is useful when:
 
 Use `agent-browser chrome status --json` for machine-readable output. When setup is needed, open `chrome://inspect/#remote-debugging` in Chrome and enable Remote debugging. Normal agent-browser launches do not require this security-sensitive setting; it is only for reusing an existing browser with `--auto-connect`.
 
+This readiness check is only for desktop Chrome-family auto-connect. iOS/Safari, remote providers, and locally launched Chrome (including `--extension`) use their existing connection paths and do not need it. Electron apps on ports other than 9222 or 9229 should use `--cdp <port>` directly.
+
 ## Tab pinning
 
 When several sessions share one browser over CDP, each session remembers which tab it is bound to (by CDP target id, persisted across daemon restarts). A restarted daemon reattaches to the session's own tab instead of adopting whatever tab is currently active, which in a shared browser is usually another session's.

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -450,6 +450,15 @@ agent-browser dashboard stop          # Stop the dashboard server
 
 Loopback dashboard origins are accepted by default without an access token. For a reverse-proxied or forwarded URL, pass its exact browser origin with `--allowed-origins` or set `AGENT_BROWSER_DASHBOARD_ALLOWED_ORIGINS`. Every configured origin must be a valid exact HTTPS origin. Ports must be integers from 1 to 65535. Unknown options, missing values, invalid ports, and malformed origins fail without starting the server. The command prints private tokenized access URLs only for external origins; open the matching URL once to establish the browser session and do not share it. Open the normal `http://localhost:<port>` URL for local access. The browser stays on the dashboard origin; per-session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed. Stop the running dashboard before changing the port or allowed origins.
 
+## Chrome status
+
+```bash
+agent-browser chrome status          # Check auto-connect readiness without attaching
+agent-browser chrome status --json   # Machine-readable readiness status
+```
+
+This command only reads Chrome's local `DevToolsActivePort` file and checks loopback TCP reachability. It does not send HTTP, open a WebSocket, attach a debugger, or trigger Chrome's approval prompt. See [CDP mode](/cdp-mode#auto-connect) for setup and platform limitations.
+
 ## Doctor
 
 Diagnose your install, auto-clean stale daemon files, and optionally repair common problems.
@@ -653,7 +662,7 @@ Profiles:
 - `core` - Default. Navigation, snapshots, interaction, waits, reads, screenshots, JavaScript eval, close, tab basics, and profile discovery
 - `network` - Network routes, request inspection, HAR, headers, credentials, offline
 - `state` - Cookies, storage, auth, saved state, sessions, profiles, skills
-- `debug` - Console/errors, tracing, profiling, recording, accessibility audits, clipboard, plugins, doctor, dashboard, install, upgrade, chat, diff, batch, confirm/deny
+- `debug` - Console/errors, tracing, profiling, recording, accessibility audits, clipboard, plugins, Chrome status, doctor, dashboard, install, upgrade, chat, diff, batch, confirm/deny
 - `tabs` - Back/forward/reload, tabs, windows, frames, dialogs
 - `react` - React tree/inspect/renders/suspense, vitals, pushstate
 - `mobile` - Viewport/device/geolocation/media, touch, swipe, mouse, keyboard

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -200,6 +200,9 @@ function showInstallReminder() {
     console.log('');
     console.log(`  ✓ System Chrome found: ${systemChrome}`);
     console.log('    agent-browser will use it automatically.');
+    console.log('    Optional: to reuse your signed-in Chrome with --auto-connect, run:');
+    console.log('      agent-browser chrome status');
+    console.log('    If Chrome is open and status is not-running, enable it at chrome://inspect/#remote-debugging.');
     console.log('');
     return;
   }

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -394,6 +394,8 @@ agent-browser doctor --json              # structured output for programmatic co
 
 `doctor` auto-cleans stale socket/pid/version sidecar files on every run. Destructive actions require `--fix`. Exit code is `0` if all checks pass (warnings OK), `1` if any fail.
 
+Before using `--auto-connect`, run `agent-browser chrome status --json`. This reads Chrome's local `DevToolsActivePort` state and checks only TCP reachability, including fallback ports 9222 and 9229; it does not send HTTP, open a WebSocket, attach a debugger, or trigger Chrome's approval prompt. Continue only after `ready` or `candidate`; candidate means a common port is reachable but is not verified as Chrome/CDP. `not-running` means Chrome may be closed or remote debugging may be disabled; ask the user to enable it at `chrome://inspect/#remote-debugging`, then pause for confirmation. `stale` and `unknown` require restarting Chrome or fixing the reported local state before retrying. Normal agent-browser launches do not need remote debugging.
+
 ## Troubleshooting
 
 **"Ref not found" / "Element not found: @eN"** Page changed since the snapshot. Run `agent-browser snapshot -i` again, then use the new refs.


### PR DESCRIPTION
## Summary
- add `agent-browser chrome status` and MCP parity for a read-only auto-connect readiness probe
- inspect `DevToolsActivePort` and loopback TCP only, with honest `ready`, `candidate`, `not-running`, `stale`, and `unknown` results
- add optional install guidance and actionable auto-connect failure text without launching Chrome or enabling remote debugging

## Motivation
Repeated `--auto-connect` attempts can trigger Chrome 144+ approval prompts. Agents need a no-prompt preflight and must ask the human before the one real attach attempt.

## Platform coverage
The probe reuses the same Chrome-family user-data discovery as auto-connect on every published binary: macOS x64/ARM64, Linux glibc/musl x64/ARM64, and Windows x64. Windows ARM64 uses the published x64 binary through OS emulation. iOS/Safari, remote providers, locally launched Chrome, and custom-port Electron sessions retain their existing connection paths.

## Tests
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- focused readiness, CLI, and MCP tests
- live read-only probe against a listener on `127.0.0.1:9222`

Full-suite note: 1,225 passed; an unrelated long-worktree UNIX socket path-length failure poisoned 11 subsequent shared-environment tests.
