### PR TITLE
feat: add action and observe batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ echo '[
 ]' | agent-browser batch --json
 ```
 
-Use `act` when a workflow needs several actions but only one final observation. Each quoted action runs through the normal parser, policy, and backend checks. The command stops after the first failure and preserves individual results, then returns the final URL plus any requested snapshot or conditional screenshot.
+Use `act` when a workflow needs several actions but only one final observation. Each quoted action runs through the normal parser, policy, and backend checks. The command stops after the first failure and preserves individual results, then returns the final URL plus any requested snapshot or conditional screenshot. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
 
 ```bash
 agent-browser act \

--- a/README.md
+++ b/README.md
@@ -279,6 +279,21 @@ echo '[
 ]' | agent-browser batch --json
 ```
 
+Use `act` when a workflow needs several actions but only one final observation. Each quoted action runs through the normal parser, policy, and backend checks. The command stops after the first failure and preserves individual results, then returns the final URL plus any requested snapshot or conditional screenshot.
+
+```bash
+agent-browser act \
+  'fill @e1 "pete@example.com"' \
+  'fill @e2 "secret"' \
+  'click @e3' \
+  --wait networkidle \
+  --observe delta \
+  --screenshot-if-changed \
+  --json
+```
+
+`--observe delta` returns a full snapshot on the first observation, a compact unchanged response when the tree matches, and a delta thereafter. Use `--observe full` to force the complete tree. Conditional screenshot history is isolated per tab and hashes decoded RGBA pixels.
+
 ### Clipboard
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ echo '[
 ]' | agent-browser batch --json
 ```
 
-Use `act` when a workflow needs several actions but only one final observation. Each quoted action runs through the normal parser, policy, and backend checks. The command stops after the first failure and preserves individual results, then returns the final URL plus any requested snapshot or conditional screenshot. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
+Use `act` to run several actions and observe the final page once. It stops on the first failure and retains results for attempted actions.
 
 ```bash
 agent-browser act \
@@ -292,7 +292,7 @@ agent-browser act \
   --json
 ```
 
-`--observe delta` returns a full snapshot on the first observation, a compact unchanged response when the tree matches, and a delta thereafter. Use `--observe full` to force the complete tree. Conditional screenshot history is isolated per tab and hashes decoded RGBA pixels.
+`--observe delta` returns a full tree initially, then changes or an unchanged result. Use `--observe full` for the complete tree and `--screenshot-if-changed` to skip unchanged images.
 
 ### Clipboard
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -158,6 +158,7 @@ pub fn is_top_level_command(value: &str) -> bool {
             | "device"
             | "diff"
             | "batch"
+            | "act"
             | "react"
             | "vitals"
             | "web-vitals"
@@ -1899,6 +1900,96 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         }
 
         "diff" => parse_diff(&rest, &id),
+
+        // === Atomic action and observation ===
+        "act" => {
+            let mut action_strings = Vec::new();
+            let mut wait = None;
+            let mut observe = None;
+            let mut screenshot_if_changed = false;
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i] {
+                    "--wait" => {
+                        let value = rest.get(i + 1).ok_or_else(|| ParseError::MissingArguments {
+                            context: "act --wait".to_string(),
+                            usage: "act \"<command>\"... [--wait <state>] [--observe <full|delta>] [--screenshot-if-changed]",
+                        })?;
+                        if !matches!(*value, "load" | "domcontentloaded" | "networkidle") {
+                            return Err(ParseError::InvalidValue {
+                                message: format!("Invalid wait state '{}'; expected load, domcontentloaded, or networkidle", value),
+                                usage: "act \"<command>\"... --wait <load|domcontentloaded|networkidle>",
+                            });
+                        }
+                        wait = Some(*value);
+                        i += 1;
+                    }
+                    "--observe" => {
+                        let value =
+                            rest.get(i + 1)
+                                .ok_or_else(|| ParseError::MissingArguments {
+                                    context: "act --observe".to_string(),
+                                    usage: "act \"<command>\"... --observe <full|delta>",
+                                })?;
+                        if !matches!(*value, "full" | "delta") {
+                            return Err(ParseError::InvalidValue {
+                                message: format!(
+                                    "Invalid observation mode '{}'; expected full or delta",
+                                    value
+                                ),
+                                usage: "act \"<command>\"... --observe <full|delta>",
+                            });
+                        }
+                        observe = Some(*value);
+                        i += 1;
+                    }
+                    "--screenshot-if-changed" => screenshot_if_changed = true,
+                    value if value.starts_with("--") => {
+                        return Err(ParseError::InvalidValue {
+                            message: format!("Unknown act option '{}'", value),
+                            usage: "act \"<command>\"... [--wait <state>] [--observe <full|delta>] [--screenshot-if-changed]",
+                        });
+                    }
+                    value => action_strings.push(value),
+                }
+                i += 1;
+            }
+            if action_strings.is_empty() {
+                return Err(ParseError::MissingArguments {
+                    context: "act".to_string(),
+                    usage: "act \"<command>\"... [--wait <state>] [--observe <full|delta>] [--screenshot-if-changed]",
+                });
+            }
+            let mut actions = Vec::with_capacity(action_strings.len());
+            for action_string in &action_strings {
+                let action_args = shell_words_split(action_string);
+                if action_args.is_empty() {
+                    return Err(ParseError::InvalidValue {
+                        message: "Act commands cannot be empty".to_string(),
+                        usage: "act \"<command>\"...",
+                    });
+                }
+                let parsed = parse_command(&action_args, flags)?;
+                if matches!(
+                    parsed.get("action").and_then(Value::as_str),
+                    Some("act" | "batch")
+                ) {
+                    return Err(ParseError::InvalidValue {
+                        message: "Nested act and batch commands are not supported".to_string(),
+                        usage: "act \"<command>\"...",
+                    });
+                }
+                actions.push(json!({ "command": action_string, "request": parsed }));
+            }
+            Ok(json!({
+                "id": id,
+                "action": "act",
+                "actions": actions,
+                "wait": wait,
+                "observe": observe,
+                "screenshotIfChanged": screenshot_if_changed
+            }))
+        }
 
         // === Batch ===
         "batch" => {
@@ -6297,6 +6388,41 @@ mod tests {
     fn test_batch_no_args_no_commands_field() {
         let cmd = parse_command(&args("batch"), &default_flags()).unwrap();
         assert!(cmd.get("commands").is_none());
+    }
+
+    #[test]
+    fn test_act_parses_actions_and_observation_options() {
+        let cmd_args = vec![
+            "act".to_string(),
+            "fill @e1 \"pete@example.com\"".to_string(),
+            "click @e2".to_string(),
+            "--wait".to_string(),
+            "networkidle".to_string(),
+            "--observe".to_string(),
+            "delta".to_string(),
+            "--screenshot-if-changed".to_string(),
+        ];
+        let cmd = parse_command(&cmd_args, &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "act");
+        assert_eq!(cmd["wait"], "networkidle");
+        assert_eq!(cmd["observe"], "delta");
+        assert_eq!(cmd["screenshotIfChanged"], true);
+        assert_eq!(cmd["actions"][0]["request"]["action"], "fill");
+        assert_eq!(cmd["actions"][0]["request"]["value"], "pete@example.com");
+        assert_eq!(cmd["actions"][1]["request"]["action"], "click");
+    }
+
+    #[test]
+    fn test_act_requires_an_action() {
+        let result = parse_command(&args("act --observe full"), &default_flags());
+        assert!(matches!(result, Err(ParseError::MissingArguments { .. })));
+    }
+
+    #[test]
+    fn test_act_rejects_nested_batches() {
+        let cmd_args = vec!["act".to_string(), "batch \"get url\"".to_string()];
+        let result = parse_command(&cmd_args, &default_flags());
+        assert!(matches!(result, Err(ParseError::InvalidValue { .. })));
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1986,6 +1986,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 "action": "act",
                 "actions": actions,
                 "wait": wait,
+                "timeout": flags.default_timeout,
                 "observe": observe,
                 "screenshotIfChanged": screenshot_if_changed
             }))

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -1097,7 +1097,25 @@ fn has_os_error(error: &str, code: u32) -> bool {
 /// avoiding the daemon's spawn-time env snapshot drifting from the client.
 fn read_timeout_for(cmd: &Value) -> Duration {
     let op_ms = cmd.get("timeout").and_then(|v| v.as_u64()).unwrap_or(0);
-    Duration::from_millis(op_ms.saturating_add(10_000).max(30_000))
+    let mut budget = Duration::from_millis(op_ms.saturating_add(10_000).max(30_000));
+    // A batch holds the socket for all actions and final observations. Timing
+    // out at the ordinary 30s floor would retry already-executed mutations.
+    if cmd.get("action").and_then(Value::as_str) == Some("act") {
+        if let Some(actions) = cmd.get("actions").and_then(Value::as_array) {
+            for request in actions.iter().filter_map(|item| item.get("request")) {
+                budget = budget.saturating_add(read_timeout_for(request));
+            }
+        }
+        for requested in [
+            cmd.get("observe").and_then(Value::as_str).is_some(),
+            cmd.get("screenshotIfChanged").and_then(Value::as_bool) == Some(true),
+        ] {
+            if requested {
+                budget = budget.saturating_add(Duration::from_secs(30));
+            }
+        }
+    }
+    budget
 }
 
 fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
@@ -1604,5 +1622,22 @@ mod tests {
         assert!(!version_path.exists());
 
         let _ = fs::remove_dir(&dir);
+    }
+}
+
+#[cfg(test)]
+mod act_timeout_tests {
+    use super::*;
+    #[test]
+    fn batch_socket_budget_covers_all_action_waits_and_observations() {
+        let command = serde_json::json!({"action": "act", "actions": [
+            {"request": {"action": "wait", "timeout": 40000}},
+            {"request": {"action": "wait", "timeout": 40000}}
+        ], "timeout": 120000, "observe": "full", "screenshotIfChanged": true});
+        assert!(read_timeout_for(&command) > Duration::from_secs(200));
+        assert_eq!(
+            read_timeout_for(&serde_json::json!({"action": "click"})),
+            Duration::from_secs(30)
+        );
     }
 }

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -136,6 +136,7 @@ const TOOL_DIFF_SNAPSHOT: &str = "agent_browser_diff_snapshot";
 const TOOL_DIFF_SCREENSHOT: &str = "agent_browser_diff_screenshot";
 const TOOL_DIFF_URL: &str = "agent_browser_diff_url";
 const TOOL_BATCH: &str = "agent_browser_batch";
+const TOOL_ACT: &str = "agent_browser_act";
 const TOOL_REACT_TREE: &str = "agent_browser_react_tree";
 const TOOL_REACT_INSPECT: &str = "agent_browser_react_inspect";
 const TOOL_REACT_RENDERS_START: &str = "agent_browser_react_renders_start";
@@ -355,6 +356,7 @@ const CORE_PROFILE_TOOLS: &[&str] = &[
     TOOL_WAIT_FOR_TEXT,
     TOOL_WAIT_FOR_LOAD,
     TOOL_SCREENSHOT,
+    TOOL_ACT,
     TOOL_GET_TEXT,
     TOOL_GET_URL,
     TOOL_GET_TITLE,
@@ -1602,6 +1604,18 @@ fn parity_tools() -> Vec<Value> {
             &["commands"],
         ),
         tool(
+            TOOL_ACT,
+            "Act and observe",
+            "Run multiple actions atomically and capture final page state once.",
+            json!({
+                "commands": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+                "wait": { "type": "string", "enum": ["load", "domcontentloaded", "networkidle"] },
+                "observe": { "type": "string", "enum": ["full", "delta"] },
+                "screenshotIfChanged": { "type": "boolean" }
+            }),
+            &["commands"],
+        ),
+        tool(
             TOOL_REACT_TREE,
             "React tree",
             "Inspect React tree.",
@@ -2208,6 +2222,7 @@ fn call_tool(params: Option<&Value>, config: &McpConfig) -> Result<Value, Protoc
         TOOL_WAIT_FOR_FUNCTION => call_wait_flag(arguments, Some("--fn"), "expression"),
         TOOL_WAIT_FOR_DOWNLOAD => call_wait_download(arguments),
         TOOL_SCREENSHOT => call_screenshot(arguments),
+        TOOL_ACT => call_act(arguments),
         TOOL_PDF => call_one_string(arguments, "pdf", "path"),
         TOOL_GET_TEXT => call_get_selector(arguments, "text"),
         TOOL_GET_HTML => call_get_selector(arguments, "html"),
@@ -3300,6 +3315,33 @@ fn call_batch(arguments: &Value) -> Result<Value, ProtocolError> {
     call_cli_tool(arguments, args, Some(stdin))
 }
 
+fn act_command_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
+    let commands = required_string_array(arguments, "commands")?;
+    if commands.is_empty() {
+        return Err(ProtocolError::invalid_params(
+            "commands must contain at least one action",
+        ));
+    }
+    let mut args = vec!["act".to_string()];
+    args.extend(commands);
+    if let Some(wait) = optional_string(arguments, "wait")? {
+        args.push("--wait".to_string());
+        args.push(wait);
+    }
+    if let Some(observe) = optional_string(arguments, "observe")? {
+        args.push("--observe".to_string());
+        args.push(observe);
+    }
+    if optional_bool(arguments, "screenshotIfChanged")?.unwrap_or(false) {
+        args.push("--screenshot-if-changed".to_string());
+    }
+    Ok(args)
+}
+
+fn call_act(arguments: &Value) -> Result<Value, ProtocolError> {
+    call_cli_tool(arguments, act_command_args(arguments)?, None)
+}
+
 fn call_react_tree(arguments: &Value) -> Result<Value, ProtocolError> {
     let mut args = vec!["react".to_string(), "tree".to_string()];
     append_react_raw_json_arg(arguments, &mut args)?;
@@ -3951,7 +3993,11 @@ fn response_text(value: &Value) -> Option<String> {
 }
 
 fn image_content_from_response(value: &Value) -> Option<Value> {
-    let path = value.get("data")?.get("path")?.as_str()?;
+    let data = value.get("data")?;
+    let path = data
+        .get("path")
+        .and_then(Value::as_str)
+        .or_else(|| data.pointer("/screenshot/path").and_then(Value::as_str))?;
     let mime_type = image_mime_type(path)?;
     let metadata = fs::metadata(path).ok()?;
     if metadata.len() > MAX_IMAGE_BYTES {
@@ -4342,6 +4388,31 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, vec!["click", "@e1", "--new-tab"]);
+    }
+
+    #[test]
+    fn act_command_args_preserve_cli_parity() {
+        let args = act_command_args(&json!({
+            "commands": ["fill @e1 pete", "click @e2"],
+            "wait": "networkidle",
+            "observe": "delta",
+            "screenshotIfChanged": true
+        }))
+        .unwrap();
+
+        assert_eq!(
+            args,
+            vec![
+                "act",
+                "fill @e1 pete",
+                "click @e2",
+                "--wait",
+                "networkidle",
+                "--observe",
+                "delta",
+                "--screenshot-if-changed"
+            ]
+        );
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -4391,6 +4391,19 @@ mod tests {
     }
 
     #[test]
+    fn act_mcp_observations_reach_the_canonical_parser() {
+        let args = act_command_args(
+            &json!({"commands": ["get url"], "observe": "full", "screenshotIfChanged": true}),
+        )
+        .unwrap();
+        let flags = crate::flags::parse_flags(&args);
+        let request = crate::commands::parse_command(&args, &flags).unwrap();
+        assert_eq!(request["action"], "act");
+        assert_eq!(request["observe"], "full");
+        assert_eq!(request["screenshotIfChanged"], true);
+    }
+
+    #[test]
     fn act_command_args_preserve_cli_parity() {
         let args = act_command_args(&json!({
             "commands": ["fill @e1 pete", "click @e2"],

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1606,7 +1606,7 @@ fn parity_tools() -> Vec<Value> {
         tool(
             TOOL_ACT,
             "Act and observe",
-            "Run multiple actions atomically and capture final page state once.",
+            "Run actions in order, stopping on failure, and capture final page state once. Completed actions are not rolled back.",
             json!({
                 "commands": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
                 "wait": { "type": "string", "enum": ["load", "domcontentloaded", "networkidle"] },

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2,6 +2,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
@@ -533,6 +534,10 @@ pub struct DaemonState {
     pub pin_tab: bool,
     /// Last binding written to disk, so persistence is write-on-change.
     last_persisted_binding: Option<tab_binding::TabBinding>,
+    /// Last action-and-observe snapshot per tab, used by `act --observe delta`.
+    act_snapshots: HashMap<String, (u64, String, String)>,
+    /// Last decoded screenshot hash per tab, used to suppress duplicate images.
+    act_screenshot_hashes: HashMap<String, (u64, u64)>,
 }
 
 fn default_idle_shutdown_is_blocked(
@@ -639,6 +644,8 @@ impl DaemonState {
             confirmed_policy_actions: HashSet::new(),
             pin_tab,
             last_persisted_binding: None,
+            act_snapshots: HashMap::new(),
+            act_screenshot_hashes: HashMap::new(),
         }
     }
 
@@ -2694,6 +2701,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "close" => handle_close(state).await,
         "snapshot" => handle_snapshot(cmd, state).await,
         "screenshot" => handle_screenshot(cmd, state).await,
+        "act" => handle_act(cmd, state).await,
         "click" => handle_click(cmd, state).await,
         "dblclick" => handle_dblclick(cmd, state).await,
         "fill" => handle_fill(cmd, state).await,
@@ -2875,6 +2883,16 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     };
 
     let mut resp = match result {
+        Ok(data)
+            if action == "act" && data.get("completed").and_then(Value::as_bool) == Some(false) =>
+        {
+            json!({
+                "id": id,
+                "success": false,
+                "error": "Act stopped after an action failed or required confirmation",
+                "data": data
+            })
+        }
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
     };
@@ -5301,6 +5319,205 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     }
 
     Ok(response)
+}
+
+fn decoded_screenshot_hash(path: &str) -> Result<u64, String> {
+    let encoded = std::fs::read(path)
+        .map_err(|e| format!("Failed to read action observation screenshot: {}", e))?;
+    let image = image::load_from_memory(&encoded)
+        .map_err(|e| format!("Failed to decode action observation screenshot: {}", e))?
+        .to_rgba8();
+    let mut hasher = DefaultHasher::new();
+    image.width().hash(&mut hasher);
+    image.height().hash(&mut hasher);
+    image.as_raw().hash(&mut hasher);
+    Ok(hasher.finish())
+}
+
+/// Executes several normal daemon commands, then captures one coherent final
+/// observation. Nested commands still pass through the canonical dispatcher,
+/// including its policy, validation, and backend checks.
+async fn handle_act(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let actions = cmd
+        .get("actions")
+        .and_then(Value::as_array)
+        .ok_or("Missing 'actions' parameter")?;
+    let inherited_fields = [
+        "plugins",
+        "pinTab",
+        "restoreKey",
+        "restoreSave",
+        "restoreCheckUrl",
+        "restoreCheckText",
+        "restoreCheckFn",
+    ];
+    let mut action_results = Vec::with_capacity(actions.len());
+    let mut completed = true;
+
+    for (index, item) in actions.iter().enumerate() {
+        let command = item.get("command").and_then(Value::as_str).unwrap_or("");
+        let mut request = item
+            .get("request")
+            .cloned()
+            .ok_or_else(|| format!("Missing request for action {}", index + 1))?;
+        request["id"] = json!(format!("act-{}", index + 1));
+        for field in inherited_fields {
+            if let Some(value) = cmd.get(field) {
+                request[field] = value.clone();
+            }
+        }
+
+        // Boxing breaks the recursive future type while retaining the normal
+        // command path for every operation in the atomic request.
+        let response = Box::pin(execute_command(&request, state)).await;
+        let success = response.get("success").and_then(Value::as_bool) == Some(true)
+            && response
+                .pointer("/data/confirmation_required")
+                .and_then(Value::as_bool)
+                != Some(true);
+        let mut result = json!({ "command": command, "success": success });
+        if let Some(data) = response.get("data") {
+            result["result"] = data.clone();
+        }
+        if let Some(error) = response.get("error") {
+            result["error"] = error.clone();
+        }
+        if let Some(code) = response.get("code") {
+            result["code"] = code.clone();
+        }
+        action_results.push(result);
+        if !success {
+            completed = false;
+            break;
+        }
+    }
+
+    let mut output = json!({ "actions": action_results, "completed": completed });
+    if !completed {
+        return Ok(output);
+    }
+
+    if let Some(wait_state) = cmd.get("wait").and_then(Value::as_str) {
+        output["wait"] = handle_waitforloadstate(
+            &json!({ "state": wait_state, "timeout": cmd.get("timeout") }),
+            state,
+        )
+        .await?;
+    }
+
+    output["url"] = handle_url(state).await?["url"].clone();
+
+    if let Some(observe) = cmd.get("observe").and_then(Value::as_str) {
+        let session_id = state
+            .browser
+            .as_ref()
+            .ok_or("Browser not launched")?
+            .active_session_id()?
+            .to_string();
+        let snapshot = handle_snapshot(&json!({}), state).await?;
+        let current = snapshot["snapshot"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let current_url = output["url"].as_str().unwrap_or_default().to_string();
+        if !state.act_snapshots.contains_key(&session_id) && state.act_snapshots.len() >= 32 {
+            if let Some(key) = state.act_snapshots.keys().next().cloned() {
+                state.act_snapshots.remove(&key);
+            }
+        }
+        let previous = state.act_snapshots.get(&session_id).cloned();
+        let revision = previous.as_ref().map_or(1, |(revision, _, _)| revision + 1);
+        let observation = if observe == "delta" {
+            match previous {
+                Some((base_revision, previous_url, baseline))
+                    if previous_url == current_url && baseline == current =>
+                {
+                    json!({
+                        "kind": "unchanged",
+                        "baseRevision": base_revision,
+                        "revision": revision
+                    })
+                }
+                Some((base_revision, previous_url, baseline)) if previous_url == current_url => {
+                    let delta = diff::diff_snapshots(&baseline, &current);
+                    json!({
+                        "kind": "delta",
+                        "baseRevision": base_revision,
+                        "revision": revision,
+                        "diff": delta.diff,
+                        "additions": delta.additions,
+                        "removals": delta.removals
+                    })
+                }
+                _ => json!({
+                    "kind": "full",
+                    "revision": revision,
+                    "tree": current,
+                    "origin": snapshot["origin"],
+                    "refs": snapshot["refs"]
+                }),
+            }
+        } else {
+            json!({
+                "kind": "full",
+                "revision": revision,
+                "tree": current,
+                "origin": snapshot["origin"],
+                "refs": snapshot["refs"]
+            })
+        };
+        state
+            .act_snapshots
+            .insert(session_id, (revision, current_url, current));
+        output["snapshot"] = observation;
+    }
+
+    if cmd
+        .get("screenshotIfChanged")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let session_id = state
+            .browser
+            .as_ref()
+            .ok_or("Browser not launched")?
+            .active_session_id()?
+            .to_string();
+        let screenshot = handle_screenshot(&json!({}), state).await?;
+        let path = screenshot["path"]
+            .as_str()
+            .ok_or("Screenshot did not return a path")?;
+        let hash = decoded_screenshot_hash(path)?;
+        if !state.act_screenshot_hashes.contains_key(&session_id)
+            && state.act_screenshot_hashes.len() >= 32
+        {
+            if let Some(key) = state.act_screenshot_hashes.keys().next().cloned() {
+                state.act_screenshot_hashes.remove(&key);
+            }
+        }
+        let previous = state.act_screenshot_hashes.get(&session_id).copied();
+        let revision = previous.map_or(1, |(revision, _)| revision + 1);
+        let changed = previous.is_none_or(|(_, previous_hash)| previous_hash != hash);
+        if changed {
+            output["screenshot"] = json!({
+                "changed": true,
+                "revision": revision,
+                "path": path
+            });
+        } else {
+            let _ = std::fs::remove_file(path);
+            output["screenshot"] = json!({
+                "changed": false,
+                "revision": revision,
+                "pixelChangeRatio": 0
+            });
+        }
+        state
+            .act_screenshot_hashes
+            .insert(session_id, (revision, hash));
+    }
+
+    Ok(output)
 }
 
 async fn handle_click(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2334,6 +2334,19 @@ fn policy_actions_for_command(
     needs_implicit_launch: bool,
 ) -> Vec<String> {
     let mut actions = vec![action.to_string()];
+    // Final observations must be authorized before any batch action runs.
+    if action == "act" {
+        actions.push("url".to_string());
+        if cmd.get("wait").and_then(Value::as_str).is_some() {
+            actions.push("waitforloadstate".to_string());
+        }
+        if cmd.get("observe").and_then(Value::as_str).is_some() {
+            actions.push("snapshot".to_string());
+        }
+        if cmd.get("screenshotIfChanged").and_then(Value::as_bool) == Some(true) {
+            actions.push("screenshot".to_string());
+        }
+    }
     // `a11y <url>` performs a real browser navigation before the audit. Keep
     // navigation deny and confirmation policies effective for the compound
     // command instead of treating it as a read-only audit.
@@ -14003,6 +14016,42 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"data":{}}'
 
         drop(listener);
         let _ = fs::remove_dir_all(&socket_dir);
+    }
+
+    #[tokio::test]
+    async fn act_observation_policy_is_checked_before_launch_or_actions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policy.json");
+        for action in ["snapshot", "screenshot", "waitforloadstate", "url"] {
+            for rule in ["deny", "confirm"] {
+                std::fs::write(
+                    &path,
+                    json!({"default": "allow", rule: [action]}).to_string(),
+                )
+                .unwrap();
+                let mut state = DaemonState::new();
+                state.policy = Some(ActionPolicy::load(path.to_str().unwrap()).unwrap());
+                let response = execute_command(
+                    &json!({
+                        "id": "review", "action": "act", "actions": [],
+                        "observe": "full", "screenshotIfChanged": true, "wait": "load"
+                    }),
+                    &mut state,
+                )
+                .await;
+                if rule == "deny" {
+                    assert_eq!(response["success"], false, "{response}");
+                    assert!(response["error"].as_str().unwrap().contains(action));
+                } else {
+                    assert_eq!(
+                        response["data"]["confirmation_required"], true,
+                        "{response}"
+                    );
+                    assert_eq!(response["data"]["action"], action);
+                }
+                assert!(state.browser.is_none());
+            }
+        }
     }
 
     #[test]

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1092,6 +1092,73 @@ async fn e2e_snapshot_and_click_ref() {
 
 #[tokio::test]
 #[ignore]
+async fn e2e_act_executes_actions_and_observes_once() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "setcontent",
+            "html": "<input id='name'><button id='save' onclick=\"document.body.dataset.saved=document.querySelector('#name').value\">Save</button>"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "act",
+            "actions": [
+                { "command": "fill #name pete", "request": { "action": "fill", "selector": "#name", "value": "pete" } },
+                { "command": "click #save", "request": { "action": "click", "selector": "#save" } }
+            ],
+            "observe": "delta",
+            "screenshotIfChanged": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["completed"], true);
+    assert_eq!(data["actions"].as_array().unwrap().len(), 2);
+    assert_eq!(data["snapshot"]["kind"], "full");
+    assert_eq!(data["screenshot"]["changed"], true);
+    let first_path = data["screenshot"]["path"].as_str().unwrap().to_string();
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "act",
+            "actions": [
+                { "command": "get url", "request": { "action": "url" } }
+            ],
+            "observe": "delta",
+            "screenshotIfChanged": true
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["snapshot"]["kind"], "unchanged");
+    assert_eq!(data["screenshot"]["changed"], false);
+    assert!(data["screenshot"].get("path").is_none());
+
+    let _ = std::fs::remove_file(first_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
 async fn e2e_screenshot() {
     let mut state = DaemonState::new();
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -454,6 +454,59 @@ fn recording_fps_suffix(data: &serde_json::Value) -> String {
         .unwrap_or_default()
 }
 
+/// Format completed and partial action batches before generic URL/error output.
+fn format_act_text(data: &serde_json::Value) -> String {
+    let mut lines = Vec::new();
+    if let Some(actions) = data.get("actions").and_then(|v| v.as_array()) {
+        for item in actions {
+            let command = item.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let success = item.get("success").and_then(|v| v.as_bool()) == Some(true);
+            let indicator = if success {
+                color::success_indicator()
+            } else {
+                color::error_indicator()
+            };
+            lines.push(format!("{} {}", indicator, command));
+            if let Some(error) = item.get("error").and_then(|v| v.as_str()) {
+                lines.push(format!("  {}", error));
+            }
+            if item
+                .pointer("/result/confirmation_required")
+                .and_then(|v| v.as_bool())
+                == Some(true)
+            {
+                let id = item
+                    .pointer("/result/confirmation_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                lines.push(format!("  Confirmation required: {}", id));
+            }
+        }
+    }
+    if let Some(url) = data.get("url").and_then(|v| v.as_str()) {
+        lines.push(format!("URL: {}", url));
+    }
+    if let Some(snapshot) = data.get("snapshot") {
+        if let Some(tree) = snapshot.get("tree").and_then(|v| v.as_str()) {
+            lines.push(tree.to_string());
+        } else if let Some(diff) = snapshot.get("diff").and_then(|v| v.as_str()) {
+            lines.push(diff.to_string());
+        } else {
+            lines.push("Snapshot: unchanged".to_string());
+        }
+    }
+    if let Some(screenshot) = data.get("screenshot") {
+        lines.push(format!(
+            "Screenshot: {}",
+            screenshot
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unchanged")
+        ));
+    }
+    lines.join("\n")
+}
+
 pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &OutputOptions) {
     if opts.json {
         if opts.content_boundaries {
@@ -477,6 +530,24 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             println!("{}", serde_json::to_string(resp).unwrap_or_default());
         }
         // JSON mode includes the warning field in the JSON payload already
+        return;
+    }
+
+    if action == Some("act")
+        && resp
+            .data
+            .as_ref()
+            .is_some_and(|data| data.get("actions").is_some())
+    {
+        let data = resp.data.as_ref().unwrap();
+        print_with_boundaries(
+            &format_act_text(data),
+            data.get("url").and_then(|v| v.as_str()),
+            opts,
+        );
+        if let Some(ref warning) = resp.warning {
+            eprintln!("{} {}", color::warning_indicator(), warning);
+        }
         return;
     }
 
@@ -1431,43 +1502,6 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             .unwrap_or(false)
         {
             println!("{} Action denied", color::success_indicator());
-            return;
-        }
-
-        if action == Some("act") {
-            if let Some(actions) = data.get("actions").and_then(|v| v.as_array()) {
-                for item in actions {
-                    let command = item.get("command").and_then(|v| v.as_str()).unwrap_or("");
-                    let success = item.get("success").and_then(|v| v.as_bool()) == Some(true);
-                    let indicator = if success {
-                        color::success_indicator()
-                    } else {
-                        color::error_indicator()
-                    };
-                    println!("{} {}", indicator, command);
-                }
-            }
-            if let Some(url) = data.get("url").and_then(|v| v.as_str()) {
-                println!("URL: {}", url);
-            }
-            if let Some(kind) = data.pointer("/snapshot/kind").and_then(|v| v.as_str()) {
-                println!("Snapshot: {}", kind);
-            }
-            if let Some(changed) = data
-                .pointer("/screenshot/changed")
-                .and_then(|v| v.as_bool())
-            {
-                if changed {
-                    println!(
-                        "Screenshot: {}",
-                        data.pointer("/screenshot/path")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("changed")
-                    );
-                } else {
-                    println!("Screenshot: unchanged");
-                }
-            }
             return;
         }
 
@@ -3381,7 +3415,7 @@ agent-browser act - Execute actions and observe once
 
 Usage: agent-browser act "<command>"... [options]
 
-Executes each quoted command through the normal CLI and daemon validation path, then optionally waits and captures the final URL, snapshot, and screenshot in one response. Execution stops after the first failed action while preserving results for actions already attempted.
+Executes each quoted command through the normal CLI and daemon validation path, then optionally waits and captures the final URL, snapshot, and screenshot in one response. Execution stops after the first failed action while preserving results for actions already attempted. Final observation policies are checked before actions begin. Plain output includes observations and individual failure details.
 
 Options:
   --wait <state>              Wait for load, domcontentloaded, or networkidle
@@ -4547,5 +4581,38 @@ hydration: -  phases: 0  hydratedComponents: 0"
         ] {
             assert_eq!(format_webmcp_availability_text(&data), None);
         }
+    }
+}
+
+#[cfg(test)]
+mod act_output_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn act_output_includes_observations_and_partial_failure_details() {
+        let full = format_act_text(&json!({
+            "actions": [{"command": "click @e1", "success": true}],
+            "url": "about:blank", "snapshot": {"kind": "full", "tree": "- button Save [ref=e1]"},
+            "screenshot": {"changed": true, "path": "/tmp/example.png"}
+        }));
+        for expected in [
+            "click @e1",
+            "URL: about:blank",
+            "- button Save [ref=e1]",
+            "/tmp/example.png",
+        ] {
+            assert!(full.contains(expected), "{full}");
+        }
+        let partial = format_act_text(&json!({"actions": [
+            {"command": "get url", "success": true},
+            {"command": "click #missing", "success": false, "error": "Element not found"}
+        ], "completed": false}));
+        for expected in ["get url", "click #missing", "Element not found"] {
+            assert!(partial.contains(expected), "{partial}");
+        }
+        let delta =
+            format_act_text(&json!({"snapshot": {"kind": "delta", "diff": "- old\n+ new"}}));
+        assert!(delta.contains("- old\n+ new"));
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1434,6 +1434,43 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
+        if action == Some("act") {
+            if let Some(actions) = data.get("actions").and_then(|v| v.as_array()) {
+                for item in actions {
+                    let command = item.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                    let success = item.get("success").and_then(|v| v.as_bool()) == Some(true);
+                    let indicator = if success {
+                        color::success_indicator()
+                    } else {
+                        color::error_indicator()
+                    };
+                    println!("{} {}", indicator, command);
+                }
+            }
+            if let Some(url) = data.get("url").and_then(|v| v.as_str()) {
+                println!("URL: {}", url);
+            }
+            if let Some(kind) = data.pointer("/snapshot/kind").and_then(|v| v.as_str()) {
+                println!("Snapshot: {}", kind);
+            }
+            if let Some(changed) = data
+                .pointer("/screenshot/changed")
+                .and_then(|v| v.as_bool())
+            {
+                if changed {
+                    println!(
+                        "Screenshot: {}",
+                        data.pointer("/screenshot/path")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("changed")
+                    );
+                } else {
+                    println!("Screenshot: unchanged");
+                }
+            }
+            return;
+        }
+
         // Default success
         println!("{} Done", color::success_indicator());
     }
@@ -3338,6 +3375,26 @@ Examples:
 "##
         }
 
+        "act" => {
+            r##"
+agent-browser act - Execute actions and observe once
+
+Usage: agent-browser act "<command>"... [options]
+
+Executes each quoted command through the normal CLI and daemon validation path, then optionally waits and captures the final URL, snapshot, and screenshot in one response. Execution stops after the first failed action while preserving results for actions already attempted.
+
+Options:
+  --wait <state>              Wait for load, domcontentloaded, or networkidle
+  --observe <full|delta>      Return a full snapshot or an incremental observation
+  --screenshot-if-changed     Return a screenshot only when decoded pixels changed
+  --json                      Output the combined result as JSON
+
+Examples:
+  agent-browser act "fill @e1 pete@example.com" "click @e2" --wait networkidle --observe delta
+  agent-browser act "click @e1" --observe full --screenshot-if-changed --json
+"##
+        }
+
         "batch" => {
             r##"
 agent-browser batch - Execute multiple commands sequentially
@@ -3782,6 +3839,7 @@ Init scripts:
 Batch:
   batch [--bail] ["cmd" ...]  Execute multiple commands sequentially (args or stdin)
                               --bail stops on first error (default: continue all)
+  act ["cmd" ...] [options]   Execute actions and capture final state once
 
 Auth Vault:
   auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3415,7 +3415,9 @@ agent-browser act - Execute actions and observe once
 
 Usage: agent-browser act "<command>"... [options]
 
-Executes each quoted command through the normal CLI and daemon validation path, then optionally waits and captures the final URL, snapshot, and screenshot in one response. Execution stops after the first failed action while preserving results for actions already attempted. Final observation policies are checked before actions begin. Plain output includes observations and individual failure details.
+Runs quoted commands in order, then optionally waits and captures final page state.
+Stops on the first failure and retains results for attempted actions.
+Normal action policies apply; completed actions are not rolled back.
 
 Options:
   --wait <state>              Wait for load, domcontentloaded, or networkidle

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -640,7 +640,7 @@ echo '[
 
 ## Action and observation batches
 
-Use `act` to execute several actions through one daemon request and capture page state once at the end. Every quoted command still uses the normal CLI parser, policy checks, and backend validation. Execution stops after the first failure while preserving individual results. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
+Use `act` to run several actions and observe the final page once. It stops on the first failure and retains results for attempted actions. Normal action policies apply.
 
 ```bash
 agent-browser act \

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -640,7 +640,7 @@ echo '[
 
 ## Action and observation batches
 
-Use `act` to execute several actions through one daemon request and capture page state once at the end. Every quoted command still uses the normal CLI parser, policy checks, and backend validation. Execution stops after the first failure while preserving individual results.
+Use `act` to execute several actions through one daemon request and capture page state once at the end. Every quoted command still uses the normal CLI parser, policy checks, and backend validation. Execution stops after the first failure while preserving individual results. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
 
 ```bash
 agent-browser act \

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -638,6 +638,34 @@ echo '[
   </tbody>
 </table>
 
+## Action and observation batches
+
+Use `act` to execute several actions through one daemon request and capture page state once at the end. Every quoted command still uses the normal CLI parser, policy checks, and backend validation. Execution stops after the first failure while preserving individual results.
+
+```bash
+agent-browser act \
+  'fill @e1 "pete@example.com"' \
+  'fill @e2 "secret"' \
+  'click @e3' \
+  --wait networkidle \
+  --observe delta \
+  --screenshot-if-changed \
+  --json
+```
+
+<table>
+  <thead>
+    <tr><th>Option</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--wait &lt;state&gt;</code></td><td>Wait for <code>load</code>, <code>domcontentloaded</code>, or <code>networkidle</code> after the actions</td></tr>
+    <tr><td><code>--observe &lt;full|delta&gt;</code></td><td>Return a full snapshot or an incremental observation</td></tr>
+    <tr><td><code>--screenshot-if-changed</code></td><td>Return a screenshot path only when decoded pixels changed for the active tab</td></tr>
+  </tbody>
+</table>
+
+The result always includes the final URL after successful actions. Delta observation returns a full tree on the first call, a compact unchanged response when the tree matches, and a delta otherwise.
+
 ## MCP server
 
 ```bash

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -288,6 +288,16 @@ Headless Chromium screenshots hide native scrollbars for consistent image output
 
 `--annotate` is designed for multimodal models: each label `[N]` maps to ref `@eN`.
 
+### Act and observe once
+
+Use `act` to execute multiple actions and capture page state only after the sequence completes:
+
+```bash
+agent-browser act 'fill @e1 "pete@example.com"' 'click @e2' --wait networkidle --observe delta --screenshot-if-changed --json
+```
+
+Each action uses the normal parser, policy, and backend checks. Execution stops on the first failure and the response preserves individual action results. `--observe delta` returns a full tree the first time, then an unchanged result or a delta; `--observe full` forces the full tree. The response always includes the final URL when all actions succeed. Conditional screenshots omit their path when decoded pixels match the preceding `act` capture for that tab.
+
 ### Handle multiple pages via tabs
 
 ```bash

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -290,7 +290,7 @@ Headless Chromium screenshots hide native scrollbars for consistent image output
 
 ### Act and observe once
 
-Use `act` to execute multiple actions and capture page state only after the sequence completes:
+Use `act` to execute multiple actions and capture page state only after the sequence completes. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
 
 ```bash
 agent-browser act 'fill @e1 "pete@example.com"' 'click @e2' --wait networkidle --observe delta --screenshot-if-changed --json

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -290,13 +290,13 @@ Headless Chromium screenshots hide native scrollbars for consistent image output
 
 ### Act and observe once
 
-Use `act` to execute multiple actions and capture page state only after the sequence completes. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
+Use `act` to run several actions and observe once. It stops on the first failure and retains individual results.
 
 ```bash
 agent-browser act 'fill @e1 "pete@example.com"' 'click @e2' --wait networkidle --observe delta --screenshot-if-changed --json
 ```
 
-Each action uses the normal parser, policy, and backend checks. Execution stops on the first failure and the response preserves individual action results. `--observe delta` returns a full tree the first time, then an unchanged result or a delta; `--observe full` forces the full tree. The response always includes the final URL when all actions succeed. Conditional screenshots omit their path when decoded pixels match the preceding `act` capture for that tab.
+`--observe delta` returns a full tree initially, then changes or an unchanged result; `--observe full` always returns the tree. `--screenshot-if-changed` skips unchanged images. See the [command reference](references/commands.md#action-and-observation-batch) for options and responses.
 
 ### Handle multiple pages via tabs
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -46,7 +46,7 @@ agent-browser batch \
 agent-browser act 'fill @e1 "pete@example.com"' 'click @e2' --wait networkidle --observe delta --screenshot-if-changed --json
 ```
 
-`act` sends one daemon request, executes quoted commands serially, and observes once at the end. Options are `--wait <load|domcontentloaded|networkidle>`, `--observe <full|delta>`, and `--screenshot-if-changed`. The JSON result contains each action's command, success state, and result; `completed`; the final `url`; and requested `snapshot` or `screenshot` objects. It stops after the first failed or confirmation-requiring action. Nested `act` and `batch` commands are rejected. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
+`act` runs quoted commands in order, then observes once. Options: `--wait <load|domcontentloaded|networkidle>`, `--observe <full|delta>`, and `--screenshot-if-changed`. JSON includes individual action results, `completed`, and, on completion, the final `url` and requested observations. Execution stops on failure or required confirmation; completed actions are not rolled back. Nested `act` and `batch` commands are rejected. Requested observation policies are checked before actions begin.
 
 ## Snapshot (page analysis)
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -46,7 +46,7 @@ agent-browser batch \
 agent-browser act 'fill @e1 "pete@example.com"' 'click @e2' --wait networkidle --observe delta --screenshot-if-changed --json
 ```
 
-`act` sends one daemon request, executes quoted commands serially, and observes once at the end. Options are `--wait <load|domcontentloaded|networkidle>`, `--observe <full|delta>`, and `--screenshot-if-changed`. The JSON result contains each action's command, success state, and result; `completed`; the final `url`; and requested `snapshot` or `screenshot` objects. It stops after the first failed or confirmation-requiring action. Nested `act` and `batch` commands are rejected.
+`act` sends one daemon request, executes quoted commands serially, and observes once at the end. Options are `--wait <load|domcontentloaded|networkidle>`, `--observe <full|delta>`, and `--screenshot-if-changed`. The JSON result contains each action's command, success state, and result; `completed`; the final `url`; and requested `snapshot` or `screenshot` objects. It stops after the first failed or confirmation-requiring action. Nested `act` and `batch` commands are rejected. Final observation policies are checked before actions begin. Plain output includes the requested tree or delta, screenshot path, and individual failure details.
 
 ## Snapshot (page analysis)
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -40,6 +40,14 @@ agent-browser batch \
 
 `open` with no URL gives you a clean launch so any interception, cookies, or init scripts you register take effect on the *first* real navigation. Use for SSR-only debug (`--resource-type script`), protected-origin auth, or capturing fresh `react suspense`/`vitals` state without noise from a prior page.
 
+### Action and observation batch
+
+```bash
+agent-browser act 'fill @e1 "pete@example.com"' 'click @e2' --wait networkidle --observe delta --screenshot-if-changed --json
+```
+
+`act` sends one daemon request, executes quoted commands serially, and observes once at the end. Options are `--wait <load|domcontentloaded|networkidle>`, `--observe <full|delta>`, and `--screenshot-if-changed`. The JSON result contains each action's command, success state, and result; `completed`; the final `url`; and requested `snapshot` or `screenshot` objects. It stops after the first failed or confirmation-requiring action. Nested `act` and `batch` commands are rejected.
+
 ## Snapshot (page analysis)
 
 ```bash


### PR DESCRIPTION
## Summary

- add an `act` command that executes quoted actions through one daemon request
- preserve individual action results and stop after the first unsuccessful action
- support a final load-state wait, full or incremental snapshot observation, and conditional screenshot
- add a typed MCP tool with the same parser semantics
- document the workflow across CLI help, README, core skill, and docs site

## Tests

- `cd cli && cargo test -- --test-threads=1`
- `cd cli && cargo test e2e_act_executes_actions_and_observes_once -- --ignored --test-threads=1`
- `cd cli && cargo clippy -- -D warnings`
- `cd cli && cargo fmt -- --check`