### PR TITLE
fix(chrome): park Windows headless window offscreen to hide ghost

### DIFF
--- a/cli/src/native/cdp/chrome.rs
+++ b/cli/src/native/cdp/chrome.rs
@@ -517,6 +517,14 @@ fn build_chrome_args(options: &LaunchOptions) -> Result<ChromeArgs, String> {
         // missing or restricted (VMs, containers, some cloud machines)
         // while preserving WebGL support.  Playwright uses the same flag.
         args.push("--enable-unsafe-swiftshader".to_string());
+        // Windows headless mode still creates a real top-level window
+        // (hidden from the window manager, but DWM keeps compositing its
+        // surface), which shows up as a blank, unclosable box at the default
+        // (10,10) position on the user's desktop.  Park the window offscreen
+        // so the ghost can never appear; other platforms have no window in
+        // headless mode and ignore the flag.  User-supplied positioning is
+        // appended later in `args` and wins ("later switches win").
+        args.push("--window-position=-32000,-32000".to_string());
     }
 
     if let Some(ref proxy) = options.proxy {
@@ -1910,6 +1918,12 @@ mod tests {
             .iter()
             .any(|a| a == "--enable-unsafe-swiftshader"));
         assert!(result.args.iter().any(|a| a == "--window-size=1280,720"));
+        // Windows headless still creates an (offscreen-parked) top-level window,
+        // so the offscreen position is part of the default headless arg set.
+        assert!(result
+            .args
+            .iter()
+            .any(|a| a == "--window-position=-32000,-32000"));
         // Temp dir created when no profile
         assert!(result.temp_user_data_dir.is_some());
         let dir = result.temp_user_data_dir.unwrap();
@@ -1931,6 +1945,11 @@ mod tests {
             .iter()
             .any(|a| a == "--enable-unsafe-swiftshader"));
         assert!(!result.args.iter().any(|a| a.starts_with("--window-size=")));
+        // Offscreen parking is headless-only: headed windows must appear normally.
+        assert!(!result
+            .args
+            .iter()
+            .any(|a| a.starts_with("--window-position=")));
         // Temp dir created when no profile
         assert!(result.temp_user_data_dir.is_some());
         let dir = result.temp_user_data_dir.unwrap();
@@ -2007,6 +2026,32 @@ mod tests {
         let result = build_chrome_args(&opts).unwrap();
         assert!(!result.args.iter().any(|a| a == "--window-size=1280,720"));
         assert!(result.args.iter().any(|a| a == "--start-maximized"));
+        if let Some(ref dir) = result.temp_user_data_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn test_build_args_user_window_position_appears_after_offscreen_default() {
+        let opts = LaunchOptions {
+            headless: true,
+            args: vec!["--window-position=100,200".to_string()],
+            ..Default::default()
+        };
+        let result = build_chrome_args(&opts).unwrap();
+        let ours = result
+            .args
+            .iter()
+            .position(|a| a == "--window-position=-32000,-32000");
+        let theirs = result
+            .args
+            .iter()
+            .position(|a| a == "--window-position=100,200");
+        // The default is present but the user switch is appended later, so
+        // Chrome applies the user's position ("later switches win").
+        assert!(ours.is_some());
+        assert!(theirs.is_some());
+        assert!(ours.unwrap() < theirs.unwrap());
         if let Some(ref dir) = result.temp_user_data_dir {
             let _ = std::fs::remove_dir_all(dir);
         }


### PR DESCRIPTION
## Summary

On Windows, headless Chrome still creates a **real top-level window** — hidden from the window manager (`WS_VISIBLE` off), but DWM keeps compositing its surface. When agent-browser launches its bundled Chrome-for-Testing engine (`--headless=new`), that window renders as a **blank, unclosable 1280×720 box at the default (10,10) position** on the user's desktop. It has no taskbar entry, cannot be dragged or closed, is invisible to `EnumWindows`/`IsWindowVisible`-based tooling, and only disappears when the agent-browser process tree is killed.

Every headless engine launch on Windows (daemon pre-warm, session open, CDP attach fallback) leaves this ghost behind, which has caused recurring "unclosable white window" reports from Hermes Agent users whose browser tooling drives agent-browser on Windows.

## Fix

Add `--window-position=-32000,-32000` to the default **headless** launch args in `cli/src/native/cdp/chrome.rs`, so the window Chrome insists on creating is parked offscreen and can never appear on the user's desktop.

- Headless-only: headed launches (extensions, `--headed`) are untouched and windows appear normally.
- Other platforms have no window in headless mode and simply ignore the flag.
- User-supplied positioning is appended later in `args` and still wins (the file already relies on Chrome's "later switches win" behavior, e.g. for `--window-size`).

## Verification

- Empirical, on Windows 11 with the actual bundled engine (`chrome-150.0.7871.24`): launching with agent-browser's exact headless arg set plus `--window-position=-32000,-32000` produces a `Chrome_WidgetWin_1` at rect `(-32000,-32000,-30720,-31280)` — offscreen — and **no ghost box appears** on screen. Without the flag the same launch ghosts at `(10,10)`. (The ghost follows the window handle if moved via `SetWindowPos` and dies with the process tree, confirming it is this window.)
- Unit tests updated: headless args include the offscreen position; headed args never do; a user-supplied `--window-position` appears after the default so it wins.
- Note: local `cargo test` was not run — the author's Windows box has no Rust/MSVC toolchain. The change is an 8-line arg addition; tests mirror existing patterns in the same module and will run in CI.

## Notes

- `AGENT_BROWSER_ARGS` cannot carry this fix for end users: agent-browser splits that env var on commas, mangling `--window-position=-32000,-32000` into two invalid args.
- `--no-startup-window` does **not** help: the ghost window is created by the CDP open target, not the startup window.
