### PR TITLE
Prepare v0.37.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,29 @@
 # agent-browser
 
-## 0.36.0
+## 0.37.0
 
 <!-- release:start -->
+### New Features
+
+- Added **higher-quality video recording**: `record start` and `record restart` now capture the current active page at 30 fps by default, support `--fps 1-60`, use `Page.startScreencast` for smoother motion, and preserve wall-clock timing. WebM and MP4 output are documented, and `doctor` reports the ffmpeg recording dependencies (#1763, #1776, #1778)
+- Added **WebMCP availability output** so navigation responses advertise when a page exposes allowed WebMCP tools, including availability metadata for CLI, JSON, and MCP clients (#1760)
+- Added **session setup inheritance for new tabs**. Tabs opened with `tab new` or through page clicks now inherit the active session's headers, credentials, user agent, locale, timezone, geolocation, offline mode, routes, color scheme, and init scripts before their first navigation (#1777)
+
+### Bug Fixes
+
+- Fixed **recording startup validation** so missing ffmpeg, extensionless output paths, and invalid recording options fail before browser or recording state changes. Failed replacements preserve the active take, and ffmpeg errors now include useful diagnostics (#1778)
+- Fixed **recording navigation state** so URL navigation during recording clears stale element refs, frame scope, and page WebMCP state like normal navigation (#1776)
+
+### Contributors
+
+- @jamesvclements
+- @ctate
+- @Railly
+
+<!-- release:end -->
+
+## 0.36.0
+
 ### New Features
 
 - Added experimental **WebMCP support** for discovering and invoking tools provided by the current page, including frame-aware tool selection, detached results, cancellation, bounded metadata and output handling, and an opt-in MCP tool profile. WebMCP is enabled by default for locally managed Chrome and can be disabled with `--no-webmcp` or `AGENT_BROWSER_NO_WEBMCP`.
@@ -23,8 +44,6 @@
 - @Railly
 - @anupamme
 - @arrufat
-
-<!-- release:end -->
 
 ## 0.35.2
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.37.0
+
+<p className="text-[#888] text-sm">September 7, 2026</p>
+
+### New Features
+
+- Added **higher-quality video recording**: `record start` and `record restart` now capture the current active page at 30 fps by default, support `--fps 1-60`, use `Page.startScreencast` for smoother motion, and preserve wall-clock timing. WebM and MP4 output are documented, and `doctor` reports the ffmpeg recording dependencies (#1763, #1776, #1778)
+- Added **WebMCP availability output** so navigation responses advertise when a page exposes allowed WebMCP tools, including availability metadata for CLI, JSON, and MCP clients (#1760)
+- Added **session setup inheritance for new tabs**. Tabs opened with `tab new` or through page clicks now inherit the active session's headers, credentials, user agent, locale, timezone, geolocation, offline mode, routes, color scheme, and init scripts before their first navigation (#1777)
+
+### Bug Fixes
+
+- Fixed **recording startup validation** so missing ffmpeg, extensionless output paths, and invalid recording options fail before browser or recording state changes. Failed replacements preserve the active take, and ffmpeg errors now include useful diagnostics (#1778)
+- Fixed **recording navigation state** so URL navigation during recording clears stale element refs, frame scope, and page WebMCP state like normal navigation (#1776)
+
+---
+
 ## v0.36.0
 
 <p className="text-[#888] text-sm">September 1, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.36.0";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.37.0";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bump all package, Cargo, and runtime versions to 0.37.0.
- Add release notes for improved recording, WebMCP navigation metadata, and session setup inheritance.
- Update the docs changelog and release metadata for publication.