### PR TITLE
fix: stop sending nativeVirtualKeyCode to Input.dispatchKeyEvent

### DIFF
--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -258,7 +258,7 @@ pub async fn type_text_into_active_context(
                         text: text_str.clone(),
                         unmodified_text: text_str,
                         windows_virtual_key_code: Some(key_code),
-                        native_virtual_key_code: Some(key_code),
+                        native_virtual_key_code: None,
                         modifiers: None,
                     },
                     Some(session_id),
@@ -275,7 +275,7 @@ pub async fn type_text_into_active_context(
                         text: None,
                         unmodified_text: None,
                         windows_virtual_key_code: Some(key_code),
-                        native_virtual_key_code: Some(key_code),
+                        native_virtual_key_code: None,
                         modifiers: None,
                     },
                     Some(session_id),
@@ -313,6 +313,12 @@ pub async fn press_key(client: &CdpClient, session_id: &str, key: &str) -> Resul
 /// Modifier values follow the CDP `Input.dispatchKeyEvent` spec:
 /// 1 = Alt, 2 = Control, 4 = Meta (Cmd), 8 = Shift.
 ///
+/// `nativeVirtualKeyCode` must stay unset. Sending it alongside
+/// `windowsVirtualKeyCode` makes headless Chrome enter an endless synthetic
+/// keydown loop (~8000 events/sec, code "Quote" / VK 222) that only stops on
+/// navigation; see issue #1775. Playwright likewise sends only
+/// `windowsVirtualKeyCode`.
+///
 /// Callers that need a platform-appropriate modifier (e.g. Cmd on macOS,
 /// Ctrl elsewhere) must choose the value themselves -- see `cfg!(target_os)`.
 pub async fn press_key_with_modifiers(
@@ -342,7 +348,7 @@ pub async fn press_key_with_modifiers(
                 text: text.clone(),
                 unmodified_text: text.clone(),
                 windows_virtual_key_code: Some(key_code),
-                native_virtual_key_code: Some(key_code),
+                native_virtual_key_code: None,
                 modifiers,
             },
             Some(session_id),
@@ -359,7 +365,7 @@ pub async fn press_key_with_modifiers(
                 text: None,
                 unmodified_text: None,
                 windows_virtual_key_code: Some(key_code),
-                native_virtual_key_code: Some(key_code),
+                native_virtual_key_code: None,
                 modifiers,
             },
             Some(session_id),


### PR DESCRIPTION
## Summary

Fixes #1775.

A single `press <key>` left the page receiving a permanent stream of phantom keydown events at roughly 8000/sec (code "Quote", keyCode 222, key "Unidentified", repeat false, isTrusted true) that only stopped on navigation. The requested key itself was delivered correctly, so `press` appeared to work while corrupting any keyboard-driven UI on the page. The affected Chrome process also spins at 100% CPU for as long as the flood runs.

## Root cause, empirically bisected

Reproduced on about:blank, then dispatched every parameter combination over a raw CDP connection to the same page and measured the keydown counter delta one second after each press (about:blank navigation between variants to reset any stuck state):

| dispatchKeyEvent params | 1s keydown delta |
| --- | --- |
| keyDown, code + windowsVirtualKeyCode + nativeVirtualKeyCode | 14284 (FLOOD) |
| rawKeyDown, same set | 19606 (FLOOD) |
| keyDown, windowsVirtualKeyCode + nativeVirtualKeyCode, no code | 11976 (FLOOD) |
| keyDown, code, no VK codes | 0 |
| keyDown, windowsVirtualKeyCode + code, no nativeVirtualKeyCode | 0 |
| key only | 0 |

Every flood variant carries `nativeVirtualKeyCode`; every clean variant omits it. Headless Chrome synthesizes new trusted keydown events in a tight loop for as long as that field is present (the phantom events carry code "Quote" / VK 222 because Blink derives the DOM code from the malformed native event rather than our requested key). Playwright's keyboard implementation likewise sends only `windowsVirtualKeyCode`, so all dispatch sites here now leave `nativeVirtualKeyCode` unset.

## Testing

- Reproduction from the issue now reports `{"delta":0}` with the fix and `{"delta":5790}` without it; the real keypress still arrives exactly once.
- `cargo test`: 1232 passed, 0 failed (one pre-existing flake, `test_execute_unknown_command`, passed on rerun).