### PR TITLE
feat: add interpolated mouse movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ agent-browser mouse up [button]       # Release button
 agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 ```
 
-Add `--human` to `click` or `drag` to approach targets along a seeded eased curve. The daemon remembers the cursor position for the session, emits intermediate `mousemove` events, and always finishes at the exact target coordinate. Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
+Add `--human` to `click` or `drag` for curved, eased movement from the current cursor position.
 
 ### Browser Settings
 

--- a/README.md
+++ b/README.md
@@ -291,11 +291,15 @@ agent-browser clipboard paste                     # Paste from clipboard (Ctrl+V
 ### Mouse Control
 
 ```bash
-agent-browser mouse move <x> <y>      # Move mouse
+agent-browser mouse move <x> <y>      # Move mouse instantly
+agent-browser mouse move 600 400 --duration 250 --steps 24 # Smooth movement
+agent-browser mouse move 600 400 --human --seed 42 # Reproducible curved movement
 agent-browser mouse down [button]     # Press button (left/right/middle)
 agent-browser mouse up [button]       # Release button
 agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 ```
+
+Add `--human` to `click` or `drag` to approach targets along a seeded eased curve. The daemon remembers the cursor position for the session, emits intermediate `mousemove` events, and always finishes at the exact target coordinate.
 
 ### Browser Settings
 
@@ -1012,6 +1016,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--confirm-actions <list>` | Action categories requiring confirmation (or `AGENT_BROWSER_CONFIRM_ACTIONS` env) |
 | `--confirm-interactive` | Interactive confirmation prompts; auto-denies if stdin is not a TTY (or `AGENT_BROWSER_CONFIRM_INTERACTIVE` env) |
 | `--engine <name>` | Browser engine: `chrome` (default), `lightpanda` (or `AGENT_BROWSER_ENGINE` env) |
+| `--input-mode <mode>` | Session pointer movement: `instant` (default), `smooth`, or `human` |
 | `--idle-timeout <time>` | Shut down the daemon after inactivity (`10s`, `3m`, `1h`, or raw ms). Defaults to `1h`; use `0` to disable (or `AGENT_BROWSER_IDLE_TIMEOUT_MS` env) |
 | `--no-auto-dialog` | Disable automatic dismissal of `alert`/`beforeunload` dialogs (or `AGENT_BROWSER_NO_AUTO_DIALOG` env) |
 | `--model <name>` | AI model for chat command (or `AI_GATEWAY_MODEL` env) |

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ agent-browser mouse up [button]       # Release button
 agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 ```
 
-Add `--human` to `click` or `drag` to approach targets along a seeded eased curve. The daemon remembers the cursor position for the session, emits intermediate `mousemove` events, and always finishes at the exact target coordinate.
+Add `--human` to `click` or `drag` to approach targets along a seeded eased curve. The daemon remembers the cursor position for the session, emits intermediate `mousemove` events, and always finishes at the exact target coordinate. Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
 
 ### Browser Settings
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -431,18 +431,22 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         // === Core Actions ===
         "click" => {
             let new_tab = rest.contains(&"--new-tab");
+            let human = rest.contains(&"--human");
             let sel = rest
                 .iter()
-                .find(|arg| **arg != "--new-tab")
+                .find(|arg| **arg != "--new-tab" && **arg != "--human")
                 .ok_or_else(|| ParseError::MissingArguments {
                     context: "click".to_string(),
-                    usage: "click <selector> [--new-tab]",
+                    usage: "click <selector> [--new-tab] [--human]",
                 })?;
+            let mut cmd = json!({ "id": id, "action": "click", "selector": sel });
             if new_tab {
-                Ok(json!({ "id": id, "action": "click", "selector": sel, "newTab": true }))
-            } else {
-                Ok(json!({ "id": id, "action": "click", "selector": sel }))
+                cmd["newTab"] = json!(true);
             }
+            if human {
+                cmd["inputMode"] = json!("human");
+            }
+            Ok(cmd)
         }
         "dblclick" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -554,7 +558,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 context: "drag".to_string(),
                 usage: "drag <source> <target>",
             })?;
-            Ok(json!({ "id": id, "action": "drag", "source": src, "target": tgt }))
+            let mut cmd = json!({ "id": id, "action": "drag", "source": src, "target": tgt });
+            if rest.contains(&"--human") {
+                cmd["inputMode"] = json!("human");
+            }
+            Ok(cmd)
         }
         "upload" => {
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
@@ -3059,7 +3067,32 @@ fn parse_mouse(rest: &[&str], id: &str) -> Result<Value, ParseError> {
                     context: "mouse move".to_string(),
                     usage: "mouse move <x> <y>",
                 })?;
-            Ok(json!({ "id": id, "action": "mousemove", "x": x, "y": y }))
+            let mut cmd = json!({ "id": id, "action": "mousemove", "x": x, "y": y });
+            let mut i = 3;
+            while i < rest.len() {
+                match rest[i] {
+                    "--duration" | "--steps" | "--seed" => {
+                        let flag = rest[i];
+                        let raw = rest.get(i + 1).ok_or_else(|| ParseError::MissingArguments {
+                            context: format!("mouse move {}", flag),
+                            usage: "mouse move <x> <y> [--duration <ms>] [--steps <n>] [--seed <n>]",
+                        })?;
+                        let value = raw.parse::<u64>().map_err(|_| ParseError::InvalidValue {
+                            message: format!("{} expects a non-negative integer, got '{}'", flag, raw),
+                            usage: "mouse move <x> <y> [--duration <ms>] [--steps <n>] [--seed <n>]",
+                        })?;
+                        let key = match flag { "--duration" => "duration", "--steps" => "steps", _ => "seed" };
+                        cmd[key] = json!(value);
+                        i += 2;
+                    }
+                    "--human" => { cmd["inputMode"] = json!("human"); i += 1; }
+                    other => return Err(ParseError::InvalidValue {
+                        message: format!("unexpected argument '{}'", other),
+                        usage: "mouse move <x> <y> [--duration <ms>] [--steps <n>] [--seed <n>] [--human]",
+                    }),
+                }
+            }
+            Ok(cmd)
         }
         Some("down") => {
             Ok(json!({ "id": id, "action": "mousedown", "button": rest.get(1).unwrap_or(&"left") }))
@@ -3482,6 +3515,7 @@ mod tests {
             cli_no_webmcp: false,
             cli_restore: false,
             cli_pin_tab: false,
+            cli_input_mode: false,
             annotate: false,
             color_scheme: None,
             download_path: None,
@@ -3502,6 +3536,7 @@ mod tests {
             plugins: Vec::new(),
             verbose: false,
             quiet: false,
+            input_mode: "instant".to_string(),
         }
     }
 
@@ -4300,6 +4335,26 @@ mod tests {
         let cmd = parse_command(&args("click #button"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "click");
         assert_eq!(cmd["selector"], "#button");
+    }
+
+    #[test]
+    fn test_click_human() {
+        let cmd = parse_command(&args("click @e1 --human"), &default_flags()).unwrap();
+        assert_eq!(cmd["selector"], "@e1");
+        assert_eq!(cmd["inputMode"], "human");
+    }
+
+    #[test]
+    fn test_mouse_move_interpolation_options() {
+        let cmd = parse_command(
+            &args("mouse move 600 400 --duration 250 --steps 24 --seed 42 --human"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["duration"], 250);
+        assert_eq!(cmd["steps"], 24);
+        assert_eq!(cmd["seed"], 42);
+        assert_eq!(cmd["inputMode"], "human");
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -308,6 +308,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--action-policy",
         "--confirm-actions",
         "--engine",
+        "--input-mode",
         "--screenshot-dir",
         "--screenshot-quality",
         "--screenshot-format",
@@ -419,6 +420,8 @@ pub struct Flags {
     pub plugins: Vec<PluginConfig>,
     pub verbose: bool,
     pub quiet: bool,
+    /// Session input behavior selected with `--input-mode`.
+    pub input_mode: String,
 
     // Track which launch-time options were explicitly passed via CLI
     // (as opposed to being set only via environment variables)
@@ -445,6 +448,8 @@ pub struct Flags {
     /// an explicit disable can be sent to the daemon (a bare `pin_tab: false`
     /// just means "absent" and must not override a sticky pin).
     pub cli_pin_tab: bool,
+    /// True when `--input-mode` was explicitly passed, including `instant`.
+    pub cli_input_mode: bool,
 }
 
 pub fn parse_flags(args: &[String]) -> Flags {
@@ -655,6 +660,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         plugins,
         verbose: false,
         quiet: false,
+        input_mode: "instant".to_string(),
         cli_executable_path: false,
         cli_extensions: false,
         cli_init_scripts: false,
@@ -675,6 +681,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         cli_no_webmcp: false,
         cli_restore: false,
         cli_pin_tab: false,
+        cli_input_mode: false,
     };
 
     let mut i = 0;
@@ -1043,6 +1050,21 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--input-mode" => {
+                if let Some(s) = args.get(i + 1) {
+                    if matches!(s.as_str(), "instant" | "smooth" | "human") {
+                        flags.input_mode = s.clone();
+                        flags.cli_input_mode = true;
+                    } else {
+                        eprintln!(
+                            "{} --input-mode must be instant, smooth, or human, got '{}'",
+                            color::warning_indicator(),
+                            s
+                        );
+                    }
+                    i += 1;
+                }
+            }
             "--screenshot-dir" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.screenshot_dir = Some(s.clone());
@@ -1176,6 +1198,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--confirm-actions",
         "--config",
         "--engine",
+        "--input-mode",
         "--screenshot-dir",
         "--screenshot-quality",
         "--screenshot-format",
@@ -2185,5 +2208,21 @@ mod tests {
             clean_args(&args("--no-webmcp open example.com")),
             args("open example.com")
         );
+    }
+
+    #[test]
+    fn test_input_mode_is_explicit_and_removed_from_command_args() {
+        let input = args("--input-mode human open example.com");
+        let flags = parse_flags(&input);
+        assert_eq!(flags.input_mode, "human");
+        assert!(flags.cli_input_mode);
+        assert_eq!(clean_args(&input), args("open example.com"));
+    }
+
+    #[test]
+    fn test_input_mode_defaults_without_overwriting_session() {
+        let flags = parse_flags(&args("click @e1"));
+        assert_eq!(flags.input_mode, "instant");
+        assert!(!flags.cli_input_mode);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1550,6 +1550,9 @@ fn main() {
             exit(1);
         }
     };
+    if flags.cli_input_mode {
+        cmd["inputMode"] = json!(flags.input_mode);
+    }
 
     // Handle --password-stdin for auth save
     if cmd.get("action").and_then(|v| v.as_str()) == Some("auth_save") {
@@ -2209,6 +2212,9 @@ fn run_batch(
                 continue;
             }
         };
+        if flags.cli_input_mode {
+            parsed["inputMode"] = json!(flags.input_mode);
+        }
 
         let action = parsed
             .get("action")

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -850,7 +850,8 @@ fn tools() -> Vec<Value> {
             "Click an element by @ref or CSS selector.",
             json!({
                 "selector": selector_schema(),
-                "newTab": { "type": "boolean", "default": false, "description": "Open link targets in a new tab." }
+                "newTab": { "type": "boolean", "default": false, "description": "Open link targets in a new tab." },
+                "human": { "type": "boolean", "default": false, "description": "Approach the target with seeded, curved mouse movement before clicking." }
             }),
             &["selector"],
         ),
@@ -982,7 +983,7 @@ fn parity_tools() -> Vec<Value> {
             TOOL_DRAG,
             "Drag and drop",
             "Drag one element to another.",
-            json!({ "source": selector_schema(), "target": selector_schema() }),
+            json!({ "source": selector_schema(), "target": selector_schema(), "human": { "type": "boolean", "default": false, "description": "Use seeded, curved mouse movement." } }),
             &["source", "target"],
         ),
         tool(
@@ -1109,7 +1110,14 @@ fn parity_tools() -> Vec<Value> {
             TOOL_MOUSE_MOVE,
             "Mouse move",
             "Move the mouse.",
-            json!({ "x": number_schema(), "y": number_schema() }),
+            json!({
+                "x": number_schema(),
+                "y": number_schema(),
+                "durationMs": { "type": "integer", "minimum": 0, "description": "Total movement duration in milliseconds." },
+                "steps": { "type": "integer", "minimum": 1, "maximum": 240, "description": "Number of interpolated events." },
+                "human": { "type": "boolean", "default": false, "description": "Add a seeded perpendicular curve." },
+                "seed": { "type": "integer", "minimum": 0, "description": "Seed for reproducible human movement." }
+            }),
             &["x", "y"],
         ),
         tool(
@@ -2605,6 +2613,9 @@ fn click_command_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
     if optional_bool(arguments, "newTab")?.unwrap_or(false) {
         args.push("--new-tab".to_string());
     }
+    if optional_bool(arguments, "human")?.unwrap_or(false) {
+        args.push("--human".to_string());
+    }
     Ok(args)
 }
 
@@ -2640,7 +2651,11 @@ fn call_press(arguments: &Value) -> Result<Value, ProtocolError> {
 fn call_drag(arguments: &Value) -> Result<Value, ProtocolError> {
     let source = required_string(arguments, "source")?;
     let target = required_string(arguments, "target")?;
-    call_cli_tool(arguments, vec!["drag".to_string(), source, target], None)
+    let mut args = vec!["drag".to_string(), source, target];
+    if optional_bool(arguments, "human")?.unwrap_or(false) {
+        args.push("--human".to_string());
+    }
+    call_cli_tool(arguments, args, None)
 }
 
 fn call_upload(arguments: &Value) -> Result<Value, ProtocolError> {
@@ -2810,11 +2825,21 @@ fn call_find(arguments: &Value) -> Result<Value, ProtocolError> {
 fn call_mouse_move(arguments: &Value) -> Result<Value, ProtocolError> {
     let x = required_number_string(arguments, "x")?;
     let y = required_number_string(arguments, "y")?;
-    call_cli_tool(
-        arguments,
-        vec!["mouse".to_string(), "move".to_string(), x, y],
-        None,
-    )
+    let mut args = vec!["mouse".to_string(), "move".to_string(), x, y];
+    for (field, flag) in [
+        ("durationMs", "--duration"),
+        ("steps", "--steps"),
+        ("seed", "--seed"),
+    ] {
+        if let Some(value) = optional_u64(arguments, field)? {
+            args.push(flag.to_string());
+            args.push(value.to_string());
+        }
+    }
+    if optional_bool(arguments, "human")?.unwrap_or(false) {
+        args.push("--human".to_string());
+    }
+    call_cli_tool(arguments, args, None)
 }
 
 fn call_mouse_button(arguments: &Value, action: &str) -> Result<Value, ProtocolError> {

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1109,7 +1109,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_MOUSE_MOVE,
             "Mouse move",
-            "Move the mouse.",
+            "Move the mouse. Interpolation starts at the last pointer or element interaction.",
             json!({
                 "x": number_schema(),
                 "y": number_schema(),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -489,6 +489,8 @@ pub struct DaemonState {
     /// so they never block the agent.
     dialog_handler_task: Option<tokio::task::JoinHandle<()>>,
     pub mouse_state: MouseState,
+    /// Session-wide pointer behavior, configured by `--input-mode`.
+    pub input_mode: String,
     /// Tracks the currently open JavaScript dialog (alert/confirm/prompt), if any.
     pub pending_dialog: Option<PendingDialog>,
     /// A mouse button left logically down because a dialog opened between
@@ -612,6 +614,7 @@ impl DaemonState {
             fetch_handler_task: None,
             dialog_handler_task: None,
             mouse_state: MouseState::default(),
+            input_mode: "instant".to_string(),
             pending_dialog: None,
             pending_pointer_release: None,
             auto_dialog: !matches!(
@@ -2372,6 +2375,11 @@ fn policy_actions_for_command(
 
 pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     let action = cmd.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    if let Some(mode @ ("instant" | "smooth" | "human")) =
+        cmd.get("inputMode").and_then(Value::as_str)
+    {
+        state.input_mode = mode.to_string();
+    }
     let id = cmd
         .get("id")
         .and_then(|v| v.as_str())
@@ -5391,6 +5399,34 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
 
     let button = cmd.get("button").and_then(|v| v.as_str()).unwrap_or("left");
     let click_count = cmd.get("clickCount").and_then(|v| v.as_i64()).unwrap_or(1) as i32;
+
+    let input_mode = cmd
+        .get("inputMode")
+        .and_then(Value::as_str)
+        .unwrap_or(&state.input_mode);
+    if input_mode != "instant" {
+        let (x, y, target_session_id) = super::element::resolve_element_center(
+            &mgr.client,
+            &session_id,
+            &state.ref_map,
+            selector,
+            &state.iframe_sessions,
+        )
+        .await?;
+        move_mouse_interpolated(
+            &mgr.client,
+            &target_session_id,
+            &mut state.mouse_state,
+            x,
+            y,
+            if input_mode == "smooth" { 200 } else { 0 },
+            None,
+            input_mode == "human",
+            cmd.get("seed").and_then(Value::as_u64).unwrap_or(0),
+            0,
+        )
+        .await?;
+    }
 
     let result = interaction::click(
         &mgr.client,
@@ -9767,14 +9803,27 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     )
     .await?;
 
-    // Mouse down at source
-    mgr.client
-        .send_command(
-            "Input.dispatchMouseEvent",
-            Some(json!({ "type": "mouseMoved", "x": sx, "y": sy })),
-            Some(&source_session_id),
-        )
-        .await?;
+    let mode = cmd
+        .get("inputMode")
+        .and_then(Value::as_str)
+        .unwrap_or(&state.input_mode);
+    let human = mode == "human";
+    let seed = cmd.get("seed").and_then(Value::as_u64).unwrap_or(0);
+
+    // Approach the source before pressing so hover and pointer path handlers fire.
+    move_mouse_interpolated(
+        &mgr.client,
+        &source_session_id,
+        &mut state.mouse_state,
+        sx,
+        sy,
+        0,
+        if human { None } else { Some(1) },
+        human,
+        seed,
+        0,
+    )
+    .await?;
     mgr.client
         .send_command(
             "Input.dispatchMouseEvent",
@@ -9785,19 +9834,22 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
 
     // Move in steps to target, keeping the left button held (buttons: 1) so
     // that the browser sees a drag rather than a plain pointer move.
-    let steps = 10;
-    for i in 1..=steps {
-        let cx = sx + (tx - sx) * (i as f64) / (steps as f64);
-        let cy = sy + (ty - sy) * (i as f64) / (steps as f64);
-        mgr.client
-            .send_command(
-                "Input.dispatchMouseEvent",
-                Some(json!({ "type": "mouseMoved", "x": cx, "y": cy, "button": "left", "buttons": 1 })),
-                Some(&target_session_id),
-            )
-            .await?;
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-    }
+    state.mouse_state.x = sx;
+    state.mouse_state.y = sy;
+    state.mouse_state.buttons = 1;
+    move_mouse_interpolated(
+        &mgr.client,
+        &target_session_id,
+        &mut state.mouse_state,
+        tx,
+        ty,
+        if human { 250 } else { 100 },
+        if human { None } else { Some(10) },
+        human,
+        seed.wrapping_add(1),
+        1,
+    )
+    .await?;
 
     // Mouse up at target
     mgr.client
@@ -9807,6 +9859,7 @@ async fn handle_drag(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
             Some(&target_session_id),
         )
         .await?;
+    state.mouse_state.buttons = 0;
 
     Ok(json!({ "dragged": true, "source": source, "target": target }))
 }
@@ -11915,28 +11968,137 @@ async fn handle_inserttext(cmd: &Value, state: &DaemonState) -> Result<Value, St
     Ok(json!({ "inserted": true }))
 }
 
+/// Move the session cursor along a deterministic eased curve. Human mode adds
+/// a seeded perpendicular bend while preserving exact, reproducible endpoints.
+#[allow(clippy::too_many_arguments)]
+async fn move_mouse_interpolated(
+    client: &CdpClient,
+    session_id: &str,
+    mouse_state: &mut MouseState,
+    target_x: f64,
+    target_y: f64,
+    duration_ms: u64,
+    requested_steps: Option<usize>,
+    human: bool,
+    seed: u64,
+    buttons: i32,
+) -> Result<(), String> {
+    let start_x = mouse_state.x;
+    let start_y = mouse_state.y;
+    let dx = target_x - start_x;
+    let dy = target_y - start_y;
+    let distance = dx.hypot(dy);
+    let duration_ms = if duration_ms == 0 && human {
+        (80.0 + distance * 0.35).clamp(100.0, 700.0) as u64
+    } else {
+        duration_ms
+    };
+    let steps = requested_steps
+        .unwrap_or_else(|| ((distance / 12.0).ceil() as usize).clamp(1, 60))
+        .clamp(1, 240);
+    let bend = if human && distance > 0.0 {
+        let mixed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let unit = ((mixed >> 11) as f64) / ((1_u64 << 53) as f64);
+        (unit * 2.0 - 1.0) * (distance * 0.08).min(36.0)
+    } else {
+        0.0
+    };
+    let (perp_x, perp_y) = if distance > 0.0 {
+        (-dy / distance, dx / distance)
+    } else {
+        (0.0, 0.0)
+    };
+    let delay = if duration_ms == 0 {
+        None
+    } else {
+        Some(tokio::time::Duration::from_micros(
+            duration_ms.saturating_mul(1000) / steps as u64,
+        ))
+    };
+
+    for i in 1..=steps {
+        let (x, y) = interpolated_mouse_point(
+            start_x, start_y, target_x, target_y, perp_x, perp_y, bend, i, steps,
+        );
+        let params = build_mouse_event_params(
+            mouse_state,
+            "mouseMoved",
+            Some(x),
+            Some(y),
+            None,
+            Some(buttons),
+            None,
+            None,
+            None,
+            None,
+        );
+        client
+            .send_command_typed::<_, Value>("Input.dispatchMouseEvent", &params, Some(session_id))
+            .await?;
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn interpolated_mouse_point(
+    start_x: f64,
+    start_y: f64,
+    target_x: f64,
+    target_y: f64,
+    perp_x: f64,
+    perp_y: f64,
+    bend: f64,
+    step: usize,
+    steps: usize,
+) -> (f64, f64) {
+    if step == steps {
+        return (target_x, target_y);
+    }
+    let t = step as f64 / steps as f64;
+    let eased = t * t * (3.0 - 2.0 * t);
+    let curve = 4.0 * t * (1.0 - t) * bend;
+    (
+        start_x + (target_x - start_x) * eased + perp_x * curve,
+        start_y + (target_y - start_y) * eased + perp_y * curve,
+    )
+}
+
 async fn handle_mousemove(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
     let x = cmd.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let y = cmd.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let params = build_mouse_event_params(
+    let duration = cmd.get("duration").and_then(Value::as_u64).unwrap_or(0);
+    let mut steps = cmd.get("steps").and_then(Value::as_u64).map(|v| v as usize);
+    let mode = cmd
+        .get("inputMode")
+        .and_then(Value::as_str)
+        .unwrap_or(&state.input_mode);
+    let human = mode == "human";
+    if mode == "instant" && duration == 0 && steps.is_none() {
+        steps = Some(1);
+    }
+    let seed = cmd.get("seed").and_then(Value::as_u64).unwrap_or(0);
+    let buttons = state.mouse_state.buttons;
+    move_mouse_interpolated(
+        &mgr.client,
+        &session_id,
         &mut state.mouse_state,
-        "mouseMoved",
-        Some(x),
-        Some(y),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
-
-    mgr.client
-        .send_command_typed::<_, Value>("Input.dispatchMouseEvent", &params, Some(&session_id))
-        .await?;
-    Ok(json!({ "moved": true }))
+        x,
+        y,
+        duration,
+        steps,
+        human,
+        seed,
+        buttons,
+    )
+    .await?;
+    Ok(json!({ "moved": true, "x": x, "y": y }))
 }
 
 async fn handle_mousedown(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -13786,6 +13948,14 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
 
         drop(listener);
         let _ = fs::remove_dir_all(&socket_dir);
+    }
+
+    #[test]
+    fn interpolated_mouse_path_uses_easing_and_exact_endpoint() {
+        let midpoint = interpolated_mouse_point(0.0, 0.0, 100.0, 0.0, 0.0, 1.0, 10.0, 1, 2);
+        assert_eq!(midpoint, (50.0, 10.0));
+        let endpoint = interpolated_mouse_point(0.0, 0.0, 100.0, 0.0, 0.0, 1.0, 10.0, 2, 2);
+        assert_eq!(endpoint, (100.0, 0.0));
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5438,6 +5438,7 @@ async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         &state.iframe_sessions,
     )
     .await?;
+    (state.mouse_state.x, state.mouse_state.y) = result.position;
 
     if result.dialog_opened {
         state.pending_pointer_release = result.pending_release;
@@ -5462,6 +5463,7 @@ async fn handle_dblclick(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &state.iframe_sessions,
     )
     .await?;
+    (state.mouse_state.x, state.mouse_state.y) = result.position;
     if result.dialog_opened {
         state.pending_pointer_release = result.pending_release;
         return Ok(json!({ "clicked": selector, "dialogOpened": true }));
@@ -5592,7 +5594,7 @@ async fn handle_hover(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         .and_then(|v| v.as_str())
         .ok_or("Missing 'selector' parameter")?;
 
-    interaction::hover(
+    let position = interaction::hover(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -5600,6 +5602,7 @@ async fn handle_hover(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         &state.iframe_sessions,
     )
     .await?;
+    (state.mouse_state.x, state.mouse_state.y) = position;
     Ok(json!({ "hovered": selector }))
 }
 
@@ -5678,14 +5681,17 @@ async fn handle_check(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         .and_then(|v| v.as_str())
         .ok_or("Missing 'selector' parameter")?;
 
-    interaction::check(
+    if let Some(position) = interaction::check(
         &mgr.client,
         &session_id,
         &state.ref_map,
         selector,
         &state.iframe_sessions,
     )
-    .await?;
+    .await?
+    {
+        (state.mouse_state.x, state.mouse_state.y) = position;
+    }
     Ok(json!({ "checked": selector }))
 }
 
@@ -5697,14 +5703,17 @@ async fn handle_uncheck(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
         .and_then(|v| v.as_str())
         .ok_or("Missing 'selector' parameter")?;
 
-    interaction::uncheck(
+    if let Some(position) = interaction::uncheck(
         &mgr.client,
         &session_id,
         &state.ref_map,
         selector,
         &state.iframe_sessions,
     )
-    .await?;
+    .await?
+    {
+        (state.mouse_state.x, state.mouse_state.y) = position;
+    }
     Ok(json!({ "unchecked": selector }))
 }
 
@@ -6860,7 +6869,7 @@ async fn handle_download(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     let mut rx = mgr.client.subscribe();
 
     // Click the element to trigger the download
-    interaction::click(
+    let result = interaction::click(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -6870,6 +6879,7 @@ async fn handle_download(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         &state.iframe_sessions,
     )
     .await?;
+    (state.mouse_state.x, state.mouse_state.y) = result.position;
 
     // Wait for download to complete
     const DOWNLOAD_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(30);
@@ -9047,6 +9057,7 @@ async fn execute_subaction(
                 &state.iframe_sessions,
             )
             .await?;
+            (state.mouse_state.x, state.mouse_state.y) = result.position;
             if result.dialog_opened {
                 state.pending_pointer_release = result.pending_release;
                 return Ok(json!({ "clicked": selector, "dialogOpened": true }));
@@ -9070,18 +9081,21 @@ async fn execute_subaction(
             Ok(json!({ "filled": selector }))
         }
         "check" => {
-            interaction::check(
+            if let Some(position) = interaction::check(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
                 selector,
                 &state.iframe_sessions,
             )
-            .await?;
+            .await?
+            {
+                (state.mouse_state.x, state.mouse_state.y) = position;
+            }
             Ok(json!({ "checked": selector }))
         }
         "hover" => {
-            interaction::hover(
+            let position = interaction::hover(
                 &mgr.client,
                 &session_id,
                 &state.ref_map,
@@ -9089,6 +9103,7 @@ async fn execute_subaction(
                 &state.iframe_sessions,
             )
             .await?;
+            (state.mouse_state.x, state.mouse_state.y) = position;
             Ok(json!({ "hovered": selector }))
         }
         "text" => {
@@ -11534,7 +11549,7 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
             )
         })?
     };
-    interaction::click(
+    let result = interaction::click(
         &mgr.client,
         &session_id,
         &state.ref_map,
@@ -11544,6 +11559,7 @@ async fn handle_auth_login(cmd: &Value, state: &mut DaemonState) -> Result<Value
         &state.iframe_sessions,
     )
     .await?;
+    (state.mouse_state.x, state.mouse_state.y) = result.position;
 
     // Wait for navigation after submit (with fallback timeout)
     let mut rx = mgr.client.subscribe();

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -9989,3 +9989,46 @@ async fn e2e_find_role_document_matches_root() {
 
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
 }
+
+#[tokio::test]
+#[ignore]
+async fn e2e_mouse_interpolation_starts_at_last_element_interaction() {
+    let mut state = DaemonState::new();
+    assert_success(
+        &execute_command(
+            &json!({"id": "1", "action": "launch", "headless": true}),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(&execute_command(&json!({"id": "2", "action": "setcontent", "html": "<button id='b' style='position:absolute;left:400px;top:300px;width:100px;height:40px'>Target</button><input id='c' type='checkbox' style='position:absolute;left:200px;top:200px'>"}), &mut state).await);
+    for action in ["click", "hover", "dblclick", "check", "uncheck"] {
+        let selector = if matches!(action, "check" | "uncheck") {
+            "#c"
+        } else {
+            "#b"
+        };
+        assert_success(
+            &execute_command(
+                &json!({"id": "3", "action": action, "selector": selector}),
+                &mut state,
+            )
+            .await,
+        );
+        let start = (state.mouse_state.x, state.mouse_state.y);
+        assert!(start.0 >= 200.0 && start.1 >= 200.0, "{action}: {start:?}");
+        assert_success(&execute_command(&json!({"id": "4", "action": "evaluate", "script": "window.moves=[];document.onmousemove=e=>moves.push([e.clientX,e.clientY]);"}), &mut state).await);
+        assert_success(&execute_command(&json!({"id": "5", "action": "mousemove", "x": start.0 + 100.0, "y": start.1, "steps": 2}), &mut state).await);
+        let result = execute_command(
+            &json!({"id": "6", "action": "evaluate", "script": "moves"}),
+            &mut state,
+        )
+        .await;
+        assert_success(&result);
+        let moves = get_data(&result)["result"].as_array().unwrap();
+        assert_eq!(moves.len(), 2, "{action}: {moves:?}");
+        assert!((moves[0][0].as_f64().unwrap() - (start.0 + 50.0)).abs() <= 1.0);
+        assert!((moves[1][0].as_f64().unwrap() - (start.0 + 100.0)).abs() <= 1.0);
+    }
+    assert_success(&execute_command(&json!({"id": "99", "action": "close"}), &mut state).await);
+}

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -14,6 +14,8 @@ use super::element::{resolve_element_center, resolve_element_object_id, RefMap};
 /// next click would register as a drag or double-click.
 #[derive(Default)]
 pub struct ClickResult {
+    /// Final dispatched pointer position, including clicks that open a dialog.
+    pub position: (f64, f64),
     pub dialog_opened: bool,
     pub pending_release: Option<PendingRelease>,
 }
@@ -82,7 +84,7 @@ pub async fn hover(
     ref_map: &RefMap,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<(), String> {
+) -> Result<(f64, f64), String> {
     let (x, y, effective_session_id) = resolve_element_center(
         client,
         session_id,
@@ -108,7 +110,7 @@ pub async fn hover(
             Some(&effective_session_id),
         )
         .await?;
-    Ok(())
+    Ok((x, y))
 }
 
 pub async fn fill(
@@ -492,7 +494,8 @@ pub async fn check(
     ref_map: &RefMap,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<(), String> {
+) -> Result<Option<(f64, f64)>, String> {
+    let mut position = None;
     let is_checked = super::element::is_element_checked(
         client,
         session_id,
@@ -502,7 +505,7 @@ pub async fn check(
     )
     .await?;
     if !is_checked {
-        click(
+        let result = click(
             client,
             session_id,
             ref_map,
@@ -512,6 +515,7 @@ pub async fn check(
             iframe_sessions,
         )
         .await?;
+        position = Some(result.position);
 
         // Verify the click changed the state (Playwright parity: _setChecked re-checks).
         // If the coordinate-based click missed (e.g. hidden input, overlay), retry
@@ -535,7 +539,7 @@ pub async fn check(
             .await?;
         }
     }
-    Ok(())
+    Ok(position)
 }
 
 pub async fn uncheck(
@@ -544,7 +548,8 @@ pub async fn uncheck(
     ref_map: &RefMap,
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
-) -> Result<(), String> {
+) -> Result<Option<(f64, f64)>, String> {
+    let mut position = None;
     let is_checked = super::element::is_element_checked(
         client,
         session_id,
@@ -554,7 +559,7 @@ pub async fn uncheck(
     )
     .await?;
     if is_checked {
-        click(
+        let result = click(
             client,
             session_id,
             ref_map,
@@ -564,6 +569,7 @@ pub async fn uncheck(
             iframe_sessions,
         )
         .await?;
+        position = Some(result.position);
 
         // Same verify-and-retry as check().
         if super::element::is_element_checked(
@@ -585,7 +591,7 @@ pub async fn uncheck(
             .await?;
         }
     }
-    Ok(())
+    Ok(position)
 }
 
 /// Fallback for when the coordinate-based CDP click did not toggle the
@@ -1017,6 +1023,7 @@ async fn dispatch_click(
     {
         // No button was pressed yet, nothing to release.
         return Ok(ClickResult {
+            position: (x, y),
             dialog_opened: true,
             pending_release: None,
         });
@@ -1051,6 +1058,7 @@ async fn dispatch_click(
         // release will never arrive on its own. Hand the caller what it needs
         // to release once the dialog is resolved.
         return Ok(ClickResult {
+            position: (x, y),
             dialog_opened: true,
             pending_release: Some(PendingRelease {
                 session_id: session_id.to_string(),
@@ -1081,6 +1089,7 @@ async fn dispatch_click(
     )
     .await?;
     Ok(ClickResult {
+        position: (x, y),
         dialog_opened,
         pending_release: None,
     })

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1645,6 +1645,7 @@ Options:
   --new-tab            Open link in a new tab instead of navigating current tab
                        (only works on elements with href attribute)
   --human              Approach along a reproducible eased curve
+                       Starts at the last pointer or element interaction
 
 Global Options:
   --json               Output as JSON

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1633,7 +1633,7 @@ Examples:
             r##"
 agent-browser click - Click an element
 
-Usage: agent-browser click <selector> [--new-tab]
+Usage: agent-browser click <selector> [--new-tab] [--human]
 
 Clicks on the specified element. The selector can be a CSS selector,
 XPath, or an element reference from snapshot (e.g., @e1).
@@ -1644,6 +1644,7 @@ covering element instead of dispatching a click to the wrong target.
 Options:
   --new-tab            Open link in a new tab instead of navigating current tab
                        (only works on elements with href attribute)
+  --human              Approach along a reproducible eased curve
 
 Global Options:
   --json               Output as JSON
@@ -1655,6 +1656,7 @@ Examples:
   agent-browser click "button.primary"
   agent-browser click "//button[@type='submit']"
   agent-browser click @e3 --new-tab
+  agent-browser click @e3 --human
 "##
         }
         "dblclick" => {
@@ -1808,7 +1810,7 @@ Examples:
             r##"
 agent-browser drag - Drag and drop
 
-Usage: agent-browser drag <source> <target>
+Usage: agent-browser drag <source> <target> [--human]
 
 Drags an element from source to target location.
 
@@ -1819,6 +1821,7 @@ Global Options:
 Examples:
   agent-browser drag "#draggable" "#drop-zone"
   agent-browser drag @e1 @e2
+  agent-browser drag @e1 @e2 --human
 "##
         }
         "upload" => {
@@ -2353,6 +2356,8 @@ Global Options:
 
 Examples:
   agent-browser mouse move 100 200
+  agent-browser mouse move 600 400 --duration 250 --steps 24
+  agent-browser mouse move 600 400 --human --seed 42
   agent-browser mouse down
   agent-browser mouse up
   agent-browser mouse down right
@@ -3887,6 +3892,7 @@ Options:
   --screenshot-dir <path>    Default screenshot output directory (or AGENT_BROWSER_SCREENSHOT_DIR)
   --screenshot-quality <n>   JPEG quality 0-100; ignored for PNG (or AGENT_BROWSER_SCREENSHOT_QUALITY)
   --screenshot-format <fmt>  Screenshot format: png, jpeg (or AGENT_BROWSER_SCREENSHOT_FORMAT)
+  --input-mode <mode>        Pointer movement: instant (default), smooth, human
   --headed                   Show browser window (not headless) (or AGENT_BROWSER_HEADED env)
   --webgpu                   Enable WebGPU; uses SwiftShader software Vulkan on Linux, no GPU required (or AGENT_BROWSER_WEBGPU env)
   --no-webmcp                Disable default experimental WebMCP support for locally launched Chrome

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -158,7 +158,7 @@ agent-browser mouse up [button]       # Release button
 agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 ```
 
-Use `--human` with `click`, `drag`, or `mouse move` to emit reproducible eased movement along a slightly curved path. The cursor position persists for the browser session. `--duration` controls total milliseconds, `--steps` controls the number of intermediate events, and `--seed` makes the human curve reproducible.
+Use `--human` with `click`, `drag`, or `mouse move` to emit reproducible eased movement along a slightly curved path. The cursor position persists for the browser session. `--duration` controls total milliseconds, `--steps` controls the number of intermediate events, and `--seed` makes the human curve reproducible. Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
 
 ## Clipboard
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -158,7 +158,7 @@ agent-browser mouse up [button]       # Release button
 agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 ```
 
-Use `--human` with `click`, `drag`, or `mouse move` to emit reproducible eased movement along a slightly curved path. The cursor position persists for the browser session. `--duration` controls total milliseconds, `--steps` controls the number of intermediate events, and `--seed` makes the human curve reproducible. Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
+Use `--human` with `click`, `drag`, or `mouse move` for curved, eased movement from the current cursor position. For `mouse move`, `--duration` sets milliseconds, `--steps` sets the number of events, and `--seed` makes the path reproducible.
 
 ## Clipboard
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -150,11 +150,15 @@ See [Files & Clipboard](/files) for upload, download, local file, screenshot, PD
 ## Mouse
 
 ```bash
-agent-browser mouse move <x> <y>      # Move mouse
+agent-browser mouse move <x> <y>      # Move mouse instantly
+agent-browser mouse move 600 400 --duration 250 --steps 24
+agent-browser mouse move 600 400 --human --seed 42
 agent-browser mouse down [button]     # Press button
 agent-browser mouse up [button]       # Release button
 agent-browser mouse wheel <dy> [dx]   # Scroll wheel
 ```
+
+Use `--human` with `click`, `drag`, or `mouse move` to emit reproducible eased movement along a slightly curved path. The cursor position persists for the browser session. `--duration` controls total milliseconds, `--steps` controls the number of intermediate events, and `--seed` makes the human curve reproducible.
 
 ## Clipboard
 
@@ -597,6 +601,7 @@ See [Init Scripts & Extensions](/init-scripts) for launch-time scripts, runtime 
 --confirm-actions <list> # Action categories requiring confirmation
 --confirm-interactive    # Interactive confirmation prompts (auto-denies if stdin is not a TTY)
 --engine <name>          # Browser engine: chrome (default), lightpanda
+--input-mode <mode>      # Pointer movement: instant (default), smooth, human
 --idle-timeout <time>    # Auto-shutdown daemon after inactivity (default: 1h; 0 disables)
 --no-auto-dialog         # Disable auto-accept for alert and beforeunload dialogs
 --model <name>           # AI model for chat (or AI_GATEWAY_MODEL env)

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -126,6 +126,7 @@ For sessions that handle sensitive data, use `--allowed-domains` to restrict nav
 ```bash
 agent-browser click @e1                   # click
 agent-browser click @e1 --new-tab         # open link in new tab instead of navigating
+agent-browser click @e1 --human           # approach with reproducible curved movement
 agent-browser dblclick @e1                # double-click
 agent-browser hover @e1                   # hover
 agent-browser focus @e1                   # focus (useful before keyboard input)
@@ -141,6 +142,7 @@ agent-browser upload @e5 file1.pdf        # upload file(s)
 agent-browser scroll down 500             # scroll page (up/down/left/right)
 agent-browser scrollintoview @e1          # scroll element into view
 agent-browser drag @e1 @e2                # drag and drop
+agent-browser drag @e1 @e2 --human        # drag with curved, eased movement
 ```
 
 ### When refs don't work or you don't want to snapshot

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -145,8 +145,6 @@ agent-browser drag @e1 @e2                # drag and drop
 agent-browser drag @e1 @e2 --human        # drag with curved, eased movement
 ```
 
-Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
-
 ### When refs don't work or you don't want to snapshot
 
 Use semantic locators:

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -145,6 +145,8 @@ agent-browser drag @e1 @e2                # drag and drop
 agent-browser drag @e1 @e2 --human        # drag with curved, eased movement
 ```
 
+Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
+
 ### When refs don't work or you don't want to snapshot
 
 Use semantic locators:

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -139,11 +139,15 @@ agent-browser wait --fn "window.ready"     # Wait for JS condition (or -f)
 ## Mouse Control
 
 ```bash
-agent-browser mouse move 100 200      # Move mouse
+agent-browser mouse move 100 200      # Move mouse instantly
+agent-browser mouse move 600 400 --duration 250 --steps 24
+agent-browser mouse move 600 400 --human --seed 42
 agent-browser mouse down left         # Press button
 agent-browser mouse up left           # Release button
 agent-browser mouse wheel 100         # Scroll wheel
 ```
+
+Use `click <selector> --human` or `drag <source> <target> --human` when pointer-path events matter. Human movement is deterministic for a given `--seed` and always ends at the exact target.
 
 ## Semantic Locators (alternative to refs)
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -147,7 +147,7 @@ agent-browser mouse up left           # Release button
 agent-browser mouse wheel 100         # Scroll wheel
 ```
 
-Use `click <selector> --human` or `drag <source> <target> --human` when pointer-path events matter. Human movement is deterministic for a given `--seed` and always ends at the exact target.
+Use `click <selector> --human` or `drag <source> <target> --human` when pointer-path events matter. Human movement is deterministic for a given `--seed` and always ends at the exact target. Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
 
 ## Semantic Locators (alternative to refs)
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -147,7 +147,7 @@ agent-browser mouse up left           # Release button
 agent-browser mouse wheel 100         # Scroll wheel
 ```
 
-Use `click <selector> --human` or `drag <source> <target> --human` when pointer-path events matter. Human movement is deterministic for a given `--seed` and always ends at the exact target. Pointer interpolation starts at the last dispatched cursor position, including element clicks, hovers, and checkbox interactions.
+Use `--human` with `click` or `drag` when pointer-path events matter. Movement starts at the current cursor position and ends at the target; `mouse move --seed` makes the path reproducible.
 
 ## Semantic Locators (alternative to refs)
 


### PR DESCRIPTION
Implements idea 1 from the browser-tool ideas gist.

Adds deterministic smooth mouse movement and seeded curved human movement for low-level moves, clicks, and drags. Cursor position persists per daemon session, movement preserves pressed-button state, and paths always finish at the exact target.

Includes CLI and MCP parity, documentation updates, parser and path unit tests, and existing mouse e2e coverage.

Validation:
- `cd cli && cargo test` (1 unrelated environment-race failure in the parallel suite; isolated rerun passes)
- `cd cli && cargo test e2e_mouse -- --ignored --test-threads=1`
- `cd cli && cargo clippy`
- `cd cli && cargo fmt -- --check`