### PR TITLE
Clarify reliable browser wait strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,12 @@ agent-browser wait <selector>         # Wait for element to be visible
 agent-browser wait <ms>               # Wait for time (milliseconds)
 agent-browser wait --text "Welcome"   # Wait for text to appear (substring match)
 agent-browser wait --url "**/dash"    # Wait for URL pattern
-agent-browser wait --load networkidle # Wait for load state
+agent-browser wait --load domcontentloaded # Wait for the DOM lifecycle event
+agent-browser wait --load load        # Wait for the page load event
 agent-browser wait --fn "window.ready === true"  # Wait for JS condition
+
+# Use networkidle only when the page is known to become quiet
+agent-browser wait --load networkidle
 
 # Wait for text/element to disappear
 agent-browser wait --fn "!document.body.innerText.includes('Loading...')"
@@ -258,6 +262,8 @@ agent-browser wait "#spinner" --state hidden
 ```
 
 **Load states:** `load`, `domcontentloaded`, `networkidle`
+
+After a page change, prefer a selector, text, URL, or JavaScript condition that represents the state you need. Use `load` or `domcontentloaded` when the lifecycle event is the milestone. `networkidle` is supported for pages known to become quiet, but SSE, WebSockets, polling, and long-polling can keep it from resolving.
 
 ### Batch Execution
 
@@ -407,7 +413,7 @@ agent-browser diff screenshot --baseline b.png -o d.png  # Save diff image to cu
 agent-browser diff screenshot --baseline b.png -t 0.2    # Adjust color threshold (0-1)
 agent-browser diff url https://v1.com https://v2.com     # Compare two URLs (snapshot diff)
 agent-browser diff url https://v1.com https://v2.com --screenshot  # Also visual diff
-agent-browser diff url https://v1.com https://v2.com --wait-until networkidle  # Custom wait strategy
+agent-browser diff url https://v1.com https://v2.com --wait-until load  # Custom wait strategy
 agent-browser diff url https://v1.com https://v2.com --selector "#main"  # Scope to element
 ```
 
@@ -1287,13 +1293,13 @@ Commands can be chained with `&&` in a single shell invocation. The browser pers
 
 ```bash
 # Open, wait for load, and snapshot in one call
-agent-browser open example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+agent-browser open example.com && agent-browser wait --load domcontentloaded && agent-browser snapshot -i
 
 # Chain multiple interactions
 agent-browser fill @e1 "user@example.com" && agent-browser fill @e2 "pass" && agent-browser click @e3
 
 # Navigate and screenshot
-agent-browser open example.com && agent-browser wait --load networkidle && agent-browser screenshot page.png
+agent-browser open example.com && agent-browser wait --load load && agent-browser screenshot page.png
 ```
 
 Use `&&` when you don't need intermediate output. Run commands separately when you need to parse output first (e.g., snapshot to discover refs before interacting).

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2050,6 +2050,7 @@ Examples:
   agent-browser wait "#loading-spinner"
   agent-browser wait 2000
   agent-browser wait --url "**/dashboard"
+  # Use networkidle only for pages known to become quiet:
   agent-browser wait --load networkidle
   agent-browser wait --fn "window.appReady === true"
   agent-browser wait --text "Welcome back"

--- a/docs/src/app/commands/page.mdx
+++ b/docs/src/app/commands/page.mdx
@@ -129,12 +129,16 @@ agent-browser wait <selector>         # Wait for element
 agent-browser wait <ms>               # Wait for time
 agent-browser wait --text "Welcome"   # Wait for text (substring match)
 agent-browser wait --url "**/dash"    # Wait for URL pattern
-agent-browser wait --load networkidle # Wait for load state
+agent-browser wait --load domcontentloaded # Wait for DOMContentLoaded
+agent-browser wait --load load        # Wait for the load event
+agent-browser wait --load networkidle # Use only for pages known to become quiet
 agent-browser wait --fn "condition"   # Wait for JS condition
 agent-browser wait --download [path]  # Wait for download
 agent-browser wait --fn "!document.body.innerText.includes('Loading...')"  # Wait for text to disappear
 agent-browser wait "#spinner" --state hidden           # Wait for element to disappear
 ```
+
+After a page change, prefer a selector, text, URL, or JavaScript condition that represents the state you need. Use `networkidle` only when the page is known to become quiet, because SSE, WebSockets, polling, and long-polling can keep it from resolving.
 
 ## Downloads
 
@@ -716,9 +720,9 @@ Tool invocations use the same config files and environment variables as the CLI.
 Chain commands with `&&` in a single shell invocation. The browser persists via a background daemon, so chaining works naturally and is more efficient than separate calls:
 
 ```bash
-agent-browser open example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+agent-browser open example.com && agent-browser wait --load domcontentloaded && agent-browser snapshot -i
 agent-browser fill @e1 "user@example.com" && agent-browser fill @e2 "pass" && agent-browser click @e3
-agent-browser open example.com && agent-browser wait --load networkidle && agent-browser screenshot page.png
+agent-browser open example.com && agent-browser wait --load load && agent-browser screenshot page.png
 ```
 
 Use `&&` when you don't need to read intermediate output. Run commands separately when you need to parse output first (e.g., snapshot to discover refs, then interact with those refs).

--- a/docs/src/app/diffing/page.mdx
+++ b/docs/src/app/diffing/page.mdx
@@ -132,6 +132,8 @@ After completion, the browser remains on the second URL.
   </tbody>
 </table>
 
+The `--wait-until` option accepts only `load`, `domcontentloaded`, and `networkidle`; it cannot express an app-specific condition. If a page needs a selector, text, URL, or JavaScript condition, use separate `open` and `wait` commands, then compare the captured snapshots or screenshots instead of using `diff url`. `networkidle` is supported for quiet pages, but SSE, WebSockets, polling, and long-polling can keep it from resolving.
+
 ## Use cases
 
 ### Verifying agent actions

--- a/docs/src/app/quick-start/page.mdx
+++ b/docs/src/app/quick-start/page.mdx
@@ -56,10 +56,13 @@ agent-browser open example.com --headed
 
 ```bash
 agent-browser wait @e1                   # Wait for element
-agent-browser wait --load networkidle    # Wait for network idle
+agent-browser wait --text "Welcome"      # Wait for expected text
 agent-browser wait --url "**/dashboard"  # Wait for URL pattern
-agent-browser wait 2000                  # Wait milliseconds
+agent-browser wait --fn "window.appReady === true" # Wait for JS condition
+agent-browser wait --load domcontentloaded # Wait for the DOM lifecycle event
 ```
+
+After a page change, prefer the condition that represents the result you need. Use `load` or `domcontentloaded` only when the lifecycle event is the milestone. `networkidle` remains available for pages known to become quiet, but SSE, WebSockets, polling, and long-polling can keep it from resolving.
 
 ## Command chaining
 
@@ -67,13 +70,13 @@ Chain commands with `&&` in a single shell call. The browser persists via a back
 
 ```bash
 # Open, wait, and snapshot in one call
-agent-browser open example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+agent-browser open example.com && agent-browser wait --load domcontentloaded && agent-browser snapshot -i
 
 # Chain multiple interactions
 agent-browser fill @e1 "user@example.com" && agent-browser fill @e2 "pass" && agent-browser click @e3
 
 # Navigate and capture
-agent-browser open example.com && agent-browser wait --load networkidle && agent-browser screenshot page.png
+agent-browser open example.com && agent-browser wait --load load && agent-browser screenshot page.png
 ```
 
 Use `&&` when you don't need intermediate output. Run commands separately when you need to parse output first (e.g., snapshot to discover refs before interacting).

--- a/docs/src/app/react/page.mdx
+++ b/docs/src/app/react/page.mdx
@@ -56,7 +56,7 @@ By default, `vitals` prints a summary using the same fields as the structured `-
 
 ```bash
 agent-browser pushstate /dashboard
-agent-browser wait --load networkidle
+agent-browser wait --url "**/dashboard"
 agent-browser snapshot -i
 ```
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -50,7 +50,7 @@ agent-browser open https://duckduckgo.com
 agent-browser snapshot -i                      # find the search box ref
 agent-browser fill @e1 "agent-browser cli"
 agent-browser press Enter
-agent-browser wait --load networkidle
+agent-browser wait --text "agent-browser cli"
 agent-browser snapshot -i                      # refs now reflect results
 agent-browser click @e5                        # click a result
 agent-browser screenshot result.png
@@ -175,19 +175,24 @@ Agents fail more often from bad waits than from bad selectors. Pick the right wa
 
 ```bash
 agent-browser wait @e1                     # until an element appears
-agent-browser wait 2000                    # dumb wait, milliseconds (last resort)
 agent-browser wait --text "Success"        # until the text appears on the page
 agent-browser wait --url "**/dashboard"    # until URL matches pattern (glob)
-agent-browser wait --load networkidle      # until network idle (post-navigation)
-agent-browser wait --load domcontentloaded # until DOMContentLoaded
 agent-browser wait --fn "window.myApp.ready === true"  # until JS condition
+agent-browser wait --load domcontentloaded # until DOMContentLoaded
+agent-browser wait --load load             # until the page load event
+# Use networkidle only when the page is known to become quiet:
+agent-browser wait --load networkidle
+agent-browser wait 2000                    # fixed delay, last resort
 ```
 
 After any page-changing action, pick one:
 
 - Wait for a specific element you expect to appear: `wait @ref` or `wait --text "..."`.
 - Wait for URL change: `wait --url "**/new-page"`.
-- Wait for network idle (catch-all for SPA navigation): `wait --load networkidle`.
+- Wait for an application condition: `wait --fn "window.myApp.ready === true"`.
+- Use `wait --load load` or `wait --load domcontentloaded` when the lifecycle event itself is the milestone.
+
+Avoid using `networkidle` as a generic post-navigation or SPA wait. Server-sent events (SSE), WebSockets, polling, and long-polling can keep network activity alive indefinitely, causing the wait to time out even when the UI is ready. Use `networkidle` only for pages that are known to become quiet after navigation.
 
 Avoid bare `wait 2000` except when debugging — it makes scripts slow and flaky. Timeouts default to 25 seconds.
 

--- a/skill-data/core/references/authentication.md
+++ b/skill-data/core/references/authentication.md
@@ -126,7 +126,8 @@ agent-browser --session secure --restore open https://app.example.com
 ```bash
 # Navigate to login page
 agent-browser open https://app.example.com/login
-agent-browser wait --load networkidle
+agent-browser wait --load domcontentloaded
+agent-browser wait --fn "(() => { const usable = (el) => { const style = getComputedStyle(el); return !el.disabled && !el.readOnly && style.display !== 'none' && style.visibility !== 'hidden' && el.getClientRects().length > 0; }; const username = Array.from(document.querySelectorAll('input[type=email], input[type=text], input[autocomplete=username], input[name*=email i], input[name*=user i], input[name*=login i]')).some(usable); const password = Array.from(document.querySelectorAll('input[type=password]')).some(usable); return username && password; })()"
 
 # Get form elements
 agent-browser snapshot -i
@@ -138,11 +139,13 @@ agent-browser fill @e2 "password123"
 
 # Submit
 agent-browser click @e3
-agent-browser wait --load networkidle
+agent-browser wait --url "**/dashboard"
 
 # Verify login succeeded
 agent-browser get url  # Should be dashboard, not login
 ```
+
+After submitting, wait for the authenticated destination, a success message, or another app-specific condition. Do not use `networkidle` as a generic login wait because long-lived background connections can keep it from resolving.
 
 For a form reached through an in-page click, challenge clearance, consent dismissal, or another stateful step, use the auth vault without discarding the prepared document:
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -135,9 +135,13 @@ agent-browser wait @e1                     # Wait for element
 agent-browser wait 2000                    # Wait milliseconds
 agent-browser wait --text "Success"        # Wait for text (or -t)
 agent-browser wait --url "**/dashboard"    # Wait for URL pattern (or -u)
-agent-browser wait --load networkidle      # Wait for network idle (or -l)
+agent-browser wait --load domcontentloaded # Wait for DOMContentLoaded (or -l)
+agent-browser wait --load load             # Wait for the load event
+agent-browser wait --load networkidle      # Wait for network idle on known-quiet pages
 agent-browser wait --fn "window.ready"     # Wait for JS condition (or -f)
 ```
+
+After a page-changing action, prefer the selector, text, URL, or JavaScript condition that represents the result you need. Use a lifecycle wait when the lifecycle event is the milestone. `networkidle` is also supported, but use it only for pages known to become quiet because SSE, WebSockets, polling, and long-polling can keep it from resolving.
 
 ## Mouse Control
 

--- a/skill-data/core/references/profiling.md
+++ b/skill-data/core/references/profiling.md
@@ -63,7 +63,7 @@ Several `disabled-by-default-*` categories are also included for detailed timeli
 ```bash
 agent-browser profiler start
 agent-browser navigate https://app.example.com
-agent-browser wait --load networkidle
+agent-browser wait --load load
 agent-browser profiler stop ./page-load-profile.json
 ```
 
@@ -83,7 +83,7 @@ agent-browser profiler stop ./interaction-profile.json
 #!/bin/bash
 agent-browser profiler start
 agent-browser navigate https://app.example.com
-agent-browser wait --load networkidle
+agent-browser wait --load load
 agent-browser profiler stop "./profiles/build-${BUILD_ID}.json"
 ```
 

--- a/skill-data/core/references/video-recording.md
+++ b/skill-data/core/references/video-recording.md
@@ -127,7 +127,7 @@ agent-browser fill @e2 "password"
 agent-browser wait 500
 
 agent-browser click @e3
-agent-browser wait --load networkidle
+agent-browser wait --url "**/dashboard"
 agent-browser wait 1000  # Show result
 
 agent-browser record stop

--- a/skill-data/core/templates/authenticated-session.sh
+++ b/skill-data/core/templates/authenticated-session.sh
@@ -35,7 +35,7 @@ echo "Authentication workflow: $LOGIN_URL"
 if [[ -f "$STATE_FILE" ]]; then
     echo "Loading saved state from $STATE_FILE..."
     if agent-browser --state "$STATE_FILE" open "$LOGIN_URL" 2>/dev/null; then
-        agent-browser wait --load networkidle
+        agent-browser wait --load load
 
         CURRENT_URL=$(agent-browser get url)
         if [[ "$CURRENT_URL" != *"login"* ]] && [[ "$CURRENT_URL" != *"signin"* ]]; then
@@ -56,7 +56,8 @@ fi
 # ================================================================
 echo "Opening login page..."
 agent-browser open "$LOGIN_URL"
-agent-browser wait --load networkidle
+agent-browser wait --load domcontentloaded
+agent-browser wait --fn "(() => { const usable = (el) => { const style = getComputedStyle(el); return !el.disabled && !el.readOnly && style.display !== 'none' && style.visibility !== 'hidden' && el.getClientRects().length > 0; }; const username = Array.from(document.querySelectorAll('input[type=email], input[type=text], input[autocomplete=username], input[name*=email i], input[name*=user i], input[name*=login i]')).some(usable); const password = Array.from(document.querySelectorAll('input[type=password]')).some(usable); return username && password; })()"
 
 echo ""
 echo "Login form structure:"
@@ -80,14 +81,17 @@ exit 0
 # : "${APP_PASSWORD:?Set APP_PASSWORD environment variable}"
 #
 # agent-browser open "$LOGIN_URL"
-# agent-browser wait --load networkidle
+# agent-browser wait --load domcontentloaded
+# agent-browser wait --fn "(() => { const usable = (el) => { const style = getComputedStyle(el); return !el.disabled && !el.readOnly && style.display !== 'none' && style.visibility !== 'hidden' && el.getClientRects().length > 0; }; const username = Array.from(document.querySelectorAll('input[type=email], input[type=text], input[autocomplete=username], input[name*=email i], input[name*=user i], input[name*=login i]')).some(usable); const password = Array.from(document.querySelectorAll('input[type=password]')).some(usable); return username && password; })()"
 # agent-browser snapshot -i
 #
 # # Fill credentials (update refs to match your form)
 # agent-browser fill @e1 "$APP_USERNAME"
 # agent-browser fill @e2 "$APP_PASSWORD"
 # agent-browser click @e3
-# agent-browser wait --load networkidle
+# Replace this with the app-specific post-login wait, for example:
+# agent-browser wait --url "**/dashboard"
+# agent-browser wait --text "Welcome"
 #
 # # Verify login succeeded
 # FINAL_URL=$(agent-browser get url)

--- a/skill-data/core/templates/capture-workflow.sh
+++ b/skill-data/core/templates/capture-workflow.sh
@@ -27,7 +27,7 @@ mkdir -p "$OUTPUT_DIR"
 
 # Navigate to target
 agent-browser open "$TARGET_URL"
-agent-browser wait --load networkidle
+agent-browser wait --load load
 
 # Get metadata
 TITLE=$(agent-browser get title)

--- a/skill-data/core/templates/form-automation.sh
+++ b/skill-data/core/templates/form-automation.sh
@@ -19,7 +19,8 @@ echo "Form automation: $FORM_URL"
 
 # Step 1: Navigate to form
 agent-browser open "$FORM_URL"
-agent-browser wait --load networkidle
+agent-browser wait --load domcontentloaded
+agent-browser wait --fn "Array.from(document.querySelectorAll('input:not([type=hidden]), textarea, select')).some((el) => { const style = getComputedStyle(el); return !el.disabled && !el.readOnly && style.display !== 'none' && style.visibility !== 'hidden' && el.getClientRects().length > 0; })"
 
 # Step 2: Snapshot to discover form elements
 echo ""
@@ -44,8 +45,8 @@ agent-browser snapshot -i
 # agent-browser click @e3  # Submit button
 
 # Step 4: Wait for submission
-# agent-browser wait --load networkidle
 # agent-browser wait --url "**/success"  # Or wait for redirect
+# agent-browser wait --text "Success"     # Or wait for confirmation text
 
 # Step 5: Verify result
 echo ""

--- a/skill-data/dogfood/SKILL.md
+++ b/skill-data/dogfood/SKILL.md
@@ -51,7 +51,7 @@ Start a named session:
 
 ```bash
 agent-browser --session {SESSION} open {TARGET_URL}
-agent-browser --session {SESSION} wait --load networkidle
+agent-browser --session {SESSION} wait --load domcontentloaded
 ```
 
 ### 2. Authenticate
@@ -64,7 +64,11 @@ agent-browser --session {SESSION} snapshot -i
 agent-browser --session {SESSION} fill @e1 "{EMAIL}"
 agent-browser --session {SESSION} fill @e2 "{PASSWORD}"
 agent-browser --session {SESSION} click @e3
-agent-browser --session {SESSION} wait --load networkidle
+# Replace this with the target app's post-login URL, text, or JS condition:
+agent-browser --session {SESSION} wait --url "{POST_LOGIN_URL_PATTERN}"
+# Or:
+# agent-browser --session {SESSION} wait --text "{POST_LOGIN_TEXT}"
+# agent-browser --session {SESSION} wait --fn "{POST_LOGIN_CONDITION}"
 ```
 
 For OTP/email codes: ask the user, wait for their response, then enter the code.

--- a/skill-data/slack/SKILL.md
+++ b/skill-data/slack/SKILL.md
@@ -83,7 +83,9 @@ agent-browser snapshot -i
 # Look for channel name in the list (e.g., "engineering", "product-design")
 # Click on the channel treeitem ref
 agent-browser click @e94  # Example: engineering channel ref
-agent-browser wait --load networkidle
+# Replace `engineering` with the clicked channel's name so the old channel
+# header cannot satisfy the wait while the new channel is still rendering.
+agent-browser wait --fn "document.querySelector('[data-qa=\"channel_header\"]')?.innerText.includes('engineering')"
 agent-browser screenshot channel.png
 ```
 
@@ -95,7 +97,8 @@ agent-browser snapshot -i
 agent-browser click @e5  # Search button (typical ref)
 agent-browser fill @e_search "keyword"
 agent-browser press Enter
-agent-browser wait --load networkidle
+# Match the submitted query so a repeated search cannot reuse the old route.
+agent-browser wait --fn "location.pathname.includes('/search') && new URL(location.href).searchParams.get('q') === 'keyword'"
 agent-browser screenshot search-results.png
 ```
 

--- a/skill-data/slack/references/slack-tasks.md
+++ b/skill-data/slack/references/slack-tasks.md
@@ -101,7 +101,8 @@ Find all messages/threads mentioning specific terms.
    # Identify search input ref from snapshot
    agent-browser fill @e_search_input "your keyword"
    agent-browser press Enter
-   agent-browser wait --load networkidle
+   # Match the submitted query so a repeated search cannot reuse the old route.
+   agent-browser wait --fn "location.pathname.includes('/search') && new URL(location.href).searchParams.get('q') === 'your keyword'"
    ```
 
 3. **Capture results**
@@ -141,7 +142,8 @@ Watch a channel and capture new messages/engagement.
    agent-browser snapshot -i
    # Find channel ref from sidebar
    agent-browser click @e_channel_ref
-   agent-browser wait --load networkidle
+   # Replace `engineering` with the clicked channel's name, or wait for its known URL:
+   agent-browser wait --fn "document.querySelector('[data-qa=\"channel_header\"]')?.innerText.includes('engineering')"
    ```
 
 2. **Check channel info**
@@ -342,7 +344,6 @@ If you can't find an element:
 
 4. **Wait for page to load**
    ```bash
-   agent-browser wait --load networkidle
-   agent-browser wait 1000
+   agent-browser wait --fn "document.querySelector('[role=main]')"
    agent-browser snapshot -i
    ```

--- a/skill-data/vercel-sandbox/SKILL.md
+++ b/skill-data/vercel-sandbox/SKILL.md
@@ -89,7 +89,11 @@ export async function snapshotUrl(url: string) {
 The sandbox persists between commands, so you can run full automation sequences:
 
 ```ts
-export async function fillAndSubmitForm(url: string, data: Record<string, string>) {
+export async function fillAndSubmitForm(
+  url: string,
+  data: Record<string, string>,
+  postSubmitWaitArgs: string[],
+) {
   return withBrowser(async (sandbox) => {
     await runAgentBrowserCommand(sandbox, ["open", url]);
 
@@ -104,7 +108,9 @@ export async function fillAndSubmitForm(url: string, data: Record<string, string
     }
 
     await runAgentBrowserCommand(sandbox, ["click", "@e5"]);
-    await runAgentBrowserCommand(sandbox, ["wait", "--load", "networkidle"]);
+    // Pass an app-specific wait, such as ["--url", "**/checkout/complete"],
+    // ["--text", "Thanks"], or ["#confirmation"].
+    await runAgentBrowserCommand(sandbox, ["wait", ...postSubmitWaitArgs]);
 
     const ssResult = await runAgentBrowserCommand<{ data?: { path?: string } }>(sandbox, [
       "screenshot",


### PR DESCRIPTION
Update the core and specialized skills, CLI help, README, and public docs to prefer selector, text, URL, JavaScript-condition, or lifecycle waits after page changes. Replace generic `networkidle` examples in authentication, profiling, recording, capture, form, Slack, dogfood, and sandbox workflows with task-specific waits while retaining `networkidle` for pages known to become quiet. Document that SSE, WebSockets, polling, and long-polling can keep network idle from resolving.