### PR TITLE
Prepare v0.37.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # agent-browser
 
-## 0.37.0
+## 0.37.1
 
 <!-- release:start -->
+### Bug Fixes
+
+- Fixed **Windows headless Chrome desktop artifacts** by isolating owned headless Chrome on a private desktop and ensuring its process tree is cleaned up when the daemon exits or is forcibly terminated. Headed and externally connected browsers retain their existing desktop behavior (#1498, #1820)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.37.0
+
 ### New Features
 
 - Added **higher-quality video recording**: `record start` and `record restart` now capture the current active page at 30 fps by default, support `--fps 1-60`, use `Page.startScreencast` for smoother motion, and preserve wall-clock timing. WebM and MP4 output are documented, and `doctor` reports the ffmpeg recording dependencies (#1763, #1776, #1778)
@@ -19,8 +30,6 @@
 - @jamesvclements
 - @ctate
 - @Railly
-
-<!-- release:end -->
 
 ## 0.36.0
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-browser"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-browser"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/docs/src/app/changelog/page.mdx
+++ b/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.37.1
+
+<p className="text-[#888] text-sm">September 8, 2026</p>
+
+### Bug Fixes
+
+- Fixed **Windows headless Chrome desktop artifacts** by isolating owned headless Chrome on a private desktop and ensuring its process tree is cleaned up when the daemon exits or is forcibly terminated. Headed and externally connected browsers retain their existing desktop behavior (#1498, #1820)
+
+---
+
 ## v0.37.0
 
 <p className="text-[#888] text-sm">September 7, 2026</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "packageManager": "pnpm@11.1.3",

--- a/packages/@agent-browser/eve/package.json
+++ b/packages/@agent-browser/eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/eve",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "eve extension that gives agents a full browser automation tool set backed by agent-browser",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/package.json
+++ b/packages/@agent-browser/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-browser/sandbox",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Helpers for running agent-browser inside sandbox runtimes",
   "type": "module",
   "sideEffects": false,

--- a/packages/@agent-browser/sandbox/src/version.ts
+++ b/packages/@agent-browser/sandbox/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_BROWSER_SANDBOX_VERSION = "0.37.0";
+export const AGENT_BROWSER_SANDBOX_VERSION = "0.37.1";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bump package and CLI versions to 0.37.1.
- Document the Windows headless Chrome desktop artifacts fix.
- Sync the root and docs changelogs for the release.