### PR TITLE
fix: reconnect to the running browser instead of relaunching on CDP socket loss

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2203,6 +2203,25 @@ async fn close_active_provider_session(state: &mut DaemonState) {
     state.active_provider_connection = false;
 }
 
+/// Reset the daemon state that belongs to a specific CDP *connection* rather
+/// than to the browser itself.
+///
+/// Everything here is invalidated when the socket goes away, whether because the
+/// browser was closed or because the connection dropped and was re-established:
+/// `Target.setAutoAttach` is a per-connection command (and the flag gates
+/// re-sending it), and the session ids in the iframe maps, the WebMCP registry
+/// and the screencast flag all belong to the sessions the old socket owned.
+///
+/// Deliberately excludes `launch_hash`: that describes the browser's
+/// configuration, which a reconnect does not change.
+fn reset_cdp_connection_state(state: &mut DaemonState) {
+    state.network_auto_attach_installed = false;
+    state.iframe_sessions.clear();
+    state.active_iframe_sessions.clear();
+    state.webmcp.clear_all();
+    state.screencasting = false;
+}
+
 pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(), String> {
     let close_error = if let Some(mut mgr) = state.browser.take() {
         mgr.close().await.err()
@@ -2212,11 +2231,7 @@ pub(crate) async fn close_current_browser(state: &mut DaemonState) -> Result<(),
 
     close_active_provider_session(state).await;
     state.launch_hash = None;
-    state.network_auto_attach_installed = false;
-    state.iframe_sessions.clear();
-    state.active_iframe_sessions.clear();
-    state.webmcp.clear_all();
-    state.screencasting = false;
+    reset_cdp_connection_state(state);
     state.reset_input_state();
     state.update_stream_client().await;
 
@@ -4578,6 +4593,16 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             // allow-domains and answers proxy auth, so skipping this would drop
             // a security control while still reporting a healthy reused browser.
             // Rebuild the same wiring the attach branches below install.
+            //
+            // Clearing the connection-scoped state first is what makes
+            // install_network_controls_or_close effective: it re-sends
+            // Target.setAutoAttach only when network_auto_attach_installed is
+            // false, and auto-attach is a per-connection command that did not
+            // survive the drop. Leaving the flag set would silently skip it, so
+            // popups and new windows opened after a reconnect would never be
+            // attached — and therefore never filtered by allow-domains or
+            // covered by proxy auth.
+            reset_cdp_connection_state(state);
             let has_proxy_auth = store_proxy_credentials(state, &launch_options).await;
             state.reset_input_state();
             state.subscribe_to_browser_events();

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3502,6 +3502,22 @@ async fn install_active_network_controls(
     Ok(())
 }
 
+/// Store proxy credentials so Fetch interception can answer `Fetch.authRequired`.
+/// Returns whether proxy authentication is configured. Must run before any path
+/// that installs network controls — including a reconnect, which rebuilds the
+/// Fetch handler from scratch.
+async fn store_proxy_credentials(state: &DaemonState, launch_options: &LaunchOptions) -> bool {
+    let has_proxy_auth = launch_options.proxy_username.is_some();
+    if has_proxy_auth {
+        let mut creds = state.proxy_credentials.write().await;
+        *creds = Some((
+            launch_options.proxy_username.clone().unwrap_or_default(),
+            launch_options.proxy_password.clone().unwrap_or_default(),
+        ));
+    }
+    has_proxy_auth
+}
+
 async fn install_network_controls_or_close(
     state: &mut DaemonState,
     handle_auth_requests: bool,
@@ -4496,6 +4512,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
     // Hash comparison and fast process-exit check are evaluated before the
     // async is_connection_alive to skip the expensive CDP liveness probe
     // when a relaunch is already certain.
+    // Set when a dead CDP socket was recovered by reconnecting to the still-running
+    // browser. The reconnect replaces the CDP client, so everything bound to the old
+    // one has to be rebuilt before this call can return "reused".
+    let mut reconnected = false;
     let needs_relaunch = if let Some(ref mut mgr) = state.browser {
         let is_external =
             launch_connection_is_external(cdp_url, cdp_port, auto_connect, provider_name);
@@ -4522,6 +4542,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             match mgr.reconnect().await {
                 Ok(()) => {
                     eprintln!("[cdp] connection lost; reconnected to the running browser");
+                    reconnected = true;
                     false
                 }
                 Err(e) => {
@@ -4548,6 +4569,24 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
             close_current_browser(state).await?;
         }
     } else {
+        if reconnected {
+            // The reconnect swapped in a new CDP client, so every subscriber and
+            // background task captured from the old one is now bound to a dead
+            // socket: the event subscription, the Fetch handler, the dialog
+            // handler, and the Arc<CdpClient> held by the stream server. Left
+            // as-is they fail silently — and the Fetch handler is what enforces
+            // allow-domains and answers proxy auth, so skipping this would drop
+            // a security control while still reporting a healthy reused browser.
+            // Rebuild the same wiring the attach branches below install.
+            let has_proxy_auth = store_proxy_credentials(state, &launch_options).await;
+            state.reset_input_state();
+            state.subscribe_to_browser_events();
+            state.start_fetch_handler();
+            state.start_dialog_handler();
+            state.update_stream_client().await;
+            install_network_controls_or_close(state, has_proxy_auth).await?;
+            apply_launch_init_scripts(state, &enable_features, &init_script_paths).await;
+        }
         load_storage_state(state, &storage_state_owned).await?;
         state.effective_ca_cert = effective_ca_cert;
         return Ok(json!({ "launched": true, "reused": true, "relaunchedBrowser": false }));
@@ -4567,14 +4606,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     // Store proxy credentials before any local or remote CDP branch enables
     // Fetch interception with authentication handling.
-    let has_proxy_auth = launch_options.proxy_username.is_some();
-    if has_proxy_auth {
-        let mut creds = state.proxy_credentials.write().await;
-        *creds = Some((
-            launch_options.proxy_username.clone().unwrap_or_default(),
-            launch_options.proxy_password.clone().unwrap_or_default(),
-        ));
-    }
+    let has_proxy_auth = store_proxy_credentials(state, &launch_options).await;
 
     if let Some(url) = cdp_url {
         state.reset_input_state();

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4502,11 +4502,34 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         let was_external = mgr.is_cdp_connection();
         let hash_changed = state.launch_hash != Some(new_hash);
         let storage_state_requires_clean_launch = storage_state_owned.is_some() && !is_external;
-        is_external != was_external
-            || hash_changed
-            || storage_state_requires_clean_launch
-            || mgr.has_process_exited()
-            || !mgr.is_connection_alive().await
+        let config_changed =
+            is_external != was_external || hash_changed || storage_state_requires_clean_launch;
+
+        if config_changed || mgr.has_process_exited() {
+            // Genuinely unusable: wrong configuration, or the process is gone.
+            true
+        } else if mgr.is_connection_alive().await {
+            false
+        } else {
+            // The process is alive and correctly configured — only our CDP
+            // socket died. Chrome resets the DevTools WebSocket on its own
+            // ("Connection reset without closing handshake") on long-lived idle
+            // sessions, leaving the browser running and still listening on the
+            // same debug port. Relaunching here closes a working browser and
+            // discards its profile — cookies, storage, logged-in state — to
+            // rebuild what we already have. Reconnect first; relaunch only if
+            // that fails.
+            match mgr.reconnect().await {
+                Ok(()) => {
+                    eprintln!("[cdp] connection lost; reconnected to the running browser");
+                    false
+                }
+                Err(e) => {
+                    eprintln!("[cdp] connection lost and reconnect failed ({e}); relaunching");
+                    true
+                }
+            }
+        }
     } else {
         true
     };

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -425,6 +425,15 @@ pub struct BrowserManager {
     /// launch rules such as extension-forced headed mode. Meaningless for
     /// attached browsers (browser_process is None).
     headless: bool,
+    /// Emulation applied over CDP after launch rather than baked into the
+    /// process, kept so [`BrowserManager::reconnect`] can replay it. A fresh
+    /// WebSocket starts without these, so a reconnected session would otherwise
+    /// silently differ from the one it replaced.
+    user_agent: Option<String>,
+    color_scheme: Option<String>,
+    /// Headers used to open an external CDP connection, so a reconnect can
+    /// present the same ones (they may carry the auth that allowed it at all).
+    cdp_headers: Option<Vec<(String, String)>>,
 }
 
 /// Stable machine-readable prefix for "the bound tab no longer exists"
@@ -537,6 +546,9 @@ impl BrowserManager {
                 bound_target_id: None,
                 bound_target_gone: None,
                 headless,
+                user_agent: user_agent.clone(),
+                color_scheme: color_scheme.clone(),
+                cdp_headers: None,
             };
             manager.discover_and_attach_targets().await?;
             manager
@@ -614,7 +626,7 @@ impl BrowserManager {
         headers: Option<Vec<(String, String)>>,
     ) -> Result<Self, String> {
         let ws_url = resolve_cdp_url(url).await?;
-        let client = Arc::new(CdpClient::connect_with_headers(&ws_url, headers).await?);
+        let client = Arc::new(CdpClient::connect_with_headers(&ws_url, headers.clone()).await?);
         let mut manager = Self {
             client,
             browser_process: None,
@@ -626,6 +638,9 @@ impl BrowserManager {
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
+            user_agent: None,
+            color_scheme: None,
+            cdp_headers: headers,
             direct_page,
             pin_tab: false,
             bound_target_id: None,
@@ -1327,6 +1342,116 @@ impl BrowserManager {
         match result {
             Ok(Ok(_)) => true,
             Ok(Err(_)) | Err(_) => false,
+        }
+    }
+
+    /// Re-establish the CDP WebSocket to a browser that is STILL RUNNING.
+    ///
+    /// A dead socket is not a dead browser. Chrome can reset the DevTools
+    /// WebSocket ("Connection reset without closing handshake") while the
+    /// process keeps running normally, and the browser-level `ws_url` stays
+    /// valid for as long as it does — its DevTools endpoint is still listening
+    /// on the same port and will hand out the same browser target. Reconnecting
+    /// recovers the session; the alternative (close and relaunch) discards the
+    /// profile with it — cookies, storage, and any logged-in state — to rebuild
+    /// a browser that was never broken.
+    ///
+    /// Session ids belong to the old socket, so all targets are re-attached. The
+    /// bound/active tab is restored by target id where it still exists, and the
+    /// CDP-applied emulation is replayed, so callers see the browser they had.
+    ///
+    /// Not supported for `direct_page` connections (provider CDP proxies), whose
+    /// WebSocket *is* the page session and whose re-attach semantics differ;
+    /// callers fall back to a relaunch for those.
+    pub async fn reconnect(&mut self) -> Result<(), String> {
+        if self.direct_page {
+            return Err("reconnect is not supported for direct-page CDP connections".to_string());
+        }
+
+        let client = Arc::new(
+            CdpClient::connect_with_headers(&self.ws_url, self.cdp_headers.clone())
+                .await
+                .map_err(|e| format!("reconnect to {}: {}", self.ws_url, e))?,
+        );
+        self.client = client;
+
+        // Prefer the explicit binding; fall back to whatever was active.
+        let previous_target = self.bound_target_id.clone().or_else(|| {
+            self.pages
+                .get(self.active_page_index)
+                .map(|p| p.target_id.clone())
+        });
+        let previous_url = self
+            .pages
+            .get(self.active_page_index)
+            .map(|p| p.url.clone())
+            .unwrap_or_default();
+
+        // discover_and_attach_targets APPENDS, so clear first — otherwise every
+        // reconnect would duplicate the entire tab list.
+        self.pages.clear();
+        self.active_page_index = 0;
+        self.discover_and_attach_targets().await?;
+
+        if let Some(target_id) = previous_target {
+            if self.restore_target_binding(&target_id, &previous_url) {
+                // discover_and_attach_targets only enables domains on pages[0].
+                let session_id = self.pages[self.active_page_index].session_id.clone();
+                self.enable_domains(&session_id).await?;
+            }
+        }
+
+        self.reapply_cdp_state().await;
+        Ok(())
+    }
+
+    /// Replay the CDP-applied settings a fresh connection does not inherit.
+    /// Best-effort by design: these mirror the post-launch calls in `launch`,
+    /// which also ignore their errors, and a failure here must not downgrade a
+    /// recovered session into a relaunch.
+    async fn reapply_cdp_state(&self) {
+        let Ok(session_id) = self.active_session_id().map(|s| s.to_string()) else {
+            return;
+        };
+        if self.ignore_https_errors {
+            let _ = self
+                .client
+                .send_command(
+                    "Security.setIgnoreCertificateErrors",
+                    Some(json!({ "ignore": true })),
+                    Some(&session_id),
+                )
+                .await;
+        }
+        if let Some(ref ua) = self.user_agent {
+            let _ = self
+                .client
+                .send_command(
+                    "Emulation.setUserAgentOverride",
+                    Some(json!({ "userAgent": ua })),
+                    Some(&session_id),
+                )
+                .await;
+        }
+        if let Some(ref scheme) = self.color_scheme {
+            let _ = self
+                .client
+                .send_command(
+                    "Emulation.setEmulatedMedia",
+                    Some(json!({ "features": [{ "name": "prefers-color-scheme", "value": scheme }] })),
+                    Some(&session_id),
+                )
+                .await;
+        }
+        if let Some(ref path) = self.download_path {
+            let _ = self
+                .client
+                .send_command(
+                    "Browser.setDownloadBehavior",
+                    Some(json!({ "behavior": "allow", "downloadPath": path })),
+                    None,
+                )
+                .await;
         }
     }
 
@@ -2321,6 +2446,9 @@ async fn initialize_lightpanda_manager(
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 1,
+            user_agent: None,
+            color_scheme: None,
+            cdp_headers: None,
             direct_page: false,
             pin_tab: false,
             bound_target_id: None,
@@ -3025,6 +3153,9 @@ mod tests {
             ignore_https_errors: false,
             visited_origins: HashSet::new(),
             next_tab_id: 100,
+            user_agent: None,
+            color_scheme: None,
+            cdp_headers: None,
             direct_page: false,
             pin_tab: false,
             bound_target_id: None,
@@ -3048,6 +3179,21 @@ mod tests {
         assert_eq!(mgr.active_target_id().unwrap(), TARGET_A);
         assert_eq!(mgr.bound_target_id(), Some(TARGET_A));
         assert!(!mgr.bound_target_is_gone());
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_rejected_for_direct_page_connections() {
+        // A direct-page connection's WebSocket IS the page session, so the
+        // browser-level re-attach reconnect performs does not apply. It must
+        // refuse rather than half-reattach, so callers fall back to a relaunch.
+        let mut mgr = test_manager(vec![page(1, TARGET_A, "https://mine.example")]).await;
+        mgr.direct_page = true;
+
+        let err = mgr.reconnect().await.unwrap_err();
+        assert!(
+            err.contains("direct-page"),
+            "expected a direct-page refusal, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The problem

A dead CDP socket is not a dead browser, but `handle_launch` treats it as one. In the relaunch decision, `!mgr.is_connection_alive()` sits in the same `||` chain as a changed launch hash and an exited process:

```rust
is_external != was_external
    || hash_changed
    || storage_state_requires_clean_launch
    || mgr.has_process_exited()
    || !mgr.is_connection_alive().await
```

So a dropped WebSocket takes the same path as a genuinely unusable browser: `close_current_browser`, then launch a new one. That discards the profile — cookies, storage, and any logged-in session — to rebuild a browser that was never broken.

Chrome drops that socket on its own. On long-lived idle sessions it resets the DevTools WebSocket while the process keeps running normally:

```
[cdp] WebSocket Error: WebSocket protocol error: Connection reset without closing handshake
```

I hit this nightly on a headed session running Chrome 152. The next morning's first command destroys a perfectly good browser, and any login in that profile has to be redone by hand.

Everything needed to resume is still there. Captured on a session in exactly this state — daemon and Chrome both still alive, socket already reset:

```
# daemon's CDP socket: dead
agent-bro 41791  TCP 127.0.0.1:50604->127.0.0.1:50603 (CLOSED)

# Chrome: still listening on the same port
Google    41792  TCP 127.0.0.1:50603 (LISTEN)

$ curl -s http://127.0.0.1:50603/json/version
Browser : Chrome/152.0.7977.76
wsUrl   : ws://127.0.0.1:50603/devtools/browser/ea6f0643-cb32-4031-86bf-4c8f80a21d15
```

The browser is up, the endpoint answers, and `ws_url` is still valid. Only our end of the connection is gone.

`auto_save_restore_state` does not cover this. Saving reads state over CDP, which is precisely what is unavailable when the socket is dead.

## The change

Split "unusable" from "unreachable". A changed configuration or an exited process still relaunches immediately, and the cheap checks still run before the expensive probe. A failed liveness probe on an otherwise-valid browser now tries `BrowserManager::reconnect()` first, and relaunches only if that fails.

`reconnect()` opens a fresh WebSocket to the same `ws_url`, re-attaches all targets, restores the bound/active tab by target id through the existing `restore_target_binding`, and replays the CDP-applied emulation that a new connection does not inherit.

Two details worth flagging for review:

- `discover_and_attach_targets` **appends** to `pages`, so `reconnect` clears it first — reusing it without clearing would duplicate the whole tab list on every reconnect.
- Replaying emulation required retaining `user_agent`, `color_scheme` and the external-connection headers on the manager. They were applied at launch and then forgotten, so without this a reconnected session would have silently differed from the one it replaced.

Direct-page connections (provider CDP proxies) are refused rather than half-reattached, since their WebSocket *is* the page session; callers fall back to a relaunch for those.

## Testing

`cargo build --release`, `cargo fmt --check` clean, `cargo clippy --all-targets` introduces no new warnings (the two it reports are pre-existing, in `cdp/client.rs` and an unrelated test). **1233 tests pass, 0 failures.**

Added coverage for the direct-page refusal.

**The reconnect path itself has no automated test**, and I want to be upfront about that: the existing `test_manager` scaffolding backs the manager with a socket that accepts the connection and then stays silent, so it cannot answer the `Target.*` commands re-attach issues. Happy to add a responding CDP mock if you'd like that before merging.

Verified manually instead:

- against a browser whose socket had been reset, the DevTools endpoint still served its browser target and the session was recoverable (output above)
- the normal reuse path is unchanged — same browser pid across repeated commands on a scratch session

## One caveat on the cause

I can demonstrate the mechanism and the fix. I have **not** proven *why* Chrome resets the socket. The onset correlates with Chrome 151 → 152 on this machine, but that is correlation, not a root cause. The fix stands regardless: agent-browser should not destroy a healthy browser and its profile because a socket dropped, whatever caused the drop.
