### PR TITLE
feat: add conditional screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ agent-browser drag <src> <tgt>        # Drag and drop
 agent-browser upload <sel> <files>    # Upload files
 agent-browser screenshot [path]       # Take screenshot (--full for full page, saves to a temporary directory if no path)
 agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
+agent-browser screenshot --if-changed # Return a path only when decoded pixels changed
+agent-browser screenshot --threshold 0.01 # Ignore changes affecting at most 1% of pixels
 agent-browser screenshot --screenshot-dir ./shots    # Save to custom directory
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
 agent-browser pdf <path>              # Save as PDF
@@ -993,6 +995,8 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--device <name>` | iOS device name, e.g. "iPhone 15 Pro" (or `AGENT_BROWSER_IOS_DEVICE` env) |
 | `--json` | JSON output (for agents) |
 | `--annotate` | Annotated screenshot with numbered element labels (or `AGENT_BROWSER_ANNOTATE` env) |
+| `--if-changed` | Return a screenshot path only when decoded pixels changed since the preceding capture with the same tab and scope |
+| `--threshold <0-1>` | Maximum changed-pixel ratio treated as unchanged; implies `--if-changed` |
 | `--screenshot-dir <path>` | Default screenshot output directory (or `AGENT_BROWSER_SCREENSHOT_DIR` env) |
 | `--screenshot-quality <n>` | JPEG quality 0-100 (or `AGENT_BROWSER_SCREENSHOT_QUALITY` env) |
 | `--screenshot-format <fmt>` | Screenshot format: `png`, `jpeg` (or `AGENT_BROWSER_SCREENSHOT_FORMAT` env) |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ agent-browser drag <src> <tgt>        # Drag and drop
 agent-browser upload <sel> <files>    # Upload files
 agent-browser screenshot [path]       # Take screenshot (--full for full page, saves to a temporary directory if no path)
 agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
-agent-browser screenshot --if-changed # Return a path only when decoded pixels changed
+agent-browser screenshot --if-changed # Recommended: skip unchanged images to save tokens
 agent-browser screenshot --threshold 0.01 # Ignore changes affecting at most 1% of pixels
 agent-browser screenshot --screenshot-dir ./shots    # Save to custom directory
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
@@ -995,7 +995,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--device <name>` | iOS device name, e.g. "iPhone 15 Pro" (or `AGENT_BROWSER_IOS_DEVICE` env) |
 | `--json` | JSON output (for agents) |
 | `--annotate` | Annotated screenshot with numbered element labels (or `AGENT_BROWSER_ANNOTATE` env) |
-| `--if-changed` | Return a screenshot path only when decoded pixels changed since the preceding capture with the same tab and scope |
+| `--if-changed` | Recommended for repeated captures: skip unchanged images to save tokens (history is per tab and scope) |
 | `--threshold <0-1>` | Maximum changed-pixel ratio treated as unchanged; implies `--if-changed` |
 | `--screenshot-dir <path>` | Default screenshot output directory (or `AGENT_BROWSER_SCREENSHOT_DIR` env) |
 | `--screenshot-quality <n>` | JPEG quality 0-100 (or `AGENT_BROWSER_SCREENSHOT_QUALITY` env) |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -806,17 +806,41 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             // selector: @ref or CSS selector
             // path: file path (contains / or . or ends with known extension)
             let mut full_page = false;
-            let positional: Vec<&str> = rest
-                .iter()
-                .filter(|arg| match **arg {
-                    "--full" | "-f" => {
-                        full_page = true;
-                        false
+            let mut if_changed = false;
+            let mut threshold = None;
+            let mut positional = Vec::new();
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i] {
+                    "--full" | "-f" => full_page = true,
+                    "--if-changed" => if_changed = true,
+                    "--threshold" => {
+                        let raw = rest.get(i + 1).ok_or_else(|| ParseError::MissingArguments {
+                            context: "screenshot --threshold".to_string(),
+                            usage: "screenshot [selector] [path] [--if-changed] [--threshold <0-1>]",
+                        })?;
+                        let value = raw.parse::<f64>().map_err(|_| ParseError::InvalidValue {
+                            message: format!(
+                                "--threshold expects a number from 0 to 1, got '{}'",
+                                raw
+                            ),
+                            usage:
+                                "screenshot [selector] [path] [--if-changed] [--threshold <0-1>]",
+                        })?;
+                        if !(0.0..=1.0).contains(&value) {
+                            return Err(ParseError::InvalidValue {
+                                message: format!("--threshold must be from 0 to 1, got '{}'", raw),
+                                usage: "screenshot [selector] [path] [--if-changed] [--threshold <0-1>]",
+                            });
+                        }
+                        threshold = Some(value);
+                        if_changed = true;
+                        i += 1;
                     }
-                    _ => true,
-                })
-                .copied()
-                .collect();
+                    arg => positional.push(arg),
+                }
+                i += 1;
+            }
             let (selector, path) = match (positional.first(), positional.get(1)) {
                 (Some(first), Some(second)) => {
                     // Two args: first is selector, second is path
@@ -861,6 +885,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             }
             if let Some(ref dir) = flags.screenshot_dir {
                 cmd["screenshotDir"] = json!(dir);
+            }
+            if if_changed {
+                cmd["ifChanged"] = json!(true);
+            }
+            if let Some(value) = threshold {
+                cmd["threshold"] = json!(value);
             }
             Ok(cmd)
         }
@@ -4657,6 +4687,38 @@ mod tests {
         assert_eq!(cmd["action"], "screenshot");
         assert_eq!(cmd["selector"], ".btn");
         assert_eq!(cmd["path"], "./button.png");
+    }
+
+    #[test]
+    fn test_screenshot_if_changed() {
+        let cmd = parse_command(&args("screenshot --if-changed"), &default_flags()).unwrap();
+        assert_eq!(cmd["ifChanged"], true);
+        assert!(cmd.get("threshold").is_none());
+    }
+
+    #[test]
+    fn test_screenshot_threshold_implies_if_changed() {
+        let cmd = parse_command(
+            &args("screenshot .btn ./button.png --threshold 0.025"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["selector"], ".btn");
+        assert_eq!(cmd["path"], "./button.png");
+        assert_eq!(cmd["ifChanged"], true);
+        assert_eq!(cmd["threshold"], 0.025);
+    }
+
+    #[test]
+    fn test_screenshot_threshold_rejects_out_of_range_value() {
+        let result = parse_command(&args("screenshot --threshold 1.1"), &default_flags());
+        assert!(matches!(result, Err(ParseError::InvalidValue { .. })));
+    }
+
+    #[test]
+    fn test_screenshot_threshold_requires_value() {
+        let result = parse_command(&args("screenshot --threshold"), &default_flags());
+        assert!(matches!(result, Err(ParseError::MissingArguments { .. })));
     }
 
     // === Snapshot ===

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -934,7 +934,7 @@ fn tools() -> Vec<Value> {
                 "format": { "type": "string", "enum": ["png", "jpeg"], "description": "Screenshot format." },
                 "quality": { "type": "integer", "minimum": 0, "maximum": 100, "description": "JPEG quality." },
                 "screenshotDir": { "type": "string", "description": "Default output directory when path is omitted." },
-                "ifChanged": { "type": "boolean", "default": false, "description": "Return image content only when decoded pixels changed since the preceding capture." },
+                "ifChanged": { "type": "boolean", "default": false, "description": "Recommended for repeated captures to save tokens: return image content only when pixels changed." },
                 "threshold": { "type": "number", "minimum": 0, "maximum": 1, "description": "Maximum changed-pixel ratio to treat as unchanged. Implies ifChanged." }
             }),
             &[],

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -933,7 +933,9 @@ fn tools() -> Vec<Value> {
                 "annotate": { "type": "boolean", "default": false, "description": "Number visible elements in the screenshot." },
                 "format": { "type": "string", "enum": ["png", "jpeg"], "description": "Screenshot format." },
                 "quality": { "type": "integer", "minimum": 0, "maximum": 100, "description": "JPEG quality." },
-                "screenshotDir": { "type": "string", "description": "Default output directory when path is omitted." }
+                "screenshotDir": { "type": "string", "description": "Default output directory when path is omitted." },
+                "ifChanged": { "type": "boolean", "default": false, "description": "Return image content only when decoded pixels changed since the preceding capture." },
+                "threshold": { "type": "number", "minimum": 0, "maximum": 1, "description": "Maximum changed-pixel ratio to treat as unchanged. Implies ifChanged." }
             }),
             &[],
         ),
@@ -2744,6 +2746,13 @@ fn call_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
     }
     if optional_bool(arguments, "fullPage")?.unwrap_or(false) {
         args.push("--full".to_string());
+    }
+    if optional_bool(arguments, "ifChanged")?.unwrap_or(false) {
+        args.push("--if-changed".to_string());
+    }
+    if let Some(threshold) = optional_number_string(arguments, "threshold")? {
+        args.push("--threshold".to_string());
+        args.push(threshold);
     }
     call_cli_tool(arguments, args, None)
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5246,7 +5246,8 @@ fn changed_pixel_ratio(
     changed as f64 / (rgba.len() / 4) as f64
 }
 
-/// Compares decoded pixels with the preceding capture for the same tab and scope.
+/// Compares decoded pixels with the last returned conditional screenshot.
+/// Suppressed captures retain that baseline so small changes can accumulate.
 /// Encoded image metadata therefore cannot create a false positive.
 fn observe_screenshot(
     state: &mut DaemonState,
@@ -5278,17 +5279,21 @@ fn observe_screenshot(
         || previous.is_some_and(|item| item.signature != signature)
         || pixel_change_ratio > threshold;
 
-    state.screenshot_observations.insert(
-        key,
-        ScreenshotObservation {
-            revision,
-            signature,
-            decoded_hash,
-            width,
-            height,
-            rgba,
-        },
-    );
+    if changed {
+        state.screenshot_observations.insert(
+            key,
+            ScreenshotObservation {
+                revision,
+                signature,
+                decoded_hash,
+                width,
+                height,
+                rgba,
+            },
+        );
+    } else if let Some(previous) = state.screenshot_observations.get_mut(&key) {
+        previous.revision = revision;
+    }
     Ok(json!({
         "changed": changed,
         "revision": revision,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5237,8 +5237,10 @@ fn changed_pixel_ratio(
     }
     let changed = previous
         .rgba
-        .chunks_exact(4)
-        .zip(rgba.chunks_exact(4))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(rgba.as_chunks::<4>().0)
         .filter(|(before, after)| before != after)
         .count();
     changed as f64 / (rgba.len() / 4) as f64

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5255,6 +5255,7 @@ fn observe_screenshot(
     signature: String,
     base64_data: &str,
     threshold: f64,
+    options: &ScreenshotOptions,
 ) -> Result<Value, String> {
     let (width, height, rgba, decoded_hash) = decode_screenshot_pixels(base64_data)?;
     // Evict stale tab history before admitting another capture scope so decoded
@@ -5279,6 +5280,11 @@ fn observe_screenshot(
         || previous.is_some_and(|item| item.signature != signature)
         || pixel_change_ratio > threshold;
 
+    let path = if changed {
+        Some(screenshot::save_screenshot(base64_data, options)?)
+    } else {
+        None
+    };
     if changed {
         state.screenshot_observations.insert(
             key,
@@ -5294,12 +5300,16 @@ fn observe_screenshot(
     } else if let Some(previous) = state.screenshot_observations.get_mut(&key) {
         previous.revision = revision;
     }
-    Ok(json!({
+    let mut response = json!({
         "changed": changed,
         "revision": revision,
         "pixelChangeRatio": pixel_change_ratio,
         "threshold": threshold
-    }))
+    });
+    if let Some(path) = path {
+        response["path"] = json!(path);
+    }
+    Ok(response)
 }
 
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -5321,52 +5331,6 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
         annotate
     );
 
-    if let Some(ref wb) = state.webdriver_backend {
-        if state.browser.is_none() {
-            if annotate {
-                return Err(
-                    "Annotated screenshots are not yet implemented on the WebDriver backend"
-                        .to_string(),
-                );
-            }
-
-            let base64_data = wb.screenshot().await?;
-            let explicit_path = cmd.get("path").and_then(|v| v.as_str());
-            let path = explicit_path.map(String::from).unwrap_or_else(|| {
-                format!(
-                    "/tmp/screenshot-{}.png",
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis())
-                        .unwrap_or(0)
-                )
-            });
-            let bytes =
-                base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &base64_data)
-                    .map_err(|e| format!("Base64 decode error: {}", e))?;
-            std::fs::write(&path, bytes)
-                .map_err(|e| format!("Failed to write screenshot: {}", e))?;
-            if if_changed {
-                let mut response = observe_screenshot(
-                    state,
-                    "webdriver-active".to_string(),
-                    signature,
-                    &base64_data,
-                    threshold,
-                )?;
-                if response["changed"].as_bool() == Some(true) {
-                    response["path"] = json!(path);
-                } else if explicit_path.is_none() {
-                    let _ = std::fs::remove_file(&path);
-                }
-                return Ok(response);
-            }
-            return Ok(json!({ "path": path }));
-        }
-    }
-    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-    let session_id = mgr.active_session_id()?.to_string();
-
     let format = cmd
         .get("format")
         .or_else(|| cmd.get("type"))
@@ -5374,7 +5338,7 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .unwrap_or("png")
         .to_string();
 
-    let options = ScreenshotOptions {
+    let mut options = ScreenshotOptions {
         selector: cmd
             .get("selector")
             .and_then(|v| v.as_str())
@@ -5396,42 +5360,75 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
             .map(String::from),
     };
 
-    if annotate {
-        state.ref_map.clear();
-        let _ = snapshot::take_snapshot(
+    let (session_id, result) = if let Some(wb) = state
+        .webdriver_backend
+        .as_ref()
+        .filter(|_| state.browser.is_none())
+    {
+        if annotate {
+            return Err(
+                "Annotated screenshots are not yet implemented on the WebDriver backend"
+                    .to_string(),
+            );
+        }
+        options.path.get_or_insert_with(|| {
+            format!(
+                "/tmp/screenshot-{}.png",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0)
+            )
+        });
+        (
+            "webdriver-active".to_string(),
+            screenshot::ScreenshotResult {
+                base64: wb.screenshot().await?,
+                annotations: Vec::new(),
+            },
+        )
+    } else {
+        let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+        let session_id = mgr.active_session_id()?.to_string();
+        if annotate {
+            state.ref_map.clear();
+            let _ = snapshot::take_snapshot(
+                &mgr.client,
+                &session_id,
+                &SnapshotOptions {
+                    interactive: true,
+                    ..SnapshotOptions::default()
+                },
+                &mut state.ref_map,
+                state.active_frame_id.as_deref(),
+                &state.iframe_sessions,
+            )
+            .await?;
+        }
+
+        let result = screenshot::take_screenshot(
             &mgr.client,
             &session_id,
-            &SnapshotOptions {
-                interactive: true,
-                ..SnapshotOptions::default()
-            },
-            &mut state.ref_map,
-            state.active_frame_id.as_deref(),
+            &state.ref_map,
+            &options,
             &state.iframe_sessions,
         )
         .await?;
-    }
 
-    let result = screenshot::take_screenshot(
-        &mgr.client,
-        &session_id,
-        &state.ref_map,
-        &options,
-        &state.iframe_sessions,
-    )
-    .await?;
+        (session_id, result)
+    };
 
     let mut response = if if_changed {
-        let mut observation =
-            observe_screenshot(state, session_id, signature, &result.base64, threshold)?;
-        if observation["changed"].as_bool() == Some(true) {
-            observation["path"] = json!(result.path);
-        } else if options.path.is_none() {
-            let _ = std::fs::remove_file(&result.path);
-        }
-        observation
+        observe_screenshot(
+            state,
+            session_id,
+            signature,
+            &result.base64,
+            threshold,
+            &options,
+        )?
     } else {
-        json!({ "path": result.path })
+        json!({ "path": screenshot::save_screenshot(&result.base64, &options)? })
     };
     if !result.annotations.is_empty() {
         response["annotations"] = serde_json::to_value(&result.annotations)

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2,6 +2,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
@@ -210,6 +211,16 @@ pub struct MouseState {
     pub x: f64,
     pub y: f64,
     pub buttons: i32,
+}
+
+#[derive(Debug, Clone)]
+struct ScreenshotObservation {
+    revision: u64,
+    signature: String,
+    decoded_hash: u64,
+    width: u32,
+    height: u32,
+    rgba: Vec<u8>,
 }
 
 #[derive(Default)]
@@ -421,6 +432,7 @@ pub struct DaemonState {
     pub webdriver_backend: Option<super::webdriver::backend::WebDriverBackend>,
     pub backend_type: BackendType,
     pub ref_map: RefMap,
+    screenshot_observations: HashMap<String, ScreenshotObservation>,
     pub domain_filter: Arc<RwLock<Option<DomainFilter>>>,
     pub event_tracker: EventTracker,
     pub session_name: Option<String>,
@@ -563,6 +575,7 @@ impl DaemonState {
             webdriver_backend: None,
             backend_type: BackendType::Cdp,
             ref_map: RefMap::new(),
+            screenshot_observations: HashMap::new(),
             domain_filter: Arc::new(RwLock::new(
                 env::var("AGENT_BROWSER_ALLOWED_DOMAINS")
                     .ok()
@@ -5195,11 +5208,111 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     Ok(json!({ "snapshot": tree, "origin": url, "refs": refs }))
 }
 
+fn decode_screenshot_pixels(base64_data: &str) -> Result<(u32, u32, Vec<u8>, u64), String> {
+    let encoded = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, base64_data)
+        .map_err(|e| format!("Base64 decode error: {}", e))?;
+    let image = image::load_from_memory(&encoded)
+        .map_err(|e| format!("Failed to decode screenshot pixels: {}", e))?
+        .to_rgba8();
+    let (width, height) = image.dimensions();
+    let rgba = image.into_raw();
+    let mut hasher = DefaultHasher::new();
+    width.hash(&mut hasher);
+    height.hash(&mut hasher);
+    rgba.hash(&mut hasher);
+    Ok((width, height, rgba, hasher.finish()))
+}
+
+fn changed_pixel_ratio(
+    previous: &ScreenshotObservation,
+    width: u32,
+    height: u32,
+    rgba: &[u8],
+) -> f64 {
+    if previous.width != width || previous.height != height || previous.rgba.len() != rgba.len() {
+        return 1.0;
+    }
+    if rgba.is_empty() {
+        return 0.0;
+    }
+    let changed = previous
+        .rgba
+        .chunks_exact(4)
+        .zip(rgba.chunks_exact(4))
+        .filter(|(before, after)| before != after)
+        .count();
+    changed as f64 / (rgba.len() / 4) as f64
+}
+
+/// Compares decoded pixels with the preceding capture for the same tab and scope.
+/// Encoded image metadata therefore cannot create a false positive.
+fn observe_screenshot(
+    state: &mut DaemonState,
+    key: String,
+    signature: String,
+    base64_data: &str,
+    threshold: f64,
+) -> Result<Value, String> {
+    let (width, height, rgba, decoded_hash) = decode_screenshot_pixels(base64_data)?;
+    // Evict stale tab history before admitting another capture scope so decoded
+    // image buffers remain bounded even during long multi-tab sessions.
+    if !state.screenshot_observations.contains_key(&key)
+        && state.screenshot_observations.len() >= 32
+    {
+        if let Some(eviction_key) = state.screenshot_observations.keys().next().cloned() {
+            state.screenshot_observations.remove(&eviction_key);
+        }
+    }
+    let previous = state.screenshot_observations.get(&key);
+    let revision = previous.map_or(1, |item| item.revision.saturating_add(1));
+    let pixel_change_ratio = match previous {
+        Some(item) if item.signature == signature && item.decoded_hash == decoded_hash => 0.0,
+        Some(item) if item.signature == signature => {
+            changed_pixel_ratio(item, width, height, &rgba)
+        }
+        _ => 1.0,
+    };
+    let changed = previous.is_none()
+        || previous.is_some_and(|item| item.signature != signature)
+        || pixel_change_ratio > threshold;
+
+    state.screenshot_observations.insert(
+        key,
+        ScreenshotObservation {
+            revision,
+            signature,
+            decoded_hash,
+            width,
+            height,
+            rgba,
+        },
+    );
+    Ok(json!({
+        "changed": changed,
+        "revision": revision,
+        "pixelChangeRatio": pixel_change_ratio,
+        "threshold": threshold
+    }))
+}
+
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let annotate = cmd
         .get("annotate")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let if_changed = cmd
+        .get("ifChanged")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let threshold = cmd.get("threshold").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let signature = format!(
+        "selector={:?};fullPage={};annotate={}",
+        cmd.get("selector").and_then(|v| v.as_str()),
+        cmd.get("fullPage")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        annotate
+    );
 
     if let Some(ref wb) = state.webdriver_backend {
         if state.browser.is_none() {
@@ -5211,30 +5324,37 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
             }
 
             let base64_data = wb.screenshot().await?;
-            let path = cmd.get("path").and_then(|v| v.as_str());
-            if let Some(p) = path {
-                let bytes = base64::Engine::decode(
-                    &base64::engine::general_purpose::STANDARD,
-                    &base64_data,
+            let explicit_path = cmd.get("path").and_then(|v| v.as_str());
+            let path = explicit_path.map(String::from).unwrap_or_else(|| {
+                format!(
+                    "/tmp/screenshot-{}.png",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis())
+                        .unwrap_or(0)
                 )
-                .map_err(|e| format!("Base64 decode error: {}", e))?;
-                std::fs::write(p, bytes)
-                    .map_err(|e| format!("Failed to write screenshot: {}", e))?;
-                return Ok(json!({ "path": p }));
-            }
-            let tmp = format!(
-                "/tmp/screenshot-{}.png",
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis())
-                    .unwrap_or(0)
-            );
+            });
             let bytes =
                 base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &base64_data)
                     .map_err(|e| format!("Base64 decode error: {}", e))?;
-            std::fs::write(&tmp, bytes)
+            std::fs::write(&path, bytes)
                 .map_err(|e| format!("Failed to write screenshot: {}", e))?;
-            return Ok(json!({ "path": tmp }));
+            if if_changed {
+                let mut response = observe_screenshot(
+                    state,
+                    "webdriver-active".to_string(),
+                    signature,
+                    &base64_data,
+                    threshold,
+                )?;
+                if response["changed"].as_bool() == Some(true) {
+                    response["path"] = json!(path);
+                } else if explicit_path.is_none() {
+                    let _ = std::fs::remove_file(&path);
+                }
+                return Ok(response);
+            }
+            return Ok(json!({ "path": path }));
         }
     }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
@@ -5294,7 +5414,18 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     )
     .await?;
 
-    let mut response = json!({ "path": result.path });
+    let mut response = if if_changed {
+        let mut observation =
+            observe_screenshot(state, session_id, signature, &result.base64, threshold)?;
+        if observation["changed"].as_bool() == Some(true) {
+            observation["path"] = json!(result.path);
+        } else if options.path.is_none() {
+            let _ = std::fs::remove_file(&result.path);
+        }
+        observation
+    } else {
+        json!({ "path": result.path })
+    };
     if !result.annotations.is_empty() {
         response["annotations"] = serde_json::to_value(&result.annotations)
             .map_err(|e| format!("Failed to serialize annotations: {}", e))?;
@@ -12168,6 +12299,33 @@ mod tests {
     use std::fs;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    #[test]
+    fn screenshot_pixel_ratio_counts_changed_pixels() {
+        let previous = ScreenshotObservation {
+            revision: 1,
+            signature: "viewport".to_string(),
+            decoded_hash: 0,
+            width: 2,
+            height: 1,
+            rgba: vec![0, 0, 0, 255, 255, 255, 255, 255],
+        };
+        let current = vec![0, 0, 0, 255, 255, 0, 255, 255];
+        assert_eq!(changed_pixel_ratio(&previous, 2, 1, &current), 0.5);
+    }
+
+    #[test]
+    fn screenshot_pixel_ratio_treats_dimension_change_as_full_change() {
+        let previous = ScreenshotObservation {
+            revision: 1,
+            signature: "viewport".to_string(),
+            decoded_hash: 0,
+            width: 1,
+            height: 1,
+            rgba: vec![0, 0, 0, 255],
+        };
+        assert_eq!(changed_pixel_ratio(&previous, 2, 1, &[0; 8]), 1.0);
+    }
 
     /// A binding-recovery failure must tear the connection down: the attach
     /// paths set `state.browser` before calling this, so returning the error

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1135,6 +1135,28 @@ async fn e2e_screenshot() {
     let _ = std::fs::remove_file(&tmp_path);
 
     let resp = execute_command(
+        &json!({ "id": "4a", "action": "screenshot", "ifChanged": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["changed"], true);
+    assert_eq!(get_data(&resp)["revision"], 1);
+    let conditional_path = get_data(&resp)["path"].as_str().unwrap().to_string();
+
+    let resp = execute_command(
+        &json!({ "id": "4b", "action": "screenshot", "ifChanged": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["changed"], false);
+    assert_eq!(get_data(&resp)["revision"], 2);
+    assert_eq!(get_data(&resp)["pixelChangeRatio"], 0.0);
+    assert!(get_data(&resp).get("path").is_none());
+    let _ = std::fs::remove_file(conditional_path);
+
+    let resp = execute_command(
         &json!({
             "id": "5",
             "action": "setcontent",
@@ -1150,6 +1172,17 @@ async fn e2e_screenshot() {
     )
     .await;
     assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5a", "action": "screenshot", "ifChanged": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["changed"], true);
+    assert_eq!(get_data(&resp)["revision"], 3);
+    assert!(get_data(&resp)["pixelChangeRatio"].as_f64().unwrap() > 0.0);
+    let _ = std::fs::remove_file(get_data(&resp)["path"].as_str().unwrap());
 
     let resp = execute_command(
         &json!({ "id": "6", "action": "screenshot", "annotate": true }),

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -46,7 +46,6 @@ pub struct ScreenshotAnnotation {
 
 #[derive(Debug, Clone)]
 pub struct ScreenshotResult {
-    pub path: String,
     pub base64: String,
     pub annotations: Vec<ScreenshotAnnotation>,
 }
@@ -95,8 +94,7 @@ impl Serialize for ScreenshotAnnotation {
     }
 }
 
-/// Captures a screenshot via CDP and optionally overlays numbered annotations
-/// that mirror the Node.js screenshot `annotate` mode.
+/// Captures screenshot bytes and optional annotations without writing a file.
 pub async fn take_screenshot(
     client: &CdpClient,
     session_id: &str,
@@ -149,20 +147,7 @@ pub async fn take_screenshot(
         Vec::new()
     };
 
-    let ext = if options.format == "jpeg" {
-        "jpg"
-    } else {
-        "png"
-    };
-    let path = save_screenshot(
-        &base64,
-        options.path.as_deref(),
-        ext,
-        options.output_dir.as_deref(),
-    )?;
-
     Ok(ScreenshotResult {
-        path,
         base64,
         annotations,
     })
@@ -551,12 +536,15 @@ fn project_annotations(
         .collect()
 }
 
-fn save_screenshot(
-    base64_data: &str,
-    explicit_path: Option<&str>,
-    ext: &str,
-    output_dir: Option<&str>,
-) -> Result<String, String> {
+/// Writes a captured image only after the caller decides it is needed.
+pub fn save_screenshot(base64_data: &str, options: &ScreenshotOptions) -> Result<String, String> {
+    let ext = if options.format == "jpeg" {
+        "jpg"
+    } else {
+        "png"
+    };
+    let explicit_path = options.path.as_deref();
+    let output_dir = options.output_dir.as_deref();
     let save_path = match explicit_path {
         Some(path) => path.to_string(),
         None => {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2087,7 +2087,7 @@ Pass --hide-scrollbars false when launching to keep native scrollbars visible.
 
 Options:
   --full, -f           Capture full page (not just viewport)
-  --if-changed         Return a screenshot only when decoded pixels changed
+  --if-changed         Recommended: skip unchanged images to save tokens
   --threshold <0-1>    Maximum changed-pixel ratio treated as unchanged
                        (implies --if-changed, default: 0)
   --annotate           Overlay numbered labels on interactive elements.

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1126,6 +1126,22 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             println!("{} Trace stopped", color::success_indicator());
             return;
         }
+        if action == Some("screenshot")
+            && data.get("changed").and_then(|v| v.as_bool()) == Some(false)
+        {
+            let revision = data.get("revision").and_then(|v| v.as_u64()).unwrap_or(0);
+            let ratio = data
+                .get("pixelChangeRatio")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            println!(
+                "{} Screenshot unchanged (revision {}, {:.4}% pixels changed)",
+                color::success_indicator(),
+                revision,
+                ratio * 100.0
+            );
+            return;
+        }
         // Path-based operations (screenshot/pdf/trace/har/download/state/video)
         if let Some(path) = data.get("path").and_then(|v| v.as_str()) {
             match action.unwrap_or("") {
@@ -2071,6 +2087,9 @@ Pass --hide-scrollbars false when launching to keep native scrollbars visible.
 
 Options:
   --full, -f           Capture full page (not just viewport)
+  --if-changed         Return a screenshot only when decoded pixels changed
+  --threshold <0-1>    Maximum changed-pixel ratio treated as unchanged
+                       (implies --if-changed, default: 0)
   --annotate           Overlay numbered labels on interactive elements.
                        Each label [N] corresponds to ref @eN from snapshot.
                        Prints a legend mapping labels to element roles/names.
@@ -2091,6 +2110,8 @@ Examples:
   agent-browser screenshot
   agent-browser screenshot ./screenshot.png
   agent-browser screenshot --full ./full-page.png
+  agent-browser screenshot --if-changed
+  agent-browser screenshot --if-changed --threshold 0.01
   agent-browser screenshot --annotate              # Labeled screenshot + legend
   agent-browser screenshot --annotate ./page.png   # Save annotated screenshot
   agent-browser screenshot --annotate --json       # JSON output with annotations

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -26,7 +26,7 @@ agent-browser drag <src> <dst>        # Drag and drop
 agent-browser upload <sel> <files>    # Upload files
 agent-browser screenshot [path]       # Screenshot (--full for full page)
 agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
-agent-browser screenshot --if-changed # Return a path only when decoded pixels changed
+agent-browser screenshot --if-changed # Recommended: skip unchanged images to save tokens
 agent-browser screenshot --threshold 0.01 # Ignore changes affecting at most 1% of pixels
 agent-browser screenshot --screenshot-dir ./shots    # Save to custom directory
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -26,6 +26,8 @@ agent-browser drag <src> <dst>        # Drag and drop
 agent-browser upload <sel> <files>    # Upload files
 agent-browser screenshot [path]       # Screenshot (--full for full page)
 agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
+agent-browser screenshot --if-changed # Return a path only when decoded pixels changed
+agent-browser screenshot --threshold 0.01 # Ignore changes affecting at most 1% of pixels
 agent-browser screenshot --screenshot-dir ./shots    # Save to custom directory
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
 agent-browser pdf <path>              # Save page as PDF

--- a/docs/src/app/files/page.mdx
+++ b/docs/src/app/files/page.mdx
@@ -40,7 +40,7 @@ agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80 ./page
 agent-browser pdf ./page.pdf
 ```
 
-Use `--if-changed` to skip unchanged images in polling loops. History is per tab and capture scope. The first capture returns a path; later unchanged captures omit it. JSON includes `changed`, `revision`, and `pixelChangeRatio`. `--threshold <0-1>` implies `--if-changed` and treats changes at or below that ratio as unchanged.
+Prefer `--if-changed` for repeated captures: skipping unchanged images is the most token-efficient option. History is per tab and capture scope. The first capture returns a path; later unchanged captures omit it. JSON includes `changed`, `revision`, and `pixelChangeRatio`. `--threshold <0-1>` implies `--if-changed` and treats changes at or below that ratio as unchanged.
 
 Screenshot defaults can also be configured with:
 

--- a/docs/src/app/files/page.mdx
+++ b/docs/src/app/files/page.mdx
@@ -34,9 +34,13 @@ Without `--download-path`, downloads go to a temporary directory that is cleaned
 ```bash
 agent-browser screenshot ./page.png
 agent-browser screenshot --full ./page-full.png
+agent-browser screenshot --if-changed
+agent-browser screenshot --threshold 0.01
 agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80 ./page.jpg
 agent-browser pdf ./page.pdf
 ```
+
+Use `--if-changed` for polling or agent loops that should not resend identical images. Comparison uses decoded RGBA pixels and is isolated by tab and capture scope. The first capture returns a path; later unchanged captures omit it and report `changed`, `revision`, and `pixelChangeRatio` in JSON. `--threshold <0-1>` implies `--if-changed` and treats changes at or below that pixel ratio as unchanged.
 
 Screenshot defaults can also be configured with:
 

--- a/docs/src/app/files/page.mdx
+++ b/docs/src/app/files/page.mdx
@@ -40,7 +40,7 @@ agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80 ./page
 agent-browser pdf ./page.pdf
 ```
 
-Use `--if-changed` for polling or agent loops that should not resend identical images. Comparison uses decoded RGBA pixels and is isolated by tab and capture scope. The first capture returns a path; later unchanged captures omit it and report `changed`, `revision`, and `pixelChangeRatio` in JSON. `--threshold <0-1>` implies `--if-changed` and treats changes at or below that pixel ratio as unchanged.
+Use `--if-changed` to skip unchanged images in polling loops. History is per tab and capture scope. The first capture returns a path; later unchanged captures omit it. JSON includes `changed`, `revision`, and `pixelChangeRatio`. `--threshold <0-1>` implies `--if-changed` and treats changes at or below that ratio as unchanged.
 
 Screenshot defaults can also be configured with:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -286,7 +286,7 @@ agent-browser screenshot --if-changed           # return a path only when pixels
 agent-browser screenshot --threshold 0.01       # ignore changes affecting at most 1% of pixels
 ```
 
-Conditional screenshots are tracked per tab and capture scope. The first capture is changed. Later captures return `changed`, `revision`, and `pixelChangeRatio`; unchanged captures omit the path so agents and MCP clients do not resend identical image content. Comparison uses decoded RGBA pixels, so image encoding metadata does not count as a page change.
+Use `--if-changed` in polling loops to skip unchanged images. The first capture returns a path; later unchanged captures omit it. See [conditional screenshot responses](references/commands.md#screenshots-and-pdf) for JSON fields.
 
 Headless Chromium screenshots hide native scrollbars for consistent image output. Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -282,11 +282,11 @@ agent-browser screenshot                        # temp path, printed on stdout
 agent-browser screenshot page.png               # specific path
 agent-browser screenshot --full full.png        # full scroll height
 agent-browser screenshot --annotate map.png     # numbered labels + legend keyed to snapshot refs
-agent-browser screenshot --if-changed           # return a path only when pixels changed
+agent-browser screenshot --if-changed           # recommended: skip unchanged images to save tokens
 agent-browser screenshot --threshold 0.01       # ignore changes affecting at most 1% of pixels
 ```
 
-Use `--if-changed` in polling loops to skip unchanged images. The first capture returns a path; later unchanged captures omit it. See [conditional screenshot responses](references/commands.md#screenshots-and-pdf) for JSON fields.
+Prefer `--if-changed` for repeated captures: skipping unchanged images is the most token-efficient option. The first capture returns a path; later unchanged captures omit it. See [conditional screenshot responses](references/commands.md#screenshots-and-pdf) for JSON fields.
 
 Headless Chromium screenshots hide native scrollbars for consistent image output. Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -282,7 +282,11 @@ agent-browser screenshot                        # temp path, printed on stdout
 agent-browser screenshot page.png               # specific path
 agent-browser screenshot --full full.png        # full scroll height
 agent-browser screenshot --annotate map.png     # numbered labels + legend keyed to snapshot refs
+agent-browser screenshot --if-changed           # return a path only when pixels changed
+agent-browser screenshot --threshold 0.01       # ignore changes affecting at most 1% of pixels
 ```
+
+Conditional screenshots are tracked per tab and capture scope. The first capture is changed. Later captures return `changed`, `revision`, and `pixelChangeRatio`; unchanged captures omit the path so agents and MCP clients do not resend identical image content. Comparison uses decoded RGBA pixels, so image encoding metadata does not count as a page change.
 
 Headless Chromium screenshots hide native scrollbars for consistent image output. Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -105,8 +105,12 @@ agent-browser is checked @e1      # Check if checked
 agent-browser screenshot          # Save to temporary directory
 agent-browser screenshot path.png # Save to specific path
 agent-browser screenshot --full   # Full page
+agent-browser screenshot --if-changed # Omit the path when decoded pixels match the preceding capture
+agent-browser screenshot --threshold 0.01 # Ignore changes affecting at most 1% of pixels
 agent-browser pdf output.pdf      # Save as PDF
 ```
+
+`--threshold <0-1>` implies `--if-changed`. Conditional history is isolated by tab and capture scope. JSON responses include `changed`, `revision`, `pixelChangeRatio`, and `threshold`; `path` is present only when the change exceeds the threshold. The first capture for a scope is always changed.
 
 Headless Chromium screenshots hide native scrollbars for consistent image output. Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -105,7 +105,7 @@ agent-browser is checked @e1      # Check if checked
 agent-browser screenshot          # Save to temporary directory
 agent-browser screenshot path.png # Save to specific path
 agent-browser screenshot --full   # Full page
-agent-browser screenshot --if-changed # Omit the path when decoded pixels match the preceding capture
+agent-browser screenshot --if-changed # Recommended: skip unchanged images to save tokens
 agent-browser screenshot --threshold 0.01 # Ignore changes affecting at most 1% of pixels
 agent-browser pdf output.pdf      # Save as PDF
 ```


### PR DESCRIPTION
## Summary

- add `screenshot --if-changed` with per-tab, per-scope revision tracking
- compare decoded RGBA pixels and omit unchanged image paths from CLI and MCP responses
- add `--threshold <0-1>` for bounded visual change tolerance
- document the feature across CLI help, README, core skill, and docs site

## Tests

- `cd cli && cargo test -- --test-threads=1`
- `cd cli && cargo test e2e_screenshot -- --ignored --test-threads=1`
- `cd cli && cargo clippy -- -D warnings`
- `cd cli && cargo fmt -- --check`