### PR TITLE
feat: add automatic snapshot deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ agent-browser snapshot --delta --full      # Force full state and refresh the ba
 | `--delta`              | Return full state once, then `unchanged` or a structural JSON delta     |
 | `--full`               | Force full state and update the delta baseline                          |
 
-Delta snapshots are tracked per tab and option set. A URL change, a changed filter, or a delta that is not materially smaller than the full tree returns `kind: "full"`. Identical observations return `kind: "unchanged"`; modest changes return `kind: "delta"` with `add`, `remove`, and `replace` operations plus base and current revision numbers. A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
+`--delta` returns `full`, `unchanged`, or incremental updates per tab and option set. It falls back to full state after URL changes or when a delta would not save space. See the [delta response format](skill-data/core/references/commands.md#snapshot-page-analysis) for applying updates.
 
 ## Annotated Screenshots
 

--- a/README.md
+++ b/README.md
@@ -928,6 +928,8 @@ agent-browser snapshot -c                 # Compact (remove empty structural ele
 agent-browser snapshot -d 3               # Limit depth to 3 levels
 agent-browser snapshot -s "#main"         # Scope to CSS selector
 agent-browser snapshot -i -c -d 5         # Combine options
+agent-browser snapshot --delta             # Full state, then bounded incremental updates
+agent-browser snapshot --delta --full      # Force full state and refresh the baseline
 ```
 
 | Option                 | Description                                                             |
@@ -937,6 +939,10 @@ agent-browser snapshot -i -c -d 5         # Combine options
 | `-c, --compact`        | Remove empty structural elements                                        |
 | `-d, --depth <n>`      | Limit tree depth                                                        |
 | `-s, --selector <sel>` | Scope to CSS selector                                                   |
+| `--delta`              | Return full state once, then `unchanged` or a structural JSON delta     |
+| `--full`               | Force full state and update the delta baseline                          |
+
+Delta snapshots are tracked per tab and option set. A URL change, a changed filter, or a delta that is not materially smaller than the full tree returns `kind: "full"`. Identical observations return `kind: "unchanged"`; modest changes return `kind: "delta"` with `add`, `remove`, and `replace` operations plus base and current revision numbers.
 
 ## Annotated Screenshots
 

--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ agent-browser snapshot --delta --full      # Force full state and refresh the ba
 | `--delta`              | Return full state once, then `unchanged` or a structural JSON delta     |
 | `--full`               | Force full state and update the delta baseline                          |
 
-Delta snapshots are tracked per tab and option set. A URL change, a changed filter, or a delta that is not materially smaller than the full tree returns `kind: "full"`. Identical observations return `kind: "unchanged"`; modest changes return `kind: "delta"` with `add`, `remove`, and `replace` operations plus base and current revision numbers.
+Delta snapshots are tracked per tab and option set. A URL change, a changed filter, or a delta that is not materially smaller than the full tree returns `kind: "full"`. Identical observations return `kind: "unchanged"`; modest changes return `kind: "delta"` with `add`, `remove`, and `replace` operations plus base and current revision numbers. A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
 
 ## Annotated Screenshots
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -905,6 +905,13 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                             i += 1;
                         }
                     }
+                    "--delta" => {
+                        obj.insert("delta".to_string(), json!(true));
+                    }
+                    "--full" => {
+                        obj.insert("full".to_string(), json!(true));
+                        obj.insert("delta".to_string(), json!(true));
+                    }
                     _ => {}
                 }
                 i += 1;
@@ -4665,6 +4672,13 @@ mod tests {
     fn test_snapshot() {
         let cmd = parse_command(&args("snapshot"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "snapshot");
+    }
+
+    #[test]
+    fn test_snapshot_delta_and_full_flags() {
+        let cmd = parse_command(&args("snapshot --delta --full"), &default_flags()).unwrap();
+        assert_eq!(cmd["delta"], true);
+        assert_eq!(cmd["full"], true);
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -840,7 +840,9 @@ fn tools() -> Vec<Value> {
                 "compact": { "type": "boolean", "default": false, "description": "Remove empty structural elements." },
                 "depth": { "type": "integer", "minimum": 0, "description": "Limit tree depth." },
                 "selector": { "type": "string", "description": "Scope the snapshot to a CSS selector." },
-                "includeUrls": { "type": "boolean", "default": false, "description": "Include href URLs on links." }
+                "includeUrls": { "type": "boolean", "default": false, "description": "Include href URLs on links." },
+                "delta": { "type": "boolean", "default": false, "description": "Return full state once, then unchanged or bounded structural deltas." },
+                "full": { "type": "boolean", "default": false, "description": "Force full state while updating the delta baseline." }
             }),
             &[],
         ),
@@ -2589,6 +2591,12 @@ fn call_snapshot(arguments: &Value) -> Result<Value, ProtocolError> {
     if let Some(selector) = optional_string(arguments, "selector")? {
         args.push("-s".to_string());
         args.push(selector);
+    }
+    if optional_bool(arguments, "delta")?.unwrap_or(false) {
+        args.push("--delta".to_string());
+    }
+    if optional_bool(arguments, "full")?.unwrap_or(false) {
+        args.push("--full".to_string());
     }
 
     call_cli_tool(arguments, args, None)

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -841,7 +841,7 @@ fn tools() -> Vec<Value> {
                 "depth": { "type": "integer", "minimum": 0, "description": "Limit tree depth." },
                 "selector": { "type": "string", "description": "Scope the snapshot to a CSS selector." },
                 "includeUrls": { "type": "boolean", "default": false, "description": "Include href URLs on links." },
-                "delta": { "type": "boolean", "default": false, "description": "Return full state once, then unchanged or bounded structural deltas." },
+                "delta": { "type": "boolean", "default": false, "description": "Return full state once, then unchanged or bounded structural deltas. Apply changes to refs and treeChange (zero-based startLine, deleteCount, lines) to the previous tree." },
                 "full": { "type": "boolean", "default": false, "description": "Force full state while updating the delta baseline." }
             }),
             &[],
@@ -4735,5 +4735,29 @@ mod tests {
     fn initialize_defaults_to_latest_protocol_version() {
         let result = initialize_result(None, &McpConfig::default());
         assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+    }
+}
+
+#[cfg(test)]
+mod snapshot_delta_schema_tests {
+    use super::*;
+    #[test]
+    fn delta_schema_explains_lossless_tree_patch() {
+        let snapshot = tools()
+            .into_iter()
+            .find(|tool| tool["name"] == TOOL_SNAPSHOT)
+            .unwrap();
+        assert!(
+            snapshot["inputSchema"]["properties"]["delta"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("treeChange")
+        );
+        let args = vec!["snapshot".to_string(), "--delta".to_string()];
+        let flags = crate::flags::parse_flags(&args);
+        assert_eq!(
+            crate::commands::parse_command(&args, &flags).unwrap()["delta"],
+            true
+        );
     }
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5292,15 +5292,36 @@ fn snapshot_delta_response(
         }
     }
 
+    // Ref metadata contains only role/name, so it cannot describe checkbox
+    // state, text, values, hierarchy, or ordering. Include an exact tree splice
+    // alongside ref operations so every accepted revision can be reconstructed.
+    let before_lines: Vec<&str> = previous.tree.split('\n').collect();
+    let after_lines: Vec<&str> = tree.split('\n').collect();
+    let prefix = before_lines
+        .iter()
+        .zip(&after_lines)
+        .take_while(|(a, b)| a == b)
+        .count();
+    let suffix = before_lines[prefix..]
+        .iter()
+        .rev()
+        .zip(after_lines[prefix..].iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let tree_change = json!({
+        "startLine": prefix,
+        "deleteCount": before_lines.len() - prefix - suffix,
+        "lines": after_lines[prefix..after_lines.len() - suffix],
+    });
     let delta = json!({
         "kind": "delta",
         "baseRevision": previous.revision,
         "revision": revision,
         "changes": changes,
+        "treeChange": tree_change,
     });
     let delta_size = serde_json::to_vec(&delta).map_or(usize::MAX, |bytes| bytes.len());
-    let structurally_unrepresented = delta["changes"].as_array().is_none_or(Vec::is_empty);
-    if structurally_unrepresented || delta_size >= tree.len().saturating_mul(7) / 10 {
+    if delta_size >= tree.len().saturating_mul(7) / 10 {
         json!({
             "snapshot": { "kind": "full", "revision": revision, "tree": tree, "refs": refs },
             "origin": origin,
@@ -13904,6 +13925,38 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
     }
 
     #[test]
+    fn snapshot_delta_tree_splice_preserves_changes_missing_from_ref_metadata() {
+        let padding = "- button \"Unchanged\" [ref=e99]\n".repeat(40);
+        let before = format!("{padding}- button \"Save\" [ref=e1]\n- checkbox \"Agree\" [ref=e2]");
+        let after = format!(
+            "{padding}- button \"Saved\" [ref=e1]\n- checkbox \"Agree\" [ref=e2] [checked]"
+        );
+        let previous = SnapshotRevision {
+            revision: 1, url: "about:blank".into(), options: "{}".into(), tree: before.clone(),
+            refs: serde_json::from_value(json!({"e1": {"role": "button", "name": "Save"}, "e2": {"role": "checkbox", "name": "Agree"}})).unwrap(),
+        };
+        let mut refs = previous.refs.clone();
+        refs["e1"]["name"] = json!("Saved");
+        for current in [after, before.replace("[ref=e2]", "[ref=e2] [checked]")] {
+            let result = snapshot_delta_response(&previous, 2, &current, &refs, &previous.url);
+            assert_eq!(result["snapshot"]["kind"], "delta");
+            let patch = &result["snapshot"]["treeChange"];
+            let start = patch["startLine"].as_u64().unwrap() as usize;
+            let count = patch["deleteCount"].as_u64().unwrap() as usize;
+            let mut reconstructed: Vec<&str> = before.split('\n').collect();
+            reconstructed.splice(
+                start..start + count,
+                patch["lines"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_str().unwrap()),
+            );
+            assert_eq!(reconstructed.join("\n"), current);
+        }
+    }
+
+    #[test]
     fn test_snapshot_delta_unchanged_is_tiny() {
         let previous = SnapshotRevision {
             revision: 4,
@@ -13926,7 +13979,7 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             revision: 1,
             url: "https://example.com".to_string(),
             options: "{}".to_string(),
-            tree: "x".repeat(1000),
+            tree: format!("{}\nold", "x".repeat(1000)),
             refs: serde_json::from_value(json!({
                 "e1": {"role": "button", "name": "Save"},
                 "e2": {"role": "alert", "name": "Old"}
@@ -13938,7 +13991,13 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
             "e3": {"role": "status", "name": "Done"}
         }))
         .unwrap();
-        let result = snapshot_delta_response(&previous, 2, &"y".repeat(1000), &refs, &previous.url);
+        let result = snapshot_delta_response(
+            &previous,
+            2,
+            &format!("{}\nnew", "x".repeat(1000)),
+            &refs,
+            &previous.url,
+        );
         assert_eq!(result["snapshot"]["kind"], "delta");
         let changes = result["snapshot"]["changes"].as_array().unwrap();
         assert!(changes

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -212,6 +212,15 @@ pub struct MouseState {
     pub buttons: i32,
 }
 
+#[derive(Debug, Clone)]
+struct SnapshotRevision {
+    revision: u64,
+    url: String,
+    options: String,
+    tree: String,
+    refs: serde_json::Map<String, Value>,
+}
+
 #[derive(Default)]
 struct DrainedEvents {
     pending_acks: Vec<i64>,
@@ -421,6 +430,8 @@ pub struct DaemonState {
     pub webdriver_backend: Option<super::webdriver::backend::WebDriverBackend>,
     pub backend_type: BackendType,
     pub ref_map: RefMap,
+    /// Last delta snapshot per page session. Bounded to the currently tracked tabs.
+    snapshot_revisions: HashMap<String, SnapshotRevision>,
     pub domain_filter: Arc<RwLock<Option<DomainFilter>>>,
     pub event_tracker: EventTracker,
     pub session_name: Option<String>,
@@ -563,6 +574,7 @@ impl DaemonState {
             webdriver_backend: None,
             backend_type: BackendType::Cdp,
             ref_map: RefMap::new(),
+            snapshot_revisions: HashMap::new(),
             domain_filter: Arc::new(RwLock::new(
                 env::var("AGENT_BROWSER_ALLOWED_DOMAINS")
                     .ok()
@@ -5192,7 +5204,110 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         })
         .collect();
 
-    Ok(json!({ "snapshot": tree, "origin": url, "refs": refs }))
+    if !cmd.get("delta").and_then(Value::as_bool).unwrap_or(false) {
+        return Ok(json!({ "snapshot": tree, "origin": url, "refs": refs }));
+    }
+
+    let options_key = serde_json::to_string(&json!({
+        "selector": options.selector,
+        "interactive": options.interactive,
+        "compact": options.compact,
+        "depth": options.depth,
+        "urls": options.urls,
+    }))
+    .unwrap_or_default();
+    let previous = state.snapshot_revisions.get(&session_id).cloned();
+    let revision = previous.as_ref().map_or(1, |entry| entry.revision + 1);
+    let force_full = cmd.get("full").and_then(Value::as_bool).unwrap_or(false)
+        || previous
+            .as_ref()
+            .is_none_or(|entry| entry.url != url || entry.options != options_key);
+    let response = if force_full {
+        json!({
+            "snapshot": { "kind": "full", "revision": revision, "tree": tree, "refs": refs },
+            "origin": url,
+        })
+    } else {
+        snapshot_delta_response(previous.as_ref().unwrap(), revision, &tree, &refs, &url)
+    };
+
+    if state.snapshot_revisions.len() >= 32 && !state.snapshot_revisions.contains_key(&session_id) {
+        if let Some(oldest_key) = state
+            .snapshot_revisions
+            .iter()
+            .min_by_key(|(_, entry)| entry.revision)
+            .map(|(key, _)| key.clone())
+        {
+            state.snapshot_revisions.remove(&oldest_key);
+        }
+    }
+    state.snapshot_revisions.insert(
+        session_id,
+        SnapshotRevision {
+            revision,
+            url,
+            options: options_key,
+            tree,
+            refs,
+        },
+    );
+    Ok(response)
+}
+
+fn snapshot_delta_response(
+    previous: &SnapshotRevision,
+    revision: u64,
+    tree: &str,
+    refs: &serde_json::Map<String, Value>,
+    origin: &str,
+) -> Value {
+    if previous.tree == tree {
+        return json!({
+            "snapshot": { "kind": "unchanged", "baseRevision": previous.revision, "revision": revision },
+            "origin": origin,
+        });
+    }
+
+    let mut changes = Vec::new();
+    for (ref_id, old_node) in &previous.refs {
+        match refs.get(ref_id) {
+            None => changes.push(json!({ "op": "remove", "ref": format!("@{}", ref_id) })),
+            Some(new_node) => {
+                for field in ["role", "name"] {
+                    if old_node.get(field) != new_node.get(field) {
+                        changes.push(json!({
+                            "op": "replace",
+                            "ref": format!("@{}", ref_id),
+                            "field": field,
+                            "value": new_node.get(field).cloned().unwrap_or(Value::Null),
+                        }));
+                    }
+                }
+            }
+        }
+    }
+    for (ref_id, node) in refs {
+        if !previous.refs.contains_key(ref_id) {
+            changes.push(json!({ "op": "add", "ref": format!("@{}", ref_id), "node": node }));
+        }
+    }
+
+    let delta = json!({
+        "kind": "delta",
+        "baseRevision": previous.revision,
+        "revision": revision,
+        "changes": changes,
+    });
+    let delta_size = serde_json::to_vec(&delta).map_or(usize::MAX, |bytes| bytes.len());
+    let structurally_unrepresented = delta["changes"].as_array().is_none_or(Vec::is_empty);
+    if structurally_unrepresented || delta_size >= tree.len().saturating_mul(7) / 10 {
+        json!({
+            "snapshot": { "kind": "full", "revision": revision, "tree": tree, "refs": refs },
+            "origin": origin,
+        })
+    } else {
+        json!({ "snapshot": delta, "origin": origin })
+    }
 }
 
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -13786,6 +13901,55 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
 
         drop(listener);
         let _ = fs::remove_dir_all(&socket_dir);
+    }
+
+    #[test]
+    fn test_snapshot_delta_unchanged_is_tiny() {
+        let previous = SnapshotRevision {
+            revision: 4,
+            url: "https://example.com".to_string(),
+            options: "{}".to_string(),
+            tree: "- button \"Save\" [ref=e1]".to_string(),
+            refs: serde_json::from_value(json!({"e1": {"role": "button", "name": "Save"}}))
+                .unwrap(),
+        };
+        let result =
+            snapshot_delta_response(&previous, 5, &previous.tree, &previous.refs, &previous.url);
+        assert_eq!(result["snapshot"]["kind"], "unchanged");
+        assert_eq!(result["snapshot"]["baseRevision"], 4);
+        assert!(result["snapshot"].get("tree").is_none());
+    }
+
+    #[test]
+    fn test_snapshot_delta_reports_replacements_and_removals() {
+        let previous = SnapshotRevision {
+            revision: 1,
+            url: "https://example.com".to_string(),
+            options: "{}".to_string(),
+            tree: "x".repeat(1000),
+            refs: serde_json::from_value(json!({
+                "e1": {"role": "button", "name": "Save"},
+                "e2": {"role": "alert", "name": "Old"}
+            }))
+            .unwrap(),
+        };
+        let refs = serde_json::from_value(json!({
+            "e1": {"role": "button", "name": "Saved"},
+            "e3": {"role": "status", "name": "Done"}
+        }))
+        .unwrap();
+        let result = snapshot_delta_response(&previous, 2, &"y".repeat(1000), &refs, &previous.url);
+        assert_eq!(result["snapshot"]["kind"], "delta");
+        let changes = result["snapshot"]["changes"].as_array().unwrap();
+        assert!(changes
+            .iter()
+            .any(|change| change["op"] == "replace" && change["ref"] == "@e1"));
+        assert!(changes
+            .iter()
+            .any(|change| change["op"] == "remove" && change["ref"] == "@e2"));
+        assert!(changes
+            .iter()
+            .any(|change| change["op"] == "add" && change["ref"] == "@e3"));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2158,6 +2158,7 @@ Options:
   -d, --depth <n>      Limit tree depth
   -s, --selector <sel> Scope snapshot to CSS selector
       --delta          Return full state once, then unchanged or structural deltas
+                       Deltas include ref changes and an exact treeChange line splice
       --full           Force full state and update the delta baseline
 
 Global Options:

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -642,6 +642,30 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             print_with_boundaries(snapshot, origin, opts);
             return;
         }
+        if let Some(snapshot) = data.get("snapshot").and_then(|v| v.as_object()) {
+            match snapshot.get("kind").and_then(|v| v.as_str()) {
+                Some("full") => {
+                    if let Some(tree) = snapshot.get("tree").and_then(|v| v.as_str()) {
+                        print_with_boundaries(tree, origin, opts);
+                    }
+                }
+                Some("unchanged") => println!(
+                    "unchanged (revision {})",
+                    snapshot
+                        .get("revision")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0)
+                ),
+                Some("delta") => println!(
+                    "{}",
+                    serde_json::to_string_pretty(snapshot).unwrap_or_else(|_| {
+                        serde_json::Value::Object(snapshot.clone()).to_string()
+                    })
+                ),
+                _ => println!("{}", serde_json::Value::Object(snapshot.clone())),
+            }
+            return;
+        }
         // Title
         if let Some(title) = data.get("title").and_then(|v| v.as_str()) {
             println!("{}", title);
@@ -2133,6 +2157,8 @@ Options:
   -c, --compact        Remove empty structural elements
   -d, --depth <n>      Limit tree depth
   -s, --selector <sel> Scope snapshot to CSS selector
+      --delta          Return full state once, then unchanged or structural deltas
+      --full           Force full state and update the delta baseline
 
 Global Options:
   --json               Output as JSON
@@ -2144,6 +2170,8 @@ Examples:
   agent-browser snapshot -i --urls
   agent-browser snapshot --compact --depth 5
   agent-browser snapshot -s "#main-content"
+  agent-browser snapshot --delta
+  agent-browser snapshot --delta --full
 "##
         }
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -273,6 +273,8 @@ Iframes are detected automatically during snapshots. `Iframe` nodes are resolved
 
 ```bash
 agent-browser snapshot -i
+agent-browser snapshot --delta
+agent-browser snapshot --delta --full
 # @e3 [Iframe] "payment-frame"
 #   @e4 [input] "Card number"
 #   @e5 [button] "Pay"
@@ -286,6 +288,8 @@ agent-browser frame @e3
 agent-browser snapshot -i             # Only elements inside that iframe
 agent-browser frame main              # Return to main frame
 ```
+
+`snapshot --delta` tracks observations per tab and option set. The first observation returns `kind: "full"`; an identical observation returns `kind: "unchanged"`; a modest change returns a structural `delta` with revision numbers and `add`, `remove`, or `replace` operations. URL changes and deltas that are not materially smaller than the tree automatically return full state. Add `--full` to force a full response and refresh the baseline.
 
 The `frame` command accepts element refs (`@e3`), CSS selectors (`"#my-iframe"`), or frame name/URL.
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -289,7 +289,7 @@ agent-browser snapshot -i             # Only elements inside that iframe
 agent-browser frame main              # Return to main frame
 ```
 
-`snapshot --delta` tracks observations per tab and option set. The first observation returns `kind: "full"`; an identical observation returns `kind: "unchanged"`; a modest change returns a structural `delta` with revision numbers and `add`, `remove`, or `replace` operations. URL changes and deltas that are not materially smaller than the tree automatically return full state. Add `--full` to force a full response and refresh the baseline.
+`snapshot --delta` tracks observations per tab and option set. The first observation returns `kind: "full"`; an identical observation returns `kind: "unchanged"`; a modest change returns a structural `delta` with revision numbers and `add`, `remove`, or `replace` operations. URL changes and deltas that are not materially smaller than the tree automatically return full state. Add `--full` to force a full response and refresh the baseline. A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
 
 The `frame` command accepts element refs (`@e3`), CSS selectors (`"#my-iframe"`), or frame name/URL.
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -267,14 +267,21 @@ agent-browser click @e3         # uses docs's refs
 
 Browsers discard background tabs to save memory, leaving a tab with no renderer to drive. Switching to a discarded tab reactivates it, which reloads the page and resets its unsaved state; the switch result adds `"revived": true` so the reload is visible rather than silent. A tab whose page is paused by a JavaScript dialog is alive rather than discarded: the switch leaves it untouched and adds `"dialogBlocked": true`. Resolve the dialog with `dialog accept` or `dialog dismiss` and the tab keeps its state. Closing the active tab onto a discarded successor revives it the same way and reports `"activeTabRevived": true`.
 
+### Snapshot deltas
+
+```bash
+agent-browser snapshot --delta
+agent-browser snapshot --delta --full
+```
+
+`snapshot --delta` returns `full`, `unchanged`, or incremental updates per tab and option set. URL changes or large deltas return full state; `--full` resets the baseline. Apply a delta’s `changes` to ref metadata and `treeChange` to the previous tree: split on newlines, replace `deleteCount` lines at zero-based `startLine` with `lines`, then rejoin. Apply both to `baseRevision` before advancing to `revision`.
+
 ### Iframe support
 
 Iframes are detected automatically during snapshots. `Iframe` nodes are resolved and their content is inlined beneath the iframe element in the snapshot output. Refs assigned to elements inside iframes carry frame context, so `click`, `fill`, and other interactions work without manually switching frames.
 
 ```bash
 agent-browser snapshot -i
-agent-browser snapshot --delta
-agent-browser snapshot --delta --full
 # @e3 [Iframe] "payment-frame"
 #   @e4 [input] "Card number"
 #   @e5 [button] "Pay"
@@ -288,8 +295,6 @@ agent-browser frame @e3
 agent-browser snapshot -i             # Only elements inside that iframe
 agent-browser frame main              # Return to main frame
 ```
-
-`snapshot --delta` tracks observations per tab and option set. The first observation returns `kind: "full"`; an identical observation returns `kind: "unchanged"`; a modest change returns a structural `delta` with revision numbers and `add`, `remove`, or `replace` operations. URL changes and deltas that are not materially smaller than the tree automatically return full state. Add `--full` to force a full response and refresh the baseline. A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
 
 The `frame` command accepts element refs (`@e3`), CSS selectors (`"#my-iframe"`), or frame name/URL.
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -84,7 +84,11 @@ agent-browser snapshot -i -c              # compact (no empty structural nodes)
 agent-browser snapshot -i -d 3            # cap depth at 3 levels
 agent-browser snapshot -s "#main"         # scope to a CSS selector
 agent-browser snapshot -i --json          # machine-readable output
+agent-browser snapshot -i --delta         # full state once, then compact changes
+agent-browser snapshot -i --delta --full  # force full state and refresh baseline
 ```
+
+Delta observations are per tab and option set. Expect `full`, `unchanged`, or `delta`; a delta includes base and current revisions plus structural ref operations. The daemon automatically falls back to full state when the URL changes or the delta would not save meaningful output.
 
 Snapshot output looks like:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -88,7 +88,7 @@ agent-browser snapshot -i --delta         # full state once, then compact change
 agent-browser snapshot -i --delta --full  # force full state and refresh baseline
 ```
 
-Delta observations are per tab and option set. Expect `full`, `unchanged`, or `delta`; a delta includes base and current revisions plus structural ref operations. The daemon automatically falls back to full state when the URL changes or the delta would not save meaningful output. A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
+Use `--delta` to reduce repeated snapshot output and `--full` to reset the baseline. See [delta responses](references/commands.md#snapshot-page-analysis) before applying incremental updates.
 
 Snapshot output looks like:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -88,7 +88,7 @@ agent-browser snapshot -i --delta         # full state once, then compact change
 agent-browser snapshot -i --delta --full  # force full state and refresh baseline
 ```
 
-Delta observations are per tab and option set. Expect `full`, `unchanged`, or `delta`; a delta includes base and current revisions plus structural ref operations. The daemon automatically falls back to full state when the URL changes or the delta would not save meaningful output.
+Delta observations are per tab and option set. Expect `full`, `unchanged`, or `delta`; a delta includes base and current revisions plus structural ref operations. The daemon automatically falls back to full state when the URL changes or the delta would not save meaningful output. A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
 
 Snapshot output looks like:
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -48,6 +48,8 @@ agent-browser snapshot -i         # Interactive elements only (recommended)
 agent-browser snapshot -c         # Compact output
 agent-browser snapshot -d 3       # Limit depth to 3
 agent-browser snapshot -s "#main" # Scope to CSS selector
+agent-browser snapshot --delta     # Full state once, then bounded structural deltas
+agent-browser snapshot --delta --full # Force full state and refresh baseline
 ```
 
 ## Interactions (use @refs from snapshot)

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -52,6 +52,8 @@ agent-browser snapshot --delta     # Full state once, then bounded structural de
 agent-browser snapshot --delta --full # Force full state and refresh baseline
 ```
 
+A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
+
 ## Interactions (use @refs from snapshot)
 
 ```bash

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -52,7 +52,7 @@ agent-browser snapshot --delta     # Full state once, then bounded structural de
 agent-browser snapshot --delta --full # Force full state and refresh baseline
 ```
 
-A `delta` includes ref metadata operations in `changes` and an exact `treeChange` splice. Split the previous tree on newlines, replace `deleteCount` lines starting at zero-based `startLine` with `lines`, then join with newlines. Apply both parts before advancing to the new revision; this preserves text, values, checked state, hierarchy, and ordering.
+Delta history is per tab and option set. Responses are `full`, `unchanged`, or `delta`; URL changes or large deltas return full state. For a delta, apply `changes` (`add`, `remove`, `replace`) to ref metadata. Split the previous tree on newlines, splice `treeChange.lines` at zero-based `startLine`, replacing `deleteCount` lines, then join with newlines. Apply both parts to `baseRevision` before advancing to `revision`; use `--full` if the baseline is unavailable.
 
 ## Interactions (use @refs from snapshot)
 


### PR DESCRIPTION
Implements idea 3 from the browser-tool ideas gist.

`agent-browser snapshot --delta` now returns full state on the first observation, a compact unchanged result for identical trees, and bounded structural add/remove/replace changes for modest updates. Baselines are isolated by page session and snapshot options, revisioned, memory-bounded, and reset to full output on URL or option changes. `--full` is the explicit full-state escape hatch.

Includes CLI and MCP parity, human-readable output, documentation updates, and tests for parser behavior, unchanged observations, structural operations, and full-suite compatibility.

Validation:
- `cd cli && cargo test -- --test-threads=1` (1,242 passed, 112 ignored)
- `cd cli && cargo clippy`
- `cd cli && cargo fmt -- --check`