### PR TITLE
feat: preserve refs across snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,8 @@ Do not put vault tokens or passwords in plugin command args. Use the vault vendo
 
 The `snapshot` command supports filtering to reduce output size:
 
+DOM-backed refs are durable across observations: a surviving element retains its ref through React updates that preserve the node, reordering, and other DOM changes. Refs are namespaced by document and frame, invalidated when their document is replaced, and never recycled within the browser session. JSON snapshots include `removedRefs` for elements that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local.
+
 ```bash
 agent-browser snapshot                    # Full accessibility tree
 agent-browser snapshot -i                 # Interactive elements only (buttons, inputs, links)

--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Do not put vault tokens or passwords in plugin command args. Use the vault vendo
 
 The `snapshot` command supports filtering to reduce output size:
 
-DOM-backed refs are durable across observations: a surviving element retains its ref through React updates that preserve the node, reordering, and other DOM changes. Refs are namespaced by document and frame, invalidated when their document is replaced, and never recycled within the browser session. JSON snapshots include `removedRefs` for elements that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
+Refs remain stable while their DOM nodes survive. A new document invalidates its refs; JSON snapshots list disappeared refs in `removedRefs`. Accessibility nodes without DOM backing have snapshot-local refs. Content diffs ignore generated ref IDs.
 
 ```bash
 agent-browser snapshot                    # Full accessibility tree

--- a/README.md
+++ b/README.md
@@ -918,9 +918,9 @@ Do not put vault tokens or passwords in plugin command args. Use the vault vendo
 
 ## Snapshot Options
 
-The `snapshot` command supports filtering to reduce output size:
+Existing elements keep their refs across snapshots. Take a fresh snapshot after navigation.
 
-Refs remain stable while their DOM nodes survive. A new document invalidates its refs; JSON snapshots list disappeared refs in `removedRefs`. Accessibility nodes without DOM backing have snapshot-local refs. Content diffs ignore generated ref IDs.
+Use filters to reduce snapshot output:
 
 ```bash
 agent-browser snapshot                    # Full accessibility tree

--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Do not put vault tokens or passwords in plugin command args. Use the vault vendo
 
 The `snapshot` command supports filtering to reduce output size:
 
-DOM-backed refs are durable across observations: a surviving element retains its ref through React updates that preserve the node, reordering, and other DOM changes. Refs are namespaced by document and frame, invalidated when their document is replaced, and never recycled within the browser session. JSON snapshots include `removedRefs` for elements that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local.
+DOM-backed refs are durable across observations: a surviving element retains its ref through React updates that preserve the node, reordering, and other DOM changes. Refs are namespaced by document and frame, invalidated when their document is replaced, and never recycled within the browser session. JSON snapshots include `removedRefs` for elements that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
 
 ```bash
 agent-browser snapshot                    # Full accessibility tree

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -834,7 +834,7 @@ fn tools() -> Vec<Value> {
         tool(
             TOOL_SNAPSHOT,
             "Snapshot page",
-            "Return an accessibility-tree snapshot with durable DOM-backed refs and removedRefs.",
+            "Return an accessibility-tree snapshot with stable element refs. Refresh after navigation.",
             json!({
                 "interactive": { "type": "boolean", "default": true, "description": "Only include interactive elements." },
                 "compact": { "type": "boolean", "default": false, "description": "Remove empty structural elements." },

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -834,7 +834,7 @@ fn tools() -> Vec<Value> {
         tool(
             TOOL_SNAPSHOT,
             "Snapshot page",
-            "Return an accessibility-tree snapshot with durable DOM-backed refs and explicit removedRefs. Snapshot and URL content diffs ignore generated ref IDs.",
+            "Return an accessibility-tree snapshot with durable DOM-backed refs and removedRefs.",
             json!({
                 "interactive": { "type": "boolean", "default": true, "description": "Only include interactive elements." },
                 "compact": { "type": "boolean", "default": false, "description": "Remove empty structural elements." },

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -834,7 +834,7 @@ fn tools() -> Vec<Value> {
         tool(
             TOOL_SNAPSHOT,
             "Snapshot page",
-            "Return an accessibility-tree snapshot with durable DOM-backed refs and explicit removedRefs.",
+            "Return an accessibility-tree snapshot with durable DOM-backed refs and explicit removedRefs. Snapshot and URL content diffs ignore generated ref IDs.",
             json!({
                 "interactive": { "type": "boolean", "default": true, "description": "Only include interactive elements." },
                 "compact": { "type": "boolean", "default": false, "description": "Remove empty structural elements." },

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -834,7 +834,7 @@ fn tools() -> Vec<Value> {
         tool(
             TOOL_SNAPSHOT,
             "Snapshot page",
-            "Return an accessibility-tree snapshot with stable element refs.",
+            "Return an accessibility-tree snapshot with durable DOM-backed refs and explicit removedRefs.",
             json!({
                 "interactive": { "type": "boolean", "default": true, "description": "Only include interactive elements." },
                 "compact": { "type": "boolean", "default": false, "description": "Remove empty structural elements." },

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4282,7 +4282,7 @@ async fn load_storage_state(state: &mut DaemonState, path: &Option<String>) -> R
 
 async fn rollback_failed_launch(state: &mut DaemonState) -> Result<(), String> {
     let close_result = close_current_browser(state).await;
-    state.ref_map.clear();
+    state.ref_map.invalidate_all_documents();
     close_result
 }
 
@@ -4544,7 +4544,7 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         state.effective_ca_cert = effective_ca_cert;
         return Ok(json!({ "launched": true, "reused": true, "relaunchedBrowser": false }));
     }
-    state.ref_map.clear();
+    state.ref_map.invalidate_all_documents();
 
     let has_cdp = cdp_url.is_some() || cdp_port.is_some();
     super::browser::validate_launch_options(
@@ -4874,7 +4874,7 @@ async fn handle_navigate(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     // WebDriver backend path
     if let Some(ref wb) = state.webdriver_backend {
         if state.browser.is_none() {
-            state.ref_map.clear();
+            state.ref_map.invalidate_current_document();
             wb.navigate(url).await?;
             let new_url = wb.get_url().await.unwrap_or_else(|_| url.to_string());
             let title = wb.get_title().await.unwrap_or_default();
@@ -4943,7 +4943,7 @@ async fn handle_navigate(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         }
     }
 
-    state.ref_map.clear();
+    state.ref_map.invalidate_current_document();
     state.active_iframe_sessions.clear();
     state.active_frame_id = None;
     let result = mgr.navigate(url, wait_until).await?;
@@ -5117,7 +5117,7 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
         server.shutdown();
     }
 
-    state.ref_map.clear();
+    state.ref_map.invalidate_all_documents();
     match save_result {
         Ok(Some(path)) => Ok(json!({
             "closed": true,
@@ -5167,6 +5167,9 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         urls: cmd.get("urls").and_then(|v| v.as_bool()).unwrap_or(false),
     };
 
+    let document_scope = snapshot_document_scope(&mgr.client, &session_id).await;
+    state.ref_map.set_scope(&document_scope);
+    let previous_refs = state.ref_map.ref_ids();
     state.ref_map.clear();
     let tree = snapshot::take_snapshot(
         &mgr.client,
@@ -5192,7 +5195,36 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         })
         .collect();
 
-    Ok(json!({ "snapshot": tree, "origin": url, "refs": refs }))
+    let current_refs = state.ref_map.ref_ids();
+    let mut removed_refs = previous_refs
+        .difference(&current_refs)
+        .map(|ref_id| format!("@{}", ref_id))
+        .collect::<Vec<_>>();
+    removed_refs.sort_by_key(|ref_id| {
+        ref_id
+            .trim_start_matches("@e")
+            .parse::<usize>()
+            .unwrap_or(usize::MAX)
+    });
+
+    Ok(json!({ "snapshot": tree, "origin": url, "refs": refs, "removedRefs": removed_refs }))
+}
+
+/// Loader IDs change only when the top-level document is replaced, while the
+/// CDP session ID keeps durable identities isolated across tabs.
+async fn snapshot_document_scope(client: &CdpClient, session_id: &str) -> String {
+    let loader_id = client
+        .send_command("Page.getFrameTree", None, Some(session_id))
+        .await
+        .ok()
+        .and_then(|value| {
+            value
+                .pointer("/frameTree/frame/loaderId")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| "unknown-document".to_string());
+    format!("{}:{}", session_id, loader_id)
 }
 
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -5270,6 +5302,8 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     };
 
     if annotate {
+        let document_scope = snapshot_document_scope(&mgr.client, &session_id).await;
+        state.ref_map.set_scope(&document_scope);
         state.ref_map.clear();
         let _ = snapshot::take_snapshot(
             &mgr.client,
@@ -5846,7 +5880,7 @@ async fn handle_back(state: &mut DaemonState) -> Result<Value, String> {
             wb.back().await?;
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
             let url = wb.get_url().await.unwrap_or_default();
-            state.ref_map.clear();
+            state.ref_map.invalidate_current_document();
             return Ok(json!({ "url": url }));
         }
     }
@@ -5854,7 +5888,7 @@ async fn handle_back(state: &mut DaemonState) -> Result<Value, String> {
     mgr.evaluate("history.back()", None).await?;
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     let url = mgr.get_url().await.unwrap_or_default();
-    state.ref_map.clear();
+    state.ref_map.invalidate_current_document();
     Ok(json!({ "url": url }))
 }
 
@@ -5864,7 +5898,7 @@ async fn handle_forward(state: &mut DaemonState) -> Result<Value, String> {
             wb.forward().await?;
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
             let url = wb.get_url().await.unwrap_or_default();
-            state.ref_map.clear();
+            state.ref_map.invalidate_current_document();
             return Ok(json!({ "url": url }));
         }
     }
@@ -5872,7 +5906,7 @@ async fn handle_forward(state: &mut DaemonState) -> Result<Value, String> {
     mgr.evaluate("history.forward()", None).await?;
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     let url = mgr.get_url().await.unwrap_or_default();
-    state.ref_map.clear();
+    state.ref_map.invalidate_current_document();
     Ok(json!({ "url": url }))
 }
 
@@ -5882,7 +5916,7 @@ async fn handle_reload(state: &mut DaemonState) -> Result<Value, String> {
             wb.reload().await?;
             tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
             let url = wb.get_url().await.unwrap_or_default();
-            state.ref_map.clear();
+            state.ref_map.invalidate_current_document();
             return Ok(json!({ "url": url }));
         }
     }
@@ -5912,7 +5946,7 @@ async fn handle_reload(state: &mut DaemonState) -> Result<Value, String> {
     .await;
 
     let url = mgr.get_url().await.unwrap_or_default();
-    state.ref_map.clear();
+    state.ref_map.invalidate_current_document();
     Ok(json!({ "url": url }))
 }
 
@@ -6337,7 +6371,9 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
     };
     // Start from the same ref base as a normal baseline snapshot so unchanged lines align.
     // Build the replacement separately so a failed diff leaves the existing refs usable.
-    let mut current_ref_map = RefMap::new();
+    let mut current_ref_map = state.ref_map.clone();
+    current_ref_map.set_scope(&session_id);
+    current_ref_map.clear();
     let current = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -6397,13 +6433,15 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         .unwrap_or(WaitUntil::Load);
 
     // Each navigation can replace the document, so invalidate refs before it starts.
-    state.ref_map.clear();
+    state.ref_map.invalidate_current_document();
 
     // Navigate to URL1 and snapshot
     mgr.navigate(url1, wait_until).await?;
     let session_id = mgr.active_session_id()?.to_string();
     let options = SnapshotOptions::default();
-    let mut snap1_ref_map = RefMap::new();
+    let mut snap1_ref_map = state.ref_map.clone();
+    snap1_ref_map.set_scope(&session_id);
+    snap1_ref_map.invalidate_current_document();
     let snap1 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -6415,9 +6453,9 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     .await?;
 
     // Navigate to URL2 and snapshot
-    state.ref_map.clear();
+    snap1_ref_map.invalidate_current_document();
     mgr.navigate(url2, wait_until).await?;
-    let mut snap2_ref_map = RefMap::new();
+    let mut snap2_ref_map = snap1_ref_map;
     let snap2 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6369,10 +6369,10 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         selector,
         ..SnapshotOptions::default()
     };
-    // Start from the same ref base as a normal baseline snapshot so unchanged lines align.
+    // Reuse the current document identities without committing a failed capture.
     // Build the replacement separately so a failed diff leaves the existing refs usable.
     let mut current_ref_map = state.ref_map.clone();
-    current_ref_map.set_scope(&session_id);
+    current_ref_map.set_scope(&snapshot_document_scope(&mgr.client, &session_id).await);
     current_ref_map.clear();
     let current = snapshot::take_snapshot(
         &mgr.client,
@@ -6403,7 +6403,10 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
         None => String::new(),
     };
 
-    let result = diff::diff_snapshots(&baseline_text, &current);
+    let result = diff::diff_snapshots(
+        &diff::snapshot_comparison_text(&baseline_text),
+        &diff::snapshot_comparison_text(&current),
+    );
     state.ref_map = current_ref_map;
     Ok(json!({
         "diff": result.diff,
@@ -6440,7 +6443,7 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     let session_id = mgr.active_session_id()?.to_string();
     let options = SnapshotOptions::default();
     let mut snap1_ref_map = state.ref_map.clone();
-    snap1_ref_map.set_scope(&session_id);
+    snap1_ref_map.set_scope(&snapshot_document_scope(&mgr.client, &session_id).await);
     snap1_ref_map.invalidate_current_document();
     let snap1 = snapshot::take_snapshot(
         &mgr.client,
@@ -6456,6 +6459,7 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     snap1_ref_map.invalidate_current_document();
     mgr.navigate(url2, wait_until).await?;
     let mut snap2_ref_map = snap1_ref_map;
+    snap2_ref_map.set_scope(&snapshot_document_scope(&mgr.client, &session_id).await);
     let snap2 = snapshot::take_snapshot(
         &mgr.client,
         &session_id,
@@ -6466,7 +6470,10 @@ async fn handle_diff_url(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     )
     .await?;
 
-    let result = diff::diff_text(&snap1, &snap2);
+    let result = diff::diff_text(
+        &diff::snapshot_comparison_text(&snap1),
+        &diff::snapshot_comparison_text(&snap2),
+    );
     state.ref_map = snap2_ref_map;
     Ok(json!({
         "diff": result,

--- a/cli/src/native/diff.rs
+++ b/cli/src/native/diff.rs
@@ -272,3 +272,79 @@ mod tests {
         );
     }
 }
+
+/// Remove generated ref annotations for content comparisons across documents.
+/// Quoted names are preserved even when they contain text resembling a ref.
+pub fn snapshot_comparison_text(tree: &str) -> String {
+    let mut output = String::with_capacity(tree.len());
+    let mut chars = tree.chars().peekable();
+    let mut quoted = false;
+    while let Some(ch) = chars.next() {
+        if quoted && ch == '\\' {
+            output.push(ch);
+            if let Some(escaped) = chars.next() {
+                output.push(escaped);
+            }
+            continue;
+        }
+        if ch == '"' {
+            quoted = !quoted;
+        }
+        if !quoted && ch == '[' && output.ends_with(' ') {
+            let mut candidate = chars.clone();
+            let mut attributes = String::new();
+            while candidate.peek().is_some_and(|ch| !matches!(ch, ']' | '\n')) {
+                attributes.push(candidate.next().unwrap());
+            }
+            if candidate.next() == Some(']') {
+                let fields: Vec<&str> = attributes.split(", ").collect();
+                let retained: Vec<&str> = fields
+                    .iter()
+                    .copied()
+                    .filter(|field| {
+                        !field.strip_prefix("ref=e").is_some_and(|id| {
+                            !id.is_empty() && id.bytes().all(|b| b.is_ascii_digit())
+                        })
+                    })
+                    .collect();
+                if retained.len() != fields.len() {
+                    if retained.is_empty() {
+                        output.pop();
+                    } else {
+                        output.push('[');
+                        output.push_str(&retained.join(", "));
+                        output.push(']');
+                    }
+                    chars = candidate;
+                    continue;
+                }
+            }
+        }
+        output.push(ch);
+    }
+    output
+}
+
+#[cfg(test)]
+mod durable_ref_diff_tests {
+    use super::*;
+
+    #[test]
+    fn content_comparison_ignores_only_generated_ref_annotations() {
+        let before =
+            "- button \"Save [ref=e3]\" [ref=e1]\n- checkbox \"Agree\" [checked=false, ref=e2]";
+        let after =
+            "- button \"Save [ref=e3]\" [ref=e20]\n- checkbox \"Agree\" [checked=false, ref=e21]";
+        let normalized = snapshot_comparison_text(before);
+        assert!(normalized.contains("Save [ref=e3]"));
+        assert!(normalized.contains("[checked=false]"));
+        assert!(!diff_snapshots(&normalized, &snapshot_comparison_text(after)).changed);
+        assert!(
+            diff_snapshots(
+                &normalized,
+                &snapshot_comparison_text(&after.replace("Agree", "Agreed"))
+            )
+            .changed
+        );
+    }
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1086,6 +1086,77 @@ async fn e2e_snapshot_and_click_ref() {
     assert_success(&resp);
 }
 
+#[tokio::test]
+#[ignore]
+async fn e2e_snapshot_refs_survive_dom_updates_and_never_recycle() {
+    let mut state = DaemonState::new();
+    assert_success(
+        &execute_command(
+            &json!({ "id": "1", "action": "launch", "headless": true }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "2", "action": "navigate", "url": "about:blank" }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "3", "action": "setcontent", "html": "<button id='a'>Alpha</button><button id='b'>Beta</button>" }),
+            &mut state,
+        )
+        .await,
+    );
+
+    let first = execute_command(&json!({ "id": "4", "action": "snapshot" }), &mut state).await;
+    assert_success(&first);
+    let alpha_ref = get_data(&first)["refs"]
+        .as_object()
+        .unwrap()
+        .iter()
+        .find(|(_, node)| node["name"] == "Alpha")
+        .map(|(ref_id, _)| ref_id.clone())
+        .unwrap();
+
+    assert_success(
+        &execute_command(
+            &json!({ "id": "5", "action": "evaluate", "script": "document.body.prepend(document.getElementById('a')); document.getElementById('b').remove()" }),
+            &mut state,
+        )
+        .await,
+    );
+    let second = execute_command(&json!({ "id": "6", "action": "snapshot" }), &mut state).await;
+    assert_success(&second);
+    assert_eq!(get_data(&second)["refs"][&alpha_ref]["name"], "Alpha");
+    assert_eq!(
+        get_data(&second)["removedRefs"].as_array().unwrap().len(),
+        1
+    );
+
+    assert_success(
+        &execute_command(
+            &json!({ "id": "7", "action": "navigate", "url": "about:blank?new-document" }),
+            &mut state,
+        )
+        .await,
+    );
+    assert_success(
+        &execute_command(
+            &json!({ "id": "8", "action": "setcontent", "html": "<button>Alpha</button>" }),
+            &mut state,
+        )
+        .await,
+    );
+    let third = execute_command(&json!({ "id": "9", "action": "snapshot" }), &mut state).await;
+    assert_success(&third);
+    assert!(get_data(&third)["refs"].get(&alpha_ref).is_none());
+    assert_success(&execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await);
+}
+
 // ---------------------------------------------------------------------------
 // Screenshot
 // ---------------------------------------------------------------------------

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3931,7 +3931,7 @@ async fn e2e_diff_snapshot() {
     .await;
     assert_success(&resp);
 
-    // Repeated diffs must each begin a fresh ref-numbering epoch.
+    // Repeated diffs preserve document refs and report no content changes.
     for id in ["6", "7"] {
         let resp = execute_command(
             &json!({ "id": id, "action": "diff_snapshot", "baseline": baseline_path }),
@@ -4065,11 +4065,34 @@ async fn e2e_diff_url_aligns_refs_after_snapshot() {
     assert_eq!(data["diff"]["changed"], false);
     assert_eq!(data["diff"]["additions"], 0);
     assert_eq!(data["diff"]["removals"], 0);
-    assert_eq!(data["snapshot1"], data["snapshot2"]);
-    assert!(data["snapshot1"]
-        .as_str()
+    assert_ne!(
+        data["snapshot1"], data["snapshot2"],
+        "Replaced documents must not recycle actionable IDs"
+    );
+    assert_eq!(
+        super::diff::snapshot_comparison_text(data["snapshot1"].as_str().unwrap()),
+        super::diff::snapshot_comparison_text(data["snapshot2"].as_str().unwrap())
+    );
+    let primary_ref = state
+        .ref_map
+        .entries_sorted()
+        .into_iter()
+        .find(|(_, entry)| entry.name == "Primary action")
         .unwrap()
-        .starts_with("- button \"Primary action\" [ref=e1]"));
+        .0;
+    let next = execute_command(&json!({"id": "9", "action": "snapshot"}), &mut state).await;
+    assert_success(&next);
+    assert_eq!(
+        get_data(&next)["refs"][&primary_ref]["name"],
+        "Primary action"
+    );
+    assert_success(
+        &execute_command(
+            &json!({"id": "10", "action": "click", "selector": primary_ref}),
+            &mut state,
+        )
+        .await,
+    );
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -15,8 +15,11 @@ pub struct RefEntry {
     pub frame_id: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct RefMap {
     map: HashMap<String, RefEntry>,
+    durable_refs: HashMap<(String, Option<String>, i64), String>,
+    scope: String,
     next_ref: usize,
 }
 
@@ -24,6 +27,8 @@ impl RefMap {
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
+            durable_refs: HashMap::new(),
+            scope: String::new(),
             next_ref: 1,
         }
     }
@@ -103,13 +108,62 @@ impl RefMap {
         entries
     }
 
+    pub fn ref_ids(&self) -> std::collections::HashSet<String> {
+        self.map.keys().cloned().collect()
+    }
+
     pub fn remove(&mut self, ref_id: &str) {
         self.map.remove(ref_id);
     }
 
     pub fn clear(&mut self) {
         self.map.clear();
-        self.next_ref = 1;
+    }
+
+    /// Select the active top-level document namespace. Frame IDs are added to
+    /// this scope when durable DOM-backed refs are resolved.
+    pub fn set_scope(&mut self, scope: &str) {
+        self.scope = scope.to_string();
+    }
+
+    pub fn durable_ref(&self, backend_node_id: i64, frame_id: Option<&str>) -> Option<&str> {
+        self.durable_refs
+            .get(&(
+                self.scope.clone(),
+                frame_id.map(ToString::to_string),
+                backend_node_id,
+            ))
+            .map(String::as_str)
+    }
+
+    pub fn remember_durable_ref(
+        &mut self,
+        backend_node_id: i64,
+        frame_id: Option<&str>,
+        ref_id: &str,
+    ) {
+        self.durable_refs.insert(
+            (
+                self.scope.clone(),
+                frame_id.map(ToString::to_string),
+                backend_node_id,
+            ),
+            ref_id.to_string(),
+        );
+    }
+
+    /// Invalidate refs for a replaced document without recycling their IDs.
+    pub fn invalidate_current_document(&mut self) {
+        let scope = &self.scope;
+        self.durable_refs
+            .retain(|(entry_scope, _, _), _| entry_scope != scope);
+        self.map.clear();
+    }
+
+    /// Drop all document identities while preserving the monotonic ref counter.
+    pub fn invalidate_all_documents(&mut self) {
+        self.durable_refs.clear();
+        self.map.clear();
     }
 
     pub fn next_ref_num(&self) -> usize {
@@ -1377,7 +1431,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_map_clear_resets_ref_numbering() {
+    fn test_ref_map_clear_preserves_monotonic_numbering() {
         let mut map = RefMap::new();
         map.add("e1".to_string(), Some(42), "button", "Submit", None);
         map.set_next_ref_num(2);
@@ -1385,6 +1439,23 @@ mod tests {
         map.clear();
 
         assert!(map.get("e1").is_none());
+        assert_eq!(map.next_ref_num(), 2);
+    }
+
+    #[test]
+    fn test_durable_refs_are_scoped_by_document_and_frame() {
+        let mut map = RefMap::new();
+        map.set_scope("page-a");
+        map.remember_durable_ref(42, None, "e1");
+        map.remember_durable_ref(42, Some("frame-a"), "e2");
+        assert_eq!(map.durable_ref(42, None), Some("e1"));
+        assert_eq!(map.durable_ref(42, Some("frame-a")), Some("e2"));
+
+        map.set_scope("page-b");
+        assert_eq!(map.durable_ref(42, None), None);
+        map.set_scope("page-a");
+        map.invalidate_current_document();
+        assert_eq!(map.durable_ref(42, None), None);
         assert_eq!(map.next_ref_num(), 1);
     }
 

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -401,8 +401,20 @@ pub async fn take_snapshot(
             None
         };
 
-        let ref_id = format!("e{}", next_ref);
-        next_ref += 1;
+        let ref_id = if let Some(backend_node_id) = tree_nodes[*idx].backend_node_id {
+            if let Some(existing) = ref_map.durable_ref(backend_node_id, frame_id) {
+                existing.to_string()
+            } else {
+                let allocated = format!("e{}", next_ref);
+                next_ref += 1;
+                ref_map.remember_durable_ref(backend_node_id, frame_id, &allocated);
+                allocated
+            }
+        } else {
+            let allocated = format!("e{}", next_ref);
+            next_ref += 1;
+            allocated
+        };
 
         ref_map.add_with_frame(
             ref_id.clone(),

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2125,9 +2125,7 @@ Usage: agent-browser snapshot [options]
 
 Returns an accessibility tree representation of the page with element
 references (like @e1, @e2) that can be used in subsequent commands.
-DOM-backed references remain stable across observations while their nodes
-survive. Removed references are reported in JSON and IDs are never recycled
-within the browser session. Content diffs ignore generated ref IDs.
+Existing elements keep their refs across snapshots. Refresh after navigation.
 
 Options:
   -i, --interactive    Only include interactive elements

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2127,7 +2127,8 @@ Returns an accessibility tree representation of the page with element
 references (like @e1, @e2) that can be used in subsequent commands.
 DOM-backed references remain stable across observations while their nodes
 survive. Removed references are reported in JSON and IDs are never recycled
-within the browser session.
+within the browser session. Snapshot and URL content diffs ignore generated
+ref annotations while captured snapshots retain their actionable refs.
 
 Options:
   -i, --interactive    Only include interactive elements

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2125,7 +2125,9 @@ Usage: agent-browser snapshot [options]
 
 Returns an accessibility tree representation of the page with element
 references (like @e1, @e2) that can be used in subsequent commands.
-Designed for AI agents to understand page structure.
+DOM-backed references remain stable across observations while their nodes
+survive. Removed references are reported in JSON and IDs are never recycled
+within the browser session.
 
 Options:
   -i, --interactive    Only include interactive elements

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2127,8 +2127,7 @@ Returns an accessibility tree representation of the page with element
 references (like @e1, @e2) that can be used in subsequent commands.
 DOM-backed references remain stable across observations while their nodes
 survive. Removed references are reported in JSON and IDs are never recycled
-within the browser session. Snapshot and URL content diffs ignore generated
-ref annotations while captured snapshots retain their actionable refs.
+within the browser session. Content diffs ignore generated ref IDs.
 
 Options:
   -i, --interactive    Only include interactive elements

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -44,7 +44,7 @@ agent-browser mcp                     # Start an MCP stdio server
 
 Successful `open <url>` and `navigate` commands advertise when WebMCP tools are available. With `--json`, the navigation response includes `data.webmcp.toolCount`.
 
-Refs remain stable while their DOM nodes survive. A new document invalidates its refs; JSON snapshots list disappeared refs in `removedRefs`. Accessibility nodes without DOM backing have snapshot-local refs. Content diffs ignore generated ref IDs.
+Existing elements keep their refs across snapshots. Take a fresh snapshot after navigation.
 
 Clicks fail before dispatch when another element covers the target's click point. The error names the covering element, for example `covered by <div#consent-banner>`. Dismiss or interact with that element, take a fresh snapshot, then retry the original action.
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -44,6 +44,8 @@ agent-browser mcp                     # Start an MCP stdio server
 
 Successful `open <url>` and `navigate` commands advertise when WebMCP tools are available. With `--json`, the navigation response includes `data.webmcp.toolCount`.
 
+Snapshot refs backed by DOM nodes remain stable across observations while the underlying node survives. Identity is isolated by document and frame; navigation invalidates the replaced document without recycling its ref IDs. JSON snapshot output includes `removedRefs` for nodes that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local.
+
 Clicks fail before dispatch when another element covers the target's click point. The error names the covering element, for example `covered by <div#consent-banner>`. Dismiss or interact with that element, take a fresh snapshot, then retry the original action.
 
 Headless Chromium screenshots hide native scrollbars for consistent image output. Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -44,7 +44,7 @@ agent-browser mcp                     # Start an MCP stdio server
 
 Successful `open <url>` and `navigate` commands advertise when WebMCP tools are available. With `--json`, the navigation response includes `data.webmcp.toolCount`.
 
-Snapshot refs backed by DOM nodes remain stable across observations while the underlying node survives. Identity is isolated by document and frame; navigation invalidates the replaced document without recycling its ref IDs. JSON snapshot output includes `removedRefs` for nodes that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
+Refs remain stable while their DOM nodes survive. A new document invalidates its refs; JSON snapshots list disappeared refs in `removedRefs`. Accessibility nodes without DOM backing have snapshot-local refs. Content diffs ignore generated ref IDs.
 
 Clicks fail before dispatch when another element covers the target's click point. The error names the covering element, for example `covered by <div#consent-banner>`. Dismiss or interact with that element, take a fresh snapshot, then retry the original action.
 

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -44,7 +44,7 @@ agent-browser mcp                     # Start an MCP stdio server
 
 Successful `open <url>` and `navigate` commands advertise when WebMCP tools are available. With `--json`, the navigation response includes `data.webmcp.toolCount`.
 
-Snapshot refs backed by DOM nodes remain stable across observations while the underlying node survives. Identity is isolated by document and frame; navigation invalidates the replaced document without recycling its ref IDs. JSON snapshot output includes `removedRefs` for nodes that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local.
+Snapshot refs backed by DOM nodes remain stable across observations while the underlying node survives. Identity is isolated by document and frame; navigation invalidates the replaced document without recycling its ref IDs. JSON snapshot output includes `removedRefs` for nodes that disappeared since the previous observation. Virtual accessibility nodes without DOM backing remain snapshot-local. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
 
 Clicks fail before dispatch when another element covers the target's click point. The error names the covering element, for example `covered by <div#consent-banner>`. Dismiss or interact with that element, take a fresh snapshot, then retry the original action.
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -88,6 +88,8 @@ agent-browser snapshot -i --json          # machine-readable output
 
 Snapshot output looks like:
 
+DOM-backed refs survive repeated observations while the underlying node survives. JSON snapshots report disappeared IDs in `removedRefs`. Navigation to a new document invalidates its refs, and invalidated IDs are never reused during the browser session. Virtual accessibility nodes can still receive snapshot-local refs.
+
 ```
 Page: Example - Log in
 URL: https://example.com/login

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -88,7 +88,7 @@ agent-browser snapshot -i --json          # machine-readable output
 
 Snapshot output looks like:
 
-DOM-backed refs survive repeated observations while the underlying node survives. JSON snapshots report disappeared IDs in `removedRefs`. Navigation to a new document invalidates its refs, and invalidated IDs are never reused during the browser session. Virtual accessibility nodes can still receive snapshot-local refs.
+DOM-backed refs survive repeated observations while the underlying node survives. JSON snapshots report disappeared IDs in `removedRefs`. Navigation to a new document invalidates its refs, and invalidated IDs are never reused during the browser session. Virtual accessibility nodes can still receive snapshot-local refs. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
 
 ```
 Page: Example - Log in

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -86,7 +86,7 @@ agent-browser snapshot -s "#main"         # scope to a CSS selector
 agent-browser snapshot -i --json          # machine-readable output
 ```
 
-Refs remain stable while their DOM nodes survive. Refresh them after navigation; JSON snapshots report disappeared refs in `removedRefs`. See [ref lifecycle](references/snapshot-refs.md) for details.
+Existing elements keep their refs across snapshots. Take a fresh snapshot after navigation.
 
 Snapshot output looks like:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -86,9 +86,9 @@ agent-browser snapshot -s "#main"         # scope to a CSS selector
 agent-browser snapshot -i --json          # machine-readable output
 ```
 
-Snapshot output looks like:
+Refs remain stable while their DOM nodes survive. Refresh them after navigation; JSON snapshots report disappeared refs in `removedRefs`. See [ref lifecycle](references/snapshot-refs.md) for details.
 
-DOM-backed refs survive repeated observations while the underlying node survives. JSON snapshots report disappeared IDs in `removedRefs`. Navigation to a new document invalidates its refs, and invalidated IDs are never reused during the browser session. Virtual accessibility nodes can still receive snapshot-local refs. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
+Snapshot output looks like:
 
 ```
 Page: Example - Log in

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -2,6 +2,8 @@
 
 Compact element references that reduce context usage dramatically for AI agents.
 
+DOM-backed refs are durable across observations. Identity is scoped by top-level document and frame, so React updates and DOM reordering preserve a surviving element's ref. A new document invalidates the old document's refs, and invalidated IDs are never recycled within the browser session. In JSON output, `removedRefs` lists refs that disappeared since the previous observation. Accessibility nodes without DOM backing use snapshot-local refs.
+
 **Related**: [commands.md](commands.md) for full command reference, [SKILL.md](../SKILL.md) for quick start.
 
 ## Contents

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -2,7 +2,7 @@
 
 Compact element references that reduce context usage dramatically for AI agents.
 
-DOM-backed refs are durable across observations. Identity is scoped by top-level document and frame, so React updates and DOM reordering preserve a surviving element's ref. A new document invalidates the old document's refs, and invalidated IDs are never recycled within the browser session. In JSON output, `removedRefs` lists refs that disappeared since the previous observation. Accessibility nodes without DOM backing use snapshot-local refs. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
+DOM-backed refs remain stable while their nodes survive, including through reordering. Refs are scoped to document and frame; replacing a document invalidates its refs. IDs are never reused within a session. JSON `removedRefs` lists refs absent since the previous observation. Accessibility nodes without DOM backing have snapshot-local refs. Content diffs ignore generated ref IDs without changing actionable refs.
 
 **Related**: [commands.md](commands.md) for full command reference, [SKILL.md](../SKILL.md) for quick start.
 

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -2,7 +2,7 @@
 
 Compact element references that reduce context usage dramatically for AI agents.
 
-DOM-backed refs remain stable while their nodes survive, including through reordering. Refs are scoped to document and frame; replacing a document invalidates its refs. IDs are never reused within a session. JSON `removedRefs` lists refs absent since the previous observation. Accessibility nodes without DOM backing have snapshot-local refs. Content diffs ignore generated ref IDs without changing actionable refs.
+Existing elements keep their refs across snapshots. Take a fresh snapshot after navigation. JSON `removedRefs` lists refs no longer in the snapshot.
 
 **Related**: [commands.md](commands.md) for full command reference, [SKILL.md](../SKILL.md) for quick start.
 

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -2,7 +2,7 @@
 
 Compact element references that reduce context usage dramatically for AI agents.
 
-DOM-backed refs are durable across observations. Identity is scoped by top-level document and frame, so React updates and DOM reordering preserve a surviving element's ref. A new document invalidates the old document's refs, and invalidated IDs are never recycled within the browser session. In JSON output, `removedRefs` lists refs that disappeared since the previous observation. Accessibility nodes without DOM backing use snapshot-local refs.
+DOM-backed refs are durable across observations. Identity is scoped by top-level document and frame, so React updates and DOM reordering preserve a surviving element's ref. A new document invalidates the old document's refs, and invalidated IDs are never recycled within the browser session. In JSON output, `removedRefs` lists refs that disappeared since the previous observation. Accessibility nodes without DOM backing use snapshot-local refs. Snapshot and URL diffs ignore generated ref annotations when comparing content; captured snapshots retain their actionable refs.
 
 **Related**: [commands.md](commands.md) for full command reference, [SKILL.md](../SKILL.md) for quick start.
 


### PR DESCRIPTION
Implements idea 4 from the browser-tool ideas gist.

DOM-backed accessibility refs now use `(CDP session, loader/document, frame, backendNodeId)` identity. Surviving nodes retain refs across observations and DOM reordering; new documents invalidate their identity namespace; invalidated IDs are never recycled during the browser session. Virtual AX nodes remain snapshot-local. JSON snapshots explicitly report `removedRefs`.

The behavior applies equally through CLI and MCP snapshot paths. Documentation and inline comments are updated.

Validation:
- `cd cli && cargo test -- --test-threads=1` (1,246 passed across unit/integration targets, 113 ignored)
- `cd cli && cargo test e2e_snapshot_refs_survive_dom_updates_and_never_recycle -- --ignored --test-threads=1`
- `cd cli && cargo clippy`
- `cd cli && cargo fmt -- --check`