### PR TITLE
fix(snapshot): treat presentational iframes as iframes so hosted card fields get refs

### DIFF
--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -27,7 +27,16 @@ const INTERACTIVE_ROLES: &[&str] = &[
     "tab",
     "treeitem",
     "Iframe",
+    // Chrome reports <iframe role="presentation"> as IframePresentational.
+    // Hosted payment fields (Stripe Elements among them) mark their frames
+    // that way, so the frame needs a ref and a child snapshot like any other.
+    "IframePresentational",
 ];
+
+/// Both accessibility roles Chrome uses for an <iframe> element.
+fn is_iframe_role(role: &str) -> bool {
+    role == "Iframe" || role == "IframePresentational"
+}
 
 const CONTENT_ROLES: &[&str] = &[
     "heading",
@@ -509,7 +518,7 @@ pub async fn take_snapshot(
     if frame_id.is_none() {
         let mut iframe_snapshots: Vec<(String, String)> = Vec::new(); // (ref_id, child_snapshot)
         for node in tree_nodes.iter() {
-            if node.role != "Iframe" || !node.has_ref {
+            if !is_iframe_role(&node.role) || !node.has_ref {
                 continue;
             }
             let Some(bid) = node.backend_node_id else {
@@ -1099,7 +1108,9 @@ fn render_tree(
         }
     }
 
-    let role = &node.role;
+    // Agents read one role for every frame; the presentational variant is
+    // still an iframe to them.
+    let role = if node.role == "IframePresentational" { "Iframe" } else { node.role.as_str() };
 
     // Skip root WebArea wrapper
     if role == "RootWebArea" || role == "WebArea" {
@@ -1364,6 +1375,14 @@ mod tests {
         assert!(INTERACTIVE_ROLES.contains(&"button"));
         assert!(INTERACTIVE_ROLES.contains(&"textbox"));
         assert!(!INTERACTIVE_ROLES.contains(&"heading"));
+    }
+
+    #[test]
+    fn test_presentational_iframes_are_iframes() {
+        assert!(INTERACTIVE_ROLES.contains(&"IframePresentational"));
+        assert!(is_iframe_role("Iframe"));
+        assert!(is_iframe_role("IframePresentational"));
+        assert!(!is_iframe_role("generic"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Stripe Elements (and other hosted card fields) render their iframes with `role="presentation"`. Chrome reports such an element as `IframePresentational`, not `Iframe`. `take_snapshot` only assigns refs to `Iframe` nodes and only recurses into child frames for `Iframe` nodes with a ref, so a presentational frame gets no ref and its contents never appear. An agent sees this at a real Stripe Elements checkout (ronixwake.com, payment step), on 0.35.1 and on 0.37.1:

```
- Iframe [ref=e32]
- radio "Credit Card Visa Mastercard JCB Discover American Express" [checked=true, ref=e66]
- Iframe [ref=e69]
- button "Place Order" [ref=e60]
```

The full snapshot shows the card frame as `IframePresentational "Secure payment input frame"` with no ref. `frame` by CSS selector reports `Frame not found` for it, and `find label "Card number"` finds nothing, so there is no way to reach the card inputs. Related: #279, #925 (the cross-origin session attach from #949 works; the frame is simply never selected for recursion).

## Fix

Treat `IframePresentational` like `Iframe`: it receives a ref, the child-frame recursion includes it, and it renders as `Iframe` so agents keep reading one role for every frame.

## Verification

Built this branch and attached it to the same Chrome tab at the ronixwake.com payment step. Plain `snapshot -i`, no other change:

```
- Iframe [ref=e32]
- Iframe "Secure payment input frame" [ref=e70]
  - textbox "Card number" [required, ref=e77]
  - textbox "Expiration date" [required, ref=e73]
  - textbox "Security code" [required, ref=e78]
  - textbox "ZIP code" [required, ref=e80]
  - textbox "Email" [required, ref=e321]
  - textbox "Mobile number" [required, ref=e320]
- Iframe [ref=e69]
- button "Place Order" [ref=e60]
```

`fill @e77 4242424242424242` followed by `get value @e77` reads back `4242 4242 4242 4242`; expiry, security code, and ZIP behave the same. Unit tests: `test_presentational_iframes_are_iframes`, existing snapshot tests unchanged.

Not covered here, worth a follow-up: nested frames (recursion is still main-frame only) and a stale `frame @ref` scope after the page replaces that frame (every later snapshot fails with `CDP error (Accessibility.getFullAXTree): Frame with the given frameId is not found` until `frame main`).
