### PR TITLE
fix: preserve explicit false debug overrides

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -480,6 +480,8 @@ fn apply_daemon_env(cmd: &mut Command, session: &str, opts: &DaemonOptions) {
     }
     if opts.debug {
         cmd.env("AGENT_BROWSER_DEBUG", "1");
+    } else {
+        cmd.env_remove("AGENT_BROWSER_DEBUG");
     }
     if let Some(path) = opts.executable_path {
         cmd.env("AGENT_BROWSER_EXECUTABLE_PATH", path);
@@ -1285,12 +1287,35 @@ mod tests {
     }
 
     #[test]
+    fn test_debug_daemon_env_matches_resolved_option() {
+        for debug in [false, true] {
+            let mut opts = test_daemon_options(None, false, None);
+            opts.debug = debug;
+            let mut cmd = Command::new("agent-browser");
+            apply_daemon_env(&mut cmd, "debug-env-test", &opts);
+            let override_value = cmd
+                .get_envs()
+                .find(|(key, _)| *key == "AGENT_BROWSER_DEBUG")
+                .map(|(_, value)| value);
+            let expected = debug.then(|| std::ffi::OsStr::new("1"));
+            assert_eq!(override_value, Some(expected));
+        }
+    }
+
+    #[test]
     fn test_daemon_config_fingerprint_tracks_daemon_owned_options() {
         let domains = vec!["example.com".to_string()];
         let base = test_daemon_options(None, false, None);
+        let mut debug_changed = test_daemon_options(None, false, None);
+        debug_changed.debug = true;
         let idle_changed = test_daemon_options(Some("1000"), false, None);
         let dialog_changed = test_daemon_options(None, true, None);
         let domains_changed = test_daemon_options(None, false, Some(&domains));
+
+        assert_ne!(
+            daemon_config_fingerprint(&base),
+            daemon_config_fingerprint(&debug_changed)
+        );
 
         assert_ne!(
             daemon_config_fingerprint(&base),

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -528,7 +528,9 @@ pub fn parse_flags(args: &[String]) -> Flags {
     let mut flags = Flags {
         json: env_var_is_truthy("AGENT_BROWSER_JSON") || config.json.unwrap_or(false),
         headed: env_var_is_truthy("AGENT_BROWSER_HEADED") || config.headed.unwrap_or(false),
-        debug: env_var_is_truthy("AGENT_BROWSER_DEBUG") || config.debug.unwrap_or(false),
+        debug: env_var_bool("AGENT_BROWSER_DEBUG")
+            .or(config.debug)
+            .unwrap_or(false),
         session: env::var("AGENT_BROWSER_SESSION")
             .ok()
             .or(config.session)
@@ -1887,6 +1889,44 @@ mod tests {
     fn test_debug_false() {
         let flags = parse_flags(&args("--debug false open example.com"));
         assert!(!flags.debug);
+    }
+
+    #[test]
+    fn test_debug_config_env_cli_precedence() {
+        let guard = EnvGuard::new(&["AGENT_BROWSER_DEBUG"]);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent-browser.json");
+        let cases = [
+            (None, None, None, false),
+            (Some(true), None, None, true),
+            (Some(true), Some("false"), None, false),
+            (Some(true), Some("0"), None, false),
+            (Some(true), Some("no"), None, false),
+            (Some(false), Some("1"), None, true),
+            (None, Some("1"), Some("false"), false),
+            (Some(true), Some("true"), Some("false"), false),
+            (Some(false), Some("false"), Some("true"), true),
+        ];
+        let mut actual = Vec::new();
+        let mut expected = Vec::new();
+        for (config, env, cli, want) in cases {
+            fs::write(&path, serde_json::json!({ "debug": config }).to_string()).unwrap();
+            match env {
+                Some(value) => guard.set("AGENT_BROWSER_DEBUG", value),
+                None => guard.remove("AGENT_BROWSER_DEBUG"),
+            }
+            let mut argv = vec!["--config".to_string(), path.to_string_lossy().into_owned()];
+            if let Some(value) = cli {
+                argv.extend(["--debug".to_string(), value.to_string()]);
+            }
+            argv.extend(args("open about:blank"));
+            let debug = parse_flags(&argv).debug;
+            println!("config={config:?} env={env:?} cli={cli:?} debug={debug}");
+            actual.push(debug);
+            expected.push(want);
+        }
+        drop(guard);
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

* Preserve explicit `false` values when resolving `AGENT_BROWSER_DEBUG` against config.
* Prevent a daemon launched with resolved `debug=false` from inheriting `AGENT_BROWSER_DEBUG` from its parent process.
* Add regression coverage for Debug precedence, daemon environment propagation, and the existing Debug fingerprint behavior.

## Problem

Debug configuration could remain enabled despite an explicit higher-priority override in two cases.

First, `AGENT_BROWSER_DEBUG=false` could not override `config.debug=true` because the environment value was reduced to a boolean before falling back to config, losing the distinction between an unset value and an explicit `false`.

Second, `--debug false` correctly resolved Debug to `false`, but daemon startup only set `AGENT_BROWSER_DEBUG` when Debug was enabled. If the parent process already had `AGENT_BROWSER_DEBUG=1`, the daemon inherited it and still enabled Debug logging.

## Fix

Use the existing tri-state environment boolean helper when resolving Debug configuration so an explicit `false` remains distinct from an unset value.

When launching the daemon, explicitly remove `AGENT_BROWSER_DEBUG` from the child command when the resolved Debug value is `false`.

No daemon lifecycle or fingerprint changes are required because Debug is already part of the daemon configuration fingerprint.

## Testing

* Added regression tests that fail against the original production behavior and pass with the fix.
* Targeted flags and connection tests pass.
* `cargo fmt --manifest-path cli/Cargo.toml -- --check`
* `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
* `cargo test --profile ci --manifest-path cli/Cargo.toml` — 1308 unit tests and 6 integration tests passed.
* Verified 9 Debug config/env/CLI precedence combinations manually.
* Verified daemon restart behavior across `true → false → true`, including the resulting daemon environment.
* Ran the ignored navigation stress case 12 times against both the unmodified baseline and patched binary under matched conditions; all 24 runs passed.
