### PR TITLE
Bind credential-provider login to approved destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,9 +919,10 @@ Use a credential provider plugin for one login:
 
 ```bash
 agent-browser auth login my-app --credential-provider vault --item "My App"
-agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login --username-selector "#email" --password-selector "#password" --submit-selector "button[type=submit]"
-agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
+agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login
 ```
+
+Credential providers use the `destination-bound-v1` contract. The provider supplies the exact login URL, approved origin, selectors, expected post-login URL, and account identity marker along with optional OTP metadata. agent-browser fills and submits credentials only in the approved main-frame document, blocks credential-bearing requests and document navigation to other origins during the attempt, supports form and form-less OTP steps, and reports success only after the expected URL and account marker are both present. `--url` is an assertion against the provider response; selector overrides are available only for saved profiles.
 
 Use a browser provider plugin:
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,7 +1,58 @@
 use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+fn collect_source_files(directory: &Path, files: &mut Vec<PathBuf>) {
+    let mut entries = fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()))
+        .map(|entry| entry.expect("failed to read source entry").path())
+        .collect::<Vec<_>>();
+    entries.sort();
+
+    for path in entries {
+        if path.is_dir() {
+            collect_source_files(&path, files);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn hash_bytes(hash: &mut u64, bytes: &[u8]) {
+    // FNV-1a is sufficient here: the build identity detects incompatible
+    // binaries, rather than serving as a security boundary.
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(0x100000001b3);
+    }
+}
+
+fn emit_build_identity() {
+    let mut inputs = vec![PathBuf::from("Cargo.toml"), PathBuf::from("Cargo.lock")];
+    collect_source_files(Path::new("src"), &mut inputs);
+    inputs.sort();
+
+    let mut hash = 0xcbf29ce484222325_u64;
+    for path in inputs {
+        println!("cargo:rerun-if-changed={}", path.display());
+        hash_bytes(&mut hash, path.to_string_lossy().as_bytes());
+        hash_bytes(
+            &mut hash,
+            &fs::read(&path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display())),
+        );
+    }
+
+    for variable in ["PROFILE", "TARGET", "CARGO_ENCODED_RUSTFLAGS"] {
+        println!("cargo:rerun-if-env-changed={variable}");
+        hash_bytes(&mut hash, variable.as_bytes());
+        hash_bytes(&mut hash, env::var(variable).unwrap_or_default().as_bytes());
+    }
+
+    let build_id = format!("{}+{hash:016x}", env!("CARGO_PKG_VERSION"));
+    println!("cargo:rustc-env=AGENT_BROWSER_BUILD_ID={build_id}");
+}
 
 /// Ensure `packages/dashboard/out/` exists so `rust-embed` doesn't fail during
 /// Rust-only dev builds where the dashboard hasn't been built. The placeholder
@@ -19,6 +70,7 @@ fn ensure_dashboard_dir() {
 }
 
 fn main() {
+    emit_build_identity();
     ensure_dashboard_dir();
 
     let protocol_dir = Path::new("cdp-protocol");

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -19,6 +19,9 @@ use windows_sys::Win32::Foundation::CloseHandle;
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
+/// Identifies daemon-compatible builds, including custom builds that share the
+/// same package version. Generated from the native source and build inputs.
+pub(crate) const DAEMON_BUILD_ID: &str = env!("AGENT_BROWSER_BUILD_ID");
 pub(crate) const INTERNAL_DAEMON_SHUTDOWN_ACTION: &str = "__agent_browser_internal_shutdown";
 
 #[derive(Serialize)]
@@ -707,7 +710,7 @@ fn concurrent_daemon_config_error(session: &str) -> String {
 fn daemon_version_matches(session: &str) -> bool {
     let version_path = get_version_path(session);
     match fs::read_to_string(&version_path) {
-        Ok(v) => v.trim() == env!("CARGO_PKG_VERSION"),
+        Ok(v) => v.trim() == DAEMON_BUILD_ID,
         Err(_) => false,
     }
 }
@@ -1551,9 +1554,25 @@ mod tests {
         _guard.set("AGENT_BROWSER_SOCKET_DIR", dir.to_str().unwrap());
 
         let version_path = dir.join("test-session.version");
-        let _ = fs::write(&version_path, env!("CARGO_PKG_VERSION"));
+        let _ = fs::write(&version_path, DAEMON_BUILD_ID);
 
         assert!(daemon_version_matches("test-session"));
+
+        let _ = fs::remove_file(&version_path);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_daemon_version_rejects_semver_without_build_identity() {
+        let dir = std::env::temp_dir().join("ab-test-semver-only-version-mismatch");
+        let _ = fs::create_dir_all(&dir);
+        let _guard = EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR", "XDG_RUNTIME_DIR"]);
+        _guard.set("AGENT_BROWSER_SOCKET_DIR", dir.to_str().unwrap());
+
+        let version_path = dir.join("test-session.version");
+        let _ = fs::write(&version_path, env!("CARGO_PKG_VERSION"));
+
+        assert!(!daemon_version_matches("test-session"));
 
         let _ = fs::remove_file(&version_path);
         let _ = fs::remove_dir(&dir);

--- a/cli/src/doctor/daemon.rs
+++ b/cli/src/doctor/daemon.rs
@@ -1,12 +1,12 @@
-//! Check running daemons: inventory of sessions, version match with the
+//! Check running daemons: inventory of sessions, build match with the
 //! CLI, and stale sidecar files cleaned up as a side effect of the walk.
 
 use super::{Check, Status};
-use crate::connection::{walk_daemons, CleanReason};
+use crate::connection::{walk_daemons, CleanReason, DAEMON_BUILD_ID};
 
 pub(super) fn check(checks: &mut Vec<Check>) {
     let category = "Daemons";
-    let cli_version = env!("CARGO_PKG_VERSION");
+    let cli_build = DAEMON_BUILD_ID;
 
     let inventory = walk_daemons();
 
@@ -33,7 +33,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         ));
     } else {
         for session in &inventory.sessions {
-            let version_match = session.version.as_deref() == Some(cli_version);
+            let version_match = session.version.as_deref() == Some(cli_build);
             let status = if version_match {
                 Status::Pass
             } else {
@@ -42,7 +42,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
             let suffix = if version_match {
                 String::new()
             } else {
-                format!(" (version mismatch with CLI {})", cli_version)
+                format!(" (build mismatch with CLI {})", cli_build)
             };
             let mut check = Check::new(
                 format!("daemon.session.{}", session.name),

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1486,14 +1486,20 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_AUTH_LOGIN,
             "Auth login",
-            "Log in with a saved auth profile.",
+            "Log in with a saved auth profile or destination-bound credential provider.",
             json!({
                 "name": { "type": "string" },
                 "noNavigate": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Use the active top-level page without performing the initial login navigation. The credential URL must match the page origin."
-                }
+                    "description": "Use the active top-level page without performing the initial login navigation. Saved profiles require a matching origin. Credential providers require the exact approved login URL."
+                },
+                "credentialProvider": { "type": "string" },
+                "item": { "type": "string" },
+                "url": { "type": "string", "description": "Saved-profile override or provider URL assertion." },
+                "usernameSelector": { "type": "string", "description": "Saved-profile login only." },
+                "passwordSelector": { "type": "string", "description": "Saved-profile login only." },
+                "submitSelector": { "type": "string", "description": "Saved-profile login only." }
             }),
             &["name"],
         ),
@@ -3152,6 +3158,19 @@ fn auth_login_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
     if optional_bool(arguments, "noNavigate")?.unwrap_or(false) {
         args.push("--no-navigate".to_string());
     }
+    for (key, flag) in [
+        ("credentialProvider", "--credential-provider"),
+        ("item", "--item"),
+        ("url", "--url"),
+        ("usernameSelector", "--username-selector"),
+        ("passwordSelector", "--password-selector"),
+        ("submitSelector", "--submit-selector"),
+    ] {
+        if let Some(value) = optional_string(arguments, key)? {
+            args.push(flag.to_string());
+            args.push(value);
+        }
+    }
     Ok(args)
 }
 
@@ -4072,6 +4091,39 @@ mod tests {
         assert!(props.get("headed").is_some());
         assert!(props.get("webgpu").is_some());
         assert!(props.get("webmcp").is_some());
+    }
+
+    #[test]
+    fn auth_login_tool_forwards_cli_options() {
+        let tools = tools();
+        let auth_login = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some(TOOL_AUTH_LOGIN))
+            .unwrap();
+        let properties = &auth_login["inputSchema"]["properties"];
+        assert!(properties.get("credentialProvider").is_some());
+        assert!(properties.get("item").is_some());
+
+        assert_eq!(
+            auth_login_args(&json!({
+                "name": "example",
+                "credentialProvider": "vault",
+                "item": "Example account",
+                "url": "https://example.com/login"
+            }))
+            .unwrap(),
+            vec![
+                "auth",
+                "login",
+                "example",
+                "--credential-provider",
+                "vault",
+                "--item",
+                "Example account",
+                "--url",
+                "https://example.com/login"
+            ]
+        );
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::sync::{broadcast, oneshot, RwLock};
@@ -183,11 +183,116 @@ pub struct TrackedRequest {
 pub struct FetchPausedRequest {
     pub request_id: String,
     pub url: String,
+    pub post_data: Option<String>,
     pub resource_type: String,
     pub session_id: String,
     /// Original request headers from the Fetch.requestPaused event, needed
     /// because Fetch.continueRequest replaces (not merges) headers.
     pub request_headers: Option<serde_json::Map<String, Value>>,
+}
+
+#[derive(Clone)]
+struct CredentialNavigationGuard {
+    session_id: String,
+    credential_origin: String,
+    credential_values: Vec<(u8, String)>,
+    blocked: Arc<AtomicU8>,
+}
+
+fn decoded_request_text(value: &str, form_encoded: bool) -> String {
+    let value = if form_encoded {
+        value.replace('+', " ")
+    } else {
+        value.to_string()
+    };
+    urlencoding::decode(&value)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or(value)
+}
+
+fn request_url_has_credential_value(request_url: &str, credential_value: &str) -> bool {
+    let Ok(url) = url::Url::parse(request_url) else {
+        return decoded_request_text(request_url, false) == credential_value;
+    };
+
+    if url.username() == credential_value || url.password() == Some(credential_value) {
+        return true;
+    }
+
+    if url
+        .path_segments()
+        .into_iter()
+        .flatten()
+        .any(|segment| decoded_request_text(segment, false) == credential_value)
+    {
+        return true;
+    }
+
+    if url
+        .query_pairs()
+        .any(|(_, value)| value == credential_value)
+    {
+        return true;
+    }
+
+    url.fragment()
+        .is_some_and(|fragment| decoded_request_text(fragment, false) == credential_value)
+}
+
+fn json_value_has_credential_value(value: &Value, credential_value: &str) -> bool {
+    match value {
+        Value::String(value) => value == credential_value,
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_has_credential_value(value, credential_value)),
+        Value::Object(values) => values
+            .values()
+            .any(|value| json_value_has_credential_value(value, credential_value)),
+        _ => false,
+    }
+}
+
+fn request_body_has_credential_value(request_body: &str, credential_value: &str) -> bool {
+    let decoded_body = decoded_request_text(request_body, true);
+    if decoded_body == credential_value {
+        return true;
+    }
+
+    if url::form_urlencoded::parse(request_body.as_bytes())
+        .any(|(_, value)| value == credential_value)
+    {
+        return true;
+    }
+
+    serde_json::from_str::<Value>(&decoded_body)
+        .is_ok_and(|value| json_value_has_credential_value(&value, credential_value))
+}
+
+fn credential_block_reason(
+    guard: &CredentialNavigationGuard,
+    request: &FetchPausedRequest,
+) -> Option<u8> {
+    let request_origin = url::Url::parse(&request.url)
+        .ok()
+        .map(|url| url.origin().ascii_serialization());
+    if request_origin.as_deref() == Some(&guard.credential_origin) {
+        return None;
+    }
+
+    if request.session_id == guard.session_id
+        && request.resource_type.eq_ignore_ascii_case("document")
+    {
+        return Some(1);
+    }
+
+    guard.credential_values.iter().find_map(|(kind, value)| {
+        (request_url_has_credential_value(&request.url, value)
+            || request
+                .post_data
+                .as_deref()
+                .is_some_and(|body| request_body_has_credential_value(body, value)))
+        .then_some(*kind)
+    })
 }
 
 pub enum BackendType {
@@ -581,6 +686,7 @@ pub struct DaemonState {
     /// Proxy authentication credentials (username, password) for handling
     /// Fetch.authRequired events from authenticated proxies.
     pub proxy_credentials: Arc<RwLock<Option<(String, String)>>>,
+    credential_navigation_guard: Arc<RwLock<Option<CredentialNavigationGuard>>>,
     /// Background task that processes Fetch.requestPaused events in real-time,
     /// handling domain filtering, route interception, and origin-scoped headers
     /// without deadlocking navigation/evaluate.
@@ -712,6 +818,7 @@ impl DaemonState {
             active_iframe_sessions: HashSet::new(),
             origin_headers: Arc::new(RwLock::new(HashMap::new())),
             proxy_credentials: Arc::new(RwLock::new(None)),
+            credential_navigation_guard: Arc::new(RwLock::new(None)),
             fetch_handler_task: None,
             dialog_handler_task: None,
             mouse_state: MouseState::default(),
@@ -818,6 +925,7 @@ impl DaemonState {
         let origin_headers = self.origin_headers.clone();
         let proxy_credentials = self.proxy_credentials.clone();
         let capture_session = self.recording_state.capture_session.clone();
+        let credential_navigation_guard = self.credential_navigation_guard.clone();
 
         self.fetch_handler_task = Some(tokio::spawn(async move {
             loop {
@@ -888,8 +996,13 @@ impl DaemonState {
 
                         let df = domain_filter.read().await.clone();
                         let has_proxy_creds = proxy_credentials.read().await.is_some();
-                        let controls_active = df.is_some() || has_proxy_creds;
-                        let controls_result = if controls_active && target_needs_controls {
+                        let has_credential_guard =
+                            credential_navigation_guard.read().await.is_some();
+                        let controls_active =
+                            df.is_some() || has_proxy_creds || has_credential_guard;
+                        let controls_result: Result<(), String> = if controls_active
+                            && target_needs_controls
+                        {
                             async {
                                 if let Some(ref target) = target_info {
                                     prepare_network_control_target_session(&client, &sid, target)
@@ -916,7 +1029,23 @@ impl DaemonState {
                                     }
                                 } else {
                                     Ok(())
+                                }?;
+                                if has_credential_guard {
+                                    client
+                                        .send_command(
+                                            "Fetch.enable",
+                                            Some(json!({
+                                                "patterns": [{
+                                                    "urlPattern": "*",
+                                                    "requestStage": "Request"
+                                                }],
+                                                "handleAuthRequests": has_proxy_creds
+                                            })),
+                                            Some(&sid),
+                                        )
+                                        .await?;
                                 }
+                                Ok(())
                             }
                             .await
                         } else {
@@ -952,6 +1081,12 @@ impl DaemonState {
                             .and_then(|v| v.as_str())
                             .unwrap_or("")
                             .to_string();
+                        let post_data = event
+                            .params
+                            .get("request")
+                            .and_then(|r| r.get("postData"))
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
                         let resource_type = event
                             .params
                             .get("resourceType")
@@ -969,10 +1104,29 @@ impl DaemonState {
                         let paused = FetchPausedRequest {
                             request_id,
                             url: request_url,
+                            post_data,
                             resource_type,
                             session_id: sid,
                             request_headers,
                         };
+
+                        let guard = credential_navigation_guard.read().await.clone();
+                        if let Some((guard, reason)) = guard.and_then(|guard| {
+                            credential_block_reason(&guard, &paused).map(|reason| (guard, reason))
+                        }) {
+                            guard.blocked.store(reason, Ordering::SeqCst);
+                            let _ = client
+                                .send_command(
+                                    "Fetch.failRequest",
+                                    Some(json!({
+                                        "requestId": paused.request_id,
+                                        "errorReason": "BlockedByClient"
+                                    })),
+                                    Some(&paused.session_id),
+                                )
+                                .await;
+                            continue;
+                        }
 
                         let df = domain_filter.read().await;
                         let rt = routes.read().await;
@@ -11174,12 +11328,35 @@ async fn build_fetch_patterns(state: &DaemonState) -> Vec<Value> {
     let has_domain_filter = state.domain_filter.read().await.is_some();
     let has_origin_headers = !state.origin_headers.read().await.is_empty();
     let has_proxy_creds = state.proxy_credentials.read().await.is_some();
+    let has_credential_guard = state.credential_navigation_guard.read().await.is_some();
+    if has_credential_guard {
+        patterns.push(json!({
+            "urlPattern": "*",
+            "requestStage": "Request"
+        }));
+    }
     if (has_domain_filter || has_origin_headers || has_proxy_creds)
         && !patterns.iter().any(|p| p["urlPattern"] == "*")
     {
         patterns.push(json!({ "urlPattern": "*" }));
     }
     patterns
+}
+
+async fn refresh_fetch_interception(state: &DaemonState, session_id: &str) -> Result<(), String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let patterns = build_fetch_patterns(state).await;
+    if patterns.is_empty() {
+        mgr.client
+            .send_command("Fetch.disable", None, Some(session_id))
+            .await?;
+    } else {
+        let params = build_fetch_enable_params(state, patterns).await;
+        mgr.client
+            .send_command("Fetch.enable", Some(params), Some(session_id))
+            .await?;
+    }
+    Ok(())
 }
 
 /// Build the full Fetch.enable params object, including `handleAuthRequests`
@@ -11540,6 +11717,267 @@ async fn wait_for_any_selector(
     }
 }
 
+async fn call_main_frame_function(
+    client: &CdpClient,
+    session_id: &str,
+    function_declaration: &str,
+    arguments: Vec<Value>,
+) -> Result<Value, String> {
+    let global = client
+        .send_command(
+            "Runtime.evaluate",
+            Some(json!({ "expression": "globalThis" })),
+            Some(session_id),
+        )
+        .await?;
+    let object_id = global
+        .get("result")
+        .and_then(|result| result.get("objectId"))
+        .and_then(Value::as_str)
+        .ok_or("Could not bind the main-frame document")?;
+    let result = client
+        .send_command(
+            "Runtime.callFunctionOn",
+            Some(json!({
+                "objectId": object_id,
+                "functionDeclaration": function_declaration,
+                "arguments": arguments
+                    .into_iter()
+                    .map(|value| json!({ "value": value }))
+                    .collect::<Vec<_>>(),
+                "returnByValue": true,
+                "awaitPromise": false,
+            })),
+            Some(session_id),
+        )
+        .await?;
+    if result.get("exceptionDetails").is_some() {
+        return Err("Destination-checked login script failed".to_string());
+    }
+    result
+        .get("result")
+        .and_then(|remote| remote.get("value"))
+        .cloned()
+        .ok_or_else(|| "Destination-checked login returned no result".to_string())
+}
+
+async fn destination_checked_submit(
+    client: &CdpClient,
+    session_id: &str,
+    expected_url: Option<&str>,
+    credential_origin: &str,
+    fields: &[(&str, &str)],
+    submit_selector: &str,
+    stage: &str,
+) -> Result<(), String> {
+    let script = r#"function(expectedUrl, credentialOrigin, fields, submitSelector) {
+        const originalDocument = document;
+        const fail = error => ({ ok: false, error });
+        if (window !== window.top) return fail('not-main-frame');
+        if (expectedUrl !== null && location.href !== expectedUrl) return fail('wrong-url');
+        if (location.origin !== credentialOrigin) return fail('wrong-origin');
+
+        const elements = [];
+        for (const [selector] of fields) {
+            const matches = originalDocument.querySelectorAll(selector);
+            if (matches.length !== 1) return fail('field-selector');
+            const element = matches[0];
+            if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) {
+                return fail('field-type');
+            }
+            if (!element.isConnected || element.disabled || element.readOnly ||
+                (element instanceof HTMLInputElement && element.type === 'hidden')) {
+                return fail('field-state');
+            }
+            elements.push(element);
+        }
+        const submitMatches = originalDocument.querySelectorAll(submitSelector);
+        if (submitMatches.length !== 1) return fail('submit-selector');
+        const submit = submitMatches[0];
+        if (!(submit instanceof HTMLElement) || !submit.isConnected || submit.matches(':disabled')) {
+            return fail('submit-state');
+        }
+        const form = elements[0].form;
+        if (elements.some(element => element.form !== form) || submit.form !== form) {
+            return fail('form-mismatch');
+        }
+        if (form !== null) {
+            if (new URL(form.action, originalDocument.baseURI).origin !== credentialOrigin) {
+                return fail('form-origin');
+            }
+            if (form.target && form.target.toLowerCase() !== '_self') return fail('form-target');
+        }
+
+        const inputSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+        const textareaSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+        for (let index = 0; index < elements.length; index++) {
+            const element = elements[index];
+            const setter = element instanceof HTMLInputElement ? inputSetter : textareaSetter;
+            setter.call(element, fields[index][1]);
+            element.dispatchEvent(new Event('input', { bubbles: true }));
+            element.dispatchEvent(new Event('change', { bubbles: true }));
+            if (document !== originalDocument || location.origin !== credentialOrigin) {
+                return fail('document-replaced');
+            }
+        }
+        if (expectedUrl !== null && location.href !== expectedUrl) return fail('url-changed');
+        if (elements.some(element => element.ownerDocument !== originalDocument || element.form !== form)) {
+            return fail('document-replaced');
+        }
+        if (submit.ownerDocument !== originalDocument || submit.form !== form) return fail('form-replaced');
+        if (form !== null) {
+            if (new URL(form.action, originalDocument.baseURI).origin !== credentialOrigin) {
+                return fail('form-origin-changed');
+            }
+            if (form.target && form.target.toLowerCase() !== '_self') return fail('form-target-changed');
+        }
+        submit.click();
+        return { ok: true };
+    }"#;
+    let result = call_main_frame_function(
+        client,
+        session_id,
+        script,
+        vec![
+            expected_url.map(Value::from).unwrap_or(Value::Null),
+            Value::from(credential_origin),
+            Value::Array(
+                fields
+                    .iter()
+                    .map(|(selector, value)| json!([selector, value]))
+                    .collect(),
+            ),
+            Value::from(submit_selector),
+        ],
+    )
+    .await?;
+    if result.get("ok").and_then(Value::as_bool) == Some(true) {
+        Ok(())
+    } else {
+        let reason = result
+            .get("error")
+            .and_then(Value::as_str)
+            .filter(|reason| {
+                matches!(
+                    *reason,
+                    "not-main-frame"
+                        | "wrong-url"
+                        | "wrong-origin"
+                        | "field-selector"
+                        | "field-type"
+                        | "field-state"
+                        | "submit-selector"
+                        | "submit-state"
+                        | "form-mismatch"
+                        | "form-origin"
+                        | "form-target"
+                        | "document-replaced"
+                        | "url-changed"
+                        | "form-replaced"
+                        | "form-origin-changed"
+                        | "form-target-changed"
+                )
+            })
+            .unwrap_or("unknown");
+        Err(format!(
+            "Destination check rejected {stage} credential submission: {reason}"
+        ))
+    }
+}
+
+async fn wait_for_provider_login_state(
+    client: &CdpClient,
+    session_id: &str,
+    credential: &crate::plugins::ResolvedCredential,
+    detect_otp: bool,
+    blocked: &AtomicU8,
+    timeout_ms: u64,
+) -> Result<&'static str, String> {
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    let script = r#"function(expectedUrl, markerSelector, markerValue, otpSelector) {
+        if (location.href === expectedUrl) {
+            const matches = document.querySelectorAll(markerSelector);
+            if (matches.length === 1 && (matches[0].textContent || '').includes(markerValue)) {
+                return 'authenticated';
+            }
+        }
+        if (otpSelector !== null && location.origin === new URL(expectedUrl).origin && document.querySelector(otpSelector)) {
+            return 'otp';
+        }
+        return 'waiting';
+    }"#;
+    loop {
+        let blocked_reason = blocked.load(Ordering::SeqCst);
+        if blocked_reason != 0 {
+            let reason = match blocked_reason {
+                1 => "document",
+                2 => "username",
+                3 => "password",
+                4 => "OTP",
+                _ => "unknown",
+            };
+            return Err(format!(
+                "Credential submission was blocked from leaving its approved origin: {reason}"
+            ));
+        }
+        if let Ok(result) = call_main_frame_function(
+            client,
+            session_id,
+            script,
+            vec![
+                Value::from(credential.expected_post_login_url.as_str()),
+                Value::from(credential.account_marker_selector.as_str()),
+                Value::from(credential.account_marker_value.as_str()),
+                detect_otp
+                    .then_some(credential.otp_selector.as_deref())
+                    .flatten()
+                    .map(Value::from)
+                    .unwrap_or(Value::Null),
+            ],
+        )
+        .await
+        {
+            match result.as_str() {
+                Some("authenticated") => return Ok("authenticated"),
+                Some("otp") => return Ok("otp"),
+                _ => {}
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err("Login destination or account identity was not verified".to_string());
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(
+            AUTH_LOGIN_SELECTOR_POLL_INTERVAL_MS,
+        ))
+        .await;
+    }
+}
+
+async fn finish_credential_navigation_guard(
+    state: &DaemonState,
+    session_id: &str,
+    target_id: &str,
+    succeeded: bool,
+) -> Result<(), String> {
+    if !succeeded {
+        if let Some(ref mgr) = state.browser {
+            mgr.client
+                .send_command(
+                    "Target.closeTarget",
+                    Some(json!({ "targetId": target_id })),
+                    None,
+                )
+                .await
+                .map_err(|error| format!("Could not close failed credential login: {error}"))?;
+        }
+    }
+    *state.credential_navigation_guard.write().await = None;
+    if succeeded {
+        refresh_fetch_interception(state, session_id).await?;
+    }
+    Ok(())
+}
+
 async fn handle_auth_save(cmd: &Value) -> Result<Value, String> {
     let name = cmd
         .get("name")
@@ -11702,28 +12140,20 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         return Err("Browser not launched".to_string());
     }
     let url_override = cmd.get("url").and_then(|v| v.as_str());
-    let override_origin = if no_navigate {
-        url_override
-            .map(|url| auth_login_origin(url, "credential"))
-            .transpose()?
-    } else {
-        None
-    };
-    if let (Some(bound_page), Some(override_origin)) = (&bound_page, &override_origin) {
-        let mgr = state
-            .browser
-            .as_ref()
-            .ok_or(AUTH_LOGIN_NO_NAVIGATE_PAGE_ERROR)?;
-        validate_auth_login_active_page(mgr, bound_page, override_origin).await?;
-    }
-    let cred = if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
+    if let Some(provider) = cmd.get("credentialProvider").and_then(|v| v.as_str()) {
+        if ["usernameSelector", "passwordSelector", "submitSelector"]
+            .iter()
+            .any(|field| cmd.get(field).is_some())
+        {
+            return Err("Credential provider login does not allow selector overrides".to_string());
+        }
         let command_plugins = cmd
             .get("plugins")
             .and_then(|v| {
                 serde_json::from_value::<Vec<crate::plugins::PluginConfig>>(v.clone()).ok()
             })
             .unwrap_or_else(crate::plugins::plugins_from_env);
-        let resolved = crate::plugins::resolve_credential_with_plugins(
+        let credential = crate::plugins::resolve_credential_with_plugins(
             provider,
             &command_plugins,
             crate::plugins::CredentialResolveRequest {
@@ -11733,27 +12163,145 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
             },
         )
         .await?;
-        auth::AuthProfile {
-            name: name.to_string(),
-            url: url_override
-                .map(String::from)
-                .or(resolved.url)
-                .unwrap_or_default(),
-            username: resolved.username,
-            password: resolved.password,
-            username_selector: resolved.username_selector,
-            password_selector: resolved.password_selector,
-            submit_selector: resolved.submit_selector,
-            created_at: None,
-            last_login_at: None,
+        if url_override.is_some_and(|url| url != credential.url) {
+            return Err("Credential provider returned a different login URL".to_string());
         }
-    } else {
-        let mut profile = auth::credentials_get_full(name)?;
-        if let Some(url) = url_override {
-            profile.url = url.to_string();
+        let auth_timeout_ms = state.timeout_ms(cmd);
+        let (client, session_id, target_id) = {
+            let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+            if no_navigate {
+                let credential_origin = auth_login_origin(&credential.url, "credential")?;
+                validate_auth_login_active_page(
+                    mgr,
+                    bound_page
+                        .as_ref()
+                        .expect("no-navigation login must bind an active page"),
+                    &credential_origin,
+                )
+                .await?;
+                super::element::set_active_frame(None);
+            } else {
+                mgr.navigate(&credential.url, AUTH_LOGIN_WAIT_UNTIL).await?;
+            }
+            (
+                mgr.client.clone(),
+                mgr.active_session_id()?.to_string(),
+                mgr.active_target_id()?.to_string(),
+            )
+        };
+        let blocked = Arc::new(AtomicU8::new(0));
+        let credential_values = [
+            (2, Some(credential.username.as_str())),
+            (3, Some(credential.password.as_str())),
+            (4, credential.otp.as_deref()),
+        ]
+        .into_iter()
+        .filter_map(|(kind, value)| value.map(|value| (kind, value.to_string())))
+        .collect();
+        *state.credential_navigation_guard.write().await = Some(CredentialNavigationGuard {
+            session_id: session_id.clone(),
+            credential_origin: credential.credential_origin.clone(),
+            credential_values,
+            blocked: blocked.clone(),
+        });
+        if let Err(error) = refresh_fetch_interception(state, &session_id).await {
+            *state.credential_navigation_guard.write().await = None;
+            return Err(error);
         }
-        profile
-    };
+
+        let login_result: Result<(), String> = async {
+            wait_for_selector(
+                &client,
+                &session_id,
+                &credential.username_selector,
+                "visible",
+                auth_timeout_ms,
+            )
+            .await
+            .map_err(|_| "Timed out waiting for approved login form".to_string())?;
+            destination_checked_submit(
+                &client,
+                &session_id,
+                Some(&credential.url),
+                &credential.credential_origin,
+                &[
+                    (&credential.username_selector, &credential.username),
+                    (&credential.password_selector, &credential.password),
+                ],
+                &credential.submit_selector,
+                "primary",
+            )
+            .await?;
+
+            let state_result = wait_for_provider_login_state(
+                &client,
+                &session_id,
+                &credential,
+                true,
+                &blocked,
+                auth_timeout_ms,
+            )
+            .await?;
+            if state_result == "otp" {
+                let otp = credential.otp.as_deref().ok_or("Credential has no OTP")?;
+                let otp_selector = credential
+                    .otp_selector
+                    .as_deref()
+                    .ok_or("Credential has no OTP selector")?;
+                let otp_submit_selector = credential
+                    .otp_submit_selector
+                    .as_deref()
+                    .ok_or("Credential has no OTP submit selector")?;
+                destination_checked_submit(
+                    &client,
+                    &session_id,
+                    None,
+                    &credential.credential_origin,
+                    &[(otp_selector, otp)],
+                    otp_submit_selector,
+                    "OTP",
+                )
+                .await?;
+                wait_for_provider_login_state(
+                    &client,
+                    &session_id,
+                    &credential,
+                    false,
+                    &blocked,
+                    auth_timeout_ms,
+                )
+                .await?;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(
+                AUTH_LOGIN_SELECTOR_POLL_INTERVAL_MS,
+            ))
+            .await;
+            if blocked.load(Ordering::SeqCst) != 0 {
+                return Err(
+                    "Credential submission was blocked from leaving its approved origin"
+                        .to_string(),
+                );
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(cleanup_error) =
+            finish_credential_navigation_guard(state, &session_id, &target_id, login_result.is_ok())
+                .await
+        {
+            return Err(match &login_result {
+                Err(login_error) => format!("{login_error}; {cleanup_error}"),
+                Ok(()) => cleanup_error,
+            });
+        }
+        login_result?;
+        return Ok(json!({ "loggedIn": true, "name": name, "verified": true }));
+    }
+
+    let mut cred = auth::credentials_get_full(name)?;
+    if let Some(url) = url_override {
+        cred.url = url.to_string();
+    }
     if cred.url.is_empty() {
         return Err("Credential has no URL".to_string());
     }
@@ -16213,6 +16761,119 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
         let patterns = build_fetch_patterns(&state).await;
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0]["urlPattern"], "https://example.com/*");
+    }
+
+    fn credential_guard() -> CredentialNavigationGuard {
+        CredentialNavigationGuard {
+            session_id: "login-session".to_string(),
+            credential_origin: "https://login.example".to_string(),
+            credential_values: vec![
+                (2, "person@example.com".to_string()),
+                (3, "correct horse".to_string()),
+                (4, "123456".to_string()),
+            ],
+            blocked: Arc::new(AtomicU8::new(0)),
+        }
+    }
+
+    fn paused_credential_request(
+        session_id: &str,
+        url: &str,
+        post_data: Option<&str>,
+        resource_type: &str,
+    ) -> FetchPausedRequest {
+        FetchPausedRequest {
+            request_id: "request".to_string(),
+            url: url.to_string(),
+            post_data: post_data.map(str::to_string),
+            resource_type: resource_type.to_string(),
+            session_id: session_id.to_string(),
+            request_headers: None,
+        }
+    }
+
+    #[test]
+    fn credential_guard_blocks_off_origin_documents_and_secret_values() {
+        let guard = credential_guard();
+        let document = paused_credential_request(
+            "login-session",
+            "https://attacker.example/landing",
+            None,
+            "Document",
+        );
+        assert_eq!(credential_block_reason(&guard, &document), Some(1));
+
+        let encoded_url = paused_credential_request(
+            "login-session",
+            "https://attacker.example/pixel?user=person%40example.com",
+            None,
+            "Image",
+        );
+        assert_eq!(credential_block_reason(&guard, &encoded_url), Some(2));
+
+        let encoded_body = paused_credential_request(
+            "popup-session",
+            "https://attacker.example/collect",
+            Some("password=correct+horse"),
+            "Fetch",
+        );
+        assert_eq!(credential_block_reason(&guard, &encoded_body), Some(3));
+    }
+
+    #[test]
+    fn credential_guard_allows_approved_origin_and_unrelated_cross_origin_requests() {
+        let guard = credential_guard();
+        let approved = paused_credential_request(
+            "login-session",
+            "https://login.example/session?user=person%40example.com",
+            Some("password=correct+horse"),
+            "Document",
+        );
+        assert_eq!(credential_block_reason(&guard, &approved), None);
+
+        let unrelated = paused_credential_request(
+            "login-session",
+            "https://cdn.example/style.css",
+            None,
+            "Stylesheet",
+        );
+        assert_eq!(credential_block_reason(&guard, &unrelated), None);
+    }
+
+    #[test]
+    fn credential_guard_matches_complete_values_not_substrings() {
+        let guard = credential_guard();
+        let incidental_otp_url = paused_credential_request(
+            "login-session",
+            "https://cdn.example/pixel?build=1234567",
+            None,
+            "Image",
+        );
+        assert_eq!(credential_block_reason(&guard, &incidental_otp_url), None);
+
+        let incidental_otp_body = paused_credential_request(
+            "login-session",
+            "https://cdn.example/metrics",
+            Some("metric=1234567&event=otp-rendered"),
+            "Fetch",
+        );
+        assert_eq!(credential_block_reason(&guard, &incidental_otp_body), None);
+
+        let exact_form_value = paused_credential_request(
+            "login-session",
+            "https://attacker.example/collect",
+            Some("otp=123456"),
+            "Fetch",
+        );
+        assert_eq!(credential_block_reason(&guard, &exact_form_value), Some(4));
+
+        let exact_json_value = paused_credential_request(
+            "login-session",
+            "https://attacker.example/collect",
+            Some(r#"{"otp":"123456"}"#),
+            "Fetch",
+        );
+        assert_eq!(credential_block_reason(&guard, &exact_json_value), Some(4));
     }
 
     #[test]

--- a/cli/src/native/daemon.rs
+++ b/cli/src/native/daemon.rs
@@ -18,7 +18,7 @@ use super::actions::{
 use super::cdp::client::CdpClient;
 use super::state;
 use super::stream::{IdleActivity, StreamServer};
-use crate::connection::INTERNAL_DAEMON_SHUTDOWN_ACTION;
+use crate::connection::{DAEMON_BUILD_ID, INTERNAL_DAEMON_SHUTDOWN_ACTION};
 
 pub async fn run_daemon(session: &str) {
     let socket_dir = get_daemon_socket_dir();
@@ -67,7 +67,7 @@ pub async fn run_daemon(session: &str) {
     let _ = fs::write(&pid_path, process::id().to_string());
 
     let version_path = socket_dir.join(format!("{}.version", session));
-    let _ = fs::write(&version_path, env!("CARGO_PKG_VERSION"));
+    let _ = fs::write(&version_path, DAEMON_BUILD_ID);
 
     // On Unix the daemon listens on a Unix domain socket; on Windows it uses
     // TCP, so there is no .sock file — only a .port file written by the server.

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -10,7 +10,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 use futures_util::StreamExt;
 use serde_json::{json, Value};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -6014,6 +6014,350 @@ async fn e2e_auth_login_waits_for_delayed_spa_form_render() {
 
     let close = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&close);
+}
+
+#[cfg(unix)]
+fn write_destination_bound_login_plugin(
+    credential: Value,
+) -> (tempfile::TempDir, crate::plugins::PluginConfig) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("credential-plugin");
+    let response = json!({
+        "protocol": crate::plugins::PROTOCOL_VERSION,
+        "success": true,
+        "credential": credential,
+    });
+    std::fs::write(
+        &path,
+        format!("#!/bin/sh\ncat >/dev/null\nprintf '%s' '{}'\n", response),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions).unwrap();
+    let plugin = crate::plugins::PluginConfig {
+        name: "destination-test".to_string(),
+        command: path.to_string_lossy().to_string(),
+        capabilities: vec![crate::plugins::CAPABILITY_CREDENTIAL_READ.to_string()],
+        ..crate::plugins::PluginConfig::default()
+    };
+    (directory, plugin)
+}
+
+async fn start_destination_bound_login_server(
+    mode: &'static str,
+) -> (String, Arc<Mutex<Vec<String>>>, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let base_url = format!("http://127.0.0.1:{}", port);
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let recorded = requests.clone();
+    let server_base = base_url.clone();
+    let handle = tokio::spawn(async move {
+        for _ in 0..100 {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let recorded = recorded.clone();
+            let server_base = server_base.clone();
+            tokio::spawn(async move {
+                let mut buffer = vec![0u8; 16 * 1024];
+                let count = stream.read(&mut buffer).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..count]);
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/")
+                    .to_string();
+                recorded.lock().unwrap().push(path.clone());
+
+                let (status, extra_headers, body) = if path == "/pre" {
+                    (
+                        "200 OK",
+                        "",
+                        "<!doctype html><iframe id=f src='/frame'></iframe>".to_string(),
+                    )
+                } else if path == "/frame" {
+                    ("200 OK", "", "<!doctype html><input id=decoy>".to_string())
+                } else if path == "/redirect" {
+                    (
+                        "302 Found",
+                        "Location: https://example.invalid/login\r\n",
+                        String::new(),
+                    )
+                } else {
+                    let action = if mode == "bad-action" {
+                        "https://example.invalid/session".to_string()
+                    } else {
+                        format!("{}/session", server_base)
+                    };
+                    let replacement = if mode == "replace-document" {
+                        "document.querySelector('#username').addEventListener('input', () => { document.open(); document.write(`<form action=\"https://example.invalid/session\"><input id=\"password\"><button id=\"submit\"></button></form>`); document.close(); });"
+                    } else {
+                        ""
+                    };
+                    let marker = if mode == "wrong-identity" {
+                        "different-user"
+                    } else {
+                        "synthetic-user"
+                    };
+                    let otp_flow = if mode == "no-otp" {
+                        format!(
+                            "history.replaceState(null, '', '/account'); document.body.innerHTML = `<div id=\"account\">{marker}</div>`;"
+                        )
+                    } else if mode == "formless-otp" {
+                        format!(
+                            "document.body.innerHTML = `<input id=\"otp\"><button id=\"otp-submit\" type=\"button\">Verify</button>`; document.querySelector('#otp-submit').addEventListener('click', () => {{ history.replaceState(null, '', '/account'); document.body.innerHTML = `<div id=\"account\">{marker}</div>`; }});"
+                        )
+                    } else {
+                        format!(
+                            "document.body.innerHTML = `<form id=\"otp-form\" action=\"{server_base}/otp\"><input id=\"otp\"><button id=\"otp-submit\" type=\"submit\">Verify</button></form>`; document.querySelector('#otp-form').addEventListener('submit', otpEvent => {{ otpEvent.preventDefault(); history.replaceState(null, '', '/account'); document.body.innerHTML = `<div id=\"account\">{marker}</div>`; }});"
+                        )
+                    };
+                    let body = format!(
+                        r#"<!doctype html><form id="login" action="{action}">
+<input id="username"><input id="password" type="password"><button id="submit" type="submit">Login</button></form>
+<script>
+{replacement}
+document.querySelector('#login').addEventListener('submit', event => {{
+  event.preventDefault();
+  {otp_flow}
+}});
+</script>"#,
+                    );
+                    ("200 OK", "", body)
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: text/html\r\n{extra_headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+    (base_url, requests, handle)
+}
+
+#[cfg(unix)]
+fn destination_bound_credential(base_url: &str, login_path: &str, marker: &str) -> Value {
+    json!({
+        "username": "synthetic-user",
+        "password": "synthetic-password",
+        "otp": "123456",
+        "url": format!("{base_url}{login_path}"),
+        "credentialOrigin": base_url,
+        "usernameSelector": "#username",
+        "passwordSelector": "#password",
+        "submitSelector": "#submit",
+        "otpSelector": "#otp",
+        "otpSubmitSelector": "#otp-submit",
+        "expectedPostLoginUrl": format!("{base_url}/account"),
+        "accountMarkerSelector": "#account",
+        "accountMarkerValue": marker,
+    })
+}
+
+#[cfg(unix)]
+async fn run_destination_bound_provider_login(
+    mode: &'static str,
+    login_path: &str,
+    marker: &str,
+) -> Value {
+    let (base_url, _requests, server) = start_destination_bound_login_server(mode).await;
+    let mut credential = destination_bound_credential(&base_url, login_path, marker);
+    if mode == "no-otp" {
+        credential.as_object_mut().unwrap().remove("otp");
+        credential.as_object_mut().unwrap().remove("otpSelector");
+        credential
+            .as_object_mut()
+            .unwrap()
+            .remove("otpSubmitSelector");
+    }
+    let (_plugin_dir, plugin) = write_destination_bound_login_plugin(credential);
+    let mut state = DaemonState::new();
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+    if mode == "stale-frame" {
+        assert_success(
+            &execute_command(
+                &json!({ "id": "2", "action": "navigate", "url": format!("{base_url}/pre") }),
+                &mut state,
+            )
+            .await,
+        );
+        assert_success(
+            &execute_command(
+                &json!({ "id": "3", "action": "frame", "selector": "#f" }),
+                &mut state,
+            )
+            .await,
+        );
+    }
+    let mut command = json!({
+        "id": "4",
+        "action": "auth_login",
+        "name": "synthetic",
+        "credentialProvider": "destination-test",
+        "plugins": [plugin],
+        "timeout": 3000,
+    });
+    if mode == "selector-override" {
+        command["usernameSelector"] = json!("#other");
+    }
+    let response = execute_command(&command, &mut state).await;
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+    response
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore]
+async fn e2e_provider_login_is_destination_checked_and_supports_otp() {
+    let response = run_destination_bound_provider_login("no-otp", "/login", "synthetic-user").await;
+    assert_success(&response);
+    assert_eq!(get_data(&response)["verified"], true);
+
+    let response =
+        run_destination_bound_provider_login("stale-frame", "/login", "synthetic-user").await;
+    assert_success(&response);
+    assert_eq!(get_data(&response)["verified"], true);
+
+    let response =
+        run_destination_bound_provider_login("formless-otp", "/login", "synthetic-user").await;
+    assert_success(&response);
+    assert_eq!(get_data(&response)["verified"], true);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore]
+async fn e2e_provider_login_rejects_wrong_destination_and_identity() {
+    for (mode, path, marker) in [
+        ("redirect", "/redirect", "synthetic-user"),
+        ("bad-action", "/login", "synthetic-user"),
+        ("replace-document", "/login", "synthetic-user"),
+        ("wrong-identity", "/login", "synthetic-user"),
+        ("selector-override", "/login", "synthetic-user"),
+    ] {
+        let response = run_destination_bound_provider_login(mode, path, marker).await;
+        assert_eq!(response["success"], false, "mode {mode}: {response}");
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore]
+async fn e2e_provider_login_blocks_cross_origin_document_redirect() {
+    let sink = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let sink_port = sink.local_addr().unwrap().port();
+    let sink_requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let sink_count = sink_requests.clone();
+    let sink_server = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = sink.accept().await {
+            sink_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let _ = stream
+                .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                .await;
+        }
+    });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let approved_posts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let approved_count = approved_posts.clone();
+    let approved_credentials = Arc::new(AtomicBool::new(false));
+    let credential_match = approved_credentials.clone();
+    let approved_server = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let approved_count = approved_count.clone();
+            let credential_match = credential_match.clone();
+            tokio::spawn(async move {
+                let mut request = vec![0u8; 16 * 1024];
+                let count = stream.read(&mut request).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&request[..count]);
+                let is_post = request.starts_with("POST /session ");
+                let (status, headers, body) = if is_post {
+                    approved_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    credential_match.store(
+                        request.contains("username=synthetic-user")
+                            && request.contains("password=synthetic-password"),
+                        std::sync::atomic::Ordering::SeqCst,
+                    );
+                    (
+                        "307 Temporary Redirect",
+                        format!(
+                            "Location: http://127.0.0.1:{sink_port}/stolen?user=synthetic-user\r\n"
+                        ),
+                        String::new(),
+                    )
+                } else {
+                    (
+                        "200 OK",
+                        String::new(),
+                        format!(
+                            r#"<!doctype html><form id="login" action="http://127.0.0.1:{port}/session" method="post"><input id="username" name="username"><input id="password" name="password"><button id="submit" type="submit">Login</button></form>"#
+                        ),
+                    )
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: text/html\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    let mut credential = destination_bound_credential(&base_url, "/login", "synthetic-user");
+    credential.as_object_mut().unwrap().remove("otp");
+    credential.as_object_mut().unwrap().remove("otpSelector");
+    credential
+        .as_object_mut()
+        .unwrap()
+        .remove("otpSubmitSelector");
+    let (_plugin_dir, plugin) = write_destination_bound_login_plugin(credential);
+    let mut state = DaemonState::new();
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+    let response = execute_command(
+        &json!({
+            "id": "2",
+            "action": "auth_login",
+            "name": "synthetic",
+            "credentialProvider": "destination-test",
+            "plugins": [plugin],
+            "timeout": 3000,
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(response["success"], false, "{response}");
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    assert_eq!(approved_posts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert!(approved_credentials.load(std::sync::atomic::Ordering::SeqCst));
+    assert_eq!(
+        sink_requests.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "unapproved origin received a credential request"
+    );
+    approved_server.abort();
+    sink_server.abort();
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2653,11 +2653,11 @@ Save Options:
 Login Options:
   --credential-provider <p> Resolve credentials from configured plugin <p>
   --item <ref>              Provider-specific vault item reference
-  --url <url>               Login URL override
   --no-navigate             Use the active top-level page without initial navigation
-  --username-selector <s>   Username selector override for this login
-  --password-selector <s>   Password selector override for this login
-  --submit-selector <s>     Submit selector override for this login
+  --url <url>               Saved-profile override or provider URL assertion
+  --username-selector <s>   Saved-profile username selector override for this login
+  --password-selector <s>   Saved-profile password selector override for this login
+  --submit-selector <s>     Saved-profile submit selector override for this login
 
 Login behavior:
   auth login navigates, then waits for form selectors before filling/clicking.
@@ -2665,6 +2665,9 @@ Login behavior:
   against the effective credential URL. Submit-triggered navigation is allowed.
   Selector wait timeout follows the default action timeout.
   Plugin credentials are resolved just-in-time and are not saved locally.
+  Plugin logins require the destination-bound-v1 credential contract.
+  Credentials stay on the approved origin; success verifies URL and account.
+  Selector overrides apply only to saved-profile logins.
 
 Global Options:
   --json                   Output as JSON
@@ -3812,9 +3815,9 @@ Auth Vault:
   auth login <name> --no-navigate
                              Use active page after verifying credential URL origin
   auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
-                             Resolve credentials from a configured plugin
+                             Run a destination-bound login from a configured plugin
   auth login <name> --username-selector <s> --password-selector <s>
-                             Override selectors for one login
+                             Override selectors for one saved-profile login
   auth list                  List saved auth profiles
   auth show <name>           Show auth profile metadata
   auth delete <name>         Delete auth profile

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -12,6 +12,9 @@ use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 
 pub const PROTOCOL_VERSION: &str = "agent-browser.plugin.v1";
+/// Credential response contract that binds secret entry and success checks to
+/// provider-approved destinations.
+pub const CREDENTIAL_CONTRACT: &str = "destination-bound-v1";
 pub const TYPE_PLUGIN_MANIFEST: &str = "plugin.manifest";
 pub const CAPABILITY_CREDENTIAL_READ: &str = "credential.read";
 pub const CAPABILITY_BROWSER_PROVIDER: &str = "browser.provider";
@@ -41,16 +44,26 @@ pub struct CredentialResolveRequest<'a> {
 pub struct ResolvedCredential {
     pub username: String,
     pub password: String,
-    #[serde(default)]
-    pub url: Option<String>,
+    /// Exact URL where the primary credential controls are approved.
+    pub url: String,
+    /// Optional one-time password. OTP selectors must be present with it.
     #[serde(default)]
     pub otp: Option<String>,
+    /// Serialized HTTP(S) origin shared by the login and verified destination.
+    pub credential_origin: String,
+    pub username_selector: String,
+    pub password_selector: String,
+    pub submit_selector: String,
+    /// Optional OTP control, including controls not associated with a form.
     #[serde(default)]
-    pub username_selector: Option<String>,
+    pub otp_selector: Option<String>,
     #[serde(default)]
-    pub password_selector: Option<String>,
-    #[serde(default)]
-    pub submit_selector: Option<String>,
+    pub otp_submit_selector: Option<String>,
+    /// Exact URL required before a provider login can report success.
+    pub expected_post_login_url: String,
+    /// Unique element and expected text used to verify the logged-in account.
+    pub account_marker_selector: String,
+    pub account_marker_value: String,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -280,6 +293,7 @@ pub async fn resolve_credential_with_plugins(
         "credential.resolve",
         CAPABILITY_CREDENTIAL_READ,
         json!({
+            "credentialContract": CREDENTIAL_CONTRACT,
             "profileName": request.profile_name,
             "itemRef": request.item_ref,
             "url": request.url,
@@ -305,9 +319,60 @@ pub async fn resolve_credential_with_plugins(
     let credential = response
         .credential
         .ok_or_else(|| format!("Credential plugin '{}' returned no credential", provider))?;
-    if credential.username.is_empty() || credential.password.is_empty() {
+    if credential.username.trim().is_empty()
+        || credential.password.is_empty()
+        || credential.url.trim().is_empty()
+        || credential.credential_origin.trim().is_empty()
+        || credential.username_selector.trim().is_empty()
+        || credential.password_selector.trim().is_empty()
+        || credential.submit_selector.trim().is_empty()
+        || credential.expected_post_login_url.trim().is_empty()
+        || credential.account_marker_selector.trim().is_empty()
+        || credential.account_marker_value.trim().is_empty()
+        || credential.otp.as_ref().is_some_and(|otp| otp.is_empty())
+        || credential.otp.is_some() != credential.otp_selector.is_some()
+        || credential.otp.is_some() != credential.otp_submit_selector.is_some()
+    {
         return Err(format!(
             "Credential plugin '{}' returned an incomplete credential",
+            provider
+        ));
+    }
+    let credential_origin = url::Url::parse(&credential.credential_origin)
+        .ok()
+        .filter(|url| {
+            matches!(url.scheme(), "http" | "https")
+                && url.username().is_empty()
+                && url.password().is_none()
+                && !url.cannot_be_a_base()
+                && url.origin().ascii_serialization() == credential.credential_origin
+                && matches!(url.path(), "" | "/")
+                && url.query().is_none()
+                && url.fragment().is_none()
+        })
+        .map(|url| url.origin().ascii_serialization());
+    let login_origin = url::Url::parse(&credential.url)
+        .ok()
+        .filter(|url| {
+            matches!(url.scheme(), "http" | "https")
+                && url.username().is_empty()
+                && url.password().is_none()
+        })
+        .map(|url| url.origin().ascii_serialization());
+    let expected_origin = url::Url::parse(&credential.expected_post_login_url)
+        .ok()
+        .filter(|url| {
+            matches!(url.scheme(), "http" | "https")
+                && url.username().is_empty()
+                && url.password().is_none()
+        })
+        .map(|url| url.origin().ascii_serialization());
+    if credential_origin.is_none()
+        || credential_origin.as_ref() != login_origin.as_ref()
+        || credential_origin.as_ref() != expected_origin.as_ref()
+    {
+        return Err(format!(
+            "Credential plugin '{}' returned inconsistent destination policy",
             provider
         ));
     }
@@ -1143,10 +1208,14 @@ mod tests {
         let plugin_path = dir.path().join("mock-credential-plugin");
         std::fs::write(
             &plugin_path,
-            r#"#!/bin/sh
-cat >/dev/null
-printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{"username":"user","password":"pass","url":"https://example.com/login"}}'
-"#,
+            r##"#!/bin/sh
+request="$(cat)"
+case "$request" in
+  *'"credentialContract":"destination-bound-v1"'*) ;;
+  *) printf '%s' '{"protocol":"agent-browser.plugin.v1","success":false}'; exit 0 ;;
+esac
+printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{"username":"user","password":"pass","url":"https://example.com/login","credentialOrigin":"https://example.com","usernameSelector":"#user","passwordSelector":"#pass","submitSelector":"#submit","expectedPostLoginUrl":"https://example.com/account","accountMarkerSelector":"#account","accountMarkerValue":"user"}}'
+"##,
         )
         .unwrap();
         let mut perms = std::fs::metadata(&plugin_path).unwrap().permissions();
@@ -1177,7 +1246,8 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"credential":{
 
         assert_eq!(credential.username, "user");
         assert_eq!(credential.password, "pass");
-        assert_eq!(credential.url.as_deref(), Some("https://example.com/login"));
+        assert_eq!(credential.url, "https://example.com/login");
+        assert_eq!(credential.credential_origin, "https://example.com");
     }
 
     #[cfg(unix)]

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -349,10 +349,10 @@ agent-browser auth save <name> [opts]    # Save auth profile
 agent-browser auth login <name>          # Login using saved credentials
 agent-browser auth login <name> --no-navigate
                                           # Use active page after origin validation
-agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
+agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <asserted-url>]
                                           # Resolve credentials from plugin
 agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>]
-                                          # Override selectors for one login
+                                          # Override selectors for one saved-profile login
 agent-browser auth list                  # List saved profiles (names and URLs only)
 agent-browser auth show <name>           # Show profile metadata (no passwords)
 agent-browser auth delete <name>         # Delete a saved profile
@@ -389,13 +389,13 @@ Plugin login options:
 
 - `--credential-provider <plugin>`: resolve credentials from a configured plugin
 - `--item <ref>`: provider-specific vault item reference
-- `--url <url>`: login URL override
-- `--no-navigate`: use the active top-level page after validating it against the effective credential origin
-- `--username-selector <sel>`: selector override for this login
-- `--password-selector <sel>`: selector override for this login
-- `--submit-selector <sel>`: selector override for this login
+- `--url <url>`: saved-profile URL override or exact provider URL assertion
+- `--no-navigate`: use the active top-level page without initial navigation. Saved profiles validate the effective credential origin. Credential providers require the current page to match the provider-approved login URL.
+- `--username-selector <sel>`: saved-profile selector override for this login
+- `--password-selector <sel>`: saved-profile selector override for this login
+- `--submit-selector <sel>`: saved-profile selector override for this login
 
-Credential provider plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol. They return credentials to the daemon for a single login and agent-browser does not save those credentials locally.
+Credential provider plugins run out-of-process over the `agent-browser.plugin.v1` stdio JSON protocol and must implement the `destination-bound-v1` credential contract. They return credentials with an approved origin, exact login and post-login URLs, selectors, account identity marker, and optional OTP metadata. agent-browser does not save those credentials locally. It binds secret entry to the approved main-frame document, blocks off-origin navigation and credential-bearing requests during submission, supports form and form-less OTP pages, and reports success only after verifying the final URL and account marker.
 
 Other plugin capabilities use the same protocol:
 

--- a/docs/src/app/plugins/page.mdx
+++ b/docs/src/app/plugins/page.mdx
@@ -288,6 +288,7 @@ A credential plugin receives:
   "type": "credential.resolve",
   "capability": "credential.read",
   "request": {
+    "credentialContract": "destination-bound-v1",
     "profileName": "my-app",
     "itemRef": "My App",
     "url": "https://app.example.com/login"
@@ -304,13 +305,26 @@ Return `credential`:
   "credential": {
     "username": "alice@example.com",
     "password": "secret",
+    "otp": "123456",
     "url": "https://app.example.com/login",
+    "credentialOrigin": "https://app.example.com",
     "usernameSelector": "#username",
     "passwordSelector": "#password",
-    "submitSelector": "input[type=submit]"
+    "submitSelector": "input[type=submit]",
+    "otpSelector": "#otp",
+    "otpSubmitSelector": "#verify",
+    "expectedPostLoginUrl": "https://app.example.com/account",
+    "accountMarkerSelector": "[data-account-email]",
+    "accountMarkerValue": "alice@example.com"
   }
 }
 ```
+
+The `destination-bound-v1` fields are required except `otp`, `otpSelector`, and `otpSubmitSelector`, which must either all be present or all be omitted. `credentialOrigin` must be an HTTP or HTTPS origin shared by `url` and `expectedPostLoginUrl`. The login and account selectors must each identify one element when used.
+
+agent-browser enters credentials in one main-frame operation after checking the exact login URL, origin, controls, and form destination. During submission it blocks the active page from navigating to another origin and blocks credential values from appearing in off-origin request URLs or bodies. OTP supports controls inside one form or form-less controls associated with no form. A provider login succeeds only when the browser reaches `expectedPostLoginUrl` and exactly one `accountMarkerSelector` contains `accountMarkerValue`; otherwise the login page is closed.
+
+The optional CLI `--url` value is sent to the provider and then checked for exact equality with the returned `url`. Selector overrides are rejected for provider logins because selectors are part of the destination-bound policy.
 
 Use it for one login:
 

--- a/docs/src/app/security/page.mdx
+++ b/docs/src/app/security/page.mdx
@@ -139,7 +139,7 @@ Use a generic plugin command:
 agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url":"https://example.com"}'
 ```
 
-Credential plugins receive `credential.resolve` and return username, password, and optionally URL or selector metadata. Browser provider plugins receive `browser.launch` and return a CDP WebSocket URL. Launch mutator plugins receive `launch.mutate` and can append local launch args, extensions, or init script source before Chrome starts. Generic command plugins receive the request type passed to `plugin run`.
+Credential plugins receive `credential.resolve` with the `destination-bound-v1` contract and return username, password, the approved login origin and selectors, final URL and account marker, plus optional OTP metadata. agent-browser atomically checks the main-frame document before entering secrets, blocks off-origin document and credential-bearing requests during the attempt, and verifies the final destination and account identity before reporting success. Browser provider plugins receive `browser.launch` and return a CDP WebSocket URL. Launch mutator plugins receive `launch.mutate` and can append local launch args, extensions, or init script source before Chrome starts. Generic command plugins receive the request type passed to `plugin run`.
 
 `plugin run` is for `command.run` and custom capabilities. Core capabilities and protocol request types use their dedicated command paths so credential, browser-provider, and launch-mutator access stays inside the normal policy gates.
 
@@ -263,7 +263,7 @@ Example policy (restrictive):
   </tbody>
 </table>
 
-Auth vault operations keep secrets out of normal command output and LLM context. Domain allowlist restrictions still apply to `auth login` navigations. Plugin-backed logins also expose the capability action `plugin:<name>:credential.read` for policy and confirmation gates.
+Auth vault operations keep secrets out of normal command output and LLM context. Domain allowlist restrictions still apply to `auth login` navigations. Plugin-backed logins also expose the capability action `plugin:<name>:credential.read` for policy and confirmation gates. Provider-sourced secrets require destination-bound metadata; selector overrides are limited to saved profiles, and `--url` acts as an exact provider-response assertion.
 
 ## Action Confirmation
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -238,9 +238,10 @@ If credentials live in an external vault, use a configured credential provider p
 agent-browser plugin add agent-browser-plugin-vault --name vault
 agent-browser plugin list
 agent-browser auth login my-app --credential-provider vault --item "My App"
-agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login --username-selector "#email" --password-selector "#password"
-agent-browser auth login my-app --credential-provider vault --item "My App" --no-navigate --url https://identity.example.com/login
+agent-browser auth login my-app --credential-provider vault --item "My App" --url https://app.example.com/login
 ```
+
+Provider logins require the `destination-bound-v1` contract. They bind credential entry and optional OTP to the provider-approved origin and verify the final URL and account identity before reporting success. `--url` asserts the provider's login URL. Use selector overrides only with saved profiles.
 
 Plugins can also provide browser providers, launch mutators such as stealth setup, and arbitrary namespaced commands:
 

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -230,7 +230,9 @@ agent-browser plugin run captcha captcha.solve --payload '{"siteKey":"...","url"
 
 `plugin run` is for `command.run` and custom capabilities. Core capabilities and protocol request types use their dedicated command paths.
 
-Use `--url`, `--username-selector`, `--password-selector`, and `--submit-selector` on `auth login` to override plugin-provided metadata for the current login only.
+Credential providers must implement the `destination-bound-v1` contract. They provide the exact login URL, approved origin, field and submit selectors, expected post-login URL, and an account marker. Optional OTP includes both the OTP field and submit selectors and works with form-based or form-less pages. agent-browser rejects inconsistent destination metadata, enters values only in the approved main-frame document, blocks off-origin document and credential-bearing requests during login, and verifies both final destination and account identity before reporting success.
+
+For provider logins, `--url` asserts that the provider returned the expected login URL. It does not override provider policy. Selector overrides apply only to saved-profile logins.
 
 Gate plugin secret access separately from normal login automation:
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -318,8 +318,8 @@ agent-browser auth save <name> --url <url> --username <user> --password-stdin
 agent-browser auth login <name>          # Login using saved credentials
 agent-browser auth login <name> --no-navigate
                                           # Use active page after same-origin validation
-agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <url>]
-agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>]
+agent-browser auth login <name> --credential-provider <plugin> [--item <ref>] [--url <asserted-url>]
+agent-browser auth login <name> --username-selector <s> --password-selector <s> [--submit-selector <s>] # Saved profiles only
 agent-browser auth list                  # List saved auth profiles
 agent-browser auth show <name>           # Show profile metadata, no passwords
 agent-browser auth delete <name>         # Delete a saved profile


### PR DESCRIPTION
## Summary

This change makes credential-provider login destination-bound and verifies the authenticated account before reporting success.

It also gives each native build a compatibility identity so a custom binary cannot reuse a different daemon with the same package version.

Fixes #1794.

## What changed

### Destination-bound credential contract

Credential providers now receive:

```json
{
  "credentialContract": "destination-bound-v1"
}
```

Their response must include:

- the exact login URL
- a canonical HTTP or HTTPS credential origin
- username, password and submit selectors
- the exact expected post-login URL
- an account marker selector and value
- optional OTP, OTP selector and OTP submit selector

The OTP fields must all be present or all be omitted.

### Safe credential entry

Provider login now:

1. validates that the login and post-login URLs use the approved origin
2. navigates to the exact provider-approved login URL
3. enables request interception before entering credentials
4. checks the main-frame URL, origin, controls and form destination in one browser operation
5. fills and submits the approved controls
6. completes an optional form-based or form-less OTP step
7. verifies the exact final URL and account marker
8. returns `verified: true` only after both checks pass

The request guard blocks:

- document navigation from the active login page to another origin
- raw or encoded credential values in off-origin request URLs
- raw or form-encoded credential values in off-origin request bodies

Failed provider-login attempts close the login target.

Stored authentication profiles keep their existing login behaviour.

### Daemon compatibility

The build script now derives a compatibility identity from:

- native Rust source
- Cargo manifests and lockfile
- compilation target and profile
- encoded Rust flags

The CLI, daemon sidecar and doctor command compare this identity instead of package version alone.

Existing semver-only daemon sidecars cause a one-time restart.

### CLI and MCP parity

The auth-login MCP tool now exposes the existing provider, item, URL and selector options through the normal CLI parser.

For provider login:

- `--url` asserts the exact URL returned by the provider
- selector overrides are rejected because selectors form part of the provider's destination policy

Selector and URL overrides for stored profiles are unchanged.

## Compatibility

Existing credential-provider plugins must implement `destination-bound-v1`. Legacy responses are rejected rather than using the previous unsafe path.

The login and verified destination must share one origin. Providers that use dynamic callback URLs must resolve the exact expected URL before returning credentials or wait for a future reviewed contract extension.

The provider remains trusted to define the approved origin, selectors and account marker. The approved origin can receive credentials by design.

## Testing

Passed:

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
  - 1,245 unit tests passed
  - 4 dashboard CLI tests passed
  - 2 doctor CLI tests passed
- focused serial native authentication tests
  - existing delayed SPA login
  - login without OTP
  - form-based OTP
  - form-less OTP
  - stale frame context
  - redirect and document replacement
  - cross-origin form action
  - wrong final account identity
  - rejected provider selector override
  - credential-bearing cross-origin document redirect

The full serial E2E run passed 110 of 112 tests. `e2e_stream_url_tracks_active_main_frame_navigation_categories` also fails on an unchanged `origin/main` worktree with the same Chrome version. The following test failed because that baseline failure poisoned the shared test mutex and passed when run independently.
