### PR TITLE
fix: try every loopback host when connecting to a launched Chrome

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -192,6 +192,52 @@ fn active_page_index_after_add(
     }
 }
 
+/// Loopback hosts to try for a launched Chrome's DevTools WebSocket, in order.
+const LAUNCH_LOOPBACK_HOSTS: [&str; 3] = ["127.0.0.1", "[::1]", "localhost"];
+
+/// Build the candidate WebSocket URLs for a launched Chrome. Port discovery
+/// hard-codes 127.0.0.1, but on some stacks (WSL2, issue #1791) the ephemeral
+/// listener comes up on the IPv6 loopback instead, so the remaining loopback
+/// hosts are tried before giving up. URLs that do not point at 127.0.0.1 are
+/// returned unchanged.
+fn loopback_ws_candidates(ws_url: &str) -> Vec<String> {
+    if !ws_url.contains("127.0.0.1") {
+        return vec![ws_url.to_string()];
+    }
+    LAUNCH_LOOPBACK_HOSTS
+        .iter()
+        .map(|host| ws_url.replacen("127.0.0.1", host, 1))
+        .collect()
+}
+
+/// Connect to a freshly launched Chrome's DevTools WebSocket.
+///
+/// `DevToolsActivePort` only tells us the port, not which loopback address the
+/// server bound, and the listen socket can come up a moment after the file
+/// appears. Try every loopback host within a short retry window so a transient
+/// refusal or an IPv6-only listener does not fail the launch.
+async fn connect_launched_chrome(ws_url: &str) -> Result<CdpClient, String> {
+    const CONNECT_DEADLINE: Duration = Duration::from_secs(6);
+    let deadline = Instant::now() + CONNECT_DEADLINE;
+    let candidates = loopback_ws_candidates(ws_url);
+    let mut last_err = String::new();
+    loop {
+        for candidate in &candidates {
+            match CdpClient::connect(candidate).await {
+                Ok(client) => return Ok(client),
+                Err(e) => last_err = format!("{candidate}: {e}"),
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "Could not connect to the launched browser's DevTools socket after trying {} loopback candidate(s). Last error: {last_err}",
+                candidates.len()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
@@ -520,7 +566,7 @@ impl BrowserManager {
         let manager = if engine == "lightpanda" {
             initialize_lightpanda_manager(ws_url, process).await?
         } else {
-            let client = Arc::new(CdpClient::connect(&ws_url).await?);
+            let client = Arc::new(connect_launched_chrome(&ws_url).await?);
             let mut manager = Self {
                 client,
                 browser_process: Some(process),
@@ -2653,6 +2699,28 @@ mod tests {
     #[test]
     fn test_validate_launch_options_valid() {
         assert!(validate_launch_options(None, false, None, None, false, None, None).is_ok());
+    }
+
+    #[test]
+    fn test_loopback_ws_candidates_cover_both_loopbacks() {
+        let url = "ws://127.0.0.1:57082/devtools/browser/abc";
+        let candidates = loopback_ws_candidates(url);
+        assert_eq!(
+            candidates,
+            vec![
+                "ws://127.0.0.1:57082/devtools/browser/abc",
+                "ws://[::1]:57082/devtools/browser/abc",
+                "ws://localhost:57082/devtools/browser/abc",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_loopback_ws_candidates_leave_other_hosts_untouched() {
+        // A user-supplied --cdp URL must not be silently rewritten to a
+        // different host: only the launch discovery path gets the fallback.
+        let url = "ws://myproxy.internal:9222/devtools/browser/abc";
+        assert_eq!(loopback_ws_candidates(url), vec![url.to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1791.

On WSL2, Chrome spawned with `--remote-debugging-port=0` LISTENs on its ephemeral port, but the daemon's connect to `ws://127.0.0.1:<port>` is refused with `os error 111`; spawning with a fixed port works. Port discovery via `DevToolsActivePort` only tells us the port, not which loopback address the server bound, and on some stacks (WSL2 kernels, IPv6-preferred loopback) the ephemeral listener comes up on the IPv6 loopback `[::1]` instead of IPv4 `127.0.0.1` — so the hard-coded `127.0.0.1` dial can never succeed no matter how long we wait.

## Changes

- New `connect_launched_chrome()` in `browser.rs`: after launch, try `127.0.0.1`, then `[::1]`, then `localhost`, within a bounded (6s) retry window so a transient gap between the port file appearing and the server accepting is also absorbed.
- New `loopback_ws_candidates()` builds the candidate URLs; URLs that do not point at `127.0.0.1` (user-supplied `--cdp` targets) are returned untouched, so the fallback never silently rewrites a host the user chose.

## Testing

- New unit tests: candidate expansion covers both loopbacks; non-127.0.0.1 URLs pass through unchanged.
- `cargo test`: 1234 passed, 0 failed on the parent branch; one known flake (`test_execute_unknown_command`) on the rebased branch passes standalone.
- Local smoke test (macOS, headless): close → open → get url → eval all succeed through the new connect loop.

We do not have a WSL2 environment in CI, so verification from @the reporter's side would be valuable — happy to cut a test build.