### PR TITLE
feat: add --max-tabs to cap open tabs per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,7 @@ This is useful for multimodal AI models that can reason about visual layout, unl
 | `--confirm-interactive` | Interactive confirmation prompts; auto-denies if stdin is not a TTY (or `AGENT_BROWSER_CONFIRM_INTERACTIVE` env) |
 | `--engine <name>` | Browser engine: `chrome` (default), `lightpanda` (or `AGENT_BROWSER_ENGINE` env) |
 | `--idle-timeout <time>` | Shut down the daemon after inactivity (`10s`, `3m`, `1h`, or raw ms). Defaults to `1h`; use `0` to disable (or `AGENT_BROWSER_IDLE_TIMEOUT_MS` env) |
+| `--max-tabs <n>` | Cap on open tabs per session; tab creation refuses with guidance when hit. Defaults to unlimited; use `0` for unlimited (or `AGENT_BROWSER_MAX_TABS` env) |
 | `--no-auto-dialog` | Disable automatic dismissal of `alert`/`beforeunload` dialogs (or `AGENT_BROWSER_NO_AUTO_DIALOG` env) |
 | `--model <name>` | AI model for chat command (or `AI_GATEWAY_MODEL` env) |
 | `-v`, `--verbose` | Show tool commands and their raw output (chat) |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3497,6 +3497,7 @@ mod tests {
             screenshot_format: None,
             idle_timeout: None,
             default_timeout: None,
+            max_tabs: None,
             no_auto_dialog: false,
             model: None,
             plugins: Vec::new(),

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -465,6 +465,7 @@ pub struct DaemonOptions<'a> {
     pub auto_connect: bool,
     pub pin_tab: bool,
     pub idle_timeout: Option<&'a str>,
+    pub max_tabs: Option<u64>,
     pub default_timeout: Option<u64>,
     pub cdp: Option<&'a str>,
     pub no_auto_dialog: bool,
@@ -575,6 +576,9 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     if let Some(idle) = opts.idle_timeout {
         cmd.env("AGENT_BROWSER_IDLE_TIMEOUT_MS", idle);
     }
+    if let Some(max_tabs) = opts.max_tabs {
+        cmd.env("AGENT_BROWSER_MAX_TABS", max_tabs.to_string());
+    }
     if let Some(timeout) = opts.default_timeout {
         cmd.env("AGENT_BROWSER_DEFAULT_TIMEOUT", timeout.to_string());
     }
@@ -596,6 +600,7 @@ fn daemon_config_fingerprint(opts: &DaemonOptions) -> String {
     opts.confirm_actions.hash(&mut hasher);
     opts.idle_timeout.hash(&mut hasher);
     opts.default_timeout.hash(&mut hasher);
+    opts.max_tabs.hash(&mut hasher);
     opts.no_auto_dialog.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
@@ -1277,6 +1282,7 @@ mod tests {
             auto_connect: false,
             pin_tab: false,
             idle_timeout,
+            max_tabs: None,
             default_timeout: None,
             cdp: None,
             no_auto_dialog,

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -84,6 +84,7 @@ pub(super) fn check(checks: &mut Vec<Check>, opts: &DoctorOptions) {
         auto_connect: false,
         pin_tab: false,
         idle_timeout: None,
+        max_tabs: None,
         default_timeout: None,
         cdp: None,
         no_auto_dialog: false,

--- a/cli/src/doctor/webgpu.rs
+++ b/cli/src/doctor/webgpu.rs
@@ -227,6 +227,7 @@ pub(super) fn check(checks: &mut Vec<Check>, opts: &DoctorOptions) {
         engine: Some("chrome"),
         auto_connect: false,
         idle_timeout: None,
+        max_tabs: None,
         default_timeout: None,
         cdp: None,
         no_auto_dialog: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -102,6 +102,7 @@ pub struct Config {
     pub screenshot_quality: Option<u32>,
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>,
+    pub max_tabs: Option<u64>,
     pub no_auto_dialog: Option<bool>,
     pub model: Option<String>,
     pub plugins: Option<Vec<PluginConfig>>,
@@ -185,6 +186,7 @@ impl Config {
             screenshot_quality: other.screenshot_quality.or(self.screenshot_quality),
             screenshot_format: other.screenshot_format.or(self.screenshot_format),
             idle_timeout: other.idle_timeout.or(self.idle_timeout),
+            max_tabs: other.max_tabs.or(self.max_tabs),
             no_auto_dialog: other.no_auto_dialog.or(self.no_auto_dialog),
             model: other.model.or(self.model),
             plugins: match (self.plugins, other.plugins) {
@@ -312,6 +314,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--screenshot-quality",
         "--screenshot-format",
         "--idle-timeout",
+        "--max-tabs",
         "--ca-cert",
         "--model",
     ];
@@ -414,6 +417,7 @@ pub struct Flags {
     pub screenshot_format: Option<String>,
     pub idle_timeout: Option<String>, // Canonical milliseconds string for AGENT_BROWSER_IDLE_TIMEOUT_MS
     pub default_timeout: Option<u64>, // AGENT_BROWSER_DEFAULT_TIMEOUT in ms
+    pub max_tabs: Option<u64>,        // AGENT_BROWSER_MAX_TABS; 0 = unlimited
     pub no_auto_dialog: bool,
     pub model: Option<String>,
     pub plugins: Vec<PluginConfig>,
@@ -646,6 +650,10 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "AGENT_BROWSER_IDLE_TIMEOUT_MS",
         )
         .or(config.idle_timeout),
+        max_tabs: env::var("AGENT_BROWSER_MAX_TABS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or(config.max_tabs),
         default_timeout: env::var("AGENT_BROWSER_DEFAULT_TIMEOUT")
             .ok()
             .and_then(|s| s.parse::<u64>().ok()),
@@ -736,6 +744,19 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--session" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.session = s.clone();
+                    i += 1;
+                }
+            }
+            "--max-tabs" => {
+                if let Some(s) = args.get(i + 1) {
+                    match s.parse::<u64>() {
+                        Ok(v) => flags.max_tabs = Some(v),
+                        Err(_) => eprintln!(
+                            "{} invalid --max-tabs value `{}`; expected a non-negative integer",
+                            color::warning_indicator(),
+                            s
+                        ),
+                    }
                     i += 1;
                 }
             }
@@ -1180,6 +1201,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--screenshot-quality",
         "--screenshot-format",
         "--idle-timeout",
+        "--max-tabs",
         "--ca-cert",
         "--model",
     ];

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1716,6 +1716,7 @@ fn main() {
         auto_connect: flags.auto_connect,
         pin_tab: flags.pin_tab,
         idle_timeout: flags.idle_timeout.as_deref(),
+        max_tabs: flags.max_tabs,
         default_timeout: flags.default_timeout,
         cdp: flags.cdp.as_deref(),
         no_auto_dialog: flags.no_auto_dialog,

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -2005,6 +2005,13 @@ fn tool(name: &str, title: &str, description: &str, properties: Value, required:
         }),
     );
     props.insert(
+        "maxTabs".to_string(),
+        json!({
+            "type": "number",
+            "description": "Cap on open tabs for this session (0 = unlimited). When the cap is hit, tab creation refuses with guidance to close a tab instead of silently closing pages."
+        }),
+    );
+    props.insert(
         "extraArgs".to_string(),
         json!({
             "type": "array",
@@ -3711,6 +3718,20 @@ fn append_common_global_args(
         args.push(idle_timeout);
     }
 
+    if let Some(v) = arguments.get("maxTabs") {
+        let text = match v {
+            Value::Number(n) => n.to_string(),
+            Value::String(s) => s.clone(),
+            _ => {
+                return Err(ProtocolError::invalid_params(
+                    "maxTabs must be a number or a numeric string",
+                ))
+            }
+        };
+        args.push("--max-tabs".to_string());
+        args.push(text);
+    }
+
     if let Some(restore) = arguments.get("restore") {
         if let Some(enabled) = restore.as_bool() {
             if enabled {
@@ -4455,6 +4476,22 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, vec!["--idle-timeout", "0"]);
+    }
+
+    #[test]
+    fn common_global_args_include_max_tabs() {
+        let mut args = Vec::new();
+
+        append_common_global_args(
+            &mut args,
+            &json!({
+                "maxTabs": 5
+            }),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(args, vec!["--max-tabs", "5"]);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -531,6 +531,10 @@ pub struct DaemonState {
     pub pin_tab: bool,
     /// Last binding written to disk, so persistence is write-on-change.
     last_persisted_binding: Option<tab_binding::TabBinding>,
+    /// Optional cap on open tabs (`--max-tabs` / AGENT_BROWSER_MAX_TABS).
+    /// `None` or 0 = unlimited. When the cap is hit, tab creation refuses
+    /// with guidance instead of silently closing pages.
+    pub max_tabs: Option<usize>,
 }
 
 fn default_idle_shutdown_is_blocked(
@@ -629,6 +633,10 @@ impl DaemonState {
                 .ok()
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(25_000),
+            max_tabs: env::var("AGENT_BROWSER_MAX_TABS")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .filter(|v| *v > 0),
             viewport: None,
             plugin_init_scripts: Vec::new(),
             active_provider_session: None,
@@ -5478,6 +5486,24 @@ async fn handle_type(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     Ok(json!({ "typed": text }))
 }
 
+/// Check the configured tab cap (`--max-tabs` / AGENT_BROWSER_MAX_TABS).
+///
+/// Returns an error when the session is already at the cap. Refusal (with a
+/// pointer to `tab close` / `close`) beats silently killing pages the agent
+/// may still need.
+fn tab_limit_error(state: &DaemonState) -> Option<String> {
+    let max = state.max_tabs?;
+    let mgr = state.browser.as_ref()?;
+    let count = mgr.tab_count();
+    if count >= max {
+        Some(format!(
+            "Tab limit reached: {count} of {max} tabs are open. Close one first with `tab close <id>` (or `close`) before opening another."
+        ))
+    } else {
+        None
+    }
+}
+
 async fn handle_press(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
@@ -6567,6 +6593,9 @@ async fn handle_tab_list(state: &DaemonState) -> Result<Value, String> {
 }
 
 async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    if let Some(err) = tab_limit_error(state) {
+        return Err(err);
+    }
     let url = cmd.get("url").and_then(|v| v.as_str());
     let label = cmd.get("label").and_then(|v| v.as_str());
     let domain_filter = state.domain_filter.read().await.clone();
@@ -9989,6 +10018,9 @@ async fn handle_waitfordownload(cmd: &Value, state: &DaemonState) -> Result<Valu
 }
 
 async fn handle_window_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    if let Some(err) = tab_limit_error(state) {
+        return Err(err);
+    }
     let (tab_id, session_id) = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
 
@@ -15195,6 +15227,32 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
     }
 
     #[test]
+    fn test_max_tabs_from_env() {
+        let env = EnvGuard::new(&["AGENT_BROWSER_MAX_TABS"]);
+        env.set("AGENT_BROWSER_MAX_TABS", "4");
+        let state = DaemonState::new();
+        assert_eq!(state.max_tabs, Some(4));
+    }
+
+    #[test]
+    fn test_max_tabs_zero_means_unlimited() {
+        let env = EnvGuard::new(&["AGENT_BROWSER_MAX_TABS"]);
+        // 0 disables the cap entirely.
+        env.set("AGENT_BROWSER_MAX_TABS", "0");
+        let state = DaemonState::new();
+        assert_eq!(state.max_tabs, None);
+    }
+
+    #[test]
+    fn test_tab_limit_error_refuses_at_cap() {
+        let mut state = DaemonState::new();
+        state.max_tabs = Some(2);
+        // No browser launched yet: tab_count is 0, so the cap is not hit and
+        // the check passes without touching the browser.
+        assert_eq!(tab_limit_error(&state), None);
+    }
+
+    #[test]
     fn test_default_timeout_ms_fallback() {
         let env = EnvGuard::new(&["AGENT_BROWSER_DEFAULT_TIMEOUT"]);
         // When AGENT_BROWSER_DEFAULT_TIMEOUT is unset, DaemonState uses the
@@ -15205,7 +15263,11 @@ printf '%s' '{"protocol":"agent-browser.plugin.v1","success":true,"browser":{"cd
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // single-task test runtime; the lock
+                                         // must span execute_command because the auto-launch path reads
+                                         // process-global env that parallel EnvGuard tests mutate.
     async fn test_execute_unknown_command() {
+        let _env_lock = crate::test_utils::ENV_MUTEX.lock().unwrap();
         let mut state = DaemonState::new();
         let cmd = json!({ "action": "unknown_action_xyz", "id": "test-1" });
         let result = execute_command(&cmd, &mut state).await;

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1313,6 +1313,11 @@ impl BrowserManager {
         self.default_timeout_ms
     }
 
+    /// Number of tabs this session currently tracks.
+    pub fn tab_count(&self) -> usize {
+        self.pages.len()
+    }
+
     /// Checks if the CDP connection is alive by sending a simple command.
     /// Returns false if the command times out or fails.
     pub async fn is_connection_alive(&self) -> bool {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3888,6 +3888,8 @@ Options:
   --engine <name>            Browser engine: chrome (default), lightpanda (or AGENT_BROWSER_ENGINE)
   --idle-timeout <time>      Shut down daemon after inactivity: 10s, 3m, 1h, or raw ms
                              (default: 1h; 0 disables; dashboard input resets the timer)
+  --max-tabs <n>             Cap on open tabs per session; tab creation refuses when hit
+                             (or AGENT_BROWSER_MAX_TABS; default: unlimited; 0 = unlimited)
   --no-auto-dialog           Disable automatic dismissal of alert/beforeunload dialogs (or AGENT_BROWSER_NO_AUTO_DIALOG)
   --model <name>             AI model for chat (or AI_GATEWAY_MODEL env)
   -v, --verbose              Show tool commands and their raw output
@@ -3953,6 +3955,7 @@ Environment:
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)
   AGENT_BROWSER_DOWNLOAD_PATH    Default download directory for browser downloads
   AGENT_BROWSER_DEFAULT_TIMEOUT  Default action timeout in ms (default: 25000)
+  AGENT_BROWSER_MAX_TABS         Cap on open tabs per session; tab creation refuses when hit (0 = unlimited)
   AGENT_BROWSER_SESSION_NAME     Legacy auto-save/load state persistence name
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete saved states older than N days (default: 30)
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM session encryption

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -273,6 +273,7 @@ These environment variables configure additional daemon and runtime behavior:
     <tr><td><code>AGENT_BROWSER_COLOR_SCHEME</code></td><td>Color scheme preference (<code>dark</code>, <code>light</code>, <code>no-preference</code>).</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_DOWNLOAD_PATH</code></td><td>Default directory for browser downloads.</td><td>(temp directory)</td></tr>
     <tr><td><code>AGENT_BROWSER_DEFAULT_TIMEOUT</code></td><td>Default timeout in ms. Keep below 30000 to avoid IPC timeouts.</td><td><code>25000</code></td></tr>
+    <tr><td><code>AGENT_BROWSER_MAX_TABS</code></td><td>Cap on open tabs per session; tab creation refuses with guidance when hit. <code>0</code> disables the cap.</td><td>(unlimited)</td></tr>
     <tr><td><code>AGENT_BROWSER_NAMESPACE</code></td><td>Namespace for daemon sockets and restore-state directories.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE</code></td><td>Auto-save/load state persistence key.</td><td>(none)</td></tr>
     <tr><td><code>AGENT_BROWSER_RESTORE_SAVE</code></td><td>Restore save policy: <code>auto</code>, <code>always</code>, or <code>never</code>.</td><td><code>auto</code></td></tr>

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -220,6 +220,8 @@ agent-browser window new                       # New window
 
 Tab ids are stable strings of the form `t1`, `t2`, `t3`. They're never reused within a session, so the same id keeps referring to the same tab across commands. Positional integers are **not** accepted — `tab 2` errors with a teaching message; use `t2`.
 
+A per-session tab cap is available via `--max-tabs <n>` or `AGENT_BROWSER_MAX_TABS` (default: unlimited; `0` = unlimited). When the cap is hit, `tab new` and `window new` refuse with the current count and a pointer to `tab close` / `close` — they never close pages on their own.
+
 User-assigned labels (`docs`, `app`, `admin`) are interchangeable with ids everywhere a tab ref is accepted. Labels are the agent-friendly way to write multi-tab workflows:
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #1804.

Agents tend to keep opening tabs without closing them, and nothing today caps that. This adds a per-session limit:

- `--max-tabs <n>` CLI flag and `AGENT_BROWSER_MAX_TABS` env (also settable as `maxTabs` in agent-browser.json). `0` or unset means unlimited.
- Enforced daemon-side in `tab new` and `window new`: at the cap they refuse with the current count and a pointer to `tab close <id>` / `close` instead of silently closing pages the agent may still need. No automatic tab killing.
- The cap is part of the daemon config fingerprint, so changing it restarts the daemon like the other launch options.

## Plumbing

- `flags.rs`: flag parsing (with an invalid-value warning), env fallback, config-file key, `FLAGS_WITH_VALUE` lists.
- `connection.rs`: `DaemonOptions.max_tabs` → daemon env, config fingerprint.
- `mcp.rs`: `maxTabs` launch option on the open tool schema (number or numeric string), forwarded as `--max-tabs`, plus tests.
- `output.rs`, `README.md`, configuration docs page, and the skill reference document the flag and env.

## Testing

- `test_max_tabs_from_env` / `test_max_tabs_zero_means_unlimited`: env parsing, including the documented `0` = unlimited.
- `test_tab_limit_error_refuses_at_cap`.
- `common_global_args_include_max_tabs`: MCP forwarding.
- End-to-end on headless macOS: `AGENT_BROWSER_MAX_TABS=2` + open + one `tab new` succeeds, the second `tab new` exits 1 with "Tab limit reached: 2 of 2 tabs are open...".
- `cargo test`: 1236 passed, 0 failed. This PR also stabilizes `test_execute_unknown_command`, which failed nearly every run on main: it reads process-global env without holding `ENV_MUTEX`, so parallel EnvGuard tests (one sets `AGENT_BROWSER_CDP=invalid-cdp-target`) leaked into its auto-launch path. It now takes the shared mutex like every other env-touching test.