### PR TITLE
docs: fix source installation steps for pnpm 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ agent-browser install  # Download Chrome from Chrome for Testing (first time onl
 
 Requires Node.js 24+, pnpm 11+, and Rust.
 
+Build the dashboard before the native binary so the CLI includes the dashboard assets.
+
 ```bash
 git clone https://github.com/vercel-labs/agent-browser
 cd agent-browser
 pnpm install
-pnpm build
+pnpm build:dashboard
 pnpm build:native   # Requires Rust (https://rustup.rs)
-pnpm link --global  # Makes agent-browser available globally
+pnpm add --global . # Makes agent-browser available globally
 agent-browser install
 ```
 

--- a/docs/src/app/installation/page.mdx
+++ b/docs/src/app/installation/page.mdx
@@ -47,14 +47,16 @@ Compiles from source (~2-3 min). Requires Node.js 24+, pnpm 11+, and the Rust to
 
 ## From source
 
+Requires Node.js 24+, pnpm 11+, and Rust. Build the dashboard before the native binary so the CLI includes the dashboard assets.
+
 ```bash
 git clone https://github.com/vercel-labs/agent-browser
 cd agent-browser
 pnpm install
-pnpm build
+pnpm build:dashboard
 pnpm build:native
-./bin/agent-browser install
-pnpm link --global
+pnpm add --global .
+agent-browser install
 ```
 
 ## Linux dependencies


### PR DESCRIPTION
The source installation instructions fail with the required pnpm 11: the root package has no `build` script, and `pnpm link --global` is no longer supported. The docs site also invokes a nonexistent `./bin/agent-browser` entry point.

Update both guides to build the dashboard before the native CLI, install the local package with `pnpm add --global .`, and then invoke `agent-browser install`. This includes the dashboard assets in the source-built binary and uses the registered CLI entry point. The docs site's source section also states the build prerequisites.

### Validation

Tested on macOS ARM64 with Node.js 24.15.0, pnpm 11.1.3, and Rust 1.98.1.

- Reproduced `pnpm build` and `pnpm link --global` failures with exit code 1.
- Passed dependency installation with the frozen lockfile, dashboard build, native release build, and `pnpm add --global .` using an isolated `PNPM_HOME`. Confirmed the installed entry point uses the source-built binary and the binary embeds the dashboard assets.
- Passed CLI version and installer-help checks, a local-page open/title/close smoke test using system Chrome, all 4 launcher tests, installation-page MDX compilation, and `git diff --check`.

The Chrome download itself was not rerun. Windows and Linux installation flows were not tested locally.
