### PR TITLE
[cli] diff snapshot: compare against the last snapshot without --baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ agent-browser diff url https://v1.com https://v2.com --wait-until networkidle  #
 agent-browser diff url https://v1.com https://v2.com --selector "#main"  # Scope to element
 ```
 
+Without `--baseline`, `diff snapshot` compares against the most recent `snapshot` taken in the session. If no snapshot has been taken yet, it fails with guidance instead of reporting the whole page as additions.
+
 ### Debug
 
 ```bash

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
@@ -6662,6 +6663,8 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
 
     let baseline = cmd.get("baseline").and_then(|v| v.as_str());
 
+    // Only a file baseline needs an owned allocation; the inline text and the
+    // stored last snapshot can be borrowed since diff_snapshots takes &str.
     let baseline_text = match baseline {
         Some(b) if std::path::Path::new(b).exists() => {
             let mut contents = std::fs::read_to_string(b)
@@ -6673,15 +6676,15 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
                     contents.pop();
                 }
             }
-            contents
+            Cow::Owned(contents)
         }
-        Some(b) => b.to_string(),
+        Some(b) => Cow::Borrowed(b),
         // Without --baseline the documented behavior is to compare against
         // the last snapshot taken in this session. Comparing against an
         // empty baseline instead would report every line as an addition.
-        None => state.last_snapshot.clone().ok_or_else(|| {
+        None => Cow::Borrowed(state.last_snapshot.as_deref().ok_or_else(|| {
             "No snapshot has been taken in this session yet. Run `snapshot` first, or pass --baseline with a saved snapshot file or text.".to_string()
-        })?,
+        })?),
     };
 
     let result = diff::diff_snapshots(&baseline_text, &current);

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -533,6 +533,11 @@ pub struct DaemonState {
     pub restore_validation_pending: bool,
     pub restore_save_status: String,
     pub restore_saved_path: Option<String>,
+    /// Text of the last successful `snapshot` command in this session.
+    /// Used by `diff snapshot` as the implicit baseline when `--baseline`
+    /// is not passed. Only the `snapshot` command updates this; internal
+    /// snapshot consumers (annotated screenshots, diffs) do not.
+    pub last_snapshot: Option<String>,
     /// When the most recent browser-touching command finished. Periodic
     /// autosaves wait for a quiet period after this so a multi-second save
     /// never lands in the middle of an active command burst.
@@ -685,6 +690,7 @@ impl DaemonState {
             restore_validation_pending: false,
             restore_save_status: "not_attempted".to_string(),
             restore_saved_path: None,
+            last_snapshot: None,
             last_command_finished: None,
             last_autosave_attempt: None,
             session_id,
@@ -5474,6 +5480,10 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
 
     let url = mgr.get_url().await.unwrap_or_default();
 
+    // Retain the text so a later bare `diff snapshot` can use it as the
+    // implicit baseline ("the last snapshot taken in this session").
+    state.last_snapshot = Some(tree.clone());
+
     let refs: serde_json::Map<String, Value> = state
         .ref_map
         .entries_sorted()
@@ -6666,7 +6676,12 @@ async fn handle_diff_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Va
             contents
         }
         Some(b) => b.to_string(),
-        None => String::new(),
+        // Without --baseline the documented behavior is to compare against
+        // the last snapshot taken in this session. Comparing against an
+        // empty baseline instead would report every line as an addition.
+        None => state.last_snapshot.clone().ok_or_else(|| {
+            "No snapshot has been taken in this session yet. Run `snapshot` first, or pass --baseline with a saved snapshot file or text.".to_string()
+        })?,
     };
 
     let result = diff::diff_snapshots(&baseline_text, &current);

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -3827,6 +3827,19 @@ async fn e2e_diff_snapshot() {
     .await;
     assert_success(&resp);
 
+    // A bare diff before any snapshot has been taken must fail with
+    // guidance instead of silently comparing against an empty baseline.
+    let resp = execute_command(
+        &json!({ "id": "2b", "action": "diff_snapshot" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    assert!(resp["error"]
+        .as_str()
+        .unwrap()
+        .contains("No snapshot has been taken in this session"));
+
     // Take a snapshot and use it as baseline for diff
     let resp = execute_command(&json!({ "id": "3", "action": "snapshot" }), &mut state).await;
     assert_success(&resp);
@@ -3835,6 +3848,20 @@ async fn e2e_diff_snapshot() {
     let baseline_dir = tempfile::tempdir().unwrap();
     let baseline_path = baseline_dir.path().join("baseline.txt");
     std::fs::write(&baseline_path, format!("{}\n", baseline)).unwrap();
+
+    // A bare diff on an unchanged page compares against the stored last
+    // snapshot and must report no changes (not the whole page as additions).
+    let resp = execute_command(
+        &json!({ "id": "3b", "action": "diff_snapshot" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["changed"], false);
+    assert_eq!(data["additions"], 0);
+    assert_eq!(data["removals"], 0);
+    assert_eq!(data["diff"], "");
 
     // A failed diff must preserve the refs from the last successful snapshot.
     let resp = execute_command(
@@ -3898,6 +3925,22 @@ async fn e2e_diff_snapshot() {
     assert_eq!(
         data["changed"], true,
         "Diff should detect the button change"
+    );
+    assert_eq!(data["additions"], 1);
+    assert_eq!(data["removals"], 1);
+    assert!(data["diff"].as_str().unwrap().contains("Updated action"));
+
+    // A bare diff must also detect the change against the stored snapshot.
+    let resp = execute_command(
+        &json!({ "id": "9b", "action": "diff_snapshot" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(
+        data["changed"], true,
+        "Bare diff should detect the button change"
     );
     assert_eq!(data["additions"], 1);
     assert_eq!(data["removals"], 1);

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3317,6 +3317,7 @@ Snapshot Diff:
     -d, --depth <n>          Limit snapshot tree depth
 
   Without --baseline, compares against the last snapshot taken in this session.
+  Fails with guidance if no snapshot has been taken yet.
 
 Screenshot Diff:
 

--- a/docs/src/app/diffing/page.mdx
+++ b/docs/src/app/diffing/page.mdx
@@ -35,7 +35,7 @@ agent-browser diff snapshot --baseline before.txt
 agent-browser diff snapshot --selector "#main" --compact
 ```
 
-Without `--baseline`, the command automatically compares against the most recent snapshot taken in the current session. This is the primary use case for agents verifying that an action had the intended effect.
+Without `--baseline`, the command automatically compares against the most recent snapshot taken in the current session. This is the primary use case for agents verifying that an action had the intended effect. If no snapshot has been taken in the session yet, the command fails with guidance instead of reporting the whole page as additions.
 
 ### Options
 


### PR DESCRIPTION
## Problem

`agent-browser diff snapshot` without `--baseline` is documented in three places as comparing against the last snapshot taken in the session:

- `cli/src/output.rs`: "Without --baseline, compares against the last snapshot taken in this session."
- `README.md`: `agent-browser diff snapshot   # Compare current vs last snapshot`
- `docs/src/app/diffing/page.mdx`: "Without `--baseline`, the command automatically compares against the most recent snapshot taken in the current session."
- `cli/src/mcp.rs`: "Diff current snapshot against last or baseline."

The implementation instead defaulted the baseline to an empty string, so the bare form compared the current page against nothing and reported every line as an addition. A bare diff on an unchanged page was strictly more verbose than `snapshot` itself and silently reported "6 additions, 0 removals" where nothing changed (#1755).

## Fix

- `DaemonState` gains a `last_snapshot: Option<String>` holding the text of the last successful `snapshot` command in the session.
- `handle_diff_snapshot` uses that stored text as the baseline when `--baseline` is absent.
- When no snapshot has been taken yet, the command fails with guidance ("No snapshot has been taken in this session yet. Run `snapshot` first, or pass `--baseline` with a saved snapshot file or text.") instead of silently diffing against an empty page. This keeps the silent failure mode the issue reported from coming back through the side door.

## Decisions

- Only the `snapshot` command updates the stored text. Internal snapshot consumers (annotated screenshots, diff snapshots themselves) do not, so the stored value always reflects what the user last saw from `snapshot`.
- The stored text is exactly what the CLI prints, so a bare diff and a `--baseline <saved snapshot output>` diff are interchangeable for the same point in time.
- The MCP tool delegates through the same CLI parser and daemon command, so both surfaces stay aligned; its existing description ("Diff current snapshot against last or baseline") becomes accurate with no MCP-side change.
- One daemon instance exists per session, so "last snapshot in this session" maps directly onto per-daemon state.

## Testing

- `cargo fmt -- --check` clean; `cargo clippy -- -D warnings` (CI settings) clean.
- All 1270 unit tests pass.
- `e2e_diff_snapshot` extended with three new assertions, run against real headless Chrome:
  - bare diff before any snapshot fails with the guidance error
  - bare diff on an unchanged page reports no changes (the previously broken case)
  - bare diff after modifying the page reports 1 addition / 1 removal against the stored snapshot
- All snapshot-related e2e tests pass (`e2e_diff_url_aligns_refs_after_snapshot`, `e2e_snapshot_and_click_ref`, `e2e_snapshot_continuous_static_text`, `e2e_snapshot_cursor_*`).
- Manually reproduced the scenario from the issue through the real CLI/daemon path: `open` -> `snapshot` -> bare `diff snapshot` now reports `No changes detected` where it previously printed the whole page as additions.

Fixes #1755