### PR TITLE
[cli] record: stop before the first frame reports "No frames captured"

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ agent-browser profiler start          # Start Chrome DevTools profiling
 agent-browser profiler stop [path]    # Stop and save profile (.json)
 agent-browser record start ./demo.webm           # Start video recording at 30 fps (.webm or .mp4; needs ffmpeg on PATH)
 agent-browser record start ./demo.webm --fps 60  # 60 fps for motion-heavy takes (1-60 allowed)
-agent-browser record stop                        # Stop and save the video
+agent-browser record stop                        # Stop and save the video (fails with "No frames captured" if stopped before the first frame)
 agent-browser record restart ./take2.webm        # Stop the current recording, start a new one
 agent-browser console                 # View console messages (log, error, warn, info)
 agent-browser console --json          # JSON output with raw CDP args for programmatic access

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1120,6 +1120,7 @@ impl DaemonState {
             client,
             capture_session,
             ffmpeg,
+            self.recording_state.output_path.clone(),
             self.recording_state.fps,
             shared_count.clone(),
             shared_captured.clone(),

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -7720,6 +7720,109 @@ async fn e2e_recording_default_records_active_page() {
     assert_success(&resp);
 }
 
+/// A stop issued right after start races the first screencast frame. When
+/// the cancel wins, ffmpeg reads an empty pipe and exits non-zero, and the
+/// recorder must surface its own "No frames captured" error instead of
+/// ffmpeg's stderr; when a frame lands first, the take is valid. Both
+/// outcomes are legal, an ffmpeg failure is not (#1780). The zero-frame
+/// teardown itself is covered deterministically by the teardown_result unit
+/// tests in recording.rs.
+#[tokio::test]
+#[ignore]
+async fn e2e_recording_stop_right_after_start() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": "data:text/html,<h1>Current</h1>" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let tmp_dir = std::env::temp_dir();
+    let rec_path = tmp_dir.join(format!("ab-e2e-rec-immediate-{}.webm", std::process::id()));
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // No sleep on purpose: the stop arrives before the first frame reaches
+    // the file, so ffmpeg sees an empty pipe.
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    let stopped_with_frames = resp
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if stopped_with_frames {
+        // The frame won the race; the take must be real, and the next
+        // start below still has to work.
+        assert!(
+            get_data(&resp)["frames"].as_u64().unwrap_or(0) > 0,
+            "a take written on immediate stop should have frames"
+        );
+    } else {
+        let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        assert_eq!(
+            err, "No frames captured",
+            "immediate stop must report the recorder's own error, got: {}",
+            err
+        );
+        assert!(!rec_path.exists(), "no take should be left behind");
+    }
+
+    // The stopped take must not block the next one.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "recording_start", "path": rec_path.to_string_lossy() }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(state.recording_state.active);
+
+    // Stop the second take too; the same contract applies.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "recording_stop" }),
+        &mut state,
+    )
+    .await;
+    if resp
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        assert!(
+            get_data(&resp)["frames"].as_u64().unwrap_or(0) > 0,
+            "a take written on immediate stop should have frames"
+        );
+    } else {
+        let err = resp.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        assert_eq!(
+            err, "No frames captured",
+            "immediate stop must report the recorder's own error, got: {}",
+            err
+        );
+        assert!(!rec_path.exists(), "no take should be left behind");
+    }
+
+    let _ = std::fs::remove_file(&rec_path);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// `recording_start` with a URL navigates the active
 /// tab to that URL before recording. No new tab is created.
 #[tokio::test]

--- a/cli/src/native/recording.rs
+++ b/cli/src/native/recording.rs
@@ -398,6 +398,7 @@ pub fn spawn_recording_task(
     client: Arc<CdpClient>,
     capture_session: String,
     mut ffmpeg: tokio::process::Child,
+    output_path: String,
     fps: u32,
     shared_count: Arc<AtomicU64>,
     shared_captured: Arc<AtomicU64>,
@@ -471,13 +472,31 @@ pub fn spawn_recording_task(
 
         capture?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("ffmpeg failed: {}", ffmpeg_error_tail(&stderr)));
-        }
-
-        Ok(())
+        teardown_result(&output_path, &output, shared_count.load(Ordering::Relaxed))
     })
+}
+
+/// Decide the capture task's outcome once ffmpeg has exited. A stop that
+/// lands before the first frame leaves ffmpeg reading an empty pipe, and
+/// it exits non-zero ("Output file does not contain any stream") even
+/// though nothing went wrong. That case is the recorder's to report via
+/// `recording_stop` ("No frames captured"), so the task returns Ok and
+/// drops whatever the failed muxer may have left on disk. Only a failure
+/// after frames were written is a real encoder failure.
+fn teardown_result(
+    output_path: &str,
+    output: &std::process::Output,
+    frames_written: u64,
+) -> Result<(), String> {
+    if frames_written == 0 {
+        let _ = std::fs::remove_file(output_path);
+        return Ok(());
+    }
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ffmpeg failed: {}", ffmpeg_error_tail(&stderr)));
+    }
+    Ok(())
 }
 
 /// Pump screencast frames into ffmpeg until cancelled, the page goes away, or
@@ -809,6 +828,76 @@ mod tests {
         let result = recording_stop(&mut state).unwrap();
         assert_eq!(result["frames"], 120);
         assert_eq!(result["fps"], 60);
+    }
+
+    #[cfg(unix)]
+    fn fake_output(raw_status: i32, stderr: &str) -> std::process::Output {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::Output {
+            status: std::process::ExitStatus::from_raw(raw_status),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    // ffmpeg exits non-zero on an empty pipe; with no frames written that is
+    // the recorder's "No frames captured" case, not an encoder failure.
+    #[cfg(unix)]
+    #[test]
+    fn test_teardown_zero_frames_ignores_ffmpeg_exit_and_removes_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("take.webm");
+        std::fs::write(&path, b"").unwrap();
+
+        let output = fake_output(0x0100, "Output file does not contain any stream\n");
+        let result = teardown_result(&path.to_string_lossy(), &output, 0);
+
+        assert!(
+            result.is_ok(),
+            "zero frames should not report ffmpeg: {:?}",
+            result
+        );
+        assert!(!path.exists(), "no take should be left on disk");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_teardown_zero_frames_with_successful_exit_still_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("take.webm");
+        std::fs::write(&path, b"").unwrap();
+
+        let output = fake_output(0, "");
+        let result = teardown_result(&path.to_string_lossy(), &output, 0);
+
+        assert!(result.is_ok());
+        assert!(!path.exists(), "an empty take is not a recording");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_teardown_frames_written_reports_ffmpeg_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("take.webm");
+
+        let output = fake_output(0x0100, "Error opening output files: Invalid argument\n");
+        let result = teardown_result(&path.to_string_lossy(), &output, 42);
+
+        let err = result.unwrap_err();
+        assert!(err.contains("ffmpeg failed"), "got: {}", err);
+        assert!(err.contains("Invalid argument"), "got: {}", err);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_teardown_frames_written_with_success_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("take.webm");
+
+        let output = fake_output(0, "");
+        let result = teardown_result(&path.to_string_lossy(), &output, 42);
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2816,6 +2816,8 @@ ffmpeg, or apt install ffmpeg). Run `agent-browser doctor` to check.
 Recording captures 30 fps, which keeps scrolls and CSS transitions smooth.
 Raise it to 60 for short, motion-heavy takes (drag interactions, animation
 work); lower it for long sessions where file size matters more than motion.
+A stop before the first frame is written fails with "No frames captured"
+and leaves no file behind.
 
 Operations:
   start <path> [url]     Start recording the active page (navigates first if url given)

--- a/docs/src/app/recording/page.mdx
+++ b/docs/src/app/recording/page.mdx
@@ -66,7 +66,7 @@ agent-browser record start ./soak.webm --fps 10
 
 Valid rates are 1 to 60. Frames come from Chrome's screencast, so every repaint up to the display rate is captured and a 60 fps take of a scroll holds 60 distinct pictures per second. While the page is static the last frame is held, so the file's duration matches wall clock; a gap longer than five seconds is held for five and the rest left out.
 
-`record stop` reports `frames` (written to the file) and `capturedFrames` (distinct frames the page produced). A static page shows a small `capturedFrames` against a full `frames` count; that is the hold working.
+`record stop` reports `frames` (written to the file) and `capturedFrames` (distinct frames the page produced). A static page shows a small `capturedFrames` against a full `frames` count; that is the hold working. A stop before the first frame is written fails with `No frames captured` and leaves no file behind.
 
 ## Commands
 

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -86,7 +86,7 @@ agent-browser record stop
 agent-browser record start ./soak.webm --fps 5
 ```
 
-Frames come from Chrome's screencast, so a 60 fps take of a scroll holds 60 distinct pictures per second. While the page is static the last frame is held, so duration matches wall clock; a gap longer than five seconds is held for five and the rest left out. `record stop --json` reports `frames` (written) and `capturedFrames` (distinct frames the page produced). 60 fps roughly doubles the bitrate of 30 fps.
+Frames come from Chrome's screencast, so a 60 fps take of a scroll holds 60 distinct pictures per second. While the page is static the last frame is held, so duration matches wall clock; a gap longer than five seconds is held for five and the rest left out. `record stop --json` reports `frames` (written) and `capturedFrames` (distinct frames the page produced). 60 fps roughly doubles the bitrate of 30 fps. A stop before the first frame is written fails with `No frames captured` and leaves no file behind.
 
 ## Use Cases
 


### PR DESCRIPTION
`record stop` right after `record start` races the first screencast frame. When the stop wins, ffmpeg has been reading an empty pipe, exits non-zero, and its stderr is what the daemon reported, instead of the "No frames captured" error `recording_stop` already had for exactly this case. Fixes #1780.

## Before / after

main:

```
$ agent-browser record start /tmp/take.webm
✓ Recording started: /tmp/take.webm (30 fps)
$ agent-browser record stop
✗ ffmpeg failed: Input #0, image2pipe, from 'pipe:0':
  Duration: N/A, bitrate: N/A
  Stream #0:0: Video: mjpeg, none(bt470bg/unknown/unknown), 30 fps, 30 tbr, 30 tbn
Output #0, webm, to '/tmp/take.webm':
[out#0/webm] Output file does not contain any stream
Error opening output file /tmp/take.webm.
Error opening output files: Invalid argument
```

this branch:

```
$ agent-browser record stop
✗ No frames captured
```

## What changed

The capture task's tail, after ffmpeg exits, now checks the written-frame counter before looking at ffmpeg's status. Zero frames written means the stop simply landed before the first tick: ffmpeg's non-zero exit is expected, so the task returns Ok and `recording_stop` reports its own error. Any output file the failed muxer managed to create is removed (the ffmpeg 7 and 8 builds I checked don't leave one, but that's not guaranteed across builds). With frames written, a non-zero exit is still a real encoder failure and is reported exactly as before, stderr tail included.

`spawn_recording_task` takes the output path so the teardown can do the cleanup. `recording_stop`, `handle_recording_stop`, and `record restart` are untouched; restart inherits the fix since it shares the same teardown path, and its zero-frame stop no longer masks whatever `recording_stop` would say either.

## Testing

- Four unit tests on the extracted teardown decision: zero frames + failed exit (Ok, file removed), zero frames + success (Ok, file removed), frames + failed exit (ffmpeg error kept), frames + success (Ok). Unix-gated, they fabricate exit statuses via `ExitStatusExt`.
- e2e `e2e_recording_stop_right_after_start`: start, immediate stop, then a second start to prove the failed take does not block the next one. Whether the first frame beats the cancel is a genuine microsecond race (Chrome acks `Page.startScreencast` and pushes the initial frame almost immediately), so the test asserts the outcome either way: a saved take must have frames, a failed stop must say "No frames captured", and ffmpeg's error must never appear. The zero-frame path itself is pinned deterministically by the unit tests.
- Recording e2e suite passes 9/9 locally against Chrome for Testing 153 and ffmpeg 7.1, full unit suite passes, `cargo fmt` and `cargo clippy -D warnings` are clean.